### PR TITLE
feat(deps): slim the default install; heavy backends behind extras

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,8 +27,11 @@ jobs:
         with:
           version: "latest"
       - name: Sync
+        # --all-extras so the test env has every optional backend
+        # (huggingface / docling / lance / channels / docker / kubernetes);
+        # without it the backend-specific suites would be skipped or fail.
         run: |
-          uv sync --dev --group docs
+          uv sync --all-extras --dev --group docs
           uv pip install --no-deps ./primectl ./runtime
       - name: Lint (ruff)
         run: uv run ruff check .

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
           version: "latest"
       - name: Sync
         run: |
-          uv sync --dev --group docs
+          uv sync --all-extras --dev --group docs
           uv pip install --no-deps ./primectl ./runtime
       - name: Lint (ruff)
         run: uv run ruff check .

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -48,7 +48,9 @@ files a task touches (never `git add -A`).
 
 - **Stack:** Python 3.12, `uv`, FastAPI, asyncio, Postgres + pgvector, a
   vanilla-React (JSX, no build step) console.
-- **Setup:** `uv sync`; Postgres via `docker compose up -d postgres`; run with
+- **Setup:** `uv sync --all-extras` (the optional backends - huggingface,
+  docling, lance, channels, docker, kubernetes - live behind extras; the dev
+  and test env needs them all); Postgres via `docker compose up -d postgres`; run with
   `uv run primer api` (starts the API plus an in-process worker). A dogfood
   instance is expected to stay healthy on `:9000` between tasks.
 - **Layout:**

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,7 +44,7 @@ Postgres + pgvector, and a vanilla-React (JSX, no build step) operator console.
 ```bash
 git clone https://github.com/primerhq/primer
 cd primer
-uv sync
+uv sync --all-extras
 docker compose up -d postgres
 uv run primer api   # starts the API plus an in-process worker; then GET /v1/health
 ```
@@ -78,7 +78,7 @@ A [Makefile](Makefile) wraps the same commands CI runs, so local green means
 CI green:
 
 ```bash
-make setup          # uv sync
+make setup          # uv sync --all-extras
 make lint           # ruff check .
 make fmt            # ruff check --fix .
 make test           # narrowed unit sweep

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,8 +56,11 @@ WORKDIR /app
 # ----- Layer 2/3: dependency install (cached on pyproject+lock) -----
 # README.md is referenced by pyproject.toml's `readme = "README.md"`
 # field, so hatchling needs it present even for a deps-only sync.
+# --all-extras: the published image is batteries-included (primer-ai[full]),
+# shipping every optional backend (huggingface, docling, lance, channels,
+# docker, kubernetes). Slim is for pip/pipx users who opt out via extras.
 COPY pyproject.toml uv.lock README.md ./
-RUN uv sync --frozen --no-install-project --no-dev
+RUN uv sync --all-extras --frozen --no-install-project --no-dev
 
 # ----- Layer 4: project source -----
 COPY primer ./primer
@@ -69,7 +72,7 @@ RUN chmod +x /usr/local/bin/primer-entrypoint.sh
 # ----- Layer 5: install the project itself -----
 # Editable install (uv default) so /app/primer is the live tree -
 # necessary for the console mount's `_UI_DIR` path math.
-RUN uv sync --frozen --no-dev
+RUN uv sync --all-extras --frozen --no-dev
 
 EXPOSE 8000
 

--- a/Makefile
+++ b/Makefile
@@ -19,8 +19,8 @@ help: ## Show this help
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
 		| awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-14s\033[0m %s\n", $$1, $$2}'
 
-setup: ## Install dependencies (uv sync)
-	uv sync
+setup: ## Install dependencies (uv sync --all-extras)
+	uv sync --all-extras
 
 test: ## Run the narrowed unit sweep (excludes e2e/distributed/ui_e2e/integration/llm)
 	uv run pytest tests/ -q $(PYTEST_IGNORES) --tb=short

--- a/README.md
+++ b/README.md
@@ -130,12 +130,14 @@ Primer does not press "go" on the loop for you - it gives you the orchestration 
 
 Pick whichever install fits. All three start the same server zero-config on an embedded SQLite database - perfect for a first look.
 
-**pipx** (isolated CLI install; needs Python 3.13+):
+**pipx** (isolated CLI install; needs Python 3.12+):
 
 ```bash
-pipx install primer-ai
+pipx install 'primer-ai[full]'                   # batteries-included
 primer api                                       # API + in-process worker
 ```
+
+The bare `pipx install primer-ai` installs a lean core (REST API, console, MCP, SQLite/Postgres storage, and the API-based LLM/embedder providers). The `[full]` extra adds the optional backends - local HuggingFace embeddings, Docling ingestion, LanceDB, Slack/Telegram/Discord channels, and the container/Kubernetes workspace backends - which pull a larger ML stack. You can also pick à la carte: `primer-ai[huggingface]`, `[docling]`, `[lance]`, `[channels]`, `[docker]`, `[kubernetes]`.
 
 **Docker** (no Python toolchain required):
 
@@ -148,7 +150,7 @@ docker run --rm -p 8000:8000 ghcr.io/primerhq/primer:latest
 ```bash
 git clone https://github.com/primerhq/primer.git
 cd primer
-uv sync
+uv sync --all-extras
 uv run primer api
 ```
 
@@ -196,7 +198,7 @@ At runtime, requests arrive from many edges (REST/console, MCP clients, chat cha
 Read [AGENTS.md](https://github.com/primerhq/primer/blob/main/AGENTS.md) first - it is the authoritative contributor contract (project layout, the Definition of Done, how to run the suites, and the hard rules). [CONTRIBUTING.md](https://github.com/primerhq/primer/blob/main/CONTRIBUTING.md) is the human-facing summary.
 
 ```bash
-uv sync
+uv sync --all-extras
 docker compose up -d postgres
 # narrowed unit sweep (excludes e2e/distributed/ui_e2e):
 uv run pytest tests/ -q --ignore=tests/distributed --ignore=tests/ui_e2e \

--- a/primer/api/app.py
+++ b/primer/api/app.py
@@ -19,6 +19,7 @@ below so external call sites keep working unchanged.
 from __future__ import annotations
 
 import asyncio
+import importlib
 import logging
 from contextlib import asynccontextmanager
 from collections.abc import AsyncIterator
@@ -35,13 +36,23 @@ from primer.api.registries import (
 )
 from primer.api.version import API_VERSION, APP_VERSION
 
-# Importing these modules registers channel adapter factories with
-# primer.channel.factory. Safe at module level; defers the
-# heavyweight platform-SDK imports until the first Channel of
-# that provider type is constructed.
-import primer.channel.slack.factory  # noqa: F401
-import primer.channel.telegram.factory  # noqa: F401
-import primer.channel.discord.factory  # noqa: F401
+# Importing these modules registers each channel adapter factory with
+# primer.channel.factory. Each platform SDK ships in the optional
+# ``channels`` extra, so a slim install may not have it; when a platform
+# package is absent we skip registering it, and ``build_adapter`` raises a
+# clear ConfigError if a Channel row later names that uninstalled provider.
+for _channel_factory_mod in (
+    "primer.channel.slack.factory",
+    "primer.channel.telegram.factory",
+    "primer.channel.discord.factory",
+):
+    try:
+        importlib.import_module(_channel_factory_mod)
+    except ModuleNotFoundError:
+        logging.getLogger(__name__).debug(
+            "channel platform not installed; skipping registration: %s",
+            _channel_factory_mod,
+        )
 from primer.model.scheduler import RuntimeMode
 from primer.toolset.misc import build_misc_toolset
 from primer.toolset.system import build_system_toolset

--- a/primer/api/registries/provider_registry.py
+++ b/primer/api/registries/provider_registry.py
@@ -107,7 +107,14 @@ def _build_default_embedder_factory(
     def _factory(provider: EmbeddingProvider) -> Embedder:  # pragma: no cover
         match provider.provider:
             case EmbeddingProviderType.HUGGINGFACE:
-                from primer.embedder.huggingface import HuggingFaceEmbedder
+                try:
+                    from primer.embedder.huggingface import HuggingFaceEmbedder
+                except ModuleNotFoundError as exc:
+                    raise ConfigError(
+                        "the HuggingFace embedder needs the optional "
+                        "'huggingface' extra; install it with: "
+                        "pip install 'primer-ai[huggingface]'"
+                    ) from exc
                 return HuggingFaceEmbedder(provider, rate_limiter=rate_limiter)
             case EmbeddingProviderType.OPENAI:
                 from primer.embedder.openai import OpenAIEmbedder
@@ -142,7 +149,16 @@ def _build_default_cross_encoder_factory(
     def _factory(provider: CrossEncoderProvider) -> CrossEncoder:  # pragma: no cover
         match provider.provider:
             case CrossEncoderProviderType.HUGGINGFACE:
-                from primer.cross_encoder.huggingface import HuggingFaceCrossEncoder
+                try:
+                    from primer.cross_encoder.huggingface import (
+                        HuggingFaceCrossEncoder,
+                    )
+                except ModuleNotFoundError as exc:
+                    raise ConfigError(
+                        "the HuggingFace cross-encoder needs the optional "
+                        "'huggingface' extra; install it with: "
+                        "pip install 'primer-ai[huggingface]'"
+                    ) from exc
                 return HuggingFaceCrossEncoder(provider, rate_limiter=rate_limiter)
             case _:
                 raise ConfigError(

--- a/primer/cross_encoder/__init__.py
+++ b/primer/cross_encoder/__init__.py
@@ -4,13 +4,32 @@ Sibling of :mod:`primer.embedder` and :mod:`primer.llm`. Each adapter
 binds the ABC to one provider backend.
 
 The default adapter is :class:`HuggingFaceCrossEncoder`, which wraps
-:class:`sentence_transformers.CrossEncoder` for local inference.
-Future managed-API adapters (Cohere, Jina) drop in alongside it
-without touching the ABC or the
-:class:`primer.search.CollectionSearcher` orchestrator.
+:class:`sentence_transformers.CrossEncoder` for local inference and
+requires the optional ``huggingface`` extra (``sentence-transformers`` ->
+``torch``). It is imported lazily via :pep:`562` ``__getattr__`` so that
+importing this package never pulls the heavy ML stack. Future managed-API
+adapters (Cohere, Jina) drop in alongside it without touching the ABC or
+the :class:`primer.search.CollectionSearcher` orchestrator.
 """
 
-from primer.cross_encoder.huggingface import HuggingFaceCrossEncoder
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from primer.cross_encoder.huggingface import HuggingFaceCrossEncoder
 
 
 __all__ = ["HuggingFaceCrossEncoder"]
+
+
+def __getattr__(name: str):
+    if name == "HuggingFaceCrossEncoder":
+        try:
+            from primer.cross_encoder.huggingface import HuggingFaceCrossEncoder
+        except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+            raise ModuleNotFoundError(
+                "HuggingFaceCrossEncoder requires the optional 'huggingface' "
+                "extra. Install it with: pip install 'primer-ai[huggingface]' "
+                "(or 'primer-ai[full]' for everything)."
+            ) from exc
+        return HuggingFaceCrossEncoder
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/primer/embedder/__init__.py
+++ b/primer/embedder/__init__.py
@@ -3,11 +3,32 @@
 Each adapter subclasses :class:`primer.int.Embedder` and implements the
 embedding interface against one provider's SDK or local model.
 
-Adapters land here one per file as the per-adapter sub-specs ship.
+``HuggingFaceEmbedder`` requires the optional ``huggingface`` extra
+(``sentence-transformers`` -> ``torch``). It is imported lazily via
+:pep:`562` ``__getattr__`` so that importing this package, or selecting an
+API-based embedder (Gemini / OpenAI), never pulls the heavy ML stack.
 """
 
+from typing import TYPE_CHECKING
+
 from primer.embedder.gemini import GeminiEmbedder
-from primer.embedder.huggingface import HuggingFaceEmbedder
 from primer.embedder.openai import OpenAIEmbedder
 
+if TYPE_CHECKING:
+    from primer.embedder.huggingface import HuggingFaceEmbedder
+
 __all__ = ["GeminiEmbedder", "HuggingFaceEmbedder", "OpenAIEmbedder"]
+
+
+def __getattr__(name: str):
+    if name == "HuggingFaceEmbedder":
+        try:
+            from primer.embedder.huggingface import HuggingFaceEmbedder
+        except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+            raise ModuleNotFoundError(
+                "HuggingFaceEmbedder requires the optional 'huggingface' "
+                "extra. Install it with: pip install 'primer-ai[huggingface]' "
+                "(or 'primer-ai[full]' for everything)."
+            ) from exc
+        return HuggingFaceEmbedder
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/primer/ingest/__init__.py
+++ b/primer/ingest/__init__.py
@@ -10,29 +10,36 @@ Public surface:
   for one :class:`primer.model.collection.Document`.
 * :class:`DoclingLoader` -- DEFAULT loader. Wraps Docling for
   high-quality multi-format parsing (PDF / DOCX / PPTX / HTML /
-  ...). Always available because ``docling`` is a core dependency.
+  ...). Requires the optional ``docling`` extra; imported lazily via
+  :pep:`562` ``__getattr__`` so importing this package never pulls the
+  heavy ingestion / OCR stack.
 * :class:`DoclingSplitter` -- DEFAULT splitter. Structure-aware
   chunking via Docling's :class:`HybridChunker`; consumes the
-  structural metadata that :class:`DoclingLoader` populates.
+  structural metadata that :class:`DoclingLoader` populates. Also part
+  of the ``docling`` extra and imported lazily.
 * :class:`RecursiveSplitter` -- pure-Python recursive splitter; a
   zero-dep fallback for callers that don't want the structural
   metadata path.
 
 The :class:`DocumentIngester` constructor defaults its ``loader`` and
 ``splitter`` to fresh :class:`DoclingLoader` / :class:`DoclingSplitter`
-instances when omitted; callers only need to supply them when
-substituting a custom backend.
+instances when omitted, so document ingestion needs the ``docling``
+extra unless a custom backend is supplied.
 
 See ``docs/superpowers/specs/2026-05-03-document-ingestion-design.md``.
 """
 
+from typing import TYPE_CHECKING
+
 from primer.ingest.ingester import DocumentIngester
 from primer.ingest.loader import DocumentLoader
-from primer.ingest.loaders.docling import DoclingLoader
 from primer.ingest.splitter import DocumentSplitter
-from primer.ingest.splitters.docling import DoclingSplitter
 from primer.ingest.splitters.recursive import RecursiveSplitter
 from primer.model.ingest import Chunk, IngestResult, LoadedDocument
+
+if TYPE_CHECKING:
+    from primer.ingest.loaders.docling import DoclingLoader
+    from primer.ingest.splitters.docling import DoclingSplitter
 
 
 __all__ = [
@@ -46,3 +53,23 @@ __all__ = [
     "LoadedDocument",
     "RecursiveSplitter",
 ]
+
+
+def __getattr__(name: str):
+    # DoclingLoader / DoclingSplitter need the optional 'docling' extra.
+    if name in ("DoclingLoader", "DoclingSplitter"):
+        try:
+            if name == "DoclingLoader":
+                from primer.ingest.loaders.docling import DoclingLoader as obj
+            else:
+                from primer.ingest.splitters.docling import (
+                    DoclingSplitter as obj,
+                )
+        except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+            raise ModuleNotFoundError(
+                f"{name} requires the optional 'docling' extra. Install it "
+                "with: pip install 'primer-ai[docling]' (or "
+                "'primer-ai[full]' for everything)."
+            ) from exc
+        return obj
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/primer/ingest/ingester.py
+++ b/primer/ingest/ingester.py
@@ -56,11 +56,13 @@ class DocumentIngester:
         if batch_size <= 0:
             raise ValueError(f"batch_size must be > 0, got {batch_size!r}")
         if loader is None:
-            from primer.ingest.loaders.docling import DoclingLoader
+            # Route through the lazy package re-export so a missing 'docling'
+            # extra surfaces the install hint rather than a bare import error.
+            from primer.ingest.loaders import DoclingLoader
 
             loader = DoclingLoader()
         if splitter is None:
-            from primer.ingest.splitters.docling import DoclingSplitter
+            from primer.ingest.splitters import DoclingSplitter
 
             splitter = DoclingSplitter()
         self._collection = collection

--- a/primer/ingest/loaders/__init__.py
+++ b/primer/ingest/loaders/__init__.py
@@ -1,15 +1,33 @@
 """Concrete :class:`DocumentLoader` implementations.
 
 Subpackage for the shipped loaders. The default loader is
-:class:`DoclingLoader`, which ships with the core install
-(``docling`` is a core dependency, not an optional extra).
+:class:`DoclingLoader`, which requires the optional ``docling`` extra and
+is imported lazily via :pep:`562` ``__getattr__`` so importing this
+subpackage never pulls the heavy ingestion / OCR stack.
 
     from primer.ingest.loaders import DoclingLoader
     # or, equivalently, the parent-package re-export:
     from primer.ingest import DoclingLoader
 """
 
-from primer.ingest.loaders.docling import DoclingLoader
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from primer.ingest.loaders.docling import DoclingLoader
 
 
 __all__ = ["DoclingLoader"]
+
+
+def __getattr__(name: str):
+    if name == "DoclingLoader":
+        try:
+            from primer.ingest.loaders.docling import DoclingLoader
+        except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+            raise ModuleNotFoundError(
+                "DoclingLoader requires the optional 'docling' extra. "
+                "Install it with: pip install 'primer-ai[docling]' "
+                "(or 'primer-ai[full]')."
+            ) from exc
+        return DoclingLoader
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/primer/ingest/splitters/__init__.py
+++ b/primer/ingest/splitters/__init__.py
@@ -2,16 +2,35 @@
 
 Subpackage for the shipped splitters. The default splitter is
 :class:`DoclingSplitter` (structure-aware, paired with
-:class:`DoclingLoader`); :class:`RecursiveSplitter` is a pure-Python
-fallback for callers that want no external parser involvement.
+:class:`DoclingLoader`), which requires the optional ``docling`` extra
+and is imported lazily via :pep:`562` ``__getattr__``;
+:class:`RecursiveSplitter` is a pure-Python, zero-dependency fallback.
 
     from primer.ingest.splitters import DoclingSplitter, RecursiveSplitter
     # or, equivalently, the parent-package re-exports:
     from primer.ingest import DoclingSplitter, RecursiveSplitter
 """
 
-from primer.ingest.splitters.docling import DoclingSplitter
+from typing import TYPE_CHECKING
+
 from primer.ingest.splitters.recursive import RecursiveSplitter
+
+if TYPE_CHECKING:
+    from primer.ingest.splitters.docling import DoclingSplitter
 
 
 __all__ = ["DoclingSplitter", "RecursiveSplitter"]
+
+
+def __getattr__(name: str):
+    if name == "DoclingSplitter":
+        try:
+            from primer.ingest.splitters.docling import DoclingSplitter
+        except ModuleNotFoundError as exc:  # pragma: no cover - import guard
+            raise ModuleNotFoundError(
+                "DoclingSplitter requires the optional 'docling' extra. "
+                "Install it with: pip install 'primer-ai[docling]' "
+                "(or 'primer-ai[full]')."
+            ) from exc
+        return DoclingSplitter
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")

--- a/primer/vector/factory.py
+++ b/primer/vector/factory.py
@@ -39,7 +39,13 @@ class VectorStoreProviderFactory:
 
             return PgVectorScaleStoreProvider(config.config)  # type: ignore[arg-type]
         if config.provider == VectorStoreProviderType.LANCE:
-            from primer.vector.lance import LanceVectorStoreProvider
+            try:
+                from primer.vector.lance import LanceVectorStoreProvider
+            except ModuleNotFoundError as exc:
+                raise ConfigError(
+                    "the LanceDB vector store needs the optional 'lance' "
+                    "extra; install it with: pip install 'primer-ai[lance]'"
+                ) from exc
 
             return LanceVectorStoreProvider(config.config)  # type: ignore[arg-type]
         raise ConfigError(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,6 @@ description = "Microagents framework"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "aiodocker>=0.27.0",
     "aiosqlite>=0.22.1",
     "aiohttp>=3.14.1",
     "anthropic>=0.109.1",
@@ -14,14 +13,11 @@ dependencies = [
     "asyncpg>=0.31.0",
     "croniter>=6.2.2",
     "ddgs>=9.14.4",
-    "docling>=2.102.1",
     "fastapi>=0.136.3",
     "google-genai>=2.8.0",
     "grpcio>=1.81.1",
     "jinja2>=3.1.6",
     "jsonschema>=4.26.0",
-    "kubernetes-asyncio>=36.1.0",
-    "lancedb>=0.33.0",
     "mcp>=1.27.2",
     "ollama>=0.6.2",
     "openai>=2.41.1",
@@ -37,13 +33,8 @@ dependencies = [
     "pydantic>=2.13.4",
     "pydantic-settings>=2.14.1",
     "regopy>=1.4.0",
-    "discord.py>=2.7.1",
-    "python-telegram-bot>=22.8",
     "python-multipart>=0.0.32",
     "pyyaml>=6.0.3",
-    "sentence-transformers>=5.5.1",
-    "slack-bolt>=1.28.0",
-    "slack-sdk>=3.42.0",
     "tiktoken>=0.13.0",
     "trafilatura>=2.1.0",
     "transformers>=5.8.1",
@@ -52,6 +43,32 @@ dependencies = [
     "uvicorn[standard]>=0.49.0",
     "opentelemetry-instrumentation-logging>=0.63b1",
 ]
+
+# Optional feature dependencies. The default `pip install primer-ai` ships a
+# lean core (REST API + console + MCP + SQLite/Postgres storage + the
+# API-based LLM/embedder providers). Heavy, feature-specific backends live
+# behind extras so a first install does not pull a multi-GB ML/CUDA stack.
+# `primer-ai[full]` restores the batteries-included experience.
+[project.optional-dependencies]
+# Local HuggingFace embeddings + cross-encoder reranking (pulls torch).
+huggingface = ["sentence-transformers>=5.5.1"]
+# Rich multi-format document ingestion (PDF/DOCX/PPTX/HTML; pulls torch + OCR).
+docling = ["docling>=2.102.1"]
+# LanceDB embedded vector store (the alternative to the core pgvector backend).
+lance = ["lancedb>=0.33.0"]
+# Kubernetes workspace backend.
+kubernetes = ["kubernetes-asyncio>=36.1.0"]
+# Container (Docker / Podman) workspace backend.
+docker = ["aiodocker>=0.27.0"]
+# Slack / Telegram / Discord channels.
+channels = [
+    "discord.py>=2.7.1",
+    "python-telegram-bot>=22.8",
+    "slack-bolt>=1.28.0",
+    "slack-sdk>=3.42.0",
+]
+# Everything: the batteries-included install.
+full = ["primer-ai[huggingface,docling,lance,kubernetes,docker,channels]"]
 
 [project.scripts]
 primer = "primer.cli:app"

--- a/uv.lock
+++ b/uv.lock
@@ -3225,7 +3225,6 @@ name = "primer-ai"
 version = "0.1.0"
 source = { editable = "." }
 dependencies = [
-    { name = "aiodocker" },
     { name = "aiohttp" },
     { name = "aiosqlite" },
     { name = "anthropic" },
@@ -3233,16 +3232,12 @@ dependencies = [
     { name = "asyncpg" },
     { name = "croniter" },
     { name = "ddgs" },
-    { name = "discord-py" },
-    { name = "docling" },
     { name = "fastapi" },
     { name = "google-genai" },
     { name = "grpcio" },
     { name = "itsdangerous" },
     { name = "jinja2" },
     { name = "jsonschema" },
-    { name = "kubernetes-asyncio" },
-    { name = "lancedb" },
     { name = "mcp" },
     { name = "mini-racer" },
     { name = "ollama" },
@@ -3259,18 +3254,48 @@ dependencies = [
     { name = "pydantic" },
     { name = "pydantic-settings" },
     { name = "python-multipart" },
-    { name = "python-telegram-bot" },
     { name = "pyyaml" },
     { name = "regopy" },
-    { name = "sentence-transformers" },
-    { name = "slack-bolt" },
-    { name = "slack-sdk" },
     { name = "tiktoken" },
     { name = "trafilatura" },
     { name = "transformers" },
     { name = "typer" },
     { name = "tzdata" },
     { name = "uvicorn", extra = ["standard"] },
+]
+
+[package.optional-dependencies]
+channels = [
+    { name = "discord-py" },
+    { name = "python-telegram-bot" },
+    { name = "slack-bolt" },
+    { name = "slack-sdk" },
+]
+docker = [
+    { name = "aiodocker" },
+]
+docling = [
+    { name = "docling" },
+]
+full = [
+    { name = "aiodocker" },
+    { name = "discord-py" },
+    { name = "docling" },
+    { name = "kubernetes-asyncio" },
+    { name = "lancedb" },
+    { name = "python-telegram-bot" },
+    { name = "sentence-transformers" },
+    { name = "slack-bolt" },
+    { name = "slack-sdk" },
+]
+huggingface = [
+    { name = "sentence-transformers" },
+]
+kubernetes = [
+    { name = "kubernetes-asyncio" },
+]
+lance = [
+    { name = "lancedb" },
 ]
 
 [package.dev-dependencies]
@@ -3297,7 +3322,7 @@ release = [
 
 [package.metadata]
 requires-dist = [
-    { name = "aiodocker", specifier = ">=0.27.0" },
+    { name = "aiodocker", marker = "extra == 'docker'", specifier = ">=0.27.0" },
     { name = "aiohttp", specifier = ">=3.14.1" },
     { name = "aiosqlite", specifier = ">=0.22.1" },
     { name = "anthropic", specifier = ">=0.109.1" },
@@ -3305,16 +3330,16 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "croniter", specifier = ">=6.2.2" },
     { name = "ddgs", specifier = ">=9.14.4" },
-    { name = "discord-py", specifier = ">=2.7.1" },
-    { name = "docling", specifier = ">=2.102.1" },
+    { name = "discord-py", marker = "extra == 'channels'", specifier = ">=2.7.1" },
+    { name = "docling", marker = "extra == 'docling'", specifier = ">=2.102.1" },
     { name = "fastapi", specifier = ">=0.136.3" },
     { name = "google-genai", specifier = ">=2.8.0" },
     { name = "grpcio", specifier = ">=1.81.1" },
     { name = "itsdangerous", specifier = ">=2.2.0" },
     { name = "jinja2", specifier = ">=3.1.6" },
     { name = "jsonschema", specifier = ">=4.26.0" },
-    { name = "kubernetes-asyncio", specifier = ">=36.1.0" },
-    { name = "lancedb", specifier = ">=0.33.0" },
+    { name = "kubernetes-asyncio", marker = "extra == 'kubernetes'", specifier = ">=36.1.0" },
+    { name = "lancedb", marker = "extra == 'lance'", specifier = ">=0.33.0" },
     { name = "mcp", specifier = ">=1.27.2" },
     { name = "mini-racer", specifier = ">=0.14.1" },
     { name = "ollama", specifier = ">=0.6.2" },
@@ -3327,16 +3352,17 @@ requires-dist = [
     { name = "opentelemetry-instrumentation-logging", specifier = ">=0.63b1" },
     { name = "opentelemetry-sdk", specifier = ">=1.42.1" },
     { name = "pgvector", specifier = ">=0.4.2" },
+    { name = "primer-ai", extras = ["huggingface", "docling", "lance", "kubernetes", "docker", "channels"], marker = "extra == 'full'" },
     { name = "prometheus-client", specifier = ">=0.25.0" },
     { name = "pydantic", specifier = ">=2.13.4" },
     { name = "pydantic-settings", specifier = ">=2.14.1" },
     { name = "python-multipart", specifier = ">=0.0.32" },
-    { name = "python-telegram-bot", specifier = ">=22.8" },
+    { name = "python-telegram-bot", marker = "extra == 'channels'", specifier = ">=22.8" },
     { name = "pyyaml", specifier = ">=6.0.3" },
     { name = "regopy", specifier = ">=1.4.0" },
-    { name = "sentence-transformers", specifier = ">=5.5.1" },
-    { name = "slack-bolt", specifier = ">=1.28.0" },
-    { name = "slack-sdk", specifier = ">=3.42.0" },
+    { name = "sentence-transformers", marker = "extra == 'huggingface'", specifier = ">=5.5.1" },
+    { name = "slack-bolt", marker = "extra == 'channels'", specifier = ">=1.28.0" },
+    { name = "slack-sdk", marker = "extra == 'channels'", specifier = ">=3.42.0" },
     { name = "tiktoken", specifier = ">=0.13.0" },
     { name = "trafilatura", specifier = ">=2.1.0" },
     { name = "transformers", specifier = ">=5.8.1" },
@@ -3344,6 +3370,7 @@ requires-dist = [
     { name = "tzdata", specifier = ">=2026.2" },
     { name = "uvicorn", extras = ["standard"], specifier = ">=0.49.0" },
 ]
+provides-extras = ["huggingface", "docling", "lance", "kubernetes", "docker", "channels", "full"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Makes `pip install primer-ai` a lean core and moves the heavy, feature-specific backends to optional extras, so a first install no longer pulls a multi-GB ML/CUDA stack (**~6.1 GB -> well under 1 GB**). `primer-ai[full]` restores the batteries-included experience.

## Extras
`huggingface` (local embeddings + cross-encoder; torch) · `docling` (rich ingestion; torch + OCR) · `lance` (LanceDB) · `channels` (Slack/Telegram/Discord) · `docker` · `kubernetes` · `full` (all of them = the previous default).

## How the lean core stays importable + bootable
- `embedder` / `cross_encoder` / `ingest` (+ ingest loaders/splitters) re-export their heavy adapters **lazily** via PEP 562 `__getattr__`; accessing one without its extra raises a clear `pip install 'primer-ai[...]'` hint.
- `app.py` registers the channel platform factories defensively (skips a platform whose SDK is absent; `build_adapter` still ConfigErrors at use time).
- the embedder / cross-encoder / vector provider factories raise `ConfigError` with an install hint when an optional backend's dep is missing.

## Stays full
The published Docker image and the dev/CI env use `uv sync --all-extras` (Dockerfile, ci.yml, release.yml, Makefile, AGENTS.md, CONTRIBUTING.md, README from-source). README pipx quickstart now installs `primer-ai[full]`.

## Verification
- A **core-only venv** imports + boots `primer api` to a healthy `/v1/health` with no torch/docling/lance/channels installed.
- Install-hints fire for missing extras.
- Full-env unit sweep green (5223 passed) + changed-package suites (242 passed); ruff + docs hygiene clean.

> Note: this changes the default-install contract - existing users who relied on `pip install primer-ai` pulling local embeddings / channels now add the relevant extra (or `[full]`). Release is manual (workflow_dispatch), so merging does not publish.