### PR TITLE
ci: manual-dispatch releases + per-PR CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,46 @@
+name: CI
+
+# Runs on every pull request and on pushes to main. This is the
+# substantive correctness gate: lint, docs hygiene, and the narrowed unit
+# sweep (the same commands `make lint` / `make docs-hygiene` / `make test`
+# run locally). Releasing is a separate, manually-dispatched workflow
+# (release.yml) so a merge never publishes by itself.
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: astral-sh/setup-uv@v7
+        with:
+          version: "latest"
+      - name: Sync
+        run: |
+          uv sync --dev --group docs
+          uv pip install --no-deps ./primectl ./runtime
+      - name: Lint (ruff)
+        run: uv run ruff check .
+      - name: Docs hygiene
+        run: uv run pytest tests/docs/ -q --tb=short
+      # Narrowed unit sweep: excludes e2e / distributed / ui_e2e / integration /
+      # llm (those need a live server, multi-process Postgres, Playwright, or a
+      # real LLM). The Postgres-gated tests skip without PRIMER_PG_TEST_DSN, so
+      # this job needs no database service. The release workflow runs the
+      # Postgres-backed boot smoke before publishing.
+      - name: Unit sweep
+        run: >-
+          uv run pytest tests/ -q
+          --ignore=tests/distributed --ignore=tests/ui_e2e
+          --ignore=tests/e2e --ignore=tests/integration --ignore=tests/llm

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,8 +1,13 @@
 name: Release
 
+# Manual-only: a release is never cut by merging to main. A maintainer with
+# write access dispatches this from the Actions tab (or `gh workflow run
+# release.yml`) when they want to publish. python-semantic-release then
+# decides the version from the conventional commits since the last tag and,
+# if a release is warranted, publishes to PyPI + GHCR. Per-PR correctness is
+# gated separately by ci.yml.
 on:
-  push:
-    branches: [main]
+  workflow_dispatch:
 
 concurrency:
   group: release


### PR DESCRIPTION
Two changes to the workflow setup:

1. **Releases are now manual.** `release.yml` switches from `on: push: [main]` to `on: workflow_dispatch`. Merging to main no longer runs the release pipeline; a maintainer dispatches it deliberately when they want to publish. (Access: `workflow_dispatch` is available to anyone with **write** access; for a stricter single-approver gate we can add a GitHub Environment with required reviewers on the publish jobs.)

2. **Per-PR CI added.** New `ci.yml` runs ruff + docs-hygiene + the narrowed unit sweep on every pull request and on pushes to main. This is the workflow the Makefile and AGENTS.md already reference but that was missing, so dependabot and contributor PRs had no automated checks until now.