### PR TITLE
feat(graph): add strip_fences template filter for code sanitization

### DIFF
--- a/primer/graph/template.py
+++ b/primer/graph/template.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import json
 import logging
+import re
 from typing import Any
 
 from jinja2 import StrictUndefined, TemplateError
@@ -54,6 +55,36 @@ def _fromjson(value: Any) -> Any:
     return value
 
 
+_FENCE_BLOCK_RE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+_FENCE_LINE_RE = re.compile(r"^\s*```")
+
+
+def _strip_fences(value: Any) -> Any:
+    """``strip_fences`` template filter: extract code from markdown fences.
+
+    Local models habitually wrap code in ```lang fenced blocks (and add prose
+    around them), which breaks a downstream ``python3``/shell run when the raw
+    text is written to a file. This filter sanitises that:
+
+    * If the text contains one or more complete ```...``` blocks, return the
+      concatenated block contents (surrounding prose dropped).
+    * Otherwise, if a stray/unclosed fence marker line is present, drop those
+      marker lines so the remaining text is valid source.
+    * Otherwise (already raw), return the text unchanged — idempotent.
+
+    Non-string values pass through unchanged.
+    """
+    if not isinstance(value, str):
+        return value
+    blocks = _FENCE_BLOCK_RE.findall(value)
+    if blocks:
+        return "\n\n".join(b.strip("\n") for b in blocks)
+    if "```" in value:
+        kept = [ln for ln in value.splitlines() if not _FENCE_LINE_RE.match(ln)]
+        return "\n".join(kept)
+    return value
+
+
 # Module-level shared environment. Sandboxed = blocks access to
 # dunder attributes / dangerous built-ins; StrictUndefined = raises
 # on missing attributes rather than silently emitting empty strings
@@ -67,6 +98,10 @@ _ENV: SandboxedEnvironment = SandboxedEnvironment(
 # Custom filters. ``fromjson`` parses a JSON string (e.g. a tool_call node's
 # ``text`` output) so downstream nodes can index into it; see ``_fromjson``.
 _ENV.filters["fromjson"] = _fromjson
+# ``strip_fences`` extracts code from markdown fences a model may add around
+# generated source, so a write-then-exec node gets clean content; see
+# ``_strip_fences``.
+_ENV.filters["strip_fences"] = _strip_fences
 
 
 def render_input_template(

--- a/tests/graph/test_template.py
+++ b/tests/graph/test_template.py
@@ -137,6 +137,45 @@ class TestFromJsonFilter:
             )
 
 
+class TestStripFencesFilter:
+    """The ``strip_fences`` filter sanitises a model's code output before it is
+    written to a file — local models habitually wrap code in ```lang fences
+    (and add prose around it), which breaks a downstream ``python3`` run."""
+
+    def test_extracts_fenced_block_dropping_prose(self) -> None:
+        ctx = _ctx(
+            nodes={
+                "code": NodeOutput(
+                    text="Here is the file:\n```python\nprint('hi')\n```\nDone.",
+                    iteration=0,
+                )
+            },
+        )
+        result = render_input_template(
+            "{{ nodes.code.text | strip_fences }}", context=ctx
+        )
+        assert result == "print('hi')"
+
+    def test_idempotent_on_raw_code(self) -> None:
+        raw = "import sys\nprint(sys.argv)"
+        ctx = _ctx(nodes={"code": NodeOutput(text=raw, iteration=0)})
+        result = render_input_template(
+            "{{ nodes.code.text | strip_fences }}", context=ctx
+        )
+        assert result == raw
+
+    def test_strips_stray_unclosed_fence_marker_lines(self) -> None:
+        # No closing fence: the bare ```python marker line must be removed so
+        # the remaining text is valid source.
+        ctx = _ctx(
+            nodes={"code": NodeOutput(text="```python\nx = 1\ny = 2", iteration=0)},
+        )
+        result = render_input_template(
+            "{{ nodes.code.text | strip_fences }}", context=ctx
+        )
+        assert result == "x = 1\ny = 2"
+
+
 class TestErrors:
     def test_syntax_error_raises_bad_request(self) -> None:
         with pytest.raises(BadRequestError, match="syntax error"):


### PR DESCRIPTION
## Problem
Local models habitually wrap generated code in ```lang markdown fences (and add prose like "Here is the file:" around them). When a graph writes that raw text to a file and then runs it (`workspace__write` → `workspace__exec`), the fence line is a `SyntaxError`. The workaround was a hand-rolled `{{ ... | replace('```python','') | replace('```','') }}` chain in the write node — fragile and repeated.

## Fix
Add a sandboxed **`strip_fences`** Jinja filter (sibling to `fromjson`):
- if the text has one or more complete ```...``` blocks → return the concatenated block contents (surrounding prose dropped);
- else if a stray/unclosed fence-marker line is present → drop those marker lines;
- else (already raw) → unchanged. Idempotent; non-strings pass through.

Usage: `{{ nodes.code.text | strip_fences }}` in a code-writing `tool_call` node.

## Tests
`tests/graph/test_template.py::TestStripFencesFilter` (written red first): extracts a fenced block dropping prose; idempotent on raw code; strips stray unclosed fence lines. Full `tests/graph/test_template.py`: 17 passed; ruff clean.

## Motivation
Makes execution-grounded code loops (write→exec→verify) robust to the local model's fencing habit without per-graph string hacks.