### PR TITLE
fix(ui): keep graph run view from overflowing the page

### DIFF
--- a/tests/ui/test_session_detail_run_view.py
+++ b/tests/ui/test_session_detail_run_view.py
@@ -17,10 +17,11 @@ def test_run_view_component_present() -> None:
 
 
 def test_run_view_reuses_shared_canvas() -> None:
-    # Reuse, not duplicate: the run view renders GR_Canvas / GR_NodeBox
-    # from the shared module rather than re-implementing node layout.
+    # Reuse, not duplicate: the run view renders the shared GR_Canvas and
+    # delegates per-node status tinting to it via the statusTint prop
+    # (rings live inside the canvas scroll, not a page-overflowing overlay).
     assert "GR_Canvas" in DETAIL
-    assert "GR_NODE_SIZE" in DETAIL
+    assert "statusTint" in DETAIL
 
 
 def test_run_view_polls_node_states() -> None:

--- a/ui/components/graph-canvas.jsx
+++ b/ui/components/graph-canvas.jsx
@@ -27,6 +27,7 @@ const GR_Canvas = React.forwardRef(function GR_Canvas(
     onNodeDoubleClick,
     onNodeMouseDown,
     onBackgroundClick,
+    statusTint,
   },
   ref,
 ) {
@@ -108,6 +109,34 @@ const GR_Canvas = React.forwardRef(function GR_Canvas(
             onMouseDown={(ev) => onNodeMouseDown(ev, n.id)}
           />
         ))}
+
+        {/* Optional per-node status tint (run view). Rendered INSIDE the
+            scroll container so the rings scroll with the nodes and never
+            overflow the page; the editor passes no statusTint. */}
+        {statusTint && draft.nodes.map((n) => {
+          const t = statusTint[n.id];
+          if (!t) return null;
+          const sz = GR_NODE_SIZE[n.kind] || GR_NODE_SIZE.agent;
+          return (
+            <div
+              key={`tint-${n.id}`}
+              data-testid={`run-node-${n.id}`}
+              data-status={t.status}
+              style={{
+                position: "absolute",
+                left: (n.x || 0) - 2,
+                top: (n.y || 0) - 2,
+                width: sz.w + 4,
+                height: sz.h + 4,
+                borderRadius: n.kind === "begin" || n.kind === "end" ? "50%" : 10,
+                border: `2px solid ${t.border}`,
+                boxShadow: t.glow || undefined,
+                animation: t.status === "running" ? "pulse 1.6s ease-in-out infinite" : undefined,
+                pointerEvents: "none",
+              }}
+            />
+          );
+        })}
 
         <div style={{
           position: "absolute",

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -1020,10 +1020,25 @@ function SD_StatusCanvas({ graph, statusByNode, selectedNodeId, onSelectNode }) 
     return base;
   }, [graph]);
 
+  // Per-node tint handed INTO the shared canvas so the status rings live
+  // inside its scroll container — they scroll with the nodes and never
+  // overflow the page. (The earlier external overlay sat outside that
+  // scroll and blew the layout wide, pushing the side rail off-screen.)
+  const statusTint = React.useMemo(() => {
+    const out = {};
+    for (const n of (draft.nodes || [])) {
+      const st = statusByNode[n.id] || "pending";
+      const t = SD_RUN_STATE_TINT[st] || SD_RUN_STATE_TINT.pending;
+      out[n.id] = { border: t.border, glow: t.glow, status: st };
+    }
+    return out;
+  }, [draft, statusByNode]);
+
   return (
-    <div style={{ position: "relative" }}>
+    <div style={{ minWidth: 0, overflow: "hidden" }}>
       <window.GR_Canvas
         draft={draft}
+        statusTint={statusTint}
         selectedNodeId={selectedNodeId}
         selectedEdgeId={null}
         addEdgeMode={null}
@@ -1033,32 +1048,6 @@ function SD_StatusCanvas({ graph, statusByNode, selectedNodeId, onSelectNode }) 
         onNodeMouseDown={() => {}}
         onBackgroundClick={() => onSelectNode(null)}
       />
-      {/* Status tint rings positioned over each node. */}
-      <div style={{ position: "absolute", inset: 0, pointerEvents: "none" }}>
-        {(draft.nodes || []).map((n) => {
-          const st = statusByNode[n.id] || "pending";
-          const tint = SD_RUN_STATE_TINT[st] || SD_RUN_STATE_TINT.pending;
-          const sz = window.GR_NODE_SIZE[n.kind] || window.GR_NODE_SIZE.agent;
-          return (
-            <div
-              key={n.id}
-              data-testid={`run-node-${n.id}`}
-              data-status={st}
-              style={{
-                position: "absolute",
-                left: (n.x || 0) - 2,
-                top: (n.y || 0) - 2,
-                width: sz.w + 4,
-                height: sz.h + 4,
-                borderRadius: n.kind === "begin" || n.kind === "end" ? "50%" : 10,
-                border: `2px solid ${tint.border}`,
-                boxShadow: tint.glow || undefined,
-                animation: st === "running" ? "pulse 1.6s ease-in-out infinite" : undefined,
-              }}
-            />
-          );
-        })}
-      </div>
     </div>
   );
 }
@@ -1133,7 +1122,7 @@ function SD_GraphRunView({ gid, rid, wid, session, pushToast }) {
           </span>
         </div>
       </div>
-      <div style={{ display: "grid", gridTemplateColumns: "1fr 360px" }}>
+      <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) 360px" }}>
         <SD_StatusCanvas
           graph={graph.data}
           statusByNode={statusByNode}

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -865,7 +865,10 @@ input, textarea, select { font: inherit; color: inherit; }
 
 .session-detail-grid {
   display: grid;
-  grid-template-columns: 1fr 360px;
+  /* minmax(0, 1fr) so the primary column can shrink below its content's
+     intrinsic width — otherwise a wide run-view canvas blows the grid
+     past the viewport and pushes the side rail off-screen. */
+  grid-template-columns: minmax(0, 1fr) 360px;
   gap: 18px;
 }
 


### PR DESCRIPTION
## Bug
On a graph session's run view, the page rendered a horizontal scrollbar and the right-hand controls (Live signals / Live stream / References) were pushed off-screen — you had to scroll right to reach them.

## Root cause
The per-node status rings were rendered in an **external overlay** sibling to `GR_Canvas`, inside a no-overflow `position: relative` wrapper. The rings are absolutely positioned out to the full graph width (~1400px for a wide pipeline), so the wrapper grew to that width and the `1fr` left column of `.session-detail-grid` (default `min-width: auto`) expanded with it — blowing the whole grid past the viewport and shoving the `360px` side rail off-screen. The rings also wouldn't scroll-sync with the canvas.

## Fix
- Add an optional `statusTint` prop to the shared `GR_Canvas`; when present it renders the rings **inside** its own scroll container (so they scroll with the nodes and can't overflow the page). The editor passes nothing → unchanged.
- `SD_StatusCanvas` now hands the tint map to the canvas and drops the external overlay.
- Constrain both the run-view grid and `.session-detail-grid` with `minmax(0, 1fr)` so the canvas column can shrink instead of widening the page.

## Testing
- `tests/ui`: 320 passed, 1 skipped (bundle transpiles; run-view + canvas reuse tests updated/green)
- `data-testid="run-node-*"` markers preserved (gated e2e journey still valid)

🤖 Generated with [Claude Code](https://claude.com/claude-code)