### PR TITLE
fix(e2e): retry DB reset to survive Postgres init-restart race in bringup

### DIFF
--- a/scripts/e2e/bringup.sh
+++ b/scripts/e2e/bringup.sh
@@ -94,15 +94,33 @@ done
 echo "[bringup] postgres ready" >&2
 
 # ---- 2. Reset DB ------------------------------------------------------------
+#
+# pg_isready (above) can report ready against the Postgres image's TEMPORARY
+# init server, which is shut down before the REAL server starts. A psql run in
+# that window dies with "FATAL: the database system is shutting down" — observed
+# as a flaky CI bring-up failure (the reset, not any test, fails with exit 2).
+# Retry the reset until the real server accepts it so the init-restart race
+# cannot fail the whole bring-up. DROP ... IF EXISTS keeps each attempt
+# idempotent (a CREATE that half-succeeded is dropped and redone next attempt).
 
 echo "[bringup] resetting database $DB_NAME..." >&2
-$RUNTIME compose exec -T -e PGPASSWORD="$DB_PASSWORD" postgres \
-    psql -U "$DB_USER" -d postgres -v ON_ERROR_STOP=1 \
-    -c "DROP DATABASE IF EXISTS $DB_NAME;" \
-    -c "CREATE DATABASE $DB_NAME;" >&2
-$RUNTIME compose exec -T -e PGPASSWORD="$DB_PASSWORD" postgres \
-    psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 \
-    -c "CREATE EXTENSION IF NOT EXISTS vector;" >&2
+reset_deadline=$(( $(date +%s) + 60 ))
+until $RUNTIME compose exec -T -e PGPASSWORD="$DB_PASSWORD" postgres \
+        psql -U "$DB_USER" -d postgres -v ON_ERROR_STOP=1 \
+        -c "DROP DATABASE IF EXISTS $DB_NAME;" \
+        -c "CREATE DATABASE $DB_NAME;" >&2 \
+    && $RUNTIME compose exec -T -e PGPASSWORD="$DB_PASSWORD" postgres \
+        psql -U "$DB_USER" -d "$DB_NAME" -v ON_ERROR_STOP=1 \
+        -c "CREATE EXTENSION IF NOT EXISTS vector;" >&2
+do
+    if [[ $(date +%s) -ge $reset_deadline ]]; then
+        echo "[bringup] FATAL: database reset did not succeed within 60s" >&2
+        $RUNTIME compose logs --tail=50 postgres >&2 || true
+        exit 1
+    fi
+    echo "[bringup] reset failed (postgres likely still initialising) — retry in 2s" >&2
+    sleep 2
+done
 echo "[bringup] database reset" >&2
 
 # ---- 3. Render config -------------------------------------------------------


### PR DESCRIPTION
## What CI actually showed
The E2E run on the connect-timeout PR failed — but **not** in any test, and **not** from that PR's code. It failed in the **"Bring up Postgres + server"** step, before the primer server (or any test) started:

```
[bringup] postgres ready
psql: error: connection ... failed: FATAL:  the database system is shutting down
##[error]Process completed with exit code 2.
```

The same commit's `ui-e2e` Playwright job passed, and the post-merge E2E on `main` passed in full — confirming a flaky bring-up, not a code regression.

## Root cause
`scripts/e2e/bringup.sh` gates on `pg_isready`, which can report ready against the Postgres image's **temporary init server**. That server is shut down before the real server starts, so the immediately-following DB-reset `psql` races the shutdown and dies with `FATAL: the database system is shutting down`, failing the whole bring-up.

## Fix
Wrap the `DROP/CREATE` + `CREATE EXTENSION` reset in a 60 s retry loop, so the init-restart race is tolerated instead of fatal. `DROP ... IF EXISTS` keeps each attempt idempotent. No behaviour change on the happy path; on the race it retries until the real server accepts the reset.

Verified `bash -n` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)