### PR TITLE
feat(harness): export document body as content_inline in outbound build

### DIFF
--- a/primer/harness/outbound.py
+++ b/primer/harness/outbound.py
@@ -176,6 +176,14 @@ async def build_outbound(
             "name": te.template_name,
             "spec": templated,
         }
+        # A Document's body lives in the content store, out-of-band of the
+        # entity model (the spec has no content field). Export it as
+        # ``content_inline`` so the inbound install restores + indexes it;
+        # without this a tracked document ships as an empty shell.
+        if te.kind == "document":
+            body = await storage_provider.get_content_store().get(te.source_id)
+            if body is not None:
+                template_body["content_inline"] = body
         text = yaml.safe_dump(template_body, sort_keys=True)
         template_files.append(
             OutboundFile(

--- a/tests/harness/test_outbound_build.py
+++ b/tests/harness/test_outbound_build.py
@@ -62,6 +62,47 @@ def _make_agent(*, id: str = "ag-bot", harness_id: str | None = None) -> Agent:
 
 
 @pytest.mark.asyncio
+async def test_build_exports_document_content_inline(fake_storage_provider) -> None:
+    """A tracked Document exports its body as ``content_inline`` so the
+    inbound install can restore + index it (the entity spec has no content
+    field; without this the document ships as an empty shell)."""
+    from primer.model.collection import Document
+
+    docs = fake_storage_provider.get_storage(Document)
+    await docs.create(
+        Document(
+            id="doc-1",
+            collection_id="kb",
+            name="python",
+            path="python.md",
+            title="python",
+        )
+    )
+    await fake_storage_provider.get_content_store().upsert(
+        document_id="doc-1",
+        collection_id="kb",
+        path="python.md",
+        content="# Python\nUse EAFP and type hints.",
+    )
+
+    harness = _make_harness(
+        tracked_entities=[
+            TrackedEntity(
+                kind="document", source_id="doc-1", template_name="python-doc"
+            ),
+        ]
+    )
+    result = await build_outbound(harness, storage_provider=fake_storage_provider)
+    text = next(
+        f.rendered_text
+        for f in result.files
+        if f.template_path == "templates/python-doc.yaml"
+    )
+    assert "content_inline:" in text
+    assert "Use EAFP and type hints." in text
+
+
+@pytest.mark.asyncio
 async def test_build_renders_templates_and_schema(
     outbound_harness: Harness, fake_storage_provider
 ) -> None:


### PR DESCRIPTION
## Problem
A tracked `Document` in an outbound harness rendered only its entity *spec* (which has no content field), so the document **body never reached the bundle**. An inbound install then recreated an empty document — knowledge collections shipped as empty shells.

## Fix
In the outbound build loop, for `kind == "document"`, fetch the body from the content store and emit it as top-level `content_inline` on the template. The inbound parser (`template.py`) and installer (`service.py`) **already** support `content_inline` → content store → index, and the push path writes the template's `source_bytes`; this wires the one missing outbound half.

## Why content_inline (not content_path)
The push serialization writes only `(template_path, source_bytes)` — `content_path`/`content_bytes` are unwired on the write side. `content_inline` embeds the body in the template YAML (a block scalar in `source_bytes`), so it flows through the existing write/hash/push + inbound-parse path with no other changes.

## Tests
- New: `test_build_exports_document_content_inline` — a tracked document exports its body as `content_inline`.
- Full `tests/harness/` suite green (139 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)