### PR TITLE
fix(ui): require a model name before enabling provider Create

### DIFF
--- a/tests/ui_e2e/test_providers_create_anomaly_helpers.py
+++ b/tests/ui_e2e/test_providers_create_anomaly_helpers.py
@@ -96,3 +96,50 @@ def test_u0011_llm_provider_modal_shows_t0379_cross_validation_warning(
         "T0379 anomaly tag missing from the modal body — copy edit "
         "dropped the anomaly reference?\nModal text was:\n" + modal_text
     )
+
+
+def test_provider_create_disabled_until_model_name_filled(
+    page,
+    console_url: str,
+) -> None:
+    """Regression: the New provider modal's Create button must stay
+    disabled until every model row has its required fields filled.
+
+    Pre-fix, ``canSubmit`` only checked ``models.length > 0``. The
+    ``Add`` button seeds a row with blank fields, so adding a row and
+    leaving the name empty enabled Create; submitting then sent
+    ``models: [{}]``, which the API rejects with 422
+    ``body.models.0.name: Field required``. The fix requires every
+    non-optional model field to be non-empty before enabling Create.
+
+    Uses the embedding provider modal (single ``name`` model field, no
+    backend precondition): fill the required Base URL, add an empty model
+    row, assert Create is disabled, then type a model name and assert it
+    becomes enabled.
+    """
+    from playwright.sync_api import expect
+
+    page.goto(
+        console_url + "#/providers/embedding", wait_until="domcontentloaded"
+    )
+    page.locator("h1.page-title").first.wait_for(state="visible", timeout=10_000)
+
+    page.get_by_role("button", name="New embedding provider").first.click()
+    modal = page.locator(".modal").first
+    modal.wait_for(state="visible", timeout=5_000)
+
+    create_btn = modal.get_by_role("button", name="Create", exact=True)
+
+    # Fill the required Base URL so only the empty model row gates submit.
+    modal.get_by_placeholder("https://api.openai.com/v1").fill(
+        "http://localhost:1234/v1"
+    )
+
+    # Add a model row but leave its name blank — the regression case.
+    modal.get_by_role("button", name="Add", exact=True).click()
+    expect(modal.get_by_placeholder("Model name")).to_be_visible()
+    expect(create_btn).to_be_disabled()
+
+    # Typing a model name unblocks Create.
+    modal.get_by_placeholder("Model name").fill("text-embedding-test")
+    expect(create_btn).to_be_enabled()

--- a/ui/components/providers.jsx
+++ b/ui/components/providers.jsx
@@ -220,7 +220,7 @@ const PROVIDER_KINDS_FIELDS = {
       ],
       modelFields: [
         { key: "name", label: "Model name", type: "text", flex: 2 },
-        { key: "max_pair_length", label: "Max pair length", type: "number", flex: 1, min: 1 },
+        { key: "max_pair_length", label: "Max pair length", type: "number", flex: 1, min: 1, optional: true },
       ],
     },
   },
@@ -791,6 +791,12 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
 
   const canSubmit = !!provider
     && models.length > 0
+    // Every model row must have its required fields filled. Model fields
+    // are required by default; only those flagged `optional` (e.g. a
+    // reranker's max_pair_length) may be blank. Without this, an empty
+    // model row (the Add button seeds blank fields) submitted
+    // `models: [{}]` and the API rejected it with a 422 on models.0.name.
+    && models.every((m) => def?.modelFields.every((f) => f.optional || String(m[f.key] ?? "").trim() !== ""))
     && def?.config.every((f) => !f.required || (configValues[f.key] != null && configValues[f.key] !== ""))
     && !create.loading;
 


### PR DESCRIPTION
## Problem

Creating an LLM / embedding / cross-encoder provider from the console fails with a confusing **422** when a model row is left blank. The **Create** button enables as soon as a model row exists — `canSubmit` only checked `models.length > 0`. The **Add** button seeds a row with blank fields, so adding a row and submitting sends `models: [{}]`, which the API rejects with `422 body.models.0.name: Field required`.

This is especially misleading because the obvious suspect — `limits` — is sent correctly; the real culprit is the empty model name, and nothing in the happy path surfaces that.

## Fix

`canSubmit` now requires every model row's required fields to be non-empty, mirroring the existing config-field validation (`def.config.every((f) => !f.required || filled)`). Model fields are **required by default**; only fields flagged `optional` may be blank — the single such field today is the reranker's `max_pair_length`, now marked `optional: true`.

```js
&& models.every((m) => def?.modelFields.every((f) => f.optional || String(m[f.key] ?? "").trim() !== ""))
```

This covers `name` (every provider kind) and `context_length` (LLM), so the Create button reflects what the API will accept. The change only *disables* submission of an already-invalid body, so no valid create flow is affected.

## Test

Adds a `ui_e2e` regression test in `test_providers_create_anomaly_helpers.py`: open the embedding provider modal, fill the Base URL, add an empty model row → **Create disabled**; type a model name → **Create enabled**.

- Fails on `main` (Create resolves to `enabled` after adding a blank row).
- Passes with the fix; sibling U0010/U0011 modal tests still pass (no JSX regression).

Verified against a local auth-disabled instance with `PRIMER_RUN_UI_E2E=1`. Note: the console runs from a server-built `_app.js` bundle, so a server restart is needed to pick up `.jsx` edits.