### PR TITLE
fix(web-fetch): local adapter sends a browser User-Agent so UA-gating sites don't 403

### DIFF
--- a/primer/web_fetch/local.py
+++ b/primer/web_fetch/local.py
@@ -29,6 +29,14 @@ logger = logging.getLogger(__name__)
 # Raw-response cap (pre-extraction); larger than http-request's 1 MB to fit PDFs.
 DEFAULT_RAW_BYTE_CAP = 5 * 1024 * 1024
 
+# Many hosts (Wikipedia, Cloudflare-fronted sites) reject httpx's default
+# ``python-httpx/x.y`` User-Agent with a 403. Present a mainstream browser UA
+# so ordinary human-readable pages are fetchable; callers may override.
+DEFAULT_USER_AGENT = (
+    "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 "
+    "(KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+
 
 async def _extract_pdf(data: bytes) -> str:
     """Convert PDF bytes to markdown via docling. Module-level so tests can
@@ -46,16 +54,21 @@ class LocalAdapter(WebFetchAdapter):
         client: httpx.AsyncClient | None = None,
         raw_byte_cap: int = DEFAULT_RAW_BYTE_CAP,
         timeout: float = 30.0,
+        user_agent: str = DEFAULT_USER_AGENT,
     ) -> None:
         self._client = client or httpx.AsyncClient(timeout=timeout)
         self._owns_client = client is None
         self._raw_byte_cap = raw_byte_cap
         self._timeout = timeout
+        self._user_agent = user_agent
 
     async def fetch(self, *, url: str) -> FetchedPage:
         try:
             r = await self._client.get(
-                url, follow_redirects=True, timeout=self._timeout,
+                url,
+                follow_redirects=True,
+                timeout=self._timeout,
+                headers={"User-Agent": self._user_agent},
             )
         except httpx.HTTPError as exc:
             raise WebFetchUnavailable(

--- a/tests/web_fetch/test_local_adapter.py
+++ b/tests/web_fetch/test_local_adapter.py
@@ -82,3 +82,36 @@ async def test_transport_error_raises_unavailable():
     def h(req): raise httpx.ConnectError("refused")
     with pytest.raises(WebFetchUnavailable):
         await _adapter(h).fetch(url="https://example.com")
+
+
+@pytest.mark.asyncio
+async def test_sends_browser_user_agent_not_default_httpx():
+    """Many sites (Wikipedia, Cloudflare-fronted hosts) 403 the default
+    ``python-httpx`` User-Agent. The local adapter must present a
+    browser-like UA so real web pages are fetchable."""
+    seen: dict[str, str] = {}
+
+    def h(req):
+        seen["ua"] = req.headers.get("user-agent", "")
+        return httpx.Response(200, headers={"content-type": "text/plain"}, text="ok")
+
+    await _adapter(h).fetch(url="https://en.wikipedia.org/wiki/Foo")
+    assert "python-httpx" not in seen["ua"].lower()
+    assert "mozilla" in seen["ua"].lower()
+
+
+@pytest.mark.asyncio
+async def test_user_agent_is_overridable():
+    """A caller may pin a custom UA (e.g. an honest bot identity)."""
+    seen: dict[str, str] = {}
+
+    def h(req):
+        seen["ua"] = req.headers.get("user-agent", "")
+        return httpx.Response(200, headers={"content-type": "text/plain"}, text="ok")
+
+    adapter = LocalAdapter(
+        client=httpx.AsyncClient(transport=httpx.MockTransport(h)),
+        user_agent="PrimerBot/1.0 (+https://primer.example)",
+    )
+    await adapter.fetch(url="https://example.com")
+    assert seen["ua"] == "PrimerBot/1.0 (+https://primer.example)"


### PR DESCRIPTION
## Problem
The bootstrapped `local` web-fetch provider (`web__web_fetch`) failed on a large fraction of the web with:

```
web-fetch not available: local fetch forbidden (HTTP 403)
```

Root cause is **not** a Primer policy guard. [`LocalAdapter.fetch`](primer/web_fetch/local.py) issues a plain `httpx` GET and reraises whatever status the remote returns. The client carried no `User-Agent`, so httpx sent its default `python-httpx/x.y`, which Wikipedia and many Cloudflare-fronted hosts reject with **403**.

Reproduced directly:

| URL | default `python-httpx` UA | browser UA |
|-----|---------------------------|------------|
| en.wikipedia.org/wiki/Mixture_of_experts | **403** | 200 |
| arxiv.org/abs/2401.04088 | 200 | 200 |
| example.com | 200 | 200 |

## Fix
- Add module-level `DEFAULT_USER_AGENT` (a mainstream Chrome/Linux UA).
- New `user_agent` constructor arg on `LocalAdapter` (overridable, e.g. for an honest bot identity).
- Send it as a request header on the GET.

## Tests
- `test_sends_browser_user_agent_not_default_httpx` — asserts the GET carries a `mozilla`/non-`python-httpx` UA (TDD: written red first).
- `test_user_agent_is_overridable` — caller-supplied UA is honored.
- Full `tests/web_fetch/` suite: 37 passed; ruff clean.

## End-to-end verification
Restarted the dogfood server on this branch and fetched the exact URL that 403'd before — now returns clean markdown:

```
# Mixture of experts - Wikipedia
**Mixture of experts** (**MoE**) is a machine learning technique where multiple expert networks ...
```
