### PR TITLE
ci: fix two CI failures + run e2e on merge to main

### DIFF
--- a/tests/graph/test_routing_failed.py
+++ b/tests/graph/test_routing_failed.py
@@ -232,12 +232,14 @@ async def test_no_match_no_default_emits_routing_failed() -> None:
     assert loaded.ended_detail == "routing_failed"
 
 
-# Fenced JSON: the agent-node parse (`json.loads`) fails on a ```json
-# code fence, so NodeOutput.parsed is None. A json_path edge must treat
-# this as "no branch matched" -- route to default_to when set, else a
-# CODED routing_failed -- never an uncoded ConfigError the executor
-# swallows into a detail-less failure.
-_FENCED_JSON = '```json\n{"go": "end"}\n```'
+# Genuinely-unparseable agent output: the assistant text is not valid JSON
+# (and is NOT a wrapping markdown code fence -- those now parse after the
+# strip-fence fix, see tests/graph/test_strip_json_fences.py), so the
+# agent-node parse (`json.loads`) fails and NodeOutput.parsed is None. A
+# json_path edge must treat this as "no branch matched" -- route to
+# default_to when set, else a CODED routing_failed -- never an uncoded
+# ConfigError the executor swallows into a detail-less failure.
+_UNPARSEABLE_OUTPUT = "Sorry, I cannot answer in JSON."
 
 
 @pytest.mark.asyncio
@@ -274,7 +276,7 @@ async def test_null_parsed_with_default_to_routes_to_default() -> None:
     llm = _FakeLLM(
         scripts=[
             [
-                TextDelta(text=_FENCED_JSON, index=0),
+                TextDelta(text=_UNPARSEABLE_OUTPUT, index=0),
                 Done(stop_reason="stop", raw_reason="stop"),
             ]
         ]
@@ -325,7 +327,7 @@ async def test_null_parsed_without_default_to_emits_routing_failed() -> None:
     llm = _FakeLLM(
         scripts=[
             [
-                TextDelta(text=_FENCED_JSON, index=0),
+                TextDelta(text=_UNPARSEABLE_OUTPUT, index=0),
                 Done(stop_reason="stop", raw_reason="stop"),
             ]
         ]


### PR DESCRIPTION
## Green the pipeline + run e2e on merge to main

Three CI changes (all small, low-risk):

### 1. Unit gate (`test`) — stale fenced-JSON fixture  *(deterministic fix)*
`b49b0476` ("tolerate markdown code fences in agent-node parsed output") made a fenced JSON block parse via `json.loads`, which invalidated the `_FENCED_JSON` "parsed is None" fixture in `test_routing_failed.py`: the fenced `{"go":"end"}` now parses and matches the `go eq end` branch, so `test_null_parsed_without_default_to_emits_routing_failed` routed to `end` instead of hitting `routing_failed` (`1 failed, 5331 passed` on main). Replaced the stale fixture with genuinely-unparseable text so both null-parse tests still exercise the real contract (`parsed=None` → `default_to`, else `routing_failed`; `3d27a784`). Fence-parsing keeps its own coverage in `test_strip_json_fences.py`. → 3/3 locally.

### 2. ui-e2e (`ui-e2e`) — flaky approvals journey  *(timing fix)*
`test_u0109_approvals_operator_journey` intermittently timed out (15s) waiting for the post-reject approval banner (`1 failed, 137 passed`; passed on the main dispatch an hour earlier → flake, not regression). The wait is deterministic — the approval park is pre-injected and **survives** the reject (no `session_leases` row → `mark_resumable` no-op → the resume cycle that clears `parked_state` never runs), so `/tool_approval/pending` stays 200 and the banner always renders; the only variable is mount + fetch latency under CI load. Widened the two heavy waits (list row + post-reject banner) 15s → 30s.

### 3. Run e2e on merge to main  *(coverage)*
The e2e workflow ran only per-PR + manual dispatch. A per-PR run tests that PR against main **in isolation**, so regressions that only appear once several independently-green PRs land together reached main unnoticed (exactly how the recent stuck-RUNNING + parse-fence issues surfaced only on a manual post-merge dispatch). Added a `push: [main]` trigger so every merge to main auto-runs e2e + ui-e2e. Still advisory / not a required check; `concurrency(cancel-in-progress)` coalesces overlapping runs.

Items 1–2 are test-only; item 3 is workflow-config only.
