### PR TITLE
feat(sessions): session state legibility + full recorded history

### DIFF
--- a/primer/api/routers/sessions.py
+++ b/primer/api/routers/sessions.py
@@ -675,6 +675,43 @@ async def _read_workspace_turn_log(
     }
 
 
+@top_session_router.get(
+    "/sessions/{session_id}/messages",
+    summary="Read the session's recorded message log (paginated)",
+    responses=common_responses(404, 500),
+)
+async def get_session_messages(
+    session_id: str = Path(..., description="Session id"),
+    limit: int = Query(default=200, ge=1, le=1000),
+    offset: int = Query(default=0, ge=0),
+    after_seq: int | None = Query(default=None, ge=0),
+    sessions=Depends(get_session_storage),
+    workspace_registry=Depends(get_workspace_registry),
+) -> dict:
+    """Return the recorded ``messages.jsonl`` rows for this session.
+
+    Unlike the WebSocket (which rejects ENDED sessions), this serves the
+    full recorded history for any status, so the console can render the
+    output of a finished run. Reuses the generic JSONL reader; a missing
+    file or absent workspace yields an empty log rather than a 5xx.
+    """
+    sess = await sessions.get(session_id)
+    if sess is None:
+        raise NotFoundError(f"Session {session_id!r} does not exist")
+    workspace = await workspace_registry.get_workspace(sess.workspace_id)
+    if workspace is None:
+        return {"items": [], "total": 0, "offset": offset, "limit": limit}
+    state_path = getattr(workspace, "state_path", ".state")
+    rel = f"{state_path}/sessions/{session_id}/messages.jsonl"
+    return await _read_workspace_turn_log(
+        workspace=workspace,
+        relative_path=rel,
+        limit=limit,
+        offset=offset,
+        since_seq=after_seq,
+    )
+
+
 # ===========================================================================
 # WebSocket: live session stream + interrupt / tool_approval / ping
 # ===========================================================================

--- a/tests/api/test_session_messages_route.py
+++ b/tests/api/test_session_messages_route.py
@@ -1,0 +1,107 @@
+"""REST tests for GET /v1/sessions/{id}/messages — the recorded message log.
+
+Mirrors test_node_states_route.py: a fake workspace exposes read_file +
+state_path. The headline behaviour is that an ENDED session still returns
+its recorded history (unlike the WS, which rejects ended sessions)."""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import httpx
+import pytest
+
+
+def _now() -> datetime:
+    return datetime(2026, 6, 5, 10, 0, 0, tzinfo=timezone.utc)
+
+
+class _FakeWorkspace:
+    state_path = ".state"
+
+    def __init__(self) -> None:
+        self._files: dict[str, bytes] = {}
+
+    def write(self, path: str, content: str) -> None:
+        self._files[path] = content.encode("utf-8")
+
+    async def read_file(self, path: str) -> bytes:
+        if path not in self._files:
+            from primer.model.except_ import NotFoundError
+            raise NotFoundError(f"{path!r} not found")
+        return self._files[path]
+
+
+async def _seed_session(fake_storage_provider, sid: str, status):
+    from primer.model.workspace_session import (
+        AgentSessionBinding, SessionStatus, WorkspaceSession,
+    )
+    sess = WorkspaceSession(
+        id=sid, workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="ag1"),
+        status=status, created_at=_now(), turn_status="idle",
+    )
+    await fake_storage_provider.get_storage(WorkspaceSession).create(sess)
+
+
+@pytest.mark.asyncio
+async def test_ended_session_still_returns_history(
+    client: httpx.AsyncClient, app, fake_storage_provider,
+):
+    from primer.model.workspace_session import SessionStatus
+    await _seed_session(fake_storage_provider, "s-ended", SessionStatus.ENDED)
+    ws = _FakeWorkspace()
+    ws.write(
+        ".state/sessions/s-ended/messages.jsonl",
+        '{"seq":1,"kind":"assistant_token","payload":{"text":"hi"}}\n'
+        '{"seq":2,"kind":"done","payload":{}}\n',
+    )
+
+    async def _get(wid):
+        return ws if wid == "ws-1" else None
+    app.state.workspace_registry.get_workspace = _get  # type: ignore[assignment]
+
+    r = await client.get("/v1/sessions/s-ended/messages")
+    assert r.status_code == 200, r.text
+    items = r.json()["items"]
+    assert [it["seq"] for it in items] == [1, 2]
+
+
+@pytest.mark.asyncio
+async def test_after_seq_filters(client, app, fake_storage_provider):
+    from primer.model.workspace_session import SessionStatus
+    await _seed_session(fake_storage_provider, "s-run", SessionStatus.RUNNING)
+    ws = _FakeWorkspace()
+    ws.write(
+        ".state/sessions/s-run/messages.jsonl",
+        '{"seq":1,"kind":"a"}\n{"seq":2,"kind":"b"}\n{"seq":3,"kind":"c"}\n',
+    )
+
+    async def _get(wid):
+        return ws if wid == "ws-1" else None
+    app.state.workspace_registry.get_workspace = _get  # type: ignore[assignment]
+
+    r = await client.get("/v1/sessions/s-run/messages?after_seq=1")
+    assert r.status_code == 200, r.text
+    assert [it["seq"] for it in r.json()["items"]] == [2, 3]
+
+
+@pytest.mark.asyncio
+async def test_missing_file_is_empty_not_500(client, app, fake_storage_provider):
+    from primer.model.workspace_session import SessionStatus
+    await _seed_session(fake_storage_provider, "s-empty", SessionStatus.RUNNING)
+    ws = _FakeWorkspace()  # no messages.jsonl written
+
+    async def _get(wid):
+        return ws if wid == "ws-1" else None
+    app.state.workspace_registry.get_workspace = _get  # type: ignore[assignment]
+
+    r = await client.get("/v1/sessions/s-empty/messages")
+    assert r.status_code == 200, r.text
+    assert r.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_unknown_session_404(client, app, fake_storage_provider):
+    r = await client.get("/v1/sessions/nope/messages")
+    assert r.status_code == 404

--- a/tests/ui/test_session_detail_outcome_banner.py
+++ b/tests/ui/test_session_detail_outcome_banner.py
@@ -1,0 +1,31 @@
+"""Terminal sessions get a decoded outcome banner; parked panels gain live
+countdowns; panel-less parks get a generic waiting line. All from the
+shared describeSessionState / SessionCountdown."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+DETAIL = (UI / "components" / "session-detail.jsx").read_text(encoding="utf-8")
+
+
+def test_outcome_banner_uses_decoder() -> None:
+    assert "describeSessionState" in DETAIL
+    assert "data-testid=\"session-outcome\"" in DETAIL
+
+
+def test_panels_show_countdown() -> None:
+    assert "SessionCountdown" in DETAIL
+
+
+def test_generic_waiting_line_for_panelless_park() -> None:
+    assert "waitingOn" in DETAIL
+
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body

--- a/tests/ui/test_session_live_history.py
+++ b/tests/ui/test_session_live_history.py
@@ -1,0 +1,34 @@
+"""SessionLiveStream loads full recorded history via the REST messages
+endpoint on mount (so ended sessions show their output), then tails the WS
+only while running. Terminal sessions read 'Session ended', not
+'connection dropped'."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+DETAIL = (UI / "components" / "session-detail.jsx").read_text(encoding="utf-8")
+
+
+def test_loads_history_from_messages_endpoint() -> None:
+    assert "/messages" in DETAIL
+    # History seeds the stream (not only the WS replay).
+    assert "after_seq" in DETAIL or "/messages" in DETAIL
+
+
+def test_ws_cursor_resumes_from_loaded_history() -> None:
+    # The WS connects with the highest loaded seq so the tail has no gap.
+    assert "cursor=" in DETAIL
+
+
+def test_terminal_says_session_ended_not_dropped() -> None:
+    assert "Session ended" in DETAIL
+
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body

--- a/tests/ui/test_session_state_decoder.py
+++ b/tests/ui/test_session_state_decoder.py
@@ -1,0 +1,67 @@
+"""The shared session-state decoder turns a session row into a render-ready
+descriptor (outcome / waiting-on / running), consumed by both the list and
+the detail page. Pure, frontend-only — derived from fields already on the row.
+Project convention: source-grep the decode rules + a bundle-transpile check."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SRC = (UI / "components" / "session-state.jsx").read_text(encoding="utf-8")
+INDEX = (UI / "index.html").read_text(encoding="utf-8")
+
+
+def _order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            s = line.index('src="') + 5
+            out.append(line[s:line.index('"', s)])
+    return out
+
+
+def test_exports_decoder_and_countdown() -> None:
+    assert "function describeSessionState" in SRC
+    assert "window.describeSessionState" in SRC
+    assert "SessionCountdown" in SRC
+    assert "window.SessionCountdown" in SRC
+
+
+def test_decodes_ended_detail_codes() -> None:
+    # Known graph/agent failure codes map to human text; unknown -> verbatim.
+    for code in (
+        "routing_failed", "max_iterations_exceeded", "node_failed",
+        "fanin_upstream_failed", "tool_execution_failed",
+    ):
+        assert code in SRC
+
+
+def test_covers_park_prefixes_and_attention() -> None:
+    for prefix in ("ask_user:", "tool_approval:", "timer:", "watch:", "mcp_task:"):
+        assert prefix in SRC
+    assert "needsAttention" in SRC
+
+
+def test_emits_groups_and_tones() -> None:
+    for token in ("running", "waiting", "ended", "failed", "cancelled", "idle"):
+        assert token in SRC
+    assert "countdownTo" in SRC
+    assert "waitingOn" in SRC
+
+
+def test_registered_before_list_and_detail() -> None:
+    order = _order()
+    assert "components/session-state.jsx" in order
+    i = order.index("components/session-state.jsx")
+    assert i < order.index("components/sessions-list.jsx")
+    assert i < order.index("components/session-detail.jsx")
+
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    assert "/* === components/session-state.jsx === */" in body.decode("utf-8")

--- a/tests/ui/test_sessions_list_state_chip.py
+++ b/tests/ui/test_sessions_list_state_chip.py
@@ -1,0 +1,35 @@
+"""The sessions list derives its per-row chip from the shared decoder and
+adds Needs-attention / Failed quick filters + an attention count."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+LIST = (UI / "components" / "sessions-list.jsx").read_text(encoding="utf-8")
+CHROME = (UI / "components" / "chrome.jsx").read_text(encoding="utf-8")
+
+
+def test_row_chip_uses_decoder() -> None:
+    assert "describeSessionState" in LIST
+
+
+def test_needs_attention_and_failed_filters() -> None:
+    assert "needsAttention" in LIST
+    low = LIST.lower()
+    assert "needs attention" in low
+    assert "failed" in low
+
+
+def test_attention_count_surfaced() -> None:
+    # Count of attention-needing sessions shown in the list and/or nav.
+    assert "needsAttention" in LIST
+    assert "session" in CHROME.lower()
+
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body

--- a/tests/ui/test_sessions_list_state_chip.py
+++ b/tests/ui/test_sessions_list_state_chip.py
@@ -23,9 +23,10 @@ def test_needs_attention_and_failed_filters() -> None:
 
 
 def test_attention_count_surfaced() -> None:
-    # Count of attention-needing sessions shown in the list and/or nav.
+    # The "N need attention" count is derived from the decoder and rendered
+    # as an in-list triage surface (the nav-dot is a deferred fast-follow).
     assert "needsAttention" in LIST
-    assert "session" in CHROME.lower()
+    assert "need attention" in LIST.lower()
 
 
 def test_bundle_transpiles() -> None:

--- a/tests/ui_e2e/test_session_state_and_history_journey.py
+++ b/tests/ui_e2e/test_session_state_and_history_journey.py
@@ -36,14 +36,16 @@ def _seed_agent(base_url: str, aid: str, pid: str) -> None:
 
 def _seed_workspace(base_url: str, wp: str, tpl: str, tmp_path) -> str:
     with httpx.Client(base_url=base_url, timeout=30.0) as c:
-        c.post("/v1/workspace_providers", json={
+        r = c.post("/v1/workspace_providers", json={
             "id": wp, "provider": "local",
             "config": {"kind": "local", "root_path": str(tmp_path)},
         })
-        c.post("/v1/workspace_templates", json={
+        assert r.status_code in (201, 409), r.text
+        r = c.post("/v1/workspace_templates", json={
             "id": tpl, "description": "tpl", "provider_id": wp,
             "backend": {"kind": "local"},
         })
+        assert r.status_code in (201, 409), r.text
         r = c.post("/v1/workspaces", json={"template_id": tpl})
         assert r.status_code == 201, r.text
         return r.json()["id"]
@@ -90,15 +92,20 @@ def test_cancelled_session_shows_outcome_banner(
 
 
 # ---------------------------------------------------------------------------
-# Journey 2: cancelled session appears under the "Failed" filter on the list
+# Journey 2: cancelled session shows a "Cancelled" outcome chip in the list
 # ---------------------------------------------------------------------------
 
 
-def test_cancelled_session_visible_under_failed_filter(
+def test_cancelled_session_shows_cancelled_chip_in_list(
     base_url, console_url, page, tmp_path,
 ) -> None:
-    """Seed + cancel an agent session, then open /sessions, click the
-    "Failed" chip, and assert the session id appears in the filtered list."""
+    """Seed + cancel an agent session, then open /sessions and assert that
+    the session row shows the "Cancelled" decoded-outcome chip.
+
+    Note: describeSessionState classifies a cancelled session as
+    group="cancelled", NOT group="failed", so it does NOT appear under the
+    "Failed" filter.  We assert the chip label directly instead.
+    """
     _seed_llm_provider(base_url, "sl-prov2")
     _seed_agent(base_url, "sl-agent2", "sl-prov2")
     wid = _seed_workspace(base_url, "sl-wp2", "sl-tpl2", tmp_path)
@@ -106,7 +113,9 @@ def test_cancelled_session_visible_under_failed_filter(
     _cancel_session(base_url, wid, sid)
 
     page.goto(f"{console_url}#/sessions")
-    page.get_by_text("Failed", exact=True).first.click()
     expect(page.get_by_text(sid[:8], exact=False).first).to_be_visible(
+        timeout=20_000,
+    )
+    expect(page.get_by_text("Cancelled", exact=False).first).to_be_visible(
         timeout=20_000,
     )

--- a/tests/ui_e2e/test_session_state_and_history_journey.py
+++ b/tests/ui_e2e/test_session_state_and_history_journey.py
@@ -1,0 +1,112 @@
+"""UI e2e: session state legibility + history. Default-skipped (conftest
+ignores test_*.py unless PRIMER_RUN_UI_E2E=1)."""
+
+from __future__ import annotations
+
+import httpx
+from playwright.sync_api import expect
+
+
+# ---------------------------------------------------------------------------
+# Seed helpers — mirrored from test_graph_run_view_journey.py, adapted for
+# an agent-bound (not graph-bound) session.
+# ---------------------------------------------------------------------------
+
+
+def _seed_llm_provider(base_url: str, pid: str) -> None:
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        r = c.post("/v1/llm_providers", json={
+            "id": pid, "provider": "ollama",
+            "config": {"url": "http://127.0.0.1:9999"},
+            "models": [{"name": "fake-model", "context_length": 4096}],
+            "limits": {"max_concurrency": 1},
+        })
+        assert r.status_code in (201, 409), r.text
+
+
+def _seed_agent(base_url: str, aid: str, pid: str) -> None:
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        r = c.post("/v1/agents", json={
+            "id": aid, "description": "state-legibility probe",
+            "model": {"provider_id": pid, "model_name": "fake-model"},
+            "tools": [], "system_prompt": ["test"],
+        })
+        assert r.status_code in (201, 409), r.text
+
+
+def _seed_workspace(base_url: str, wp: str, tpl: str, tmp_path) -> str:
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        c.post("/v1/workspace_providers", json={
+            "id": wp, "provider": "local",
+            "config": {"kind": "local", "root_path": str(tmp_path)},
+        })
+        c.post("/v1/workspace_templates", json={
+            "id": tpl, "description": "tpl", "provider_id": wp,
+            "backend": {"kind": "local"},
+        })
+        r = c.post("/v1/workspaces", json={"template_id": tpl})
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+
+def _seed_agent_session(base_url: str, wid: str, aid: str) -> str:
+    """Create an agent-bound session (auto_start=False → stays in CREATED)."""
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        r = c.post(f"/v1/workspaces/{wid}/sessions", json={
+            "binding": {"kind": "agent", "agent_id": aid},
+            "auto_start": False,
+        })
+        assert r.status_code == 201, r.text
+        return r.json()["id"]
+
+
+def _cancel_session(base_url: str, wid: str, sid: str) -> None:
+    """Hard-cancel a CREATED session → ENDED/cancelled (terminal state)."""
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        r = c.post(f"/v1/workspaces/{wid}/sessions/{sid}/cancel")
+        assert r.status_code in (200, 409), r.text
+
+
+# ---------------------------------------------------------------------------
+# Journey 1: cancelled session shows outcome banner on detail page
+# ---------------------------------------------------------------------------
+
+
+def test_cancelled_session_shows_outcome_banner(
+    base_url, console_url, page, tmp_path,
+) -> None:
+    """Seed an agent session, cancel it via API (→ ENDED/cancelled), open
+    the detail page, and assert the outcome banner is visible."""
+    _seed_llm_provider(base_url, "sl-prov")
+    _seed_agent(base_url, "sl-agent", "sl-prov")
+    wid = _seed_workspace(base_url, "sl-wp", "sl-tpl", tmp_path)
+    sid = _seed_agent_session(base_url, wid, "sl-agent")
+    _cancel_session(base_url, wid, sid)
+
+    page.goto(f"{console_url}#/sessions/{sid}")
+    expect(page.locator('[data-testid="session-outcome"]')).to_be_visible(
+        timeout=20_000,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Journey 2: cancelled session appears under the "Failed" filter on the list
+# ---------------------------------------------------------------------------
+
+
+def test_cancelled_session_visible_under_failed_filter(
+    base_url, console_url, page, tmp_path,
+) -> None:
+    """Seed + cancel an agent session, then open /sessions, click the
+    "Failed" chip, and assert the session id appears in the filtered list."""
+    _seed_llm_provider(base_url, "sl-prov2")
+    _seed_agent(base_url, "sl-agent2", "sl-prov2")
+    wid = _seed_workspace(base_url, "sl-wp2", "sl-tpl2", tmp_path)
+    sid = _seed_agent_session(base_url, wid, "sl-agent2")
+    _cancel_session(base_url, wid, sid)
+
+    page.goto(f"{console_url}#/sessions")
+    page.get_by_text("Failed", exact=True).first.click()
+    expect(page.get_by_text(sid[:8], exact=False).first).to_be_visible(
+        timeout=20_000,
+    )

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -745,6 +745,35 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
   const [usage, setUsage] = React.useState({ input_tokens: 0, output_tokens: 0, context_length: 0 });
   const wsRef = React.useRef(null);
   const scrollRef = React.useRef(null);
+  const { apiFetch } = window.primerApi;
+  const historyCursorRef = React.useRef(0);
+  React.useEffect(() => {
+    let alive = true;
+    (async () => {
+      try {
+        const res = await apiFetch("GET", `/sessions/${encodeURIComponent(sid)}/messages?limit=1000`);
+        if (!alive) return;
+        const items = (res && res.items) || [];
+        if (items.length) {
+          let maxSeq = 0;
+          for (const it of items) { if (typeof it.seq === "number" && it.seq > maxSeq) maxSeq = it.seq; }
+          historyCursorRef.current = maxSeq;
+          setMessages((prev) => {
+            const seen = new Set(prev.map((p) => p.seq));
+            const merged = [...prev];
+            for (const it of items) {
+              if (seen.has(it.seq)) continue;
+              const payload = it.payload && typeof it.payload === "object" ? it.payload : {};
+              merged.push({ ...payload, ...it });
+            }
+            merged.sort((a, b) => (a.seq || 0) - (b.seq || 0));
+            return merged;
+          });
+        }
+      } catch (_e) { /* history is best-effort; WS still tails for live runs */ }
+    })();
+    return () => { alive = false; };
+  }, [sid]);  // eslint-disable-line react-hooks/exhaustive-deps
   // Whether the session is terminal. A terminal run has no live frames to
   // tail: the server accepts the socket, replays (often nothing), then
   // closes — and since onopen resets the backoff, an unguarded reconnect
@@ -772,9 +801,10 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
     let backoffMs = 1000;
     const MAX_BACKOFF_MS = 30000;
     let reconnectTimer = null;
-    // Track the highest seq seen. Starts at 0 (full replay on first
-    // connect); updated on each frame so reconnects resume cleanly.
-    let latestSeq = 0;
+    // Track the highest seq seen. Seeded from REST history so the live
+    // tail resumes with no gap and no full re-replay. Updated on each
+    // WS frame so reconnects also resume cleanly.
+    let latestSeq = historyCursorRef.current || 0;
 
     function connect() {
       if (intentional) return;
@@ -904,6 +934,7 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
 
   const coalesced = _SLS_coalesceMessages(messages);
   const isTerminalSession = session && SESSION_TERMINAL.has(session.status);
+  const isGraph = (session?.binding?.kind || session?.binding_kind) === "graph";
 
   // Fallback for the read-only TokenMeter when no `"usage"` envelope
   // has landed yet. Use the most recent turn's recorded tokens_in so
@@ -954,13 +985,23 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
         style={{ flex: 1, overflow: "auto", padding: "14px 18px", minHeight: 120, maxHeight: 480 }}
       >
         {coalesced.length === 0 && (
-          <div className="muted text-sm" style={{ textAlign: "center", padding: 20 }}>
-            {wsState === "connecting"
-              ? "Connecting to session stream…"
-              : wsState === "closed"
-                ? "Stream offline. No frames received or connection dropped."
-                : "No frames yet — session has not started a turn."}
-          </div>
+          terminalRef.current ? (
+            <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }}>
+              Session ended — no recorded output at the session level.
+              {isGraph ? " See the run view for per-node detail." : ""}
+            </div>
+          ) : (
+            <div className="muted text-sm" style={{ textAlign: "center", padding: 20 }}>
+              {wsState === "connecting"
+                ? "Connecting to session stream…"
+                : wsState === "closed"
+                  ? "Stream offline. No frames received or connection dropped."
+                  : "No frames yet — session has not started a turn."}
+            </div>
+          )
+        )}
+        {coalesced.length > 0 && terminalRef.current && (
+          <div className="muted text-sm" style={{ padding: "6px 12px" }}>Session ended</div>
         )}
         {coalesced.map((m, i) =>
           m.kind === "_assistant_message"

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -743,6 +743,7 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
   // WS never carries one, we fall back below to the most recent turn's
   // tokens_in so the meter still surfaces something meaningful.
   const [usage, setUsage] = React.useState({ input_tokens: 0, output_tokens: 0, context_length: 0 });
+  const [historyLoaded, setHistoryLoaded] = React.useState(false);
   const wsRef = React.useRef(null);
   const scrollRef = React.useRef(null);
   const { apiFetch } = window.primerApi;
@@ -770,7 +771,11 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
             return merged;
           });
         }
-      } catch (_e) { /* history is best-effort; WS still tails for live runs */ }
+        setHistoryLoaded(true);
+      } catch (_e) {
+        /* history is best-effort; WS still tails for live runs */
+        if (alive) setHistoryLoaded(true);
+      }
     })();
     return () => { alive = false; };
   }, [sid]);  // eslint-disable-line react-hooks/exhaustive-deps
@@ -796,7 +801,7 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
   // the last received seq (latestSeq) so no frames are missed or
   // replayed in full. Terminal close code 4404 does not reconnect.
   React.useEffect(() => {
-    if (!wid || !sid) return;
+    if (!wid || !sid || !historyLoaded) return;
     let intentional = false;
     let backoffMs = 1000;
     const MAX_BACKOFF_MS = 30000;
@@ -896,7 +901,7 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
       try { wsRef.current && wsRef.current.close(); } catch { /* no-op */ }
       wsRef.current = null;
     };
-  }, [wid, sid]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [wid, sid, historyLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Stick-to-bottom auto-scroll.
   const stickRef = React.useRef(true);

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -572,8 +572,36 @@ function SessionDetail({ sid: sidProp, pushToast, onBack }) {
   return (
     <div className="col">
       {/* Yielding-tools surfaces. Each polls /ask_user/pending (404 = nothing). */}
-      <AskUserPanel sid={sid} sessionStatus={session.status} pushToast={pushToast} />
-      <ApprovalBannerPanel sid={sid} sessionStatus={session.status} pushToast={pushToast} />
+      <AskUserPanel sid={sid} sessionStatus={session.status} session={session} pushToast={pushToast} />
+      <ApprovalBannerPanel sid={sid} sessionStatus={session.status} session={session} pushToast={pushToast} />
+      {(() => {
+        const st = window.describeSessionState(session);
+        if (!(st.group === "ended" || st.group === "failed" || st.group === "cancelled")) return null;
+        const color = st.tone === "green" ? "var(--green)" : st.tone === "red" ? "var(--red)" : "var(--text-3)";
+        return (
+          <div className="panel" data-testid="session-outcome" style={{ borderColor: st.tone === "red" ? "oklch(0.7 0.2 25 / 0.5)" : undefined }}>
+            <div className="panel-body" style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px" }}>
+              <span className="dot" style={{ background: color, width: 8, height: 8, borderRadius: "50%", display: "inline-block" }}></span>
+              <span style={{ color, fontWeight: 600 }}>{st.label}</span>
+              {st.detail && <span className="muted text-sm">— {st.detail}</span>}
+            </div>
+          </div>
+        );
+      })()}
+      {(() => {
+        const st = window.describeSessionState(session);
+        if (st.group !== "waiting" || !st.waitingOn) return null;
+        // ask_user / approval / timer(sleep) / watch already have dedicated panels.
+        if (st.waitingOn !== "task") return null;
+        return (
+          <div className="panel" data-testid="session-waiting">
+            <div className="panel-body" style={{ display: "flex", alignItems: "center", gap: 8, padding: "10px 14px" }}>
+              <span className="muted text-sm">{st.label}</span>
+              <window.SessionCountdown to={st.countdownTo} prefix="· auto-resumes in " />
+            </div>
+          </div>
+        );
+      })()}
       {isGraph && boundGraph && (
         <SD_CannotRunBanner gid={boundGraph} session={session} />
       )}
@@ -1364,7 +1392,7 @@ window.SD_NodeTurnLog = SD_NodeTurnLog;
 // render; 404 = render nothing). Submit/Skip post to the real
 // endpoints; 422/500 are surfaced INLINE via data-testid="ask-user-error"
 // (U0051/U0060), success surfaces as a toast (U0049/U0050).
-function AskUserPanel({ sid, sessionStatus, pushToast }) {
+function AskUserPanel({ sid, sessionStatus, session, pushToast }) {
   const { useResource, apiFetch } = window.primerApi;
   const isTerminal = SESSION_TERMINAL.has(sessionStatus);
 
@@ -1460,6 +1488,7 @@ function AskUserPanel({ sid, sessionStatus, pushToast }) {
         {parked_at && (
           <span className="sub muted">· waiting since {fmtDate(new Date(parked_at))}</span>
         )}
+        <window.SessionCountdown to={pending?.data?.parked_until || pending?.data?.timeout_at || session?.parked_until} prefix="auto-resumes in " />
       </div>
       <div className="panel-body" style={{ display: "flex", flexDirection: "column", gap: 12 }}>
         <div style={{ whiteSpace: "pre-wrap", color: "var(--text)" }}>{prompt}</div>
@@ -1609,6 +1638,7 @@ function SleepPanel({ sid, wid, session, pushToast }) {
         <div style={{ height: 6, background: "var(--bg-2)", borderRadius: 3, overflow: "hidden" }}>
           <div style={{ width: `${pct}%`, height: "100%", background: "var(--amber)", transition: "width 1s linear" }}></div>
         </div>
+        <window.SessionCountdown to={meta.resume_at || session?.parked_until} prefix="auto-resumes in " />
       </div>
     </div>
   );
@@ -1644,7 +1674,7 @@ function CancelYieldBtn({ sid, wid, tcid, pushToast }) {
 // (200 = render banner; 404 = render nothing) and renders ApprovalBanner
 // from approvals.jsx. The banner owns the respond mutation; this wrapper
 // owns the poll so session-detail can keep wiring concerns local.
-function ApprovalBannerPanel({ sid, sessionStatus, pushToast }) {
+function ApprovalBannerPanel({ sid, sessionStatus, session, pushToast }) {
   const { useResource, apiFetch } = window.primerApi;
   const isTerminal = SESSION_TERMINAL.has(sessionStatus);
   const pending = useResource(
@@ -1658,7 +1688,10 @@ function ApprovalBannerPanel({ sid, sessionStatus, pushToast }) {
   if (pending.error?.status === 404) return null;
   if (!pending.data) return null;
   return (
-    <ApprovalBanner data={pending.data} scope="sessions" id={sid} pushToast={pushToast} />
+    <div>
+      <ApprovalBanner data={pending.data} scope="sessions" id={sid} pushToast={pushToast} />
+      <window.SessionCountdown to={pending.data?.parked_until || pending.data?.timeout_at || session?.parked_until} prefix="expires in " />
+    </div>
   );
 }
 

--- a/ui/components/session-state.jsx
+++ b/ui/components/session-state.jsx
@@ -1,0 +1,120 @@
+/* global React */
+// Shared session-state decoder + countdown. ONE source of truth for "what
+// state is this session in, in plain language", consumed by both the
+// sessions list (row chips + filters) and the session detail page (outcome
+// banner + waiting line). Pure: derives only from fields already on the
+// session row returned by GET /sessions. No backend call.
+
+// Known graph/agent ended_detail codes -> human text. Unknown codes are
+// returned verbatim (the log is observability data, not a closed contract).
+const _SS_ENDED_DETAIL = {
+  routing_failed: "a conditional edge matched no branch",
+  max_iterations_exceeded: "hit the iteration cap",
+  node_failed: "a node failed",
+  fanin_upstream_failed: "an upstream branch failed before fan-in",
+  tool_execution_failed: "a tool call failed",
+  any_failed: "a required branch failed",
+  begin_input_invalid: "invalid begin input",
+  template_error: "the End output template failed to render",
+};
+
+function _ssDecodeEndedDetail(code) {
+  if (!code) return null;
+  return _SS_ENDED_DETAIL[code] || String(code);
+}
+
+// parked_event_keys carry a prefix that says what the park is waiting on.
+function _ssWaitingOn(session) {
+  const keys = session.parked_event_keys
+    || (session.parked_event_key ? [session.parked_event_key] : []);
+  for (const k of keys) {
+    if (typeof k !== "string") continue;
+    if (k.startsWith("ask_user:")) return "input";
+    if (k.startsWith("tool_approval:") || k.startsWith("approval:")) return "approval";
+    if (k.startsWith("timer:") || k.startsWith("sleep:")) return "timer";
+    if (k.startsWith("watch:")) return "watch";
+    if (k.startsWith("mcp_task:")) return "task";
+  }
+  return null;
+}
+
+const _SS_WAIT_LABEL = {
+  input: "input", approval: "approval", timer: "a timer",
+  watch: "file changes", task: "a background task",
+};
+
+function describeSessionState(session) {
+  if (!session) return { group: "idle", label: "—", tone: "neutral", detail: null, needsAttention: false, countdownTo: null, waitingOn: null };
+  const status = session.status;
+  const reason = session.ended_reason;
+
+  // Terminal: outcome. Check failure/cancel BEFORE "completed" so an
+  // ended-but-failed (or ended-but-cancelled) row never reads "Completed".
+  // (failed / cancelled may arrive as a status OR only as an ended_reason.)
+  if (status === "failed" || reason === "failed") {
+    return { group: "failed", label: "Failed", tone: "red", detail: _ssDecodeEndedDetail(session.ended_detail), needsAttention: false, countdownTo: null, waitingOn: null };
+  }
+  if (reason === "workspace_lost") {
+    return { group: "failed", label: "Workspace lost", tone: "red", detail: _ssDecodeEndedDetail(session.ended_detail), needsAttention: false, countdownTo: null, waitingOn: null };
+  }
+  if (status === "cancelled" || reason === "cancelled") {
+    return { group: "cancelled", label: "Cancelled", tone: "neutral", detail: null, needsAttention: false, countdownTo: null, waitingOn: null };
+  }
+  if (reason === "force_deleted") {
+    return { group: "cancelled", label: "Force-deleted", tone: "neutral", detail: null, needsAttention: false, countdownTo: null, waitingOn: null };
+  }
+  if (status === "ended" || status === "completed" || reason === "completed") {
+    return { group: "ended", label: "Completed", tone: "green", detail: null, needsAttention: false, countdownTo: null, waitingOn: null };
+  }
+
+  // Parked / waiting.
+  if (session.parked_status === "parked" || status === "waiting") {
+    const waitingOn = _ssWaitingOn(session);
+    return {
+      group: "waiting",
+      label: "Waiting on " + (_SS_WAIT_LABEL[waitingOn] || "an event"),
+      tone: "amber",
+      detail: null,
+      needsAttention: waitingOn === "input" || waitingOn === "approval",
+      countdownTo: session.parked_until || null,
+      waitingOn,
+    };
+  }
+
+  if (status === "paused") {
+    return { group: "waiting", label: "Paused", tone: "amber", detail: null, needsAttention: false, countdownTo: null, waitingOn: null };
+  }
+  if (status === "running") {
+    const turn = session.turn_no != null ? session.turn_no : (session.turn_count != null ? session.turn_count : 0);
+    return { group: "running", label: "Running", tone: "blue", detail: "turn " + turn, needsAttention: false, countdownTo: null, waitingOn: null };
+  }
+  if (status === "created") {
+    return { group: "idle", label: "Awaiting worker", tone: "neutral", detail: null, needsAttention: false, countdownTo: null, waitingOn: null };
+  }
+  return { group: "idle", label: String(status || "—"), tone: "neutral", detail: null, needsAttention: false, countdownTo: null, waitingOn: null };
+}
+
+// Live countdown to an ISO target. Ticks once/sec. null target renders
+// nothing; at/after zero renders "any moment now".
+function SessionCountdown({ to, prefix }) {
+  const [, force] = React.useState(0);
+  React.useEffect(() => {
+    if (!to) return undefined;
+    const id = setInterval(() => force((n) => n + 1), 1000);
+    return () => clearInterval(id);
+  }, [to]);
+  if (!to) return null;
+  const ms = new Date(to).getTime() - Date.now();
+  let text;
+  if (!(ms > 0)) {
+    text = "any moment now";
+  } else {
+    const s = Math.floor(ms / 1000);
+    const m = Math.floor(s / 60);
+    text = m > 0 ? `${m}m ${s % 60}s` : `${s}s`;
+  }
+  return <span className="muted text-sm mono">{(prefix || "") + text}</span>;
+}
+
+window.describeSessionState = describeSessionState;
+window.SessionCountdown = SessionCountdown;

--- a/ui/components/sessions-list.jsx
+++ b/ui/components/sessions-list.jsx
@@ -36,6 +36,8 @@ function SessionsList({ onOpenSession, onNewSession, demoState, filterPreset }) 
   const [sortDir, setSortDir] = React.useState("desc");
   const [selected, setSelected] = React.useState(() => new Set());
   const [page, setPage] = React.useState(1);
+  const [attnOnly, setAttnOnly] = React.useState(false);
+  const [failedOnly, setFailedOnly] = React.useState(false);
 
   // Confirmation modal state. ``confirm`` is { kind, sessions } where
   // ``kind`` is "delete" | "force-delete" | "bulk-delete" and
@@ -69,6 +71,11 @@ function SessionsList({ onOpenSession, onNewSession, demoState, filterPreset }) 
 
   const items = list.data?.items ?? [];
 
+  const attnCount = React.useMemo(
+    () => (items || []).filter((s) => window.describeSessionState(s).needsAttention).length,
+    [items],
+  );
+
   // Apply UI filters client-side.
   const filtered = React.useMemo(() => {
     let arr = items;
@@ -90,8 +97,16 @@ function SessionsList({ onOpenSession, onNewSession, demoState, filterPreset }) 
         ((s.workspace_id || "")).toLowerCase().includes(q)
       );
     }
+    if (attnOnly || failedOnly) {
+      arr = arr.filter((s) => {
+        const st = window.describeSessionState(s);
+        if (attnOnly && !st.needsAttention) return false;
+        if (failedOnly && st.group !== "failed") return false;
+        return true;
+      });
+    }
     return arr;
-  }, [items, statusSet, agentFilter, workspaceFilter, textQuery]);
+  }, [items, statusSet, agentFilter, workspaceFilter, textQuery, attnOnly, failedOnly]);
 
   const sorted = React.useMemo(() => {
     const arr = [...filtered];
@@ -435,10 +450,19 @@ function SessionsList({ onOpenSession, onNewSession, demoState, filterPreset }) 
             <option key={w.id} value={w.id}>{w.id.slice(0, 14)}{w.id.length > 14 ? "…" : ""}</option>
           ))}
         </select>
+        <button type="button" className={"chip" + (attnOnly ? " active" : "")} onClick={() => { setAttnOnly((v) => !v); setPage(1); }}>Needs attention</button>
+        <button type="button" className={"chip" + (failedOnly ? " active" : "")} onClick={() => { setFailedOnly((v) => !v); setPage(1); }}>Failed</button>
         {selected.size > 0 && (
           <Btn size="sm" kind="danger" icon="trash" onClick={_openBulkDeleteConfirm}>Delete {selected.size}</Btn>
         )}
       </div>
+      {attnCount > 0 && (
+        <div style={{ padding: "4px 0 0" }}>
+          <a style={{ cursor: "pointer", color: "var(--amber)", fontSize: 12 }} onClick={() => { setAttnOnly(true); setPage(1); }}>
+            {attnCount} need attention
+          </a>
+        </div>
+      )}
 
       {isMobile ? (
         <CardList
@@ -522,7 +546,17 @@ function SessionsList({ onOpenSession, onNewSession, demoState, filterPreset }) 
                   <td onClick={(e) => { e.stopPropagation(); toggleRow(s.id); }} style={{ width: 36 }}>
                     <input type="checkbox" checked={selected.has(s.id)} onChange={() => toggleRow(s.id)} />
                   </td>
-                  <td><StatusPill status={s.status} /></td>
+                  <td>{(() => {
+                    const st = window.describeSessionState(s);
+                    const cls = st.tone === "green" ? "pill-ended" : st.tone === "red" ? "pill-failed" : st.tone === "amber" ? "pill-paused" : st.tone === "blue" ? "pill-running" : "";
+                    return (
+                      <span className={"pill " + cls} title={st.detail || ""}>
+                        <span className="dot"></span>{st.label}
+                        {st.detail ? <span className="muted" style={{ marginLeft: 4 }}>· {st.detail}</span> : null}
+                        {st.countdownTo ? <window.SessionCountdown to={st.countdownTo} prefix=" · " /> : null}
+                      </span>
+                    );
+                  })()}</td>
                   <td className="mono">{(s.id || "").length > 22 ? (s.id.slice(0, 22) + "…") : s.id}</td>
                   <td className="mono">
                     {isGraph ? (

--- a/ui/index.html
+++ b/ui/index.html
@@ -63,6 +63,7 @@
 
 <!-- Shared components first (Icon/Btn/Modal etc.) + mock data + unused helper -->
 <script type="text/babel" src="components/shared.jsx"></script>
+<script type="text/babel" src="components/session-state.jsx"></script>
 <script type="text/babel" src="components/shared/token-meter.jsx"></script>
 <script type="text/babel" src="components/shared/card-list.jsx"></script>
 <script type="text/babel" src="components/shared/bottom-sheet.jsx"></script>


### PR DESCRIPTION
## Summary

Spec A of the sessions-UX work: make a session's state self-explanatory everywhere — *why it ended, what it's waiting on (with a live countdown), and at-a-glance triage* — from **one shared frontend decoder**, plus let the live-stream panel show a session's **full recorded history** (not just live events), including ended sessions the WebSocket refuses to stream.

Built via brainstorm → spec → plan → subagent-driven execution (a fresh implementer + reviewer per task; final whole-branch review = ready to merge).

## What's in it

- **Shared decoder** `describeSessionState(session)` (`ui/components/session-state.jsx`, window-attached) → `{ group, label, tone, detail, needsAttention, countdownTo, waitingOn }`. Decodes `ended_reason`/`ended_detail` into human text (failure/cancel checked before "completed"; unknown codes shown verbatim) and `parked_event_keys` into a waiting-on target. Plus a `SessionCountdown` component.
- **Backend `GET /v1/sessions/{id}/messages`** — read-only, paginated (`after_seq`/`limit`/`offset`), mirrors `GET /chats/{id}/messages` and reuses the existing JSONL reader. Serves recorded history for **any** status (the WS rejects ended sessions with 4410); missing file / absent workspace → empty 200, never 5xx.
- **Live-stream history + tail** — `SessionLiveStream` loads full history via the new endpoint on mount (so ended sessions show their output), then tails the WS only while live (gated on history-load so the initial connect resumes from the right cursor — no full re-replay; deduped by seq). Terminal sessions read **"Session ended"**, not "connection dropped".
- **Detail surfaces** — a decoded outcome banner for terminal sessions, live countdowns in the ask-user/approval/sleep panels, and a generic waiting line for panel-less parks. Additive (the cannot-run/why-idle banner is untouched).
- **List as a triage board** — each row's chip from the decoder (outcome / waiting-on + countdown / running·turn), "Needs attention" + "Failed" quick filters, and a "N need attention" count.

## Testing

- `tests/ui` + the new messages-route tests: **345 passed, 1 skipped**; bundle transpiles; `ruff check .` clean.
- Backend endpoint: 4 tests incl. the headline "an ENDED session still returns its history".
- **Gated Playwright e2e (ran green, 2/2)** against a fresh docker build of this branch: a cancelled session shows the outcome banner on the detail page and the "Cancelled" chip in the list. (Suite stays default-skipped unless `PRIMER_RUN_UI_E2E=1`.)

## Deferred fast-follows (intentional)

- **Nav count dot** on the Sessions nav item — the plan deferred cross-page state; the in-list "N need attention" count covers the intent.
- **Mobile `CardList` chip** — the decoder chip was added to the desktop table row; the mobile card still shows the raw `StatusPill`. Worth a follow-up for parity.
- A few extra `ended_detail` codes (`end_output_invalid`, `fanout_source_invalid`, `tool_output_invalid`) — the decoder's verbatim fallback already renders them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
