### PR TITLE
fix(llm): abort the SDK stream on every exit path (frees backend slot)

### DIFF
--- a/primer/llm/openresponses.py
+++ b/primer/llm/openresponses.py
@@ -1014,6 +1014,25 @@ class OpenResponsesLLM(LLM):
                             message=err.message,
                         )
                         return
+                    finally:
+                        # Abort the upstream generation so a stalled, cancelled, or
+                        # errored stream releases the backend slot promptly. On a
+                        # max_concurrency:1 backend an unclosed SDK stream leaves the
+                        # HTTP request open and the model keeps generating, which
+                        # blocks every subsequent request behind it -- the root cause
+                        # of compounding stalls. Runs on every exit path (timeout
+                        # raise, error return, normal completion, and GeneratorExit
+                        # when the consumer cancels mid-stream).
+                        try:
+                            _closer = getattr(sdk_stream, "aclose", None) or getattr(
+                                sdk_stream, "close", None
+                            )
+                            if _closer is not None:
+                                _res = _closer()
+                                if hasattr(_res, "__await__"):
+                                    await _res
+                        except Exception:
+                            pass
                     _span.set_attribute("llm.usage.tokens_in", tokens_in)
                     _span.set_attribute("llm.usage.tokens_out", tokens_out)
                     _metrics.llm_tokens_total.labels(_provider_kind, "in").inc(tokens_in)

--- a/tests/llm/test_openresponses.py
+++ b/tests/llm/test_openresponses.py
@@ -1022,6 +1022,32 @@ def _patched_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
     return mock_instance
 
 
+class _RecordingStream:
+    """Fake SDK stream that records whether it was closed; can stall forever.
+
+    Used to assert the adapter aborts the upstream generation (frees the
+    backend slot) on every exit path.
+    """
+
+    def __init__(self, events: Any, *, stall: bool = False) -> None:
+        self._events = list(events)
+        self._stall = stall
+        self.closed = False
+
+    def __aiter__(self) -> "_RecordingStream":
+        return self
+
+    async def __anext__(self) -> Any:
+        if self._stall:
+            await asyncio.sleep(3600)
+        if not self._events:
+            raise StopAsyncIteration
+        return self._events.pop(0)
+
+    async def close(self) -> None:
+        self.closed = True
+
+
 class TestStream:
     async def test_unknown_model_raises_model_not_found(self) -> None:
         provider = _make_provider(models=["gpt-4o-mini"])
@@ -1032,6 +1058,46 @@ class TestStream:
                 messages=[Message(role="user", parts=[TextPart(text="hi")])],
             ):
                 pass
+
+    async def test_stream_closed_on_normal_completion(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _make_provider()
+        llm = OpenResponsesLLM(provider)
+        client = _patched_client(monkeypatch)
+        fake = _RecordingStream(
+            [
+                NS(type="response.created", response=NS(id="r", model="gpt-4o-mini")),
+                NS(type="response.completed", response=NS(usage=None)),
+            ]
+        )
+        client.responses.create.return_value = fake
+        async for _ in llm.stream(
+            model="gpt-4o-mini",
+            messages=[Message(role="user", parts=[TextPart(text="hi")])],
+        ):
+            pass
+        assert fake.closed is True
+
+    async def test_stream_closed_on_stall_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        provider = _make_provider()
+        llm = OpenResponsesLLM(provider)
+        llm._request_timeout_seconds = 0.05  # fail fast for the test
+        client = _patched_client(monkeypatch)
+        fake = _RecordingStream([], stall=True)
+        client.responses.create.return_value = fake
+        with pytest.raises(ProviderTimeoutError):
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+        # Stalled stream must still be aborted so the backend slot is freed.
+        assert fake.closed is True
 
     async def test_full_stream_emits_start_text_done(
         self, monkeypatch: pytest.MonkeyPatch


### PR DESCRIPTION
## Root cause
The OpenResponses adapter (`stream()`) opens the streaming response (`sdk_stream = await client.responses.create(...)`) and iterates it, but on **timeout, error, or mid-stream cancellation** it raises/returns **without ever closing `sdk_stream`** — only a normally-drained stream gets cleaned up.

On a **`max_concurrency:1` backend** (a single LM Studio instance) this is the root cause of the recurring "stuck stream" hangs:
1. A generation stalls (model stops emitting). The per-event timeout will eventually fire after `request_timeout_seconds` (300s by default).
2. But because the abandoned stream is never closed, the HTTP request to the model stays open and **the model keeps generating on its one slot**.
3. Every subsequent request acquires Primer's freed rate-limit slot, hits a still-busy backend, and **stalls behind the abandoned generation** → another full timeout → another abandoned generation. The hangs **compound** (observed as 3–4 consecutive 5-minute stalls, with cancels not helping).

## Fix
Wrap the stream loop in a `finally` that aborts the upstream generation (`aclose`/`close`, whichever the SDK exposes) on **all** exit paths: timeout raise, error return, normal completion, and `GeneratorExit` when the consumer cancels mid-stream. Closing the SDK stream tears down the HTTP request, which tells the backend to stop generating and frees its slot immediately.

## Tests
- `test_stream_closed_on_normal_completion` — stream closed after a normal run.
- `test_stream_closed_on_stall_timeout` — a stalling stream still raises `ProviderTimeoutError` **and** is closed (slot freed).
- Full `tests/llm/` adapter + timeout suites green (123 passed); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)