### PR TITLE
feat(graph): on_max_iterations route — graceful finalize instead of hard-fail at the cap

### DIFF
--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -252,6 +252,10 @@ class _BaseGraphExecutor(
         # blocks (its routing decision is settled), and resume only re-admits
         # nodes that are pending anyway.
         self._admitted: set[str] = set()
+        # One-shot guard: once a ``max_iterations`` hit has been rerouted via
+        # ``graph.on_max_iterations``, the cap no longer trips (so the finalize
+        # tail can run to completion without re-triggering).
+        self._max_iter_routed: bool = False
         self._node_states: dict[str, NodeRuntimeState] = {}
 
         # Turn-log emission. Subclasses (WorkspaceGraphExecutor /
@@ -800,6 +804,7 @@ class _BaseGraphExecutor(
         )
         ready: set[str] = {_resolve_initial_ready_node(self._graph)}
         self._admitted = set(ready)
+        self._max_iter_routed = False
         ended_reason: str | None = None
         ended_detail: str | None = None
         # Phase 6 — expose mid-flight state on the executor so
@@ -845,7 +850,23 @@ class _BaseGraphExecutor(
             if (
                 self._graph.max_iterations is not None
                 and context.iteration >= self._graph.max_iterations
+                and not self._max_iter_routed
             ):
+                route_to = self._graph.on_max_iterations
+                if route_to is not None and route_to in self._nodes_by_id:
+                    # Graceful landing: route once to the configured node
+                    # (typically a finalize/report node) instead of failing.
+                    # ``_max_iter_routed`` keeps the cap from re-tripping while
+                    # the (acyclic) finalize tail runs to an End.
+                    self._max_iter_routed = True
+                    logger.warning(
+                        "graph %s hit max_iterations=%s; routing to "
+                        "on_max_iterations=%r instead of failing",
+                        self._graph.id, self._graph.max_iterations, route_to,
+                    )
+                    ready = {route_to}
+                    self._admitted.add(route_to)
+                    continue
                 yield _GraphErrorEvent(  # type: ignore[misc]
                     code="max_iterations_exceeded",
                     message=f"graph ran for {context.iteration} iterations",

--- a/primer/model/graph.py
+++ b/primer/model/graph.py
@@ -692,6 +692,18 @@ class Graph(Describeable):
             "Recommended for any graph that contains a cycle."
         ),
     )
+    on_max_iterations: str | None = Field(
+        default=None,
+        description=(
+            "Optional node id to route to (once) when ``max_iterations`` is "
+            "hit, INSTEAD of ending ``failed`` with "
+            "``ended_detail='max_iterations_exceeded'``. Use it to point a "
+            "bounded loop at its finalize/report node so the cap is a "
+            "graceful landing rather than a crash. Must reference an existing "
+            "node that can still reach an End. ``None`` keeps the hard-fail "
+            "behaviour."
+        ),
+    )
     harness_id: str | None = Field(
         default=None,
         description=(
@@ -720,6 +732,12 @@ class Graph(Describeable):
                     f"duplicate node id {n.id!r}; node ids must be unique within a graph"
                 )
             ids.add(n.id)
+
+        if self.on_max_iterations is not None and self.on_max_iterations not in ids:
+            raise ValueError(
+                f"on_max_iterations {self.on_max_iterations!r} does not match any "
+                "node id"
+            )
 
         begins = [n for n in self.nodes if n.kind == "begin"]
         ends = [n for n in self.nodes if n.kind == "end"]

--- a/tests/graph/test_max_iterations.py
+++ b/tests/graph/test_max_iterations.py
@@ -228,3 +228,86 @@ async def test_max_iterations_exceeded_ended_detail() -> None:
     assert loaded.status == SessionStatus.ENDED
     assert loaded.ended_reason == "failed"
     assert loaded.ended_detail == "max_iterations_exceeded"
+
+
+@pytest.mark.asyncio
+async def test_on_max_iterations_routes_to_node_instead_of_failing() -> None:
+    """Same looping graph, but ``on_max_iterations='exit'`` is set. When the
+    cycle bound trips, the executor routes to that node (here the End) and the
+    graph ends ``completed`` — no ``max_iterations_exceeded`` failure. This is
+    the guaranteed-finalize backstop: the cap becomes a safe landing, not a
+    cliff."""
+    graph = Graph(
+        id="g-max-iter-route",
+        description="Begin -> A -> A (forever, bounded) with on_max_iterations",
+        max_iterations=2,
+        on_max_iterations="exit",
+        nodes=[
+            _BeginNode(id="b"),
+            _AgentNodeRef(id="a", agent_id="x", response_format={"type": "object"}),
+            _EndNode(id="exit", output_template="done"),
+        ],
+        edges=[
+            _StaticEdge(from_node="b", to_node="a"),
+            _ConditionalEdge(
+                from_node="a",
+                router=_JsonPathRouter(
+                    branches=[
+                        JsonPathBranch(
+                            conditions=[
+                                BranchCondition(path="go", op="eq", value="a")
+                            ],
+                            to_node="a",
+                        )
+                    ],
+                    default_to="exit",
+                ),
+            ),
+        ],
+    )
+    llm = _FakeLLM(
+        scripts=[
+            [
+                TextDelta(text='{"go": "a"}', index=0),
+                Done(stop_reason="stop", raw_reason="stop"),
+            ]
+        ]
+    )
+
+    async def agent_resolver(agent_id: str):
+        return _agent(agent_id) if agent_id == "x" else None
+
+    async def llm_resolver(_agent: Agent):
+        return (llm, _model())
+
+    thread_storage: _InMemoryStorage[GraphThread] = _InMemoryStorage(GraphThread)
+    message_storage: _InMemoryStorage[GraphNodeMessage] = _InMemoryStorage(
+        GraphNodeMessage
+    )
+    thread = await GraphExecutor.open_thread(
+        graph=graph,
+        thread_storage=thread_storage,  # type: ignore[arg-type]
+        title="t",
+    )
+    executor = GraphExecutor(
+        graph=graph,
+        agent_resolver=agent_resolver,
+        llm_resolver=llm_resolver,  # type: ignore[arg-type]
+        thread_storage=thread_storage,  # type: ignore[arg-type]
+        message_storage=message_storage,  # type: ignore[arg-type]
+        graph_thread_id=thread.id,
+    )
+
+    events = [ev async for ev in executor.invoke([])]
+    err_events = [
+        ev
+        for ev in events
+        if isinstance(ev, _GraphErrorEvent) and ev.code == "max_iterations_exceeded"
+    ]
+    assert not err_events, "expected NO max_iterations_exceeded failure"
+
+    loaded = await thread_storage.get(thread.id)
+    assert loaded is not None
+    assert loaded.status == SessionStatus.ENDED
+    assert loaded.ended_reason == "completed"
+    assert loaded.ended_detail != "max_iterations_exceeded"


### PR DESCRIPTION
## Problem
A cyclic graph that reaches `max_iterations` ends `failed` with `ended_detail='max_iterations_exceeded'` and **no output** ([base.py](primer/graph/base.py) cap check). For bounded work/refine loops (e.g. a research or coding loop), hitting the cap should produce the best-so-far result, not a crash.

## Fix
Add an optional **`Graph.on_max_iterations`** (a node id). When the cap trips and it is set, the executor routes **once** to that node — typically a finalize/report node — instead of failing, so the loop lands gracefully with a deliverable.

- `primer/model/graph.py`: new `on_max_iterations: str | None` field + topology validation (must reference an existing node).
- `primer/graph/base.py`: at the cap check, if `on_max_iterations` is set, set `ready = {that_node}` and continue; a one-shot `_max_iter_routed` guard prevents the cap from re-tripping while the acyclic finalize tail runs to an End. `None` preserves the existing hard-fail behaviour.

## Tests
`tests/graph/test_max_iterations.py`:
- existing hard-fail test unchanged (no `on_max_iterations` → still `failed` / `max_iterations_exceeded`).
- new `test_on_max_iterations_routes_to_node_instead_of_failing` (written red first): same looping graph with `on_max_iterations='exit'` ends `completed`, no failure event.

Full `tests/graph/`: 318 passed; ruff clean.

## Motivation
Backstop for bounded autonomous loops (tenacious / autoresearch-deep) so the iteration cap is a safe landing rather than a cliff.