### PR TITLE
perf(test): speed up the unit suite ~29% (memoize JSX bundle + stub AI-docs ingest)

### DIFF
--- a/primer/api/_jsx_bundle.py
+++ b/primer/api/_jsx_bundle.py
@@ -25,6 +25,7 @@ import hashlib
 import json
 import logging
 import re
+from functools import cache
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -139,12 +140,23 @@ class JSXBundler:
         return etag, body
 
 
+@cache
 def build_jsx_bundle(ui_dir: Path) -> tuple[str, bytes]:
     """One-shot helper used at app startup.
 
     Returns ``("", b"")`` when the UI dir is missing or Babel can't be
     found — the route handler treats an empty body as "no bundle
     available" and returns 404 instead of crashing.
+
+    Memoized on ``ui_dir``: the bundle is a pure function of the UI directory
+    contents, and the ~700 KB Babel/V8 transpile is otherwise recomputed from
+    scratch on every ``create_app()`` and every ``tests/ui`` transpile check
+    (dozens of identical builds per process). The per-``docs_url`` preamble +
+    ETag are applied by the caller after this returns, so caching the raw
+    bundle does not affect docs-url behaviour. Production builds the bundle
+    once at startup, so the cache is invisible there; a process that needs a
+    fresh build (e.g. after editing UI files) can call
+    ``build_jsx_bundle.cache_clear()``.
     """
     if not ui_dir.is_dir():
         return "", b""

--- a/tests/test_internal_collections.py
+++ b/tests/test_internal_collections.py
@@ -11,6 +11,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any
+from unittest.mock import patch
 
 import pytest
 
@@ -185,6 +186,43 @@ class _FakePR:
 # ===========================================================================
 # Fixtures
 # ===========================================================================
+
+
+@pytest.fixture(autouse=True)
+def _stub_ingest_ai_docs(request):
+    """Stub bootstrap()'s AI-docs ingest to a no-op.
+
+    bootstrap() defaults to the production DocumentIngester (Docling + the
+    sentence-transformers OCR stack) walking ~30 real markdown files, which
+    costs 7-10s per call and dominated this file's runtime. No bootstrap-path
+    test asserts the doc-walk output, so stub it out — exactly as
+    tests/api/test_internal_collections.py already does.
+
+    TestAiDocsBootstrap exercises the real ingest seam directly with a fast
+    in-test ingester_factory, so it must run un-stubbed — EXCEPT
+    test_materialise_creates_ai_docs_collection_row, which calls bootstrap()
+    (and only asserts the collection row), so it keeps the stub.
+    """
+    cls = request.cls
+    real_ingest = (
+        cls is not None
+        and cls.__name__ == "TestAiDocsBootstrap"
+        and request.function.__name__
+        != "test_materialise_creates_ai_docs_collection_row"
+    )
+    if real_ingest:
+        yield
+        return
+
+    async def _noop(self, emit, counts, **kwargs):
+        counts["docs"] = 0
+        return 0
+
+    with patch(
+        "primer.internal_collections.InternalCollectionsSubsystem._ingest_ai_docs",
+        new=_noop,
+    ):
+        yield
 
 
 @pytest.fixture


### PR DESCRIPTION
## Speed up the unit suite (~29% faster)

Profiling the narrowed unit sweep (`--durations`) showed the time was concentrated in **two repeated expensive computations**, not spread across redundant tests. This PR fixes both. Net: the full `make test` sweep drops from **~160s to ~114s at `-n4`** (5327 passed, **zero** test-count change), with larger CPU savings (~165s) under the project's CPU-cap constraint.

### 1. Memoize `build_jsx_bundle` (`perf(test): memoize…`)
`build_jsx_bundle(ui_dir)` is a pure function of the UI directory, but the ~700KB Babel/V8 transpile was recomputed on **every `create_app()`** and **every `tests/ui/*::test_bundle_transpiles`** — dozens of byte-identical builds per process. `functools.cache` it.
- `tests/api/test_runtime_modes.py`: **~30s → ~4s** (these weren't slow because of app startup — that's ~150ms — but the bundle build inside `create_app`).
- Also speeds the bootstrap/observability lifespan boot tests and the whole `tests/ui` transpile suite.
- The per-`docs_url` preamble + ETag are applied by the caller *after* this returns, so `test_docs_url_surface` stays green; production builds once at startup, so the cache is invisible there.

### 2. Stub the AI-docs ingest in `tests/test_internal_collections.py` (`perf(test): stub…`)
`bootstrap()` defaults to the production `DocumentIngester` (Docling + sentence-transformers OCR) walking ~30 real markdown files — **7–10s per call**, ~13 bootstrap-path tests, **~100s total**. The API-layer sibling already stubs this; this file was the one place that didn't. Stub `_ingest_ai_docs` to a no-op (no bootstrap-path test asserts the doc-walk output).
- `tests/test_internal_collections.py`: **~100s → ~12s**.
- `TestAiDocsBootstrap` keeps the **real** ingest seam (it uses a fast in-test `ingester_factory`) — un-stubbed, so the doc-walk/frontmatter/content-hash behaviour stays fully covered.

### On *deleting* tests
There's little true duplication to shed — same-named files across dirs are distinct modules, and the app-boot tests each guard a different startup branch. The wins are these two targeted optimizations, not removals. Verified: same pass count (5327), ruff clean.
