### PR TITLE
chore(ci): bump GitHub Actions (incorporates #2 #4 #5 #6 #7)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,8 +27,8 @@ jobs:
           --health-cmd "pg_isready -U primer"
           --health-interval 5s --health-timeout 5s --health-retries 20
     steps:
-      - uses: actions/checkout@v4
-      - uses: astral-sh/setup-uv@v4
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
         with:
           version: "latest"
       - name: Sync
@@ -102,7 +102,7 @@ jobs:
       version: ${{ steps.psr.outputs.version }}
       tag: ${{ steps.psr.outputs.tag }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -122,10 +122,10 @@ jobs:
     if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.release.outputs.tag }}
-      - uses: astral-sh/setup-uv@v4
+      - uses: astral-sh/setup-uv@v7
       - name: Build all three packages
         run: |
           uv build --wheel --sdist -o dist_primer .
@@ -152,17 +152,17 @@ jobs:
     if: needs.release.outputs.released == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ needs.release.outputs.tag }}
-      - uses: docker/setup-buildx-action@v3
-      - uses: docker/login-action@v3
+      - uses: docker/setup-buildx-action@v4
+      - uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
       - name: Build + push primer
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
@@ -171,7 +171,7 @@ jobs:
             ghcr.io/primerhq/primer:${{ needs.release.outputs.version }}
             ghcr.io/primerhq/primer:latest
       - name: Build + push primer-runtime
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@v7
         with:
           context: ./runtime
           file: ./runtime/Dockerfile


### PR DESCRIPTION
Applies the five dependabot GitHub-Actions bumps in one commit (they edit adjacent `release.yml` lines, so the individual bot branches would conflict on merge):

- actions/checkout v4 -> v7 (#4)
- astral-sh/setup-uv v4 -> v7 (#6)
- docker/setup-buildx-action v3 -> v4 (#2)
- docker/login-action v3 -> v4 (#7)
- docker/build-push-action v6 -> v7 (#5)

All five `uses:` are still inputs-compatible with the workflow. Closes #2, #4, #5, #6, #7.