### PR TITLE
test(e2e): fix the 2 e2e failures surfaced by the first main run

### DIFF
--- a/tests/_support/runs.py
+++ b/tests/_support/runs.py
@@ -219,3 +219,32 @@ async def wait_terminal(
                 return last
         await asyncio.sleep(interval_s)
     return last
+
+
+async def wait_turn_advanced(
+    client: httpx.AsyncClient,
+    session_id: str,
+    *,
+    min_turn_no: int = 0,
+    timeout_s: float = 10.0,
+    interval_s: float = 0.25,
+) -> dict:
+    """Poll until the session's ``turn_no`` exceeds ``min_turn_no``.
+
+    ``turn_no`` is bumped by the claim engine's ``on_release`` hook, which
+    commits in a transaction landing just AFTER the terminal-status write — so
+    a freshly-completed session can momentarily read ``status=ended`` with
+    ``turn_no`` not yet incremented. Use this (after :func:`wait_terminal`)
+    when asserting a turn actually ran, to avoid a read-after-write race.
+    Returns the latest row seen (caller asserts on it).
+    """
+    iters = max(1, int(timeout_s / interval_s))
+    last: dict = {}
+    for _ in range(iters):
+        resp = await client.get(f"/v1/sessions/{session_id}")
+        if resp.status_code == 200:
+            last = resp.json()
+            if last.get("turn_no", 0) > min_turn_no:
+                return last
+        await asyncio.sleep(interval_s)
+    return last

--- a/tests/e2e/test_session_invoke_graph_journey.py
+++ b/tests/e2e/test_session_invoke_graph_journey.py
@@ -56,6 +56,7 @@ from tests._support.runs import (
     make_scripted_agent,
     start_agent_session,
     wait_terminal,
+    wait_turn_advanced,
 )
 
 
@@ -147,9 +148,13 @@ async def test_session_invoke_graph_runs_child_graph_to_completion(
             f"tool plumb-back errored: {final!r}"
         )
         # The agent ran at least one full turn (the invoke_graph call + the
-        # continuation that emitted the final reply).
-        assert final.get("turn_no", 0) > 0, (
-            f"invoke_graph session ran zero turns: {final!r}"
+        # continuation that emitted the final reply). turn_no is bumped by the
+        # claim engine's on_release in a transaction that commits just after
+        # the ENDED write, so the terminal snapshot can still read turn_no=0 —
+        # re-poll until the counter settles to avoid a read-after-write race.
+        settled = await wait_turn_advanced(client, session_id, min_turn_no=0)
+        assert settled.get("turn_no", 0) > 0, (
+            f"invoke_graph session ran zero turns: {settled!r}"
         )
         # Strong, non-vacuous signal: invoke_graph nests the invoked graph's
         # state under the session as a ``<gsid>__invoke_<tcid>`` subtree on the

--- a/tests/ui_e2e/test_console_loads.py
+++ b/tests/ui_e2e/test_console_loads.py
@@ -78,6 +78,11 @@ def test_route_renders_with_zero_console_errors(
     real_failures = [
         r for r in failed_requests
         if not any(re.search(p, r["url"]) for p in by_design_404_patterns)
+        # net::ERR_ABORTED is a fetch cancelled by navigation / useResource
+        # cleanup (a route change aborts the prior route's in-flight mount
+        # fetches). It is harmless (the conftest documents it as such), not a
+        # server/route failure — exclude it so route timing doesn't flake this.
+        and "ERR_ABORTED" not in (r.get("failure") or "")
     ]
     assert not real_failures, (
         "Unexpected fetch failures on route nav:\n"


### PR DESCRIPTION
## Fix the 2 e2e failures the main run surfaced

The first full e2e run on `main` (all prior fixes merged) left exactly two failures — both **new**, neither among the original 7. This fixes both.

### 1. `test_route_renders_with_zero_console_errors[/sessions]` (ui-e2e)
The route's failure assertion flagged `net::ERR_ABORTED` entries (the sessions/workspaces/workers/find mount fetches), which are **navigation/cleanup cancellations** when the test changes routes after `/console/` already loaded — harmless (the conftest documents them as such), not server failures. The by-design `internal_collections/config` 404 was already handled; this adds an `ERR_ABORTED` exclusion to `real_failures`. **Verified green on a live stack (14/14 routes).**

### 2. `test_session_invoke_graph` "ran zero turns" (e2e)
A read-after-write race in the **test**, not a product bug (the child graph runs fine). `turn_no` is bumped by the claim engine's `on_release` in a transaction that commits just **after** the `status=ENDED` write, so `wait_terminal` (returns on `status=="ended"`) can snapshot `turn_no=0`. Added a `wait_turn_advanced` helper (mirrors `wait_terminal`) and re-poll until the counter settles before asserting. This is why it recurred deterministically rather than flaking randomly.

The other flake I'd flagged (`approvals`) did **not** recur on the main run → confirmed flaky, left as-is.

### Note (optional follow-up, not done here)
The invoke_graph race has a product-side smell: the ENDED status write and the `turn_no` bump aren't atomic, so any reader polling a just-completed session can briefly see `turn_no=0`. Making `_transition_session_status(ENDED)` also bump the counter would remove the race for all readers — but it touches the claim engine's park/turn accounting and deserves its own review, so it's left out of this test-only PR.
