### PR TITLE
feat(agent): per-agent max_output_tokens cap

### DIFF
--- a/primer/agent/loop.py
+++ b/primer/agent/loop.py
@@ -109,6 +109,7 @@ async def run_agent_turn(
             model=llm_model.name,
             messages=prompt,
             temperature=agent.temperature,
+            max_output_tokens=agent.max_output_tokens,
             response_format=response_format,
             tools=tools,
             tool_choice="auto",

--- a/primer/agent/workspace_executor.py
+++ b/primer/agent/workspace_executor.py
@@ -76,6 +76,7 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
             description=agent.description,
             model=agent.model,
             temperature=agent.temperature,
+            max_output_tokens=agent.max_output_tokens,
             tools=list(agent.tools),
             system_prompt=composite_system_prompt,
             compaction_prompt=list(agent.compaction_prompt),

--- a/primer/model/agent.py
+++ b/primer/model/agent.py
@@ -120,6 +120,17 @@ class Agent(Describeable):
             "the turn is force-stopped. None means unbounded."
         ),
     )
+    max_output_tokens: PositiveInt | None = Field(
+        default=None,
+        description=(
+            "Hard cap on the tokens the model may generate in a single "
+            "turn. ``None`` (default) defers to the adapter / model-server "
+            "default, which is often unbounded. Set this to bound runaway "
+            "or looping generations -- e.g. an agent that rambles on a "
+            "list-shaped input and never stops emitting tokens, which on a "
+            "single-slot backend reads as a multi-minute hang."
+        ),
+    )
     tools: list[str] = Field(
         default_factory=list,
         description=(

--- a/tests/agent/test_executor.py
+++ b/tests/agent/test_executor.py
@@ -194,11 +194,13 @@ def _agent(
     *,
     system_prompt: list[str] | None = None,
     compaction_prompt: list[str] | None = None,
+    max_output_tokens: int | None = None,
 ) -> Agent:
     return Agent(
         id="researcher",
         description="Research agent",
         model=AgentModel(provider_id="openai-1", model_name="gpt-4o-mini"),
+        max_output_tokens=max_output_tokens,
         system_prompt=list(system_prompt or []),
         compaction_prompt=list(compaction_prompt or []),
     )
@@ -224,6 +226,7 @@ async def _build_executor(
     compaction: CompactionStrategy | None = None,
     system_prompt: list[str] | None = None,
     tools: list[Tool] | None = None,
+    max_output_tokens: int | None = None,
 ) -> tuple[
     AgentExecutor,
     _InMemoryStorage[Thread],
@@ -239,7 +242,9 @@ async def _build_executor(
     if tools is None:
         tools = [_tool()]
 
-    agent = _agent(system_prompt=system_prompt)
+    agent = _agent(
+        system_prompt=system_prompt, max_output_tokens=max_output_tokens
+    )
     thread_storage: _InMemoryStorage[Thread] = _InMemoryStorage(Thread)
     message_storage: _InMemoryStorage[ThreadMessage] = _InMemoryStorage(ThreadMessage)
     thread = await AgentExecutor.open_thread(
@@ -264,6 +269,34 @@ async def _build_executor(
 
 async def _drain(it: AsyncIterator[StreamEvent]) -> list[StreamEvent]:
     return [ev async for ev in it]
+
+
+class TestMaxOutputTokens:
+    @pytest.mark.asyncio
+    async def test_agent_max_output_tokens_passed_to_stream(self) -> None:
+        llm = _FakeLLM(
+            scripts=[
+                [TextDelta(text="ok", index=0), Done(stop_reason="stop", raw_reason="stop")]
+            ]
+        )
+        executor, _, _, _ = await _build_executor(llm=llm, max_output_tokens=321)
+        await _drain(
+            executor.invoke([Message(role="user", parts=[TextPart(text="hi")])])
+        )
+        assert llm.calls and llm.calls[0]["max_output_tokens"] == 321
+
+    @pytest.mark.asyncio
+    async def test_agent_max_output_tokens_defaults_to_none(self) -> None:
+        llm = _FakeLLM(
+            scripts=[
+                [TextDelta(text="ok", index=0), Done(stop_reason="stop", raw_reason="stop")]
+            ]
+        )
+        executor, _, _, _ = await _build_executor(llm=llm)
+        await _drain(
+            executor.invoke([Message(role="user", parts=[TextPart(text="hi")])])
+        )
+        assert llm.calls and llm.calls[0]["max_output_tokens"] is None
 
 
 # ===========================================================================


### PR DESCRIPTION
Add Agent.max_output_tokens (default None) and pass it to llm.stream() from the loop + workspace_executor composite agent, so agents can bound runaway/looping generations that read as multi-minute hangs on a single-slot backend (tokens flow, so the inactivity timeout doesn't fire). Base LLM.stream already accepts the param. Tests: 2 new (passed/default) + tests/agent/test_executor.py green (14); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)