### PR TITLE
fix(ui): batch document upload uses the path-addressed upsert

### DIFF
--- a/ui/components/knowledge.jsx
+++ b/ui/components/knowledge.jsx
@@ -2148,13 +2148,18 @@ function KN_NewDocumentModal({ collections, defaultCollection, pushToast, onClos
         const fd = new FormData();
         fd.append("file", arr[i]);
         const conv = await apiFetch("POST", "/documents/_convert_file", fd);
-        const docId = "doc-" + Math.random().toString(16).slice(2, 10);
-        await apiFetch("POST", "/documents", {
-          id: docId,
-          collection_id: collectionId,
-          name: conv.filename || arr[i].name,
-          meta: { text: conv.text || "" },
-        });
+        // User collections are path-addressed: upsert through the same
+        // PUT /collections/{id}/documents?path= contract the single-file
+        // flow uses, with the converted filename as the path. The earlier
+        // POST /documents shape omitted `path` (and put the body in
+        // `meta.text`), so every file 422'd with "Missing or invalid: path".
+        const docPath = conv.filename || arr[i].name;
+        await apiFetch(
+          "PUT",
+          `/collections/${encodeURIComponent(collectionId)}/documents` +
+            `?path=${encodeURIComponent(docPath)}`,
+          { content: conv.text || "", title: conv.filename || arr[i].name },
+        );
         created += 1;
         setStatus(i, "done");
       } catch (err) {


### PR DESCRIPTION
**Bug:** uploading multiple files to a user collection from the console fails with *"Missing or invalid: path."* on every file (`0 created, N failed`).

**Cause:** the batch loop in `processBatchFiles` (knowledge.jsx) posted each doc to the generic `POST /documents` with `{id, collection_id, name, meta:{text}}` - no `path`, body in `meta.text`. User-collection documents are **path-addressed**, so the backend 422'd. The single-file upload and manual create already use the correct `PUT /collections/{id}/documents?path=<p>` upsert.

**Fix:** the batch loop now uses that same path-addressed PUT, with the converted filename as the path and the text as `content`.

**Verified:** JSX bundle transpiles (validated via `build_jsx_bundle`); CI's `tests/ui` bundle build covers the transpile. Pre-existing bug, unrelated to the recent dependency work.

**Follow-up:** a `tests/ui_e2e/` multi-file-upload regression test (no `set_input_files` pattern exists yet; ui_e2e is gated out of CI).