### PR TITLE
fix(sessions): serialize resume/pause/cancel — fix T0432 stuck-RUNNING race

### DIFF
--- a/primer/api/routers/sessions.py
+++ b/primer/api/routers/sessions.py
@@ -37,6 +37,7 @@ from primer.api.errors import common_responses
 from primer.observability import tracing as _tracing
 import primer.observability.metrics as _metrics
 from primer.api.pagination import FindRequest, parse_order_by, parse_page
+from primer.session.mutation_lock import session_lifecycle_lock
 from primer.model.except_ import (
     ConflictError,
     NotFoundError,
@@ -178,31 +179,37 @@ async def resume_session(
       the scheduler.
     * 409 when the session is ENDED.
     """
-    s = await sessions.get(session_id)
-    if s is None or s.workspace_id != workspace_id:
-        raise NotFoundError(
-            f"Session {session_id!r} does not exist on workspace "
-            f"{workspace_id!r}"
+    # Serialize against a concurrent cancel/pause on the same session: the
+    # status read-modify-write and the lease upsert must not interleave with
+    # a cancel's ENDED write + delete_lease, or the row can land RUNNING with
+    # no lease — a stuck session no worker can claim (T0432). See
+    # primer.session.mutation_lock.
+    async with session_lifecycle_lock().acquire(session_id):
+        s = await sessions.get(session_id)
+        if s is None or s.workspace_id != workspace_id:
+            raise NotFoundError(
+                f"Session {session_id!r} does not exist on workspace "
+                f"{workspace_id!r}"
+            )
+        if s.status == SessionStatus.ENDED:
+            raise ConflictError(f"Session {session_id!r} has ended")
+        if s.status == SessionStatus.RUNNING:
+            return s  # idempotent no-op
+        if s.status in _RESUMABLE:
+            s.status = SessionStatus.RUNNING
+            if s.started_at is None:
+                s.started_at = datetime.now(timezone.utc)
+            s.pause_requested = False
+            await sessions.update(s)
+            await scheduler.enqueue(session_id)
+            # Notify the ClaimEngine (forward-compat; no-op when not wired).
+            if engine is not None:
+                from primer.int.claim import ClaimKind
+                await engine.upsert(ClaimKind.SESSION, session_id)
+            return s
+        raise ConflictError(
+            f"Session {session_id!r} cannot resume from status {s.status.value}"
         )
-    if s.status == SessionStatus.ENDED:
-        raise ConflictError(f"Session {session_id!r} has ended")
-    if s.status == SessionStatus.RUNNING:
-        return s  # idempotent no-op
-    if s.status in _RESUMABLE:
-        s.status = SessionStatus.RUNNING
-        if s.started_at is None:
-            s.started_at = datetime.now(timezone.utc)
-        s.pause_requested = False
-        await sessions.update(s)
-        await scheduler.enqueue(session_id)
-        # Notify the ClaimEngine (forward-compat; no-op when not wired).
-        if engine is not None:
-            from primer.int.claim import ClaimKind
-            await engine.upsert(ClaimKind.SESSION, session_id)
-        return s
-    raise ConflictError(
-        f"Session {session_id!r} cannot resume from status {s.status.value}"
-    )
 
 
 @nested_session_router.post(
@@ -225,20 +232,24 @@ async def pause_session(
       transition the row itself.
     * 409 when the session is already ENDED.
     """
-    s = await sessions.get(session_id)
-    if s is None or s.workspace_id != workspace_id:
-        raise NotFoundError(
-            f"Session {session_id!r} does not exist on workspace "
-            f"{workspace_id!r}"
-        )
-    if s.status == SessionStatus.ENDED:
-        raise ConflictError(f"Session {session_id!r} has ended")
-    if s.status in {SessionStatus.WAITING, SessionStatus.CREATED}:
-        s.status = SessionStatus.PAUSED
+    # Serialize against a concurrent resume/cancel on the same session so the
+    # PAUSED write is not clobbered (and does not clobber) a racing
+    # transition. See primer.session.mutation_lock / T0432.
+    async with session_lifecycle_lock().acquire(session_id):
+        s = await sessions.get(session_id)
+        if s is None or s.workspace_id != workspace_id:
+            raise NotFoundError(
+                f"Session {session_id!r} does not exist on workspace "
+                f"{workspace_id!r}"
+            )
+        if s.status == SessionStatus.ENDED:
+            raise ConflictError(f"Session {session_id!r} has ended")
+        if s.status in {SessionStatus.WAITING, SessionStatus.CREATED}:
+            s.status = SessionStatus.PAUSED
+            await sessions.update(s)
+            return
+        s.pause_requested = True
         await sessions.update(s)
-        return
-    s.pause_requested = True
-    await sessions.update(s)
 
 
 @nested_session_router.post(

--- a/primer/session/mutation_lock.py
+++ b/primer/session/mutation_lock.py
@@ -1,0 +1,83 @@
+"""Per-session serialization of lifecycle transitions.
+
+``resume`` / ``pause`` / ``cancel`` each do a non-atomic
+read-modify-write of the session row (a full-blob ``Storage.update``)
+*and* an independent claim-lease mutation (``engine.upsert`` /
+``engine.delete_lease``). Run concurrently against the same session they
+lost-update each other: e.g. a ``resume`` racing a ``cancel`` on a
+freshly-created (``auto_start=False``) session can land the row on
+``RUNNING`` (resume's write wins) while the lease is dropped (cancel's
+``delete_lease`` wins). The in-memory claim engine only ever claims rows
+that have a lease (``claim_due`` walks ``self._leases``), so a
+``RUNNING`` row with no lease is invisible to every worker forever — it
+never converges to a terminal state. That is the T0432 stuck-RUNNING
+fingerprint (``status=running, turn_no=0, cancel_requested=False``).
+
+The fix is mutual exclusion: serialize the conflicting transitions per
+session so whichever lands first is fully observed by the next. The API,
+the in-memory claim engine, and the worker pool all run inside one
+process (see :mod:`primer.api._app_lifespan`), so a process-local
+``asyncio`` lock is a sufficient and complete serialization point for
+this race. The Postgres/distributed lane does not share this engine and
+gates claims through its query-driven eligibility instead.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from contextlib import asynccontextmanager
+
+__all__ = ["KeyedLock", "session_lifecycle_lock"]
+
+
+class KeyedLock:
+    """Async locks keyed by string, with reference-counted cleanup.
+
+    Coroutines sharing a ``key`` are serialized; distinct keys never
+    contend. The lock object is created on first use and dropped once its
+    last holder releases, so a long-lived process does not leak one lock
+    per key ever seen.
+
+    Single-event-loop only (the concurrency model inside a uvicorn
+    worker). The dict bookkeeping runs synchronously between ``await``
+    points, so no guard lock is needed; the per-key ``asyncio.Lock`` binds
+    lazily to the running loop on first ``await`` and is gone before the
+    next loop could touch it.
+    """
+
+    def __init__(self) -> None:
+        self._locks: dict[str, asyncio.Lock] = {}
+        self._refs: dict[str, int] = {}
+
+    @asynccontextmanager
+    async def acquire(self, key: str) -> AsyncIterator[None]:
+        lock = self._locks.get(key)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[key] = lock
+        # Bump the refcount BEFORE awaiting the lock so a holder that is
+        # mid-release does not drop the shared lock object out from under a
+        # coroutine that is about to wait on it. Both bookkeeping spans run
+        # with no intervening await, so they are atomic on this loop.
+        self._refs[key] = self._refs.get(key, 0) + 1
+        try:
+            async with lock:
+                yield
+        finally:
+            self._refs[key] -= 1
+            if self._refs[key] == 0:
+                self._refs.pop(key, None)
+                self._locks.pop(key, None)
+
+
+# Process-wide lock guarding session lifecycle transitions. resume / pause /
+# cancel acquire it on the session id before reading-and-writing the row +
+# its claim lease, so two concurrent control-plane calls cannot interleave
+# into a stuck RUNNING-without-lease orphan. See T0432 / the module docstring.
+_SESSION_LIFECYCLE_LOCK = KeyedLock()
+
+
+def session_lifecycle_lock() -> KeyedLock:
+    """Return the process-wide session-lifecycle :class:`KeyedLock`."""
+    return _SESSION_LIFECYCLE_LOCK

--- a/primer/workspace/session_factory.py
+++ b/primer/workspace/session_factory.py
@@ -45,6 +45,7 @@ from primer.model.except_ import (
 )
 from primer.model.graph import Graph
 from primer.model.workspace import Workspace as WorkspaceRow
+from primer.session.mutation_lock import session_lifecycle_lock
 from primer.model.workspace_session import (
     AgentBinding as OnDiskAgentBinding,
 )
@@ -423,54 +424,62 @@ async def cancel_session(
     """
     sessions = deps.storage_provider.get_storage(WorkspaceSession)
 
-    s = await sessions.get(session_id)
-    if s is None or s.workspace_id != workspace_id:
-        raise NotFoundError(
-            f"Session {session_id!r} does not exist on workspace "
-            f"{workspace_id!r}"
-        )
-    if s.status == SessionStatus.ENDED:
-        raise ConflictError(f"Session {session_id!r} has ended")
-    if s.status in {
-        SessionStatus.CREATED,
-        SessionStatus.WAITING,
-        SessionStatus.PAUSED,
-    }:
-        s.status = SessionStatus.ENDED
-        s.ended_reason = "cancelled"
-        s.ended_at = datetime.now(timezone.utc)
-        await sessions.update(s)
-        # Mirror onto the on-disk slot so workspace-side reads agree (no
-        # worker runs for an inline-cancelled session, so nothing else
-        # would update session.json).
-        await _mirror_inline_cancel_to_slot(
-            workspace_id=workspace_id, session_id=session_id, deps=deps,
-        )
-        # Drop the lease -- session is gone, no point claiming it.
-        if deps.claim_engine is not None:
-            await deps.claim_engine.delete_lease(ClaimKind.SESSION, session_id)
-        return s
-    now = datetime.now(timezone.utc)
-    s.cancel_requested = True
-    s.cancel_requested_at = now
-    await sessions.update(s)
-    # Publish on the bus so the engine-path worker's _cancel_watcher
-    # preempts the running turn. The WS interrupt handler publishes the
-    # same key.
-    if deps.event_bus is not None:
-        try:
-            await deps.event_bus.publish(f"session:{session_id}:cancel", {})
-        except Exception as exc:  # noqa: BLE001
-            logger.warning(
-                "cancel_session: event_bus.publish failed "
-                "(legacy path still signalled)",
-                extra={
-                    "session_id": session_id,
-                    "exception": type(exc).__name__,
-                },
+    # Serialize the whole read-modify-write (+ lease mutation) against a
+    # concurrent resume/pause on the same session. Without this, a resume
+    # racing this cancel can clobber the ENDED write back to RUNNING while
+    # this branch drops the lease, leaving a RUNNING row no worker can
+    # claim (T0432). See primer.session.mutation_lock.
+    async with session_lifecycle_lock().acquire(session_id):
+        s = await sessions.get(session_id)
+        if s is None or s.workspace_id != workspace_id:
+            raise NotFoundError(
+                f"Session {session_id!r} does not exist on workspace "
+                f"{workspace_id!r}"
             )
-    await deps.scheduler.signal_cancel(session_id)
-    return s
+        if s.status == SessionStatus.ENDED:
+            raise ConflictError(f"Session {session_id!r} has ended")
+        if s.status in {
+            SessionStatus.CREATED,
+            SessionStatus.WAITING,
+            SessionStatus.PAUSED,
+        }:
+            s.status = SessionStatus.ENDED
+            s.ended_reason = "cancelled"
+            s.ended_at = datetime.now(timezone.utc)
+            await sessions.update(s)
+            # Mirror onto the on-disk slot so workspace-side reads agree (no
+            # worker runs for an inline-cancelled session, so nothing else
+            # would update session.json).
+            await _mirror_inline_cancel_to_slot(
+                workspace_id=workspace_id, session_id=session_id, deps=deps,
+            )
+            # Drop the lease -- session is gone, no point claiming it.
+            if deps.claim_engine is not None:
+                await deps.claim_engine.delete_lease(
+                    ClaimKind.SESSION, session_id
+                )
+            return s
+        now = datetime.now(timezone.utc)
+        s.cancel_requested = True
+        s.cancel_requested_at = now
+        await sessions.update(s)
+        # Publish on the bus so the engine-path worker's _cancel_watcher
+        # preempts the running turn. The WS interrupt handler publishes the
+        # same key.
+        if deps.event_bus is not None:
+            try:
+                await deps.event_bus.publish(f"session:{session_id}:cancel", {})
+            except Exception as exc:  # noqa: BLE001
+                logger.warning(
+                    "cancel_session: event_bus.publish failed "
+                    "(legacy path still signalled)",
+                    extra={
+                        "session_id": session_id,
+                        "exception": type(exc).__name__,
+                    },
+                )
+        await deps.scheduler.signal_cancel(session_id)
+        return s
 
 
 __all__ = [

--- a/tests/session/test_lifecycle_race.py
+++ b/tests/session/test_lifecycle_race.py
@@ -1,0 +1,214 @@
+"""T0432 regression: a resume racing a cancel must not strand a session.
+
+The bug: ``resume`` and ``cancel`` each do a non-atomic read-modify-write of
+the session row plus an independent claim-lease mutation. Run concurrently on
+a freshly-created (``auto_start=False``) session they lost-update each other —
+one interleaving lands ``status=RUNNING`` (resume's write wins) with the lease
+dropped (cancel's ``delete_lease`` wins). The in-memory claim engine only ever
+claims rows that hold a lease, so that row never converges: stuck RUNNING,
+``turn_no=0``, ``cancel_requested=False``.
+
+These tests drive the REAL ``resume_session`` (api router) and
+``cancel_session`` (workspace factory) handlers against a shared real
+``InMemoryClaimEngine``, and pin the serialization contract the fix
+restores: while one lifecycle handler is mid-flight on a session, the other
+cannot race in. One handler is parked inside its critical section (holding the
+``session_lifecycle_lock``); the sibling is then shown to make no progress
+until the first completes. Without the lock the sibling races in and the
+mid-flight assertion fails — that is the regression these guard.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+
+from primer.api.routers.sessions import resume_session
+from primer.claim.in_memory import InMemoryClaimEngine
+from primer.int.claim import ClaimKind
+from primer.model.except_ import ConflictError
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+from primer.workspace.session_factory import SessionCancelDeps, cancel_session
+
+
+class _Scheduler:
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+        self.signalled: list[str] = []
+
+    async def enqueue(self, sid: str) -> None:
+        self.enqueued.append(sid)
+
+    async def signal_cancel(self, sid: str) -> None:
+        self.signalled.append(sid)
+
+
+class _EventBus:
+    async def publish(self, key: str, payload: Any) -> None:
+        pass
+
+
+class _GatedStorage:
+    """Models the real backend and parks the FIRST ``update`` mid-flight.
+
+    Two fidelity points that make this match the SQLite/Postgres lane the bug
+    lives in:
+
+    * ``get`` returns a fresh deep copy (the real backend round-trips through
+      a JSON blob), so concurrent handlers read INDEPENDENT row objects; and
+    * the first ``update`` call parks on ``release`` after announcing itself
+      via ``at_gate``. The test starts the handler it wants to hold the lock
+      first and waits on ``at_gate``, so that handler is deterministically
+      inside its critical section before the sibling is launched.
+    """
+
+    def __init__(self, inner) -> None:
+        self._inner = inner
+        self.at_gate = asyncio.Event()
+        self.release = asyncio.Event()
+        self._first = True
+
+    async def get(self, sid: str, conn=None):
+        row = await self._inner.get(sid, conn=conn)
+        return row.model_copy(deep=True) if row is not None else None
+
+    async def update(self, s, conn=None):
+        if self._first:
+            self._first = False
+            self.at_gate.set()
+            await self.release.wait()
+        return await self._inner.update(s.model_copy(deep=True), conn=conn)
+
+    def __getattr__(self, name: str):
+        return getattr(self._inner, name)
+
+
+class _YieldingProvider:
+    def __init__(self, inner, wrapped_session_storage) -> None:
+        self._inner = inner
+        self._wrapped = wrapped_session_storage
+
+    def get_storage(self, model):
+        if model is WorkspaceSession:
+            return self._wrapped
+        return self._inner.get_storage(model)
+
+
+async def _seed_created(inner, sid: str) -> None:
+    await inner.create(
+        WorkspaceSession(
+            id=sid,
+            workspace_id="ws-1",
+            binding=AgentSessionBinding(agent_id="ag-1"),
+            status=SessionStatus.CREATED,
+            created_at=datetime.now(timezone.utc),
+        )
+    )
+
+
+@pytest.mark.asyncio
+async def test_cancel_in_flight_blocks_resume_then_converges_ended(
+    fake_storage_provider,
+) -> None:
+    """Cancel holds the lock mid-flight; a concurrent resume must not flip the
+    row to RUNNING. Once cancel finishes, the session is ENDED/cancelled with
+    no lease, and the resume reports the session ended (409)."""
+    inner = fake_storage_provider.get_storage(WorkspaceSession)
+    storage = _GatedStorage(inner)
+    provider = _YieldingProvider(fake_storage_provider, storage)
+    engine = InMemoryClaimEngine(adapters={})
+    scheduler = _Scheduler()
+    sid = "sess-cancel-first"
+    await _seed_created(inner, sid)
+    deps = SessionCancelDeps(
+        storage_provider=provider, scheduler=scheduler,
+        claim_engine=engine, event_bus=_EventBus(),
+    )
+
+    cancel_task = asyncio.create_task(
+        cancel_session(workspace_id="ws-1", session_id=sid, deps=deps)
+    )
+    await storage.at_gate.wait()  # cancel is inside its critical section
+
+    resume_task = asyncio.create_task(
+        resume_session(
+            workspace_id="ws-1", session_id=sid,
+            sessions=storage, scheduler=scheduler, engine=engine,
+        )
+    )
+    await asyncio.sleep(0.02)  # let resume run (it should be blocked on the lock)
+
+    mid = await inner.get(sid)
+    assert mid.status == SessionStatus.CREATED, (
+        "resume modified the session while cancel held the lock "
+        f"(status={mid.status.value}) — serialization broken"
+    )
+
+    storage.release.set()
+    _, resume_res = await asyncio.gather(
+        cancel_task, resume_task, return_exceptions=True,
+    )
+
+    final = await inner.get(sid)
+    assert final.status == SessionStatus.ENDED
+    assert final.ended_reason == "cancelled"
+    assert (ClaimKind.SESSION, sid) not in engine._leases
+    assert isinstance(resume_res, ConflictError)
+
+
+@pytest.mark.asyncio
+async def test_resume_in_flight_blocks_cancel_then_cancel_is_honored(
+    fake_storage_provider,
+) -> None:
+    """Resume holds the lock mid-flight; a concurrent cancel must not end the
+    row out from under it. Once resume finishes, the session is RUNNING with a
+    live lease, and cancel — observing RUNNING — records cancel_requested +
+    signals the worker (the cancel is honored, not lost, and not stranded)."""
+    inner = fake_storage_provider.get_storage(WorkspaceSession)
+    storage = _GatedStorage(inner)
+    provider = _YieldingProvider(fake_storage_provider, storage)
+    engine = InMemoryClaimEngine(adapters={})
+    scheduler = _Scheduler()
+    sid = "sess-resume-first"
+    await _seed_created(inner, sid)
+    deps = SessionCancelDeps(
+        storage_provider=provider, scheduler=scheduler,
+        claim_engine=engine, event_bus=_EventBus(),
+    )
+
+    resume_task = asyncio.create_task(
+        resume_session(
+            workspace_id="ws-1", session_id=sid,
+            sessions=storage, scheduler=scheduler, engine=engine,
+        )
+    )
+    await storage.at_gate.wait()  # resume is inside its critical section
+
+    cancel_task = asyncio.create_task(
+        cancel_session(workspace_id="ws-1", session_id=sid, deps=deps)
+    )
+    await asyncio.sleep(0.02)  # let cancel run (it should be blocked on the lock)
+
+    mid = await inner.get(sid)
+    assert mid.status == SessionStatus.CREATED, (
+        "cancel ended the session while resume held the lock "
+        f"(status={mid.status.value}) — serialization broken"
+    )
+
+    storage.release.set()
+    await asyncio.gather(resume_task, cancel_task, return_exceptions=True)
+
+    final = await inner.get(sid)
+    # Resume won the row; cancel saw RUNNING and recorded the cancel against a
+    # live lease, so a worker converges it on the next claim.
+    assert final.status == SessionStatus.RUNNING
+    assert final.cancel_requested is True
+    assert (ClaimKind.SESSION, sid) in engine._leases
+    assert sid in scheduler.signalled

--- a/tests/session/test_mutation_lock.py
+++ b/tests/session/test_mutation_lock.py
@@ -1,0 +1,106 @@
+"""Unit tests for the per-session lifecycle KeyedLock (T0432)."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from primer.session.mutation_lock import KeyedLock, session_lifecycle_lock
+
+
+@pytest.mark.asyncio
+async def test_same_key_is_mutually_exclusive() -> None:
+    """Two coroutines sharing a key never overlap their critical sections."""
+    kl = KeyedLock()
+    order: list[str] = []
+
+    async def worker(tag: str, hold: float) -> None:
+        async with kl.acquire("k"):
+            order.append(f"{tag}-enter")
+            await asyncio.sleep(hold)
+            order.append(f"{tag}-exit")
+
+    # A is scheduled first and holds the lock across a sleep; B must wait
+    # for A to fully exit before it can enter.
+    await asyncio.gather(worker("A", 0.05), worker("B", 0.0))
+
+    assert order == ["A-enter", "A-exit", "B-enter", "B-exit"]
+
+
+@pytest.mark.asyncio
+async def test_distinct_keys_do_not_contend() -> None:
+    """Different keys run concurrently — no false serialization."""
+    kl = KeyedLock()
+    order: list[str] = []
+
+    async def worker(tag: str, key: str, hold: float) -> None:
+        async with kl.acquire(key):
+            order.append(f"{tag}-enter")
+            await asyncio.sleep(hold)
+            order.append(f"{tag}-exit")
+
+    # B (key 'kb') enters and exits while A (key 'ka') is still sleeping.
+    await asyncio.gather(worker("A", "ka", 0.05), worker("B", "kb", 0.0))
+
+    assert order.index("B-exit") < order.index("A-exit")
+
+
+@pytest.mark.asyncio
+async def test_lock_object_is_dropped_after_last_release() -> None:
+    """No per-key leak: the lock + refcount are cleaned up on last release."""
+    kl = KeyedLock()
+    async with kl.acquire("k"):
+        assert "k" in kl._locks
+        assert kl._refs["k"] == 1
+    assert "k" not in kl._locks
+    assert "k" not in kl._refs
+
+
+@pytest.mark.asyncio
+async def test_waiter_keeps_lock_object_alive() -> None:
+    """While a second coroutine waits, the shared lock object must survive
+    the first holder's release bookkeeping (refcount counts the waiter)."""
+    kl = KeyedLock()
+    acquired = asyncio.Event()
+    release = asyncio.Event()
+
+    async def first() -> None:
+        async with kl.acquire("k"):
+            acquired.set()
+            await release.wait()
+
+    async def second() -> None:
+        async with kl.acquire("k"):
+            pass
+
+    t1 = asyncio.create_task(first())
+    await acquired.wait()              # first holds the lock (refcount 1)
+    t2 = asyncio.create_task(second())
+    await asyncio.sleep(0.01)          # second bumps refcount to 2, then blocks
+
+    assert kl._refs["k"] == 2          # the waiter is counted → lock kept alive
+
+    release.set()
+    await asyncio.gather(t1, t2)
+
+    # Both released → the shared object is cleaned up (no per-key leak).
+    assert "k" not in kl._locks
+    assert "k" not in kl._refs
+
+
+@pytest.mark.asyncio
+async def test_cleans_up_when_body_raises() -> None:
+    """An exception in the guarded body still releases + cleans up."""
+    kl = KeyedLock()
+    with pytest.raises(ValueError):
+        async with kl.acquire("k"):
+            raise ValueError("boom")
+    assert "k" not in kl._locks
+    assert "k" not in kl._refs
+
+
+def test_session_lifecycle_lock_is_a_process_singleton() -> None:
+    """The handlers must share one lock instance to serialize each other."""
+    assert session_lifecycle_lock() is session_lifecycle_lock()
+    assert isinstance(session_lifecycle_lock(), KeyedLock)


### PR DESCRIPTION
## Fix the T0432 stuck-RUNNING cancel/resume race

The advisory e2e job surfaced `test_t0432_graph_session_cancel_during_fatal_converges_cleanly` intermittently failing with a session stuck **`status=running, turn_no=0, cancel_requested=False`** that never converged. This is a real concurrency bug (not a flaky test).

### Root cause — a lost-update race
`resume_session`, `pause_session`, and `cancel_session` each do a non-atomic **read-modify-write** of the session row (a full-blob `Storage.update`) **plus** an independent claim-lease mutation, with **zero concurrency control**. On a freshly-created (`auto_start=False`) session, a `resume` racing a `cancel`:

1. both read the row as `CREATED`;
2. `cancel` (inline branch) writes `ENDED` + `delete_lease`;
3. `resume` writes `RUNNING` — **clobbering** `ENDED` (its stale copy never saw the cancel);
4. lease ordering lands `resume.upsert` *before* `cancel.delete_lease`.

Result: `RUNNING` with **no lease**. The in-memory claim engine's `claim_due` only ever returns rows that hold a lease (`primer/claim/in_memory.py:60`), so a RUNNING-without-lease row is invisible to every worker **forever** — exactly the stuck fingerprint. The outcome flips on interleaving, which is why it was intermittent.

### Fix — serialize the conflicting transitions
A process-local **`KeyedLock`** (per-session `asyncio.Lock` with refcounted cleanup) wraps the read-modify-write + lease op in all three handlers. The API, the in-memory claim engine, and the worker pool all run **in one process** (`_app_lifespan.py` starts the pool inline), so an asyncio lock is a *complete* serialization point for this race. Whichever transition lands first is now fully observed by the next:

- **cancel-first** → resume sees `ENDED` → `409` (no resurrection);
- **resume-first** → cancel sees `RUNNING` → sets `cancel_requested` + signals the worker, which converges it via the existing dispatch on-entry guard.

No row ends up RUNNING-without-lease.

### Tests
- `tests/session/test_mutation_lock.py` — `KeyedLock` unit tests (mutual exclusion, distinct keys don't contend, refcounted cleanup, exception safety).
- `tests/session/test_lifecycle_race.py` — drives the **real** `resume_session` + `cancel_session` against a real `InMemoryClaimEngine`, modelling the SQLite blob round-trip (deep-copy on read). It parks one handler mid-critical-section and asserts the sibling cannot race in. **Teeth-verified**: both fail without the lock (`resume modified the session while cancel held the lock (status=running)` / `cancel ended the session while resume held the lock (status=ended)`) and pass with it.

Local: 315 passed across `tests/session`, `tests/worker`, `tests/claim`, `tests/workspace/test_session_factory.py`, `tests/api/test_sessions.py` — no regressions. The advisory e2e job on this PR exercises t0432 end-to-end.

### Scope note
This targets the in-memory-engine / single-process deployment, which is where the stuck-orphan failure mode exists (the engine is per-process state; the worker pool runs in-process). A multi-API-process Postgres deployment claims via query-driven eligibility rather than the lease set, and true cross-process atomicity there would want DB-level optimistic concurrency — out of scope for this fix and worth its own design if that topology is adopted.
