### PR TITLE
fix(sessions): keep delete_session from 500ing when its workspace is gone

### DIFF
--- a/primer/api/routers/sessions.py
+++ b/primer/api/routers/sessions.py
@@ -423,7 +423,10 @@ async def delete_session(
                 "session_id": session_id,
                 "workspace_id": workspace_id,
                 "exception": type(exc).__name__,
-                "message": str(exc),
+                # NB: not "message" -- that is a reserved LogRecord attribute
+                # and makeRecord() would raise KeyError, turning this
+                # best-effort log into a 500 that skips the row delete below.
+                "error": str(exc),
             },
         )
 

--- a/tests/api/test_sessions.py
+++ b/tests/api/test_sessions.py
@@ -643,6 +643,48 @@ async def test_delete_ended_session_removes_row(
     assert await storage.get(sid) is None
 
 
+async def test_delete_session_survives_on_disk_cleanup_failure(
+    sessions_client, seeded_workspace, seeded_agent, app, monkeypatch,
+):
+    """DELETE must still remove the row (and return 204) when the
+    best-effort on-disk cleanup raises -- e.g. the workspace was deleted
+    before its session, so get_workspace() 404s.
+
+    Regression: the cleanup except-branch logged the caught exception
+    with extra={"message": str(exc)}. "message" is a reserved
+    LogRecord attribute, so logging.Logger.makeRecord raised KeyError
+    before the warning was emitted; that KeyError propagated out of the
+    handler as a 500 and the final sessions.delete() never ran. The row
+    was orphaned with no API path to remove it (the only delete route is
+    nested under the now-missing workspace)."""
+    from primer.model.workspace_session import WorkspaceSession
+
+    create = await sessions_client.post(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions",
+        json={"binding": {"kind": "agent", "agent_id": seeded_agent.id}},
+    )
+    sid = create.json()["id"]
+    await sessions_client.post(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions/{sid}/cancel"
+    )
+
+    # Force the best-effort cleanup to fail, mirroring a workspace that
+    # was deleted before its session.
+    async def _raise_workspace_gone(_workspace_id):
+        raise RuntimeError("workspace gone")
+
+    monkeypatch.setattr(
+        app.state.workspace_registry, "get_workspace", _raise_workspace_gone
+    )
+
+    resp = await sessions_client.delete(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions/{sid}"
+    )
+    assert resp.status_code == 204, resp.text
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    assert await storage.get(sid) is None
+
+
 async def test_delete_created_session_auto_cancels_and_removes_row(
     sessions_client, seeded_workspace, seeded_agent, app,
 ):


### PR DESCRIPTION
## Problem

`DELETE /v1/workspaces/{wid}/sessions/{sid}` returns **500** and never deletes the row when the session's workspace has already been deleted. Because that nested route is the *only* delete path, the session becomes an orphan with no API way to remove it.

Root cause is in `delete_session`'s best-effort on-disk cleanup branch:

```python
except Exception as exc:
    logger.warning(
        "delete_session: on-disk cleanup failed (row still removed)",
        extra={..., "message": str(exc)},   # <-- reserved key
    )
await sessions.delete(session_id)            # <-- never reached
```

`message` is a reserved `LogRecord` attribute, so `logging.Logger.makeRecord` raises `KeyError: "Attempt to overwrite 'message' in LogRecord"` *before* the warning is emitted. The `KeyError` propagates out of the handler as a 500, and the `sessions.delete()` on the next line never runs. (It fires whenever the cleanup raises — most easily when the workspace was deleted before its session, so `get_workspace()` 404s.)

## Fix

Rename the offending `extra` key from `message` to `error` — the convention already used for exception strings across `agent/`, `graph/`, and `toolset/` logging (paired with the existing `"exception": type(exc).__name__`). The cleanup failure is now logged and the row is still deleted.

One-line behavioural change; no API or schema change.

## Test

Added `test_delete_session_survives_on_disk_cleanup_failure`, which forces the on-disk cleanup to raise (mirroring a workspace deleted before its session) and asserts the delete returns 204 and removes the row.

- Fails on `main` with the exact `KeyError` at the `logger.warning` call.
- Passes with the fix.
- `tests/api/test_sessions.py`: 37 passed. `ruff check` clean on both files.