### PR TITLE
fix(ui): widen-able modals + openchat live model discovery

### DIFF
--- a/primer/api/routers/providers.py
+++ b/primer/api/routers/providers.py
@@ -242,10 +242,10 @@ async def discover_llm_models(
     endpoint deliberately bypasses the adapter for discovery and calls
     the provider's native list endpoint directly.
 
-    ``ollama``, ``openresponses``, ``openrouter``, ``anthropic``, and
-    ``gemini`` expose a live list-models API. Any other provider type
-    returns 400 and the frontend falls back to its curated
-    suggested-model list.
+    ``ollama``, ``openresponses``, ``openchat``, ``openrouter``,
+    ``anthropic``, and ``gemini`` expose a live list-models API. Any
+    other provider type returns 400 and the frontend falls back to its
+    curated suggested-model list.
     """
     # Validate the draft via the canonical model so config shape errors
     # surface cleanly. We never persist or run anything from the stub.
@@ -258,6 +258,10 @@ async def discover_llm_models(
     if body.provider == "ollama":
         result = await _probe_ollama_models(body.config)
     elif body.provider == "openresponses":
+        result = await _probe_openai_compatible_models(body.config)
+    elif body.provider == "openchat":
+        # OpenAI-compatible Chat Completions: same /v1/models probe as
+        # openresponses (both carry an OpenAI-style base URL).
         result = await _probe_openai_compatible_models(body.config)
     elif body.provider == "openrouter":
         try:
@@ -341,7 +345,7 @@ async def discover_llm_models(
     # verbatim, so skip the default for that branch. Gemini reports
     # inputTokenLimit for most models but not all, so seed the default
     # only where the helper omitted it.
-    if body.provider in ("ollama", "openresponses", "anthropic", "gemini"):
+    if body.provider in ("ollama", "openresponses", "openchat", "anthropic", "gemini"):
         for m in result.get("models", []):
             m.setdefault("context_length", _DEFAULT_LLM_CONTEXT_LENGTH)
     return result

--- a/tests/api/test_llm_providers_router.py
+++ b/tests/api/test_llm_providers_router.py
@@ -204,3 +204,51 @@ class TestDiscoverGemini:
             or "401" in r.text
             or "invalid" in r.text.lower()
         )
+
+
+class TestDiscoverOpenChat:
+    """openchat is an OpenAI-compatible Chat Completions provider, so its
+    /v1/models endpoint is live-discoverable via the shared probe (same
+    path openresponses uses)."""
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_discovers_models_from_v1_models(self, client) -> None:
+        respx.get("http://oc-test.local/v1/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={"data": [
+                    {"id": "llama-3.1-8b-instruct"},
+                    {"id": "qwen2.5-coder-7b"},
+                ]},
+            ),
+        )
+        r = await client.post(
+            "/v1/llm_providers/_discover_models",
+            json={
+                "provider": "openchat",
+                "config": {"url": "http://oc-test.local/v1", "flavor": "lmstudio"},
+            },
+        )
+        assert r.status_code == 200, r.text
+        body = r.json()
+        names = [m["name"] for m in body["models"]]
+        assert names == ["llama-3.1-8b-instruct", "qwen2.5-coder-7b"]
+        # /v1/models exposes no context window; the route seeds a default.
+        assert body["models"][0]["context_length"] > 0
+
+    @respx.mock
+    @pytest.mark.asyncio
+    async def test_unreachable_surfaces_4xx(self, client) -> None:
+        respx.get("http://oc-down.local/v1/models").mock(
+            side_effect=httpx.ConnectError("connection refused"),
+        )
+        r = await client.post(
+            "/v1/llm_providers/_discover_models",
+            json={
+                "provider": "openchat",
+                "config": {"url": "http://oc-down.local/v1", "flavor": "lmstudio"},
+            },
+        )
+        assert r.status_code >= 400
+        assert "probe failed" in r.text.lower()

--- a/tests/ui/test_modal_width_override.py
+++ b/tests/ui/test_modal_width_override.py
@@ -1,0 +1,37 @@
+"""The Modal component supports a width override so wide content (the
+collection document browser) is not crushed by the default 420px .modal
+cap. The collection browse modal opts into a wide modal; without the
+override the fixed-width left tree column starved the content pane to a
+few pixels (one word per line)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SHARED = (UI / "components" / "shared.jsx").read_text(encoding="utf-8")
+KNOWLEDGE = (UI / "components" / "knowledge.jsx").read_text(encoding="utf-8")
+
+
+def test_modal_destructures_width_prop() -> None:
+    # Modal accepts a width prop alongside its existing props.
+    assert "danger, width })" in SHARED
+
+
+def test_modal_applies_width_to_modal_element() -> None:
+    # The desktop .modal element takes the inline width override so the
+    # CSS `width: 420px` cap can be widened by callers.
+    assert 'className="modal" style={width' in SHARED
+
+
+def test_collection_browse_modal_opts_into_wide() -> None:
+    # The collection doc browser passes a wide width to its Modal.
+    assert 'width="min(92vw, 1280px)"' in KNOWLEDGE
+
+
+def test_bundle_transpiles_with_modal_width() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body

--- a/ui/components/knowledge.jsx
+++ b/ui/components/knowledge.jsx
@@ -536,8 +536,9 @@ function KN_UserCollectionListView({ collection, pushToast, onClose, titleBar })
           </div>
         </div>
       }
+      width="min(86vw, 1000px)"
     >
-      <div style={{ width: "min(86vw, 1000px)", maxWidth: "100%", minWidth: 0 }}>
+      <div style={{ width: "100%", minWidth: 0 }}>
         <div className="muted text-sm mb-3" style={{ overflowWrap: "anywhere" }}>
           <span className="mono">GET /v1/collections/{cid}/documents?prefix=</span>
         </div>
@@ -1012,9 +1013,10 @@ function KN_CollectionDocBrowserModal({ collection, pushToast, onClose }) {
           </div>
         </div>
       }
+      width="min(92vw, 1280px)"
     >
-      {/* Near-full-viewport wrapper so the two-pane explorer has room */}
-      <div style={{ width: "min(92vw, 1280px)", maxWidth: "100%", minWidth: 0 }}>
+      {/* The .modal element is widened via Modal's width prop; fill it. */}
+      <div style={{ width: "100%", minWidth: 0 }}>
 
         {/* Two-pane file explorer: tree left, content right */}
         <div style={{

--- a/ui/components/shared.jsx
+++ b/ui/components/shared.jsx
@@ -124,7 +124,7 @@ function fmtDate(d) {
 // Modal — desktop: centered dialog. Mobile: bottom sheet via the
 // same API. Consumers (every form modal in the app) get the mobile
 // behavior automatically.
-const Modal = ({ title, onClose, children, footer, danger }) => {
+const Modal = ({ title, onClose, children, footer, danger, width }) => {
   const useViewport = (window.primerApi && window.primerApi.useViewport) || null;
   const vp = useViewport ? useViewport() : { isMobile: false };
   const isMobile = !!vp.isMobile;
@@ -165,7 +165,7 @@ const Modal = ({ title, onClose, children, footer, danger }) => {
 
   return (
     <div className="modal-overlay" onClick={onClose}>
-      <div className="modal" onClick={(e) => e.stopPropagation()}>
+      <div className="modal" style={width ? { width } : undefined} onClick={(e) => e.stopPropagation()}>
         <div className="modal-h">
           <span className="title" style={{ color: danger ? "var(--red)" : undefined }}>{title}</span>
           <button className="close" onClick={onClose}><Icon name="x" size={14} /></button>


### PR DESCRIPTION
Two independent UI/provider bug fixes.

## Bug 1 — collection document viewer crushed to one word per line
`.modal` is hard-capped at `width: 420px`, so the document-browser's inner wrapper (`maxWidth: 100%`) collapsed to ~388px and the fixed 300px file-tree column starved the content pane to a few pixels. Added a `width` prop to the `Modal` component that overrides the cap inline (CSS `max-width: calc(100vw - 40px)` still keeps it on-screen) and opted both document-browser modals into it.

## Bug 2 — openchat couldn't fetch models
`discover_llm_models` had no branch for `openchat`, so it fell through to the "not supported" error despite being OpenAI-compatible with a `/v1/models` endpoint. Routed it through the same `_probe_openai_compatible_models` path `openresponses` uses, and seeded the default `context_length`.

## Testing
- `tests/api/test_llm_providers_router.py::TestDiscoverOpenChat`: 2 new tests (8 in file)
- `tests/ui/test_modal_width_override.py`: 4 new tests; full `tests/ui` sweep 320 passed
- `ruff check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)