### PR TITLE
fix(graph): tolerate code fences in agent-node parsed output

### DIFF
--- a/primer/graph/_agent_node.py
+++ b/primer/graph/_agent_node.py
@@ -37,6 +37,30 @@ if TYPE_CHECKING:
     from primer.model.agent import Agent
 
 
+def _strip_json_fences(text: str) -> str:
+    """Strip a single wrapping markdown code fence from ``text``.
+
+    Local models habitually wrap structured output in `````json ... ``````
+    fences even when a ``response_format`` JSON schema is requested -- backends
+    like LM Studio / llama.cpp treat the schema as a soft hint, not constrained
+    decoding, so the fence survives. A plain ``json.loads`` then fails and the
+    node's ``parsed`` is silently lost, which breaks any ``json_path`` router
+    gating on a parsed field (the gate sees nothing and falls through to its
+    default branch -- e.g. a loop that never converges). Tolerate the common
+    fence shapes so the gate still sees the structured verdict. A string with
+    no leading fence is returned unchanged (only surrounding whitespace
+    trimmed), so raw-JSON output is unaffected.
+    """
+    s = text.strip()
+    if s.startswith("```"):
+        newline = s.find("\n")
+        if newline != -1:
+            s = s[newline + 1:]  # drop the opening ``` / ```json line
+        if s.rstrip().endswith("```"):
+            s = s.rstrip()[:-3]  # drop the closing fence
+    return s.strip()
+
+
 class _AgentNodeMixin:
     """Agent-node turn + resume methods for `_BaseGraphExecutor`."""
 
@@ -82,7 +106,7 @@ class _AgentNodeMixin:
         parsed: dict[str, Any] | None = None
         if response_format is not None and text:
             try:
-                loaded = json.loads(text)
+                loaded = json.loads(_strip_json_fences(text))
                 parsed = loaded if isinstance(loaded, dict) else {"value": loaded}
             except json.JSONDecodeError:
                 parsed = None

--- a/tests/graph/test_strip_json_fences.py
+++ b/tests/graph/test_strip_json_fences.py
@@ -1,0 +1,39 @@
+"""Unit tests for `_strip_json_fences` -- the gate-parser fence tolerance.
+
+A local model often wraps a response_format verdict in ```json fences even
+when a JSON schema is requested; without stripping them the node's `parsed`
+is lost and json_path gates silently fall through (e.g. a loop that never
+converges). These tests pin the common fence shapes plus the raw-JSON
+passthrough.
+"""
+import json
+
+from primer.graph._agent_node import _strip_json_fences
+
+
+def test_raw_json_unchanged() -> None:
+    raw = '{"sufficient": true, "gaps": []}'
+    assert json.loads(_strip_json_fences(raw)) == {"sufficient": True, "gaps": []}
+
+
+def test_json_lang_fence_stripped() -> None:
+    fenced = '```json\n{"sufficient": true, "gaps": [], "feedback": "ok"}\n```'
+    assert json.loads(_strip_json_fences(fenced)) == {
+        "sufficient": True,
+        "gaps": [],
+        "feedback": "ok",
+    }
+
+
+def test_bare_fence_stripped() -> None:
+    fenced = '```\n{"done": false}\n```'
+    assert json.loads(_strip_json_fences(fenced)) == {"done": False}
+
+
+def test_surrounding_whitespace_and_trailing_fence() -> None:
+    fenced = '  ```json\n{"score": 100}\n```  '
+    assert json.loads(_strip_json_fences(fenced)) == {"score": 100}
+
+
+def test_no_fence_with_whitespace() -> None:
+    assert _strip_json_fences('  {"a": 1}  ') == '{"a": 1}'


### PR DESCRIPTION
## Problem
A `response_format` agent node parses the assistant's text with `json.loads` to populate `NodeOutput.parsed`, which `json_path` routers gate on. But local backends (LM Studio / llama.cpp / Ollama) treat the JSON schema as a **soft hint, not constrained decoding**, and habitually wrap the verdict in a markdown code fence:
```
```json
{"sufficient": true, "gaps": [], "feedback": "..."}
```
```
`json.loads` on that fenced string throws → `parsed` is silently `None` → the router finds no match and falls through to its `default_to` branch. A verify/evaluate loop then **never sees `sufficient==true` even though the model produced a correct verdict**, and runs all the way to `max_iterations`.

Observed concretely: a researcher→evaluator loop where the evaluator emitted the right `{"sufficient": true}` verdict on iteration 1 but, fenced, looped to the cap every time.

## Fix
Strip a single wrapping code fence (````json … ```` or bare ```` … ````) before `json.loads`. Raw-JSON output is unaffected — a string with no leading fence is returned with only surrounding whitespace trimmed. This is in the shared `_agent_node_output`, so **every gate node benefits**, not just one graph.

## Tests
`tests/graph/test_strip_json_fences.py` — raw passthrough, ````json fence, bare fence, surrounding whitespace + trailing fence. 5 passed; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)