### PR TITLE
ci: run e2e on merge to main + ui-e2e console-error/approvals de-flake

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -18,6 +18,11 @@ name: E2E
 on:
   pull_request:
     branches: [main]
+  # Also run on merge to main: a post-merge run catches regressions that only
+  # surface once independently-green PRs land together (the per-PR run tests a
+  # PR against main in isolation, not against its sibling merges).
+  push:
+    branches: [main]
   workflow_dispatch:
 
 concurrency:

--- a/tests/ui_e2e/conftest.py
+++ b/tests/ui_e2e/conftest.py
@@ -221,10 +221,20 @@ def page(
         })
 
     def _on_requestfailed(req) -> None:
+        failure = req.failure or "unknown"
+        # net::ERR_ABORTED is a fetch cancelled by navigation / useResource
+        # cleanup — a route change aborts the prior route's in-flight mount
+        # fetches (sessions/workspaces/workers/find). It is never a
+        # server/route failure, so it is universally benign for these console
+        # smoke tests. Filter it at the capture point so no individual
+        # route-nav test has to special-case it (several didn't, and flaked
+        # the e2e job intermittently).
+        if "ERR_ABORTED" in failure:
+            return
         failed_requests.append({
             "url": req.url,
             "method": req.method,
-            "failure": (req.failure or "unknown"),
+            "failure": failure,
             "status": None,
         })
 

--- a/tests/ui_e2e/test_approvals_journey.py
+++ b/tests/ui_e2e/test_approvals_journey.py
@@ -330,7 +330,11 @@ def test_u0109_approvals_operator_journey(
         # Pending tab is the default; it shows a count chip when at
         # least one row is parked. Wait for our seeded row to appear.
         row = page.locator(f"[data-testid='approval-row-{sid}']")
-        expect(row).to_be_visible(timeout=15_000)
+        # Generous timeout: this runs against a shared eval stack under CI
+        # load where the find + per-row pending fetches that drive the list
+        # can lag. The row is deterministic (the park is pre-injected), so a
+        # longer wait only absorbs latency, it never masks a missing row.
+        expect(row).to_be_visible(timeout=30_000)
         # The row should mention the inner tool name + policy id (these
         # come from resume_metadata.original_call.name / policy_id).
         expect(row).to_contain_text(inner_tool)
@@ -387,8 +391,12 @@ def test_u0109_approvals_operator_journey(
 
         # Session-detail's ApprovalBannerPanel polls /tool_approval/pending
         # and renders <ApprovalBanner> on 200 → data-testid='approval-banner'.
+        # The parked_state is intact (no lease → no resume cycle clears it), so
+        # the banner is deterministic; the only variable is mount + fetch
+        # latency under CI load, hence the generous timeout (this is the wait
+        # that occasionally tipped over 15s and flaked the run).
         banner = page.locator("[data-testid='approval-banner']")
-        expect(banner).to_be_visible(timeout=15_000)
+        expect(banner).to_be_visible(timeout=30_000)
         # Banner header includes the tool name from the same payload.
         expect(banner).to_contain_text(inner_tool)
 

--- a/tests/ui_e2e/test_approvals_journey.py
+++ b/tests/ui_e2e/test_approvals_journey.py
@@ -292,17 +292,17 @@ def test_u0109_approvals_operator_journey(
       * "Send rejection" stays disabled while reason is empty/whitespace
         (approvals.jsx `disabled={!reason.trim() || respond.loading}`).
       * "Decision sent" toast appears on a successful Reject + Approve.
-      * Cross-page: session-detail's ApprovalBanner renders on the
-        same row because the parked_state survives the respond POST
-        in THIS test's setup — the asyncpg-injected session has no
-        session_leases row, so mark_resumable's lease UPDATE is a
-        no-op and the worker pool never claims the row to drive the
-        resume cycle. (Roadmap §7 resume wiring landed 2026-05-25
-        in commits 068184a/496c886/731a05b/f83fee7; T0861 covers
-        the full park→respond→resume cycle when the lease row IS
-        present. A future U-test could repeat that on the UI side
-        with explicit lease injection — for now U0109 stays focused
-        on the click-flow surface.)
+      * Cross-page: session-detail's ApprovalBanner renders for a
+        pending approval. The banner check runs against a SECOND,
+        freshly parked session — never responded-to — rather than the
+        rejected one. Rejecting flips parked_status to 'resumable',
+        which the claim-eligibility filter admits, so the worker pool
+        claims + resumes that row and clears parked_state out from
+        under the banner (an intermittent race that used to flake this
+        test). A never-responded session stays parked_status='parked'
+        (excluded by the eligibility filter), so its park is stable and
+        the banner renders deterministically. (T0861 covers the full
+        park→respond→resume cycle when a lease row IS present.)
     """
     ids = _seed_session_ladder(base_url, unique_suffix)
     sid = ids["session"]
@@ -310,6 +310,7 @@ def test_u0109_approvals_operator_journey(
     policy_id = f"pol-u0109-{unique_suffix}"
     inner_tool = "fs.delete"
     gate_reason = "destructive path under /etc"
+    sid_banner: str | None = None  # 2nd session for the cross-page banner
 
     try:
         # --- 0. Inject the approval park BEFORE the page is opened so
@@ -376,25 +377,43 @@ def test_u0109_approvals_operator_journey(
         toast = page.locator(".toast", has_text="Decision sent")
         expect(toast).to_be_visible(timeout=10_000)
 
-        # --- 6. Cross-page: navigate to session detail ----------------
-        # parked_state survives the respond POST in this setup because
-        # the asyncpg-injected session has no session_leases row →
-        # mark_resumable's lease UPDATE is a no-op → the worker pool
-        # never claims the row to run the resume cycle. Both the
-        # approvals list and the session-detail banner are driven by
-        # GET /v1/sessions/{sid}/tool_approval/pending, which still
-        # returns 200 because parked_state is intact.
+        # --- 5b. Seed a SECOND, freshly parked session for the banner.
+        # The step-1 session was just rejected → parked_status='resumable'
+        # → the worker pool claims + resumes it and clears parked_state, so
+        # its banner is racy. A never-responded session stays
+        # parked_status='parked' (excluded by the claim-eligibility filter),
+        # so its park is stable and the banner renders deterministically. --
+        with httpx.Client(base_url=base_url, timeout=30.0) as c:
+            r = c.post(
+                f"/v1/workspaces/{ids['workspace']}/sessions",
+                json={
+                    "binding": {"kind": "agent", "agent_id": ids["agent"]},
+                    "auto_start": False,
+                },
+            )
+            assert r.status_code == 201, f"seed banner session: {r.text}"
+            sid_banner = r.json()["id"]
+        _inject_approval_park(
+            session_id=sid_banner,
+            tool_call_id=f"tc-u0109-banner-{unique_suffix}",
+            inner_tool_name=inner_tool,
+            policy_id=policy_id,
+            gate_reason=gate_reason,
+        )
+
+        # --- 6. Cross-page: navigate to the fresh session's detail -----
         page.goto(
-            f"{console_url}#/sessions/{sid}",
+            f"{console_url}#/sessions/{sid_banner}",
             wait_until="domcontentloaded",
         )
 
         # Session-detail's ApprovalBannerPanel polls /tool_approval/pending
         # and renders <ApprovalBanner> on 200 → data-testid='approval-banner'.
-        # The parked_state is intact (no lease → no resume cycle clears it), so
-        # the banner is deterministic; the only variable is mount + fetch
-        # latency under CI load, hence the generous timeout (this is the wait
-        # that occasionally tipped over 15s and flaked the run).
+        # sid_banner is freshly parked and never responded-to, so its park is
+        # stable (parked_status='parked' is excluded by the claim-eligibility
+        # filter → the worker never resumes it and clears parked_state). The
+        # banner is therefore deterministic; the 30s timeout only absorbs
+        # mount + fetch latency under CI load.
         banner = page.locator("[data-testid='approval-banner']")
         expect(banner).to_be_visible(timeout=30_000)
         # Banner header includes the tool name from the same payload.
@@ -414,4 +433,15 @@ def test_u0109_approvals_operator_journey(
         approve_toast = page.locator(".toast", has_text="Decision sent")
         expect(approve_toast.last).to_be_visible(timeout=10_000)
     finally:
+        # Cancel the extra banner session before tearing the ladder down so
+        # it doesn't linger parked in the shared DB.
+        if sid_banner is not None and ids.get("workspace"):
+            try:
+                with httpx.Client(base_url=base_url, timeout=30.0) as c:
+                    c.post(
+                        f"/v1/workspaces/{ids['workspace']}/sessions/"
+                        f"{sid_banner}/cancel"
+                    )
+            except Exception:  # noqa: BLE001
+                pass
         _cleanup(base_url, ids)

--- a/tests/ui_e2e/test_approvals_journey.py
+++ b/tests/ui_e2e/test_approvals_journey.py
@@ -211,13 +211,15 @@ async def _inject_approval_park_async(
         WHERE id = $1
     """
     # The ui_e2e server is brought up against the `primer_e2e` DB (see
-    # tests/.e2e/config.yaml). Default to it; honour the env override so
-    # an alternate bringup (e.g. the docker-compose `primer` DB) still
+    # tests/.e2e/config.yaml). Default to it; honour the env overrides
+    # (PRIMER_UI_E2E_DB / PRIMER_UI_E2E_DB_PORT) so an alternate bringup
+    # (e.g. the docker-compose `primer` DB on a remapped host port) still
     # works.
     import os
     db = os.environ.get("PRIMER_UI_E2E_DB", "primer_e2e")
+    port = int(os.environ.get("PRIMER_UI_E2E_DB_PORT", "5432"))
     conn = await asyncpg.connect(
-        host="localhost", port=5432,
+        host="localhost", port=port,
         user="primer", password="primer", database=db,
     )
     try:


### PR DESCRIPTION
## ui-e2e de-flake + run e2e on merge to main

(The stale-routing-fixture unit-gate fix already landed on main via #53; not included here.)

### 1. Run e2e on merge to main
`e2e.yml` ran only per-PR + manual dispatch. A per-PR run tests a PR against main in isolation, so regressions that only surface once sibling PRs land together reached main unseen (how the stuck-RUNNING + parse-fence issues only showed on a manual post-merge dispatch). Adds `push: [main]` so every merge auto-runs e2e + ui-e2e. Still advisory; `concurrency(cancel-in-progress)` coalesces overlaps.

### 2. Filter benign `net::ERR_ABORTED` centrally
The `page` fixture recorded *every* `requestfailed` — including `ERR_ABORTED`, the harmless fetch-cancelled-by-navigation — so each route-nav console test had to special-case it, and `test_channel_rules_page` didn't (it flaked on the sessions/workspaces/workers/find mount fetches a route change aborts). Now dropped at the capture point in conftest, so every console test is covered.

### 3. Decouple the approvals banner check  *(corrected fix)*
`test_u0109_approvals_operator_journey` reused the just-rejected session for the cross-page banner check and relied on its park surviving. But a reject flips `parked_status` to `resumable`, which the claim-eligibility filter admits → the worker claims + resumes the row and clears `parked_state` → `/tool_approval/pending` 404s → the banner never renders. This is a genuine race (an earlier 15s→30s timeout bump did **not** fix it — it failed at 30s). The banner+approve check now runs against a **second, freshly parked, never-responded** session, which stays `parked_status='parked'` (excluded by the eligibility filter) so the worker never resumes it → deterministic banner.

All three are test/workflow-only. Validated by this PR's e2e run.
