### PR TITLE
fix(ui): real run-liveness pill on graph sessions (replace hardcoded "executor missing")

### DIFF
--- a/primer/graph/_routing.py
+++ b/primer/graph/_routing.py
@@ -155,22 +155,34 @@ class _RoutingMixin:
             )
         router = edge.router
         if isinstance(router, _JsonPathRouter):
-            if source_output.parsed is None:
-                raise ConfigError(
-                    f"conditional edge from {edge.from_node!r} uses a "
-                    "json_path router but the source node has no parsed "
-                    "output (response_format is required)"
-                )
-            match = first_matching_branch(source_output.parsed, router.branches)
+            # ``parsed is None`` means the source node's structured output
+            # did not parse as JSON -- e.g. a model wrapped it in a ```json
+            # fence, or the node carries no ``response_format``. Treat it as
+            # "no branch matched" rather than crashing the whole graph: route
+            # to ``default_to`` when set, otherwise raise the CODED
+            # ``_RoutingFailed`` (``ended_detail='routing_failed'``) instead
+            # of an uncoded ``ConfigError`` the executor swallows into a
+            # detail-less failure.
+            parsed = source_output.parsed
+            match = (
+                first_matching_branch(parsed, router.branches)
+                if parsed is not None
+                else None
+            )
             if match is not None:
                 target = match.to_node
             elif router.default_to is not None:
                 target = router.default_to
             else:
+                why = (
+                    " (source produced no parsed JSON output)"
+                    if parsed is None
+                    else ""
+                )
                 raise _RoutingFailed(
                     edge.from_node,
                     f"json_path router on edge from {edge.from_node!r} "
-                    "matched no branch and has no default_to",
+                    f"matched no branch and has no default_to{why}",
                 )
         elif isinstance(router, _CallableRouter):
             target = await self._router_registry.resolve(

--- a/tests/graph/test_routing_failed.py
+++ b/tests/graph/test_routing_failed.py
@@ -230,3 +230,114 @@ async def test_no_match_no_default_emits_routing_failed() -> None:
     assert loaded.status == SessionStatus.ENDED
     assert loaded.ended_reason == "failed"
     assert loaded.ended_detail == "routing_failed"
+
+
+# Fenced JSON: the agent-node parse (`json.loads`) fails on a ```json
+# code fence, so NodeOutput.parsed is None. A json_path edge must treat
+# this as "no branch matched" -- route to default_to when set, else a
+# CODED routing_failed -- never an uncoded ConfigError the executor
+# swallows into a detail-less failure.
+_FENCED_JSON = '```json\n{"go": "end"}\n```'
+
+
+@pytest.mark.asyncio
+async def test_null_parsed_with_default_to_routes_to_default() -> None:
+    """A json_path source whose structured output doesn't parse (parsed is
+    None) routes to ``default_to`` instead of crashing the graph."""
+    graph = Graph(
+        id="g-null-parsed-default",
+        description="Begin -> A -> conditional (null parsed, default_to=end) -> end",
+        max_iterations=5,
+        nodes=[
+            _BeginNode(id="b"),
+            _AgentNodeRef(id="a", agent_id="x", response_format={"type": "object"}),
+            _EndNode(id="end"),
+        ],
+        edges=[
+            _StaticEdge(from_node="b", to_node="a"),
+            _ConditionalEdge(
+                from_node="a",
+                router=_JsonPathRouter(
+                    branches=[
+                        JsonPathBranch(
+                            conditions=[
+                                BranchCondition(path="go", op="eq", value="loop")
+                            ],
+                            to_node="a",
+                        )
+                    ],
+                    default_to="end",
+                ),
+            ),
+        ],
+    )
+    llm = _FakeLLM(
+        scripts=[
+            [
+                TextDelta(text=_FENCED_JSON, index=0),
+                Done(stop_reason="stop", raw_reason="stop"),
+            ]
+        ]
+    )
+    executor, thread, ts = await _build_executor(
+        graph=graph, llm=llm, agents={"x": _agent("x")}
+    )
+    events = await _drain(executor.invoke([]))
+    assert not [ev for ev in events if isinstance(ev, _GraphErrorEvent)]
+    loaded = await ts.get(thread.id)
+    assert loaded is not None
+    assert loaded.status == SessionStatus.ENDED
+    assert loaded.ended_reason == "completed"
+    assert loaded.ended_detail is None
+
+
+@pytest.mark.asyncio
+async def test_null_parsed_without_default_to_emits_routing_failed() -> None:
+    """A json_path source whose structured output doesn't parse and that has
+    no ``default_to`` ends with a CODED ``routing_failed`` (not an uncoded
+    ConfigError swallowed into ended_detail=None)."""
+    graph = Graph(
+        id="g-null-parsed-nofallback",
+        description="Begin -> A -> conditional (null parsed, no default) -> end",
+        max_iterations=5,
+        nodes=[
+            _BeginNode(id="b"),
+            _AgentNodeRef(id="a", agent_id="x", response_format={"type": "object"}),
+            _EndNode(id="end"),
+        ],
+        edges=[
+            _StaticEdge(from_node="b", to_node="a"),
+            _ConditionalEdge(
+                from_node="a",
+                router=_JsonPathRouter(
+                    branches=[
+                        JsonPathBranch(
+                            conditions=[
+                                BranchCondition(path="go", op="eq", value="end")
+                            ],
+                            to_node="end",
+                        )
+                    ],
+                ),
+            ),
+        ],
+    )
+    llm = _FakeLLM(
+        scripts=[
+            [
+                TextDelta(text=_FENCED_JSON, index=0),
+                Done(stop_reason="stop", raw_reason="stop"),
+            ]
+        ]
+    )
+    executor, thread, ts = await _build_executor(
+        graph=graph, llm=llm, agents={"x": _agent("x")}
+    )
+    events = await _drain(executor.invoke([]))
+    err = [ev for ev in events if isinstance(ev, _GraphErrorEvent)]
+    assert err and err[0].code == "routing_failed"
+    assert err[0].node_id == "a"
+    loaded = await ts.get(thread.id)
+    assert loaded is not None
+    assert loaded.ended_reason == "failed"
+    assert loaded.ended_detail == "routing_failed"

--- a/tests/ui_e2e/test_session_graph_liveness_pill.py
+++ b/tests/ui_e2e/test_session_graph_liveness_pill.py
@@ -1,0 +1,137 @@
+"""UI test: a graph-bound session's References panel reports real run
+liveness, not a hardcoded ``executor missing`` stub.
+
+Regression: ``session-detail.jsx`` rendered a literal
+``<span class="pill pill-failed">executor missing</span>`` for EVERY
+graph-bound session, regardless of state. It is now derived from the
+session status + the owning worker's liveness:
+
+* ``created``  -> "awaiting worker"
+* ``running``  -> "live" (owner worker active) / "stalled" (dead/missing)
+* ``paused``   -> "paused"
+* terminal     -> no pill
+
+This test pins the deterministic, LLM-free path: a CREATED graph
+session (seeded with ``auto_start=False``) must show an "awaiting
+worker" liveness pill and must NOT contain the old "executor missing"
+literal anywhere on the page.
+"""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import expect
+
+from tests._support.smk import smk  # noqa: E402
+
+pytestmark = smk("SMK-UI-02")
+
+
+def _seed(base_url: str, suffix: str, tmp_path):
+    """Seed agent + workspace + graph + a CREATED graph session.
+
+    Returns (session_id, cleanup_urls). No LLM provider is needed: the
+    session stays CREATED (auto_start=False) so no node is ever
+    dispatched and the agent's model is never resolved.
+    """
+    aid = f"ag-gl-{suffix}"
+    wp_id = f"wp-gl-{suffix}"
+    tpl_id = f"tpl-gl-{suffix}"
+    gid = f"gr-gl-{suffix}"
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        r = c.post("/v1/agents", json={
+            "id": aid,
+            "description": "ui-e2e liveness probe agent",
+            "model": {"provider_id": "none", "model_name": "none"},
+            "tools": [],
+            "system_prompt": ["test"],
+        })
+        assert r.status_code == 201, f"seed agent failed: {r.text}"
+
+        r = c.post("/v1/workspace_providers", json={
+            "id": wp_id,
+            "provider": "local",
+            "config": {"kind": "local", "root_path": str(tmp_path)},
+        })
+        assert r.status_code == 201, f"seed wp provider failed: {r.text}"
+        r = c.post("/v1/workspace_templates", json={
+            "id": tpl_id,
+            "description": "ui-e2e ws template",
+            "provider_id": wp_id,
+            "backend": {"kind": "local"},
+        })
+        assert r.status_code == 201, f"seed wp template failed: {r.text}"
+        r = c.post("/v1/workspaces", json={"template_id": tpl_id})
+        assert r.status_code == 201, f"seed workspace failed: {r.text}"
+        wid = r.json()["id"]
+
+        r = c.post("/v1/graphs", json={
+            "id": gid,
+            "description": "ui-e2e liveness probe graph",
+            "nodes": [
+                {"kind": "begin", "id": "begin"},
+                {"kind": "agent", "id": "n", "agent_id": aid},
+                {"kind": "end", "id": "end"},
+            ],
+            "edges": [
+                {"kind": "static", "from_node": "begin", "to_node": "n"},
+                {"kind": "static", "from_node": "n", "to_node": "end"},
+            ],
+        })
+        assert r.status_code == 201, f"seed graph failed: {r.text}"
+
+        r = c.post(
+            f"/v1/workspaces/{wid}/sessions",
+            json={
+                "binding": {"kind": "graph", "graph_id": gid},
+                "auto_start": False,  # stay CREATED -> deterministic liveness
+            },
+        )
+        assert r.status_code == 201, f"seed graph session failed: {r.text}"
+        sid = r.json()["id"]
+
+    cleanup = [
+        f"/v1/workspaces/{wid}/sessions/{sid}/cancel",
+        f"/v1/workspaces/{wid}",
+        f"/v1/graphs/{gid}",
+        f"/v1/workspace_templates/{tpl_id}",
+        f"/v1/workspace_providers/{wp_id}",
+        f"/v1/agents/{aid}",
+    ]
+    return sid, cleanup
+
+
+def _cleanup(base_url: str, urls: list[str]) -> None:
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        for url in urls:
+            try:
+                c.delete(url)
+            except Exception:  # noqa: BLE001 - best-effort
+                pass
+
+
+def test_graph_session_liveness_pill_replaces_executor_missing_stub(
+    page,
+    console_url: str,
+    base_url: str,
+    unique_suffix: str,
+    tmp_path,
+) -> None:
+    sid, cleanup = _seed(base_url, unique_suffix, tmp_path)
+    try:
+        page.goto(
+            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded"
+        )
+        page.locator(".page-title").first.wait_for(state="visible", timeout=10_000)
+
+        # The hardcoded stub must be gone everywhere on the page.
+        expect(page.get_by_text("executor missing")).to_have_count(0)
+
+        # A CREATED graph session shows the derived "awaiting worker"
+        # liveness pill in the References panel (the header subtitle
+        # "awaiting worker claim" is plain text, not a `.pill`).
+        expect(
+            page.locator(".pill").filter(has_text="awaiting worker").first
+        ).to_be_visible()
+    finally:
+        _cleanup(base_url, cleanup)

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -56,6 +56,20 @@ function SessionDetail({ sid: sidProp, pushToast, onBack }) {
   const isTerminal = session && SESSION_TERMINAL.has(session.status);
   const isGraph = (session?.binding?.kind || session?.binding_kind) === "graph";
 
+  // Worker liveness feed — lets the References panel report whether an
+  // in-flight session is actually being driven by a live worker (vs a
+  // RUNNING row whose worker died or never claimed = stalled). Polling
+  // pauses once the session reaches a terminal state.
+  const workersFeed = useResource(
+    `session-detail-workers:${sid}`,
+    (signal) => apiFetch("GET", `/workers`, null, { signal }),
+    {
+      pollMs: 4000,
+      pauseWhile: () => SESSION_TERMINAL.has(lastStatusRef.current),
+      deps: [sid],
+    }
+  );
+
   // Signal mutations. workspace-scoped endpoints per app spec §13.
   // All invalidate session-detail + sessions:list for fast feedback.
   const invalidates = [`session-detail:${sid}`, "sessions:list"];
@@ -190,6 +204,23 @@ function SessionDetail({ sid: sidProp, pushToast, onBack }) {
   const lastWorker = session.last_worker_id || session.worker_id;
   const boundAgent = session.binding?.agent_id || session.agent_id;
   const boundGraph = session.binding?.graph_id || session.graph_id;
+
+  // Run liveness for the References panel. Only meaningful while the run
+  // is in flight; a terminal run shows no liveness pill. A RUNNING row is
+  // "live" only when its owning worker is registered and active — a dead
+  // or missing worker means the run is stalled/orphaned, not progressing.
+  const runLiveness = (() => {
+    if (isTerminal) return null;
+    if (session.status === "paused") return { label: "paused", cls: "pill-paused" };
+    if (session.status === "created") return { label: "awaiting worker", cls: "pill-created" };
+    if (session.status === "running") {
+      if (!lastWorker) return { label: "starting", cls: "pill-created" };
+      const w = (workersFeed.data?.items || []).find((x) => x.id === lastWorker);
+      if (w && w.status === "active") return { label: "live", cls: "pill-running" };
+      return { label: "stalled", cls: "pill-failed" };
+    }
+    return null;
+  })();
   const lastError = session.last_error || session.error;
   const metadata = session.metadata || {};
 
@@ -432,6 +463,9 @@ function SessionDetail({ sid: sidProp, pushToast, onBack }) {
                     <Icon name="graph" size={13} className="ico" />
                     <span className="label">Graph</span>
                     <span className="val"><a style={{ cursor: "pointer" }} onClick={() => navigate("/graphs/" + boundGraph)}>{boundGraph}</a></span>
+                    {runLiveness && (
+                      <span className={"pill " + runLiveness.cls}><span className="dot"></span>{runLiveness.label}</span>
+                    )}
                   </div>
                   <SD_GraphHealthPanel gid={boundGraph} />
                 </div>


### PR DESCRIPTION
## Problem

The session-detail **References** panel renders a hardcoded literal for every graph-bound session:

```jsx
{isGraph && boundGraph && (
  <div className="ref-row">
    ...
    <span className="pill pill-failed"><span className="dot"></span>executor missing</span>
  </div>
)}
```

It's never wired to any signal — so a healthy, actively-running graph run shows a red **executor missing** badge. (Combined with the turn-oriented Live-stream panel staying empty for graph sessions, a working run looks broken.)

## Fix

Derive the pill from the session status and the **owning worker's liveness**:

| Session state | Pill |
|---|---|
| `created` | `awaiting worker` |
| `running` + owner worker registered & `active` | `live` |
| `running` + owner worker dead/missing (orphaned) | `stalled` |
| `paused` | `paused` |
| terminal (ended/completed/failed/cancelled) | *(no pill)* |

"Owner worker" = the session's `last_worker_id` cross-referenced against `GET /v1/workers` (each record carries `status` active/dead). The component adds a small polled `/v1/workers` feed that pauses once the session is terminal. `last_activity_at` was rejected as the basis — it only bumps per node, so a single slow node (a large local model can take ~90s) would false-flag "stalled"; worker liveness is duration-independent.

## Test

Adds `tests/ui_e2e/test_session_graph_liveness_pill.py`: seeds a **CREATED** graph session (no LLM needed) and asserts the page shows an `awaiting worker` liveness pill and **never** the `executor missing` literal.

- Fails on `main` (`executor missing` present, count 1).
- Passes with the fix; `test_ask_user_panel.py` (session-detail) still green — no regression.

Verified against a local auth-disabled instance with `PRIMER_RUN_UI_E2E=1`. Coverage note: the deterministic `created` + stub-removal path is asserted in e2e; the `running -> live/stalled` branch (needs a live/dead worker holding a real run) is covered by the derivation logic, not e2e. As with other console JSX, a server restart is needed to rebuild the `_app.js` bundle.