### PR TITLE
fix(openresponses): time out post-slot stream open, not queue wait

### DIFF
--- a/primer/llm/openresponses.py
+++ b/primer/llm/openresponses.py
@@ -956,7 +956,34 @@ class OpenResponsesLLM(LLM):
                 ):
                     client = self._get_client()
                     try:
-                        sdk_stream = await client.responses.create(**request)
+                        # Post-slot timeout ONLY. The queue wait above
+                        # (rate_limiter.acquire) is intentionally untimed: blocking
+                        # on a busy concurrency slot is normal backpressure, not
+                        # unavailability, so it waits as long as it takes for a slot
+                        # to free. But once we HOLD a slot, the upstream must begin
+                        # responding within the budget -- a connect/open that never
+                        # returns (the per-event stream timeout below can't catch
+                        # this, because we never reach the stream) is unavailability.
+                        async with asyncio.timeout(self._request_timeout_seconds):
+                            sdk_stream = await client.responses.create(**request)
+                    except TimeoutError as exc:
+                        from primer.model.except_ import ProviderTimeoutError
+                        timeout_val = self._request_timeout_seconds
+                        logger.error(
+                            "OpenResponses upstream did not begin responding within "
+                            "%.1f s after acquiring a concurrency slot",
+                            timeout_val,
+                            extra={
+                                "provider_id": self._provider.id,
+                                "model": model,
+                            },
+                        )
+                        raise ProviderTimeoutError(
+                            "OpenResponses upstream did not begin responding within "
+                            f"{timeout_val} s after acquiring a concurrency slot "
+                            f"(provider_id={self._provider.id!r}, model={model!r})",
+                            code="connect_timeout",
+                        ) from exc
                     except Exception as exc:
                         err = classify_openai_exception(exc)
                         logger.error(

--- a/tests/llm/test_openresponses.py
+++ b/tests/llm/test_openresponses.py
@@ -1099,6 +1099,30 @@ class TestStream:
         # Stalled stream must still be aborted so the backend slot is freed.
         assert fake.closed is True
 
+    async def test_create_timeout_after_slot_is_unavailability(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        # Once a concurrency slot is held, an upstream that never starts
+        # responding (create/open hangs) is unavailability, not queue time:
+        # it must time out as ProviderTimeoutError rather than hang forever.
+        from primer.model.except_ import ProviderTimeoutError
+
+        provider = _make_provider()
+        llm = OpenResponsesLLM(provider)
+        llm._request_timeout_seconds = 0.05  # tiny: fail fast post-slot
+        client = _patched_client(monkeypatch)
+
+        async def _stalling_create(**kwargs: Any) -> Any:
+            await asyncio.sleep(3600)
+
+        client.responses.create = _stalling_create
+        with pytest.raises(ProviderTimeoutError):
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
     async def test_full_stream_emits_start_text_done(
         self, monkeypatch: pytest.MonkeyPatch
     ) -> None:


### PR DESCRIPTION
## Problem
The per-event stream timeout (`_iter_with_timeout`) only covers iterating an **already-open** stream. The provider call has two earlier stages:
1. **Queue wait** — `rate_limiter.acquire(...)` blocks until a concurrency slot frees.
2. **Stream open** — `client.responses.create(...)` once a slot is held.

Stage 2 had **no timeout**. So when a slot is held but the upstream never starts responding (busy/wedged backend, e.g. a generation abandoned by a hard restart still occupying `max_concurrency:1`), `create()` hangs **indefinitely** — and the per-event timeout never fires because the stream never opens. Observed as a graph node stuck "running" for 200s+ with zero timeouts logged.

## Design (per maintainer guidance)
- **Queue time is not unavailability.** Waiting on a busy concurrency slot is normal backpressure and must wait as long as needed — `acquire()` stays **untimed**.
- **Once you hold a slot**, the upstream must actually begin responding within the budget. A held-slot connect/open that never returns **is** unavailability and should time out.

## Fix
Wrap **only** `create()` (which already sits inside the acquired-slot `async with`) in `asyncio.timeout(request_timeout_seconds)`, and surface the resulting `TimeoutError` as `ProviderTimeoutError(code='connect_timeout')` — distinct from the existing per-event `stream_timeout`. `acquire()` is left untouched, so queue time is unaffected.

## Tests
- `test_create_timeout_after_slot_is_unavailability` — a stalling `create()` raises `ProviderTimeoutError` instead of hanging.
- `tests/llm/test_openresponses.py` green (109); ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)