### PR TITLE
fix(ui): stop the session live stream reconnecting a terminal run

### DIFF
--- a/tests/ui/test_session_live_stream_terminal_reconnect.py
+++ b/tests/ui/test_session_live_stream_terminal_reconnect.py
@@ -1,0 +1,31 @@
+"""SessionLiveStream must not reconnect a terminal session's WS forever.
+
+A terminal run has no live frames to tail: the server accepts the socket,
+replays (often nothing), then closes — and because onopen resets the
+backoff, an unguarded reconnect loops at ~1s indefinitely. The reconnect
+is gated on a terminal ref so an ended/failed/cancelled session opens the
+socket at most once (for history replay) and then stops.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DETAIL = (ROOT / "ui" / "components" / "session-detail.jsx").read_text(encoding="utf-8")
+
+
+def test_terminal_ref_present() -> None:
+    assert "terminalRef" in DETAIL
+
+
+def test_reconnect_gated_on_terminal() -> None:
+    # The WS reconnect branch must be skipped once the session is terminal.
+    assert "!terminalRef.current" in DETAIL
+
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(ROOT / "ui")
+    assert etag and body

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -745,6 +745,16 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
   const [usage, setUsage] = React.useState({ input_tokens: 0, output_tokens: 0, context_length: 0 });
   const wsRef = React.useRef(null);
   const scrollRef = React.useRef(null);
+  // Whether the session is terminal. A terminal run has no live frames to
+  // tail: the server accepts the socket, replays (often nothing), then
+  // closes — and since onopen resets the backoff, an unguarded reconnect
+  // loops forever at ~1s. Gate reconnects on this. Kept in a ref (seeded
+  // from the initial prop, refreshed as the prop changes) so a run that
+  // ends mid-stream also stops reconnecting without re-opening the socket.
+  const terminalRef = React.useRef(!!(session && SESSION_TERMINAL.has(session.status)));
+  React.useEffect(() => {
+    terminalRef.current = !!(session && SESSION_TERMINAL.has(session.status));
+  }, [session?.status]);
 
   const isRunning = session?.turn_status === "running" || session?.turn_status === "claimable";
 
@@ -833,8 +843,11 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
           }
           return;
         }
-        // Unexpected close - reconnect with exponential backoff.
-        if (!intentional) {
+        // Unexpected close - reconnect with exponential backoff. But a
+        // terminal session has nothing left to stream, so don't reconnect:
+        // the server closes after the (often empty) replay and we'd
+        // otherwise loop forever (onopen keeps resetting the backoff).
+        if (!intentional && !terminalRef.current) {
           reconnectTimer = setTimeout(() => {
             backoffMs = Math.min(backoffMs * 2, MAX_BACKOFF_MS);
             connect();


### PR DESCRIPTION
## Bug
On an **ended** session, the page opened a fresh `ws?cursor=0` WebSocket roughly every second, forever — visible as a constant stream of `101` handshakes in the Network tab, while the Live stream UI just showed "offline / 0 frames".

## Root cause
`SessionLiveStream`'s WS effect reconnects on *every* unexpected close, with **no terminal guard**. And `onopen` resets the backoff to 1s. So for a terminal run — where the server accepts the socket, has nothing live to tail, and closes it — the client reconnects, the backoff never grows (onopen keeps resetting it), and it loops at ~1s indefinitely.

## Fix
Gate the reconnect on a `terminalRef` (seeded from the `session` prop and refreshed via an effect on `session.status`, so a run that ends mid-stream also stops without re-opening the socket). The socket still opens once so history can replay; it just no longer churns. My run-view WS effects were already terminal/node-guarded, so they weren't involved.

## Testing
- `tests/ui`: 323 passed, 1 skipped (bundle transpiles; new regression test pins the terminal reconnect guard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)