### PR TITLE
feat(graph): add fromjson template filter for tool_call JSON output

### DIFF
--- a/primer/graph/template.py
+++ b/primer/graph/template.py
@@ -15,6 +15,7 @@ attributable to the user-supplied template.
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import Any
 
@@ -29,6 +30,30 @@ from primer.model.graph import GraphContext
 logger = logging.getLogger(__name__)
 
 
+def _fromjson(value: Any) -> Any:
+    """``fromjson`` template filter: parse a JSON string into Python data.
+
+    A ``tool_call`` node's ``NodeOutput.parsed`` is only populated when the
+    node carries an ``output_schema`` AND the parsed value is a dict, so a
+    tool that returns a top-level JSON array (e.g. ``web_search``) leaves
+    ``parsed`` as ``None``. This filter lets a downstream node template over
+    the JSON ``text`` instead — ``{{ (nodes.search.text | fromjson)[0].url }}``.
+
+    Non-string values (already-parsed dict/list/scalar) pass through
+    unchanged, so the filter is idempotent. Invalid JSON raises
+    :class:`jinja2.TemplateError` so it surfaces through both render paths as
+    a template error (``render_input_template`` → ``BadRequestError``;
+    ``render_template_safely`` → ``ended_detail='template_error'``) rather
+    than an uncoded crash.
+    """
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise TemplateError(f"fromjson: invalid JSON: {exc}") from exc
+    return value
+
+
 # Module-level shared environment. Sandboxed = blocks access to
 # dunder attributes / dangerous built-ins; StrictUndefined = raises
 # on missing attributes rather than silently emitting empty strings
@@ -39,6 +64,9 @@ _ENV: SandboxedEnvironment = SandboxedEnvironment(
     trim_blocks=False,
     lstrip_blocks=False,
 )
+# Custom filters. ``fromjson`` parses a JSON string (e.g. a tool_call node's
+# ``text`` output) so downstream nodes can index into it; see ``_fromjson``.
+_ENV.filters["fromjson"] = _fromjson
 
 
 def render_input_template(

--- a/tests/graph/test_template.py
+++ b/tests/graph/test_template.py
@@ -85,6 +85,58 @@ class TestRender:
         assert "from C" in result
 
 
+class TestFromJsonFilter:
+    """The ``fromjson`` filter lets a node template over a tool_call node's
+    JSON ``text`` output -- e.g. web_search returns a top-level JSON array,
+    whose ``.parsed`` stays None (NodeOutput.parsed is dict-only), so the
+    only way to reach ``[0].url`` is to parse the text in the template."""
+
+    def test_parses_json_array_and_indexes(self) -> None:
+        ctx = _ctx(
+            nodes={
+                "search": NodeOutput(
+                    text='[{"url": "https://a.example/x", "title": "X"}, '
+                    '{"url": "https://b.example/y", "title": "Y"}]',
+                    iteration=0,
+                )
+            },
+        )
+        result = render_input_template(
+            "First: {{ (nodes.search.text | fromjson)[0].url }}", context=ctx
+        )
+        assert result == "First: https://a.example/x"
+
+    def test_parses_json_object(self) -> None:
+        ctx = _ctx(
+            nodes={"t": NodeOutput(text='{"k": "v"}', iteration=0)},
+        )
+        result = render_input_template(
+            "{{ (nodes.t.text | fromjson).k }}", context=ctx
+        )
+        assert result == "v"
+
+    def test_idempotent_on_already_parsed(self) -> None:
+        # A non-string (already-parsed) value passes through unchanged.
+        ctx = _ctx(
+            nodes={
+                "p": NodeOutput(
+                    text="{...}", parsed={"items": [1, 2, 3]}, iteration=0
+                )
+            },
+        )
+        result = render_input_template(
+            "{{ (nodes.p.parsed | fromjson)['items'][2] }}", context=ctx
+        )
+        assert result == "3"
+
+    def test_invalid_json_raises_bad_request(self) -> None:
+        ctx = _ctx(nodes={"bad": NodeOutput(text="not json{", iteration=0)})
+        with pytest.raises(BadRequestError, match="render error"):
+            render_input_template(
+                "{{ (nodes.bad.text | fromjson)[0] }}", context=ctx
+            )
+
+
 class TestErrors:
     def test_syntax_error_raises_bad_request(self) -> None:
         with pytest.raises(BadRequestError, match="syntax error"):


### PR DESCRIPTION
## Problem
Chaining graph nodes off a `tool_call` node that returns JSON is currently impossible when the JSON is a **top-level array**.

`_map_toolcall_result` only populates `NodeOutput.parsed` when the node has an `output_schema`, **and** only when the parsed value is a `dict` (`NodeOutput.parsed` is dict-typed). So a tool like `web_search` — which returns `json.dumps([{title,url,snippet}, ...])` — always yields `parsed = None`. A downstream node templating `{{ nodes.search.parsed[0].url }}` fails with `None has no element 0` → `ended_detail='template_error'`.

The graph Jinja env is a stock `SandboxedEnvironment` with no JSON-parse filter, so there was no way to reach the array from `text` either.

## Fix
Register a sandboxed `fromjson` filter on the shared graph template env:

```jinja
{{ (nodes.search.text | fromjson)[0].url }}
```

- Parses a JSON **string** into Python data (dict/list/scalar).
- Non-string (already-parsed) values pass through unchanged → idempotent.
- Invalid JSON raises `jinja2.TemplateError`, so it surfaces consistently through both render paths (`render_input_template` → `BadRequestError`; `render_template_safely` → `ended_detail='template_error'`) instead of an uncoded crash.

Applies to both agent-node `input_template` and `tool_call` `arguments` rendering (they share `_ENV`).

## Tests
`tests/graph/test_template.py::TestFromJsonFilter` (written red first):
- parses a JSON array and indexes `[0].url`
- parses a JSON object
- idempotent on already-parsed values
- invalid JSON → `BadRequestError`

Full `tests/graph/test_template.py`: 14 passed; ruff clean.

## Motivation
Surfaced while composing a multi-step web-research graph (`web_search` tool_call → `web_fetch` tool_call). This is the general fix for "a tool returns JSON, the next node needs a field from it."