### PR TITLE
feat(api): Studio backend — file tree, edit-conflict 412, watch-wake, aggregated yields

### DIFF
--- a/primer/api/_app_routes.py
+++ b/primer/api/_app_routes.py
@@ -119,6 +119,7 @@ def _mount_routers(
     app.include_router(workspaces_router.sessions_router, prefix=prefix, dependencies=auth_dep)
     app.include_router(workspaces_router.files_router, prefix=prefix, dependencies=auth_dep)
     app.include_router(workspaces_router.log_router, prefix=prefix, dependencies=auth_dep)
+    app.include_router(workspaces_router.yields_pending_router, prefix=prefix, dependencies=auth_dep)
     # Sessions.
     app.include_router(sessions_router.nested_session_router, prefix=prefix, dependencies=auth_dep)
     app.include_router(sessions_router.top_session_router, prefix=prefix, dependencies=auth_dep)

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -17,6 +17,7 @@ Sub-resources on ``/v1/workspaces/{id}``:
 * Sessions — list, get, pause, resume, steer.
 * Files — list (paginated ls), info, read, download, delete, write.
 * Log — git log over the ``.state`` repo.
+* Yields — aggregated pending yields across all sessions (Studio A3).
 """
 
 from __future__ import annotations
@@ -35,6 +36,7 @@ from pydantic import BaseModel, Field
 from primer.api.deps import (
     get_event_bus,
     get_scheduler,
+    get_session_storage,
     get_storage_provider,
     get_workspace_provider_storage,
     get_workspace_registry,
@@ -1125,6 +1127,151 @@ async def workspace_show_commit(
 
 
 # ===========================================================================
+# Yields pending sub-resource (Studio A3)
+# ===========================================================================
+
+yields_pending_router = APIRouter(tags=["workspace-yields"])
+
+
+def _extract_yield_kind(tool_name: str) -> str:
+    """Map the internal ``tool_name`` stored in the parked_state blob to the
+    human-facing ``kind`` field exposed in the API response.
+
+    * ``_approval`` → ``"approval"`` (tool-approval gate)
+    * everything else is returned verbatim (``ask_user``, ``watch_files``,
+      ``sleep``, ``invoke_graph``, …).
+    """
+    if tool_name == "_approval":
+        return "approval"
+    return tool_name
+
+
+def _extract_yield_prompt(tool_name: str, metadata: dict) -> str:
+    """Return the best human-facing description for a parked yield.
+
+    ``metadata`` is ``blob["yielded"]["resume_metadata"]`` (or ``{}``).
+
+    Per-kind extraction:
+    * ``ask_user``   → the ``prompt`` string the agent emitted.
+    * ``_approval``  → ``original_call.name`` (the tool awaiting approval).
+    * ``watch_files``→ the watched paths joined as a comma-separated string.
+    * ``sleep``      → ``"<N>s"`` from ``requested_seconds``.
+    * others         → empty string (callers may flag as unknown).
+    """
+    if tool_name == "ask_user":
+        return str(metadata.get("prompt") or "")
+    if tool_name == "_approval":
+        original = metadata.get("original_call") or {}
+        return str(original.get("name") or "")
+    if tool_name == "watch_files":
+        paths = metadata.get("paths") or []
+        return ", ".join(str(p) for p in paths)
+    if tool_name == "sleep":
+        secs = metadata.get("requested_seconds")
+        if secs is not None:
+            return f"{secs}s"
+        return ""
+    return ""
+
+
+def _tool_call_id_from_blob(blob: dict) -> str | None:
+    """Resolve the tool_call_id from a raw parked_state blob.
+
+    Mirrors the logic in ``yields.py::_tool_call_id_for``: top-level key
+    first, then fallback into ``yielded.resume_metadata``.
+    """
+    tcid = blob.get("tool_call_id")
+    if tcid:
+        return str(tcid)
+    yielded = blob.get("yielded") or {}
+    meta = yielded.get("resume_metadata") or {}
+    tcid = meta.get("tool_call_id")
+    return str(tcid) if tcid else None
+
+
+@yields_pending_router.get(
+    "/workspaces/{workspace_id}/yields/pending",
+    summary="Aggregated pending yields across all sessions (Studio Action Required)",
+    responses=common_responses(404, 500),
+)
+async def list_pending_yields(
+    workspace_id: str = Path(..., description="Workspace id"),
+    session_storage=Depends(get_session_storage),
+) -> dict:
+    """Return every pending yield across **all** parked sessions in the
+    workspace.
+
+    Drives the Studio right-sidebar "Action Required" panel on load;
+    live deltas arrive via ``yielded``/``done`` tap events.
+
+    Response shape::
+
+        {
+            "items": [
+                {
+                    "session_id": str,
+                    "kind": "ask_user" | "approval" | "watch_files" | "sleep" | …,
+                    "prompt": str,           # human-facing description
+                    "tool_call_id": str | null,
+                    "parked_at": str | null  # ISO-8601
+                },
+                …
+            ]
+        }
+
+    Only sessions with ``parked_status == "parked"`` are included; running
+    and ended sessions are excluded. Sessions from other workspaces are never
+    returned.
+    """
+    from primer.model.storage import OffsetPage
+    from primer.storage.q import Q
+    from primer.model.workspace_session import WorkspaceSession
+
+    predicate = (
+        Q(WorkspaceSession)
+        .where("workspace_id", workspace_id)
+        .where("parked_status", "parked")
+        .build()
+    )
+
+    items = []
+    offset = 0
+    page_size = 200
+    while True:
+        resp = await session_storage.find(
+            predicate,
+            OffsetPage(offset=offset, length=page_size),
+        )
+        for sess in resp.items:
+            blob: dict = sess.parked_state or {}
+            yielded_blob: dict = blob.get("yielded") or {}
+            tool_name: str = yielded_blob.get("tool_name") or ""
+            metadata: dict = yielded_blob.get("resume_metadata") or {}
+
+            kind = _extract_yield_kind(tool_name)
+            prompt = _extract_yield_prompt(tool_name, metadata)
+            tcid = _tool_call_id_from_blob(blob)
+            parked_at = (
+                sess.parked_at.isoformat() if sess.parked_at is not None else None
+            )
+
+            items.append(
+                {
+                    "session_id": sess.id,
+                    "kind": kind,
+                    "prompt": prompt,
+                    "tool_call_id": tcid,
+                    "parked_at": parked_at,
+                }
+            )
+        if len(resp.items) < page_size:
+            break
+        offset += page_size
+
+    return {"items": items}
+
+
+# ===========================================================================
 # Helpers
 # ===========================================================================
 
@@ -1168,4 +1315,5 @@ __all__ = [
     "sessions_router",
     "template_router",
     "workspace_router",
+    "yields_pending_router",
 ]

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -33,6 +33,8 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from primer.api.deps import (
+    get_event_bus,
+    get_scheduler,
     get_storage_provider,
     get_workspace_provider_storage,
     get_workspace_registry,
@@ -986,6 +988,8 @@ async def write_file(
         description="Optimistic-concurrency etag from a prior read response",
     ),
     registry: WorkspaceRegistry = Depends(get_workspace_registry),
+    scheduler=Depends(get_scheduler),
+    event_bus=Depends(get_event_bus),
 ) -> Response:
     ws = await registry.get_workspace(workspace_id)
     if body.encoding == "text":
@@ -1040,6 +1044,26 @@ async def write_file(
                     media_type=PROBLEM_JSON_MEDIA_TYPE,
                 )
     await ws.write_file(path, raw)
+    # Deterministically wake any watch_files-parked session in this
+    # workspace whose watched paths match the just-written file. This
+    # reuses the event-bus -> YieldEventListener resume path; inotify
+    # stays as the backstop. Best-effort: a wake failure must never fail
+    # the write itself.
+    try:
+        from primer.bus.watch_notify import wake_watch_files_on_write
+
+        await wake_watch_files_on_write(
+            workspace_id=workspace_id,
+            path=path,
+            scheduler=scheduler,
+            event_bus=event_bus,
+        )
+    except Exception:  # noqa: BLE001 — wake is best-effort
+        logger.exception(
+            "wake_watch_files_on_write failed for workspace=%r path=%r",
+            workspace_id,
+            path,
+        )
     return Response(status_code=204)
 
 

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -22,12 +22,14 @@ Sub-resources on ``/v1/workspaces/{id}``:
 from __future__ import annotations
 
 import base64
+import email.utils
+import hashlib
 import logging
 from datetime import datetime, timezone
 from typing import Any, Literal
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request
-from fastapi.responses import StreamingResponse
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, Response
+from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from primer.api.deps import (
@@ -37,7 +39,8 @@ from primer.api.deps import (
     get_workspace_storage,
     get_workspace_template_storage,
 )
-from primer.api.errors import common_responses
+from primer.api.errors import PROBLEM_JSON_MEDIA_TYPE, common_responses
+from primer.model.problem_details import ProblemDetails
 from primer.api.pagination import FindRequest, parse_order_by, parse_page
 from primer.api.registries import WorkspaceRegistry
 from primer.api.registries.provider_registry import RESERVED_WORKSPACE_PROVIDER_IDS
@@ -138,6 +141,9 @@ class FileReadResponse(BaseModel):
     encoding: Literal["text", "base64"]
     content: str
     size_bytes: int
+    mtime: float | None = None
+    mtime_iso: str | None = None
+    etag: str | None = None
 
 
 class DiagnosticExecBody(BaseModel):
@@ -779,6 +785,39 @@ files_router = APIRouter(tags=["workspace-files"])
 
 
 @files_router.get(
+    "/workspaces/{workspace_id}/files/tree",
+    summary="Return a one-level directory tree",
+    responses=common_responses(400, 404, 500),
+)
+async def file_tree(
+    workspace_id: str = Path(...),
+    path: str = Query(default=".", description="Workspace-relative path"),
+    depth: int = Query(default=1, ge=1, description="Tree depth (only depth=1 is supported; deeper values are accepted but treated as 1)"),
+    hidden: bool = Query(default=False, description="Include hidden entries (e.g. .state)"),
+    registry: WorkspaceRegistry = Depends(get_workspace_registry),
+) -> dict:
+    ws = await registry.get_workspace(workspace_id)
+    entries = await ws.list_files(path, recursive=False)
+    items = []
+    for entry in entries:
+        name = entry.path.rsplit("/", 1)[-1] if "/" in entry.path else entry.path
+        if not hidden and (entry.path == ".state" or entry.path.endswith("/.state")):
+            continue
+        items.append(
+            {
+                "name": name,
+                "path": entry.path,
+                "is_dir": entry.kind == "dir",
+                "size_bytes": entry.size_bytes,
+                "mtime": entry.modified_at.timestamp(),
+                "mtime_iso": entry.modified_at.isoformat(),
+            }
+        )
+    items.sort(key=lambda x: (0 if x["is_dir"] else 1, x["name"]))
+    return {"path": path, "items": items}
+
+
+@files_router.get(
     "/workspaces/{workspace_id}/files",
     summary="List files at a workspace path",
     responses=common_responses(400, 404, 500),
@@ -848,8 +887,18 @@ async def read_file(
             ) from exc
     else:
         content = base64.b64encode(raw).decode("ascii")
+    entry = await ws.file_info(path)
+    mtime_iso = entry.modified_at.isoformat()
+    mtime = entry.modified_at.timestamp()
+    etag = hashlib.md5(f"{mtime_iso}:{len(raw)}".encode()).hexdigest()
     return FileReadResponse(
-        path=path, encoding=encoding, content=content, size_bytes=len(raw)
+        path=path,
+        encoding=encoding,
+        content=content,
+        size_bytes=len(raw),
+        mtime=mtime,
+        mtime_iso=mtime_iso,
+        etag=etag,
     )
 
 
@@ -918,14 +967,26 @@ async def delete_file(
     "/workspaces/{workspace_id}/files",
     status_code=204,
     summary="Replace (or create) a file's contents",
-    responses=common_responses(400, 404, 422, 500),
+    responses={
+        **common_responses(400, 422, 500),
+        412: {
+            "model": ProblemDetails,
+            "description": "Precondition Failed",
+            "content": {PROBLEM_JSON_MEDIA_TYPE: {}},
+        },
+    },
 )
 async def write_file(
+    request: Request,
     workspace_id: str = Path(...),
     path: str = Query(..., description="Workspace-relative path"),
     body: FileWriteBody = Body(...),
+    etag: str | None = Query(
+        default=None,
+        description="Optimistic-concurrency etag from a prior read response",
+    ),
     registry: WorkspaceRegistry = Depends(get_workspace_registry),
-) -> None:
+) -> Response:
     ws = await registry.get_workspace(workspace_id)
     if body.encoding == "text":
         try:
@@ -942,7 +1003,44 @@ async def write_file(
             raw = base64.b64decode(body.content, validate=True)
         except Exception as exc:  # noqa: BLE001 — base64.binascii.Error
             raise BadRequestError(f"invalid base64 content: {exc}") from exc
+    if_unmodified_since_hdr = request.headers.get("if-unmodified-since")
+    if etag is not None or if_unmodified_since_hdr is not None:
+        try:
+            entry = await ws.file_info(path)
+        except NotFoundError:
+            entry = None
+        if entry is not None:
+            conflict = False
+            if etag is not None:
+                current_etag = hashlib.md5(
+                    f"{entry.modified_at.isoformat()}:{entry.size_bytes}".encode()
+                ).hexdigest()
+                if etag != current_etag:
+                    conflict = True
+            elif if_unmodified_since_hdr is not None:
+                try:
+                    parsed_date = email.utils.parsedate_to_datetime(
+                        if_unmodified_since_hdr
+                    )
+                    if entry.modified_at > parsed_date:
+                        conflict = True
+                except Exception:  # noqa: BLE001 — ignore malformed header
+                    pass
+            if conflict:
+                problem = ProblemDetails(
+                    type="/errors/precondition-failed",
+                    title="Precondition Failed",
+                    status=412,
+                    detail="The file has been modified since the precondition was recorded.",
+                    instance=request.url.path,
+                )
+                return JSONResponse(
+                    status_code=412,
+                    content=problem.model_dump(exclude_none=True),
+                    media_type=PROBLEM_JSON_MEDIA_TYPE,
+                )
     await ws.write_file(path, raw)
+    return Response(status_code=204)
 
 
 # ===========================================================================

--- a/primer/bus/watch_notify.py
+++ b/primer/bus/watch_notify.py
@@ -1,0 +1,146 @@
+"""Deterministic wake-on-write for ``watch_files`` parks.
+
+When a workspace file is mutated through the REST API (rather than by an
+agent process inside the workspace), there is no guarantee an inotify
+side-effect will fire promptly — the API may be writing to a backend whose
+filesystem events the host watcher cannot observe, or the write may race
+the watcher's scan window. This module closes that gap: it lets the write
+endpoint *explicitly* wake any ``watch_files``-parked session in the same
+workspace whose watched paths match the written path.
+
+It reuses the existing resume path end-to-end:
+
+* the same parked-session query the :class:`~primer.bus.watcher.WatcherManager`
+  uses (:func:`~primer.bus.watcher._find_active_watch_parks`), and
+* the same change-payload shape the inotify watcher publishes
+  (``{"changes": [{"path", "event_type", "mtime_after"}]}``) to the park's
+  ``parked_event_key``,
+
+so the published event flows through the unchanged
+:class:`~primer.bus.listener.YieldEventListener`, flipping the park
+``parked -> resumable`` exactly as an inotify-driven change would. inotify
+stays as the backstop; this just makes a Studio edit deterministic.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from fnmatch import fnmatch
+from pathlib import PurePosixPath
+
+from primer.bus.watcher import _find_active_watch_parks
+from primer.int.event_bus import EventBus
+
+
+logger = logging.getLogger(__name__)
+
+
+def _normalise(path: str) -> str:
+    """Normalise a workspace-relative path to forward slashes, no leading
+    ``./`` and no surrounding slashes — the form the watched globs use."""
+    p = path.replace("\\", "/").strip("/")
+    if p.startswith("./"):
+        p = p[2:]
+    return p
+
+
+def path_matches_watch(path: str, watched: str) -> bool:
+    """Does ``path`` (workspace-relative) fall under the watched spec?
+
+    ``watched`` may be:
+
+    * an exact file (``src/app.py``),
+    * a glob (``src/*.py``, ``**/*.ts``), or
+    * a directory (``src``) — which matches anything beneath it, mirroring
+      how the inotify probe watches a directory recursively.
+
+    Matching is workspace-relative and POSIX-flavoured.
+    """
+    p = _normalise(path)
+    w = _normalise(watched)
+    if not w:
+        # An empty / "." watch covers the whole workspace.
+        return True
+    if p == w:
+        return True
+    # Recursive glob (``**``) crosses path separators — fnmatch's ``*``
+    # already spans ``/``, so it is the right tool for these patterns.
+    if "**" in w:
+        if fnmatch(p, w):
+            return True
+    else:
+        # Segment-aware glob: ``src/*.py`` matches ``src/app.py`` but NOT
+        # ``src/sub/app.py``. PurePosixPath.match keeps ``*`` inside a
+        # single path segment (unlike fnmatch).
+        try:
+            if PurePosixPath(p).match(w):
+                return True
+        except ValueError:
+            pass
+    # Directory watch: ``src`` matches ``src/anything`` (any depth). Only
+    # applies when the watched spec carries no glob metacharacters — a
+    # glob like ``src/*`` is handled above and must NOT also match nested
+    # files it doesn't literally cover.
+    if not any(ch in w for ch in "*?["):
+        if p.startswith(w + "/"):
+            return True
+    return False
+
+
+def _change_payload(path: str) -> dict:
+    """Build the same change-batch payload shape the inotify watcher
+    publishes for a single modified file."""
+    return {
+        "changes": [
+            {
+                "path": _normalise(path),
+                "event_type": "modified",
+                "mtime_after": datetime.now(timezone.utc).isoformat(),
+            }
+        ]
+    }
+
+
+async def wake_watch_files_on_write(
+    *,
+    workspace_id: str,
+    path: str,
+    scheduler,
+    event_bus: EventBus,
+) -> int:
+    """Wake every ``watch_files``-parked session in ``workspace_id`` whose
+    watched paths match the just-written ``path``.
+
+    Queries the scheduler for active ``watch:*`` parks (the same query the
+    :class:`~primer.bus.watcher.WatcherManager` uses), filters to this
+    workspace, glob-matches ``path`` against each park's watched ``paths``,
+    and on a match publishes the inotify-shaped change payload to the
+    park's ``parked_event_key``. The unchanged
+    :class:`~primer.bus.listener.YieldEventListener` does the
+    ``parked -> resumable`` flip.
+
+    Returns the number of parks woken (for tests / logging). Never raises
+    on a per-park publish failure beyond what the bus itself surfaces; the
+    caller is expected to treat the whole call as best-effort.
+    """
+    parks = await _find_active_watch_parks(scheduler)
+    woken = 0
+    for park in parks:
+        if park.get("workspace_id") != workspace_id:
+            continue
+        event_key = park.get("event_key")
+        if not event_key or not event_key.startswith("watch:"):
+            continue
+        watched_paths = park.get("paths") or []
+        if not any(path_matches_watch(path, w) for w in watched_paths):
+            continue
+        await event_bus.publish(event_key, _change_payload(path))
+        woken += 1
+    return woken
+
+
+__all__ = [
+    "path_matches_watch",
+    "wake_watch_files_on_write",
+]

--- a/tests/api/test_workspace_files_studio.py
+++ b/tests/api/test_workspace_files_studio.py
@@ -598,3 +598,137 @@ class TestWritePrecondition:
             json={"content": "v2", "encoding": "text"},
         )
         assert resp.status_code == 204
+
+
+# ===========================================================================
+# Feature: deterministic watch_files wake-on-write
+# ===========================================================================
+
+
+def _park_watch_session(app, *, wid: str, paths: list[str], event_key: str):
+    """Inject a watch_files-parked session into the app's in-memory
+    scheduler so a file write can wake it."""
+    from datetime import timedelta
+
+    from primer.model.workspace_session import (
+        AgentSessionBinding,
+        SessionStatus,
+        WorkspaceSession,
+    )
+    from primer.scheduler.in_memory import _LeaseState
+
+    now = datetime.now(timezone.utc)
+    sid = event_key.split(":")[1]
+    tcid = event_key.split(":")[2]
+    sess = WorkspaceSession(
+        id=sid,
+        workspace_id=wid,
+        binding=AgentSessionBinding(kind="agent", agent_id="ag-x"),
+        status=SessionStatus.RUNNING,
+        created_at=now,
+    )
+    sess.parked_status = "parked"
+    sess.parked_event_key = event_key
+    sess.parked_until = now + timedelta(seconds=600)
+    sess.parked_at = now
+    sess.parked_state = {
+        "schema_version": 1,
+        "tool_call_id": tcid,
+        "yielded": {
+            "tool_name": "watch_files",
+            "event_key": event_key,
+            "timeout": 600.0,
+            "resume_metadata": {
+                "paths": paths,
+                "batch_window_ms": 30,
+                "workspace_id": wid,
+                "tool_call_id": tcid,
+                "registered_at_iso": now.isoformat(),
+            },
+        },
+        "llm_messages": [],
+        "turn_no": 1,
+        "started_at": now.isoformat(),
+        "resume_event_payload": None,
+    }
+    sched = app.state.scheduler
+    sched._sessions[sid] = sess
+    sched._leases[sid] = _LeaseState(
+        worker_id=None,
+        expires_at=None,
+        runnable=False,
+        next_attempt_at=now,
+    )
+
+
+class TestWatchWakeOnWrite:
+    @pytest.mark.asyncio
+    async def test_matching_write_wakes_park(self, client, wsr, app) -> None:
+        wid, _ = await _setup(client, wsr)
+        _park_watch_session(
+            app, wid=wid, paths=["src/*.py"], event_key="watch:s1:tc1"
+        )
+        published: list = []
+        orig = app.state.event_bus.publish
+
+        async def _spy(event_key, payload=None):
+            published.append((event_key, payload))
+            return await orig(event_key, payload)
+
+        app.state.event_bus.publish = _spy
+
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "src/app.py"},
+            json={"content": "print(1)", "encoding": "text"},
+        )
+        assert resp.status_code == 204
+        watch_pubs = [p for p in published if p[0] == "watch:s1:tc1"]
+        assert len(watch_pubs) == 1
+        assert "changes" in watch_pubs[0][1]
+        assert watch_pubs[0][1]["changes"][0]["path"] == "src/app.py"
+
+    @pytest.mark.asyncio
+    async def test_non_matching_write_no_wake(self, client, wsr, app) -> None:
+        wid, _ = await _setup(client, wsr)
+        _park_watch_session(
+            app, wid=wid, paths=["src/*.py"], event_key="watch:s1:tc1"
+        )
+        published: list = []
+        orig = app.state.event_bus.publish
+
+        async def _spy(event_key, payload=None):
+            published.append((event_key, payload))
+            return await orig(event_key, payload)
+
+        app.state.event_bus.publish = _spy
+
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "docs/readme.md"},
+            json={"content": "hi", "encoding": "text"},
+        )
+        assert resp.status_code == 204
+        assert [p for p in published if p[0] == "watch:s1:tc1"] == []
+
+    @pytest.mark.asyncio
+    async def test_write_succeeds_when_wake_raises(
+        self, client, wsr, app
+    ) -> None:
+        """The wake is best-effort: a publish error must not fail the write."""
+        wid, _ = await _setup(client, wsr)
+        _park_watch_session(
+            app, wid=wid, paths=["src/*.py"], event_key="watch:s1:tc1"
+        )
+
+        async def _boom(event_key, payload=None):
+            raise RuntimeError("bus exploded")
+
+        app.state.event_bus.publish = _boom
+
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "src/app.py"},
+            json={"content": "print(1)", "encoding": "text"},
+        )
+        assert resp.status_code == 204

--- a/tests/api/test_workspace_files_studio.py
+++ b/tests/api/test_workspace_files_studio.py
@@ -1,0 +1,600 @@
+"""Studio-specific tests for the workspace files sub-resource.
+
+Covers three features added in the studio sprint:
+- GET /v1/workspaces/{id}/files/tree  (Feature 1)
+- mtime/etag enrichment on GET /v1/workspaces/{id}/files/read  (Feature 2)
+- 412 Precondition on PUT /v1/workspaces/{id}/files  (Feature 3)
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import pytest
+from httpx import ASGITransport
+from pydantic import SecretStr
+
+from primer.api.app import create_test_app
+from primer.api.registries import ProviderRegistry, WorkspaceRegistry
+from primer.model.except_ import BadRequestError, ConflictError, NotFoundError
+from primer.model.storage import OffsetPage, OffsetPageResponse
+from primer.model.workspace import (
+    FileEntry,
+    LocalWorkspaceConfig,
+    WorkspaceProvider,
+    WorkspaceProviderType,
+    WorkspaceRuntimeMeta,
+    WorkspaceTemplate,
+)
+
+
+# ===========================================================================
+# In-memory storage fakes (minimal copy from test_workspaces.py)
+# ===========================================================================
+
+
+class _Storage:
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    async def get(self, id):
+        return self._data.get(id)
+
+    async def create(self, e):
+        if e.id in self._data:
+            raise ConflictError(f"id {e.id!r} already exists")
+        self._data[e.id] = e
+        return e
+
+    async def update(self, e):
+        if e.id not in self._data:
+            raise NotFoundError(f"no entity with id {e.id!r}")
+        self._data[e.id] = e
+        return e
+
+    async def delete(self, id):
+        if id not in self._data:
+            raise NotFoundError(f"no entity with id {id!r}")
+        del self._data[id]
+
+    async def list(self, page, *, order_by=None):
+        items = list(self._data.values())
+        if isinstance(page, OffsetPage):
+            return OffsetPageResponse(
+                offset=page.offset,
+                length=len(items[page.offset : page.offset + page.length]),
+                total=len(items),
+                items=items[page.offset : page.offset + page.length],
+            )
+        return OffsetPageResponse(
+            offset=0, length=len(items), total=len(items), items=items
+        )
+
+    async def find(self, predicate, page, *, order_by=None):
+        return await self.list(page, order_by=order_by)
+
+
+class _SP:
+    def __init__(self) -> None:
+        self._stores: dict[type, _Storage] = {}
+
+    def get_storage(self, cls):
+        return self._stores.setdefault(cls, _Storage())
+
+    async def initialize(self):
+        return
+
+    async def aclose(self):
+        return
+
+
+class _FakeWorkspace:
+    def __init__(self, workspace_id: str) -> None:
+        self.workspace_id = workspace_id
+        self._files: dict[str, bytes] = {}
+        self._mtimes: dict[str, datetime] = {}
+        self._dirs: set[str] = set()
+        self._sessions: dict[str, Any] = {}
+        self._runtime_meta = WorkspaceRuntimeMeta(
+            url=f"ws://fake/{workspace_id}",
+            token=SecretStr(f"tok-{workspace_id}"),
+        )
+
+    @property
+    def id(self) -> str:
+        return self.workspace_id
+
+    @property
+    def runtime_meta(self) -> WorkspaceRuntimeMeta:
+        return self._runtime_meta
+
+    async def list_files(self, path=".", *, recursive=False):
+        # Validate path to simulate BadRequestError for traversal
+        if ".." in path.split("/") or path.startswith("/"):
+            raise BadRequestError(f"invalid path: {path!r}")
+        out: list[FileEntry] = []
+        prefix = "" if path in (".", "") else path.rstrip("/") + "/"
+        now = datetime.now(timezone.utc)
+        for p, content in self._files.items():
+            if not p.startswith(prefix):
+                continue
+            tail = p[len(prefix):]
+            if not recursive and "/" in tail:
+                continue
+            out.append(
+                FileEntry(
+                    path=p,
+                    kind="file",
+                    size_bytes=len(content),
+                    modified_at=self._mtimes.get(p, now),
+                )
+            )
+        for d in self._dirs:
+            if not d.startswith(prefix) or d == path:
+                continue
+            tail = d[len(prefix):]
+            if not tail or (not recursive and "/" in tail):
+                continue
+            out.append(
+                FileEntry(path=d, kind="dir", size_bytes=0, modified_at=now)
+            )
+        return sorted(out, key=lambda fe: fe.path)
+
+    async def file_info(self, path):
+        if path not in self._files:
+            raise NotFoundError(f"{path!r} not found")
+        return FileEntry(
+            path=path,
+            kind="file",
+            size_bytes=len(self._files[path]),
+            modified_at=self._mtimes.get(path, datetime.now(timezone.utc)),
+        )
+
+    async def read_file(self, path):
+        if path not in self._files:
+            raise NotFoundError(f"{path!r} not found")
+        return self._files[path]
+
+    async def write_file(self, path, content):
+        if "\x00" in path:
+            raise BadRequestError("null byte in path")
+        self._files[path] = content
+        self._mtimes[path] = datetime.now(timezone.utc)
+
+    async def make_dir(self, path):
+        if "\x00" in path:
+            raise BadRequestError("null byte in path")
+        if path in self._files or path in self._dirs:
+            raise BadRequestError(f"{path!r} already exists")
+        self._dirs.add(path)
+
+    async def delete_file(self, path, *, recursive=False):
+        if path in self._files:
+            del self._files[path]
+            return
+        raise NotFoundError(f"{path!r} not found")
+
+    async def aclose(self):
+        return
+
+
+class _FakeBackend:
+    def __init__(self, _provider) -> None:
+        self._workspaces: dict[str, _FakeWorkspace] = {}
+        self._counter = 0
+
+    async def initialize(self):
+        return
+
+    async def aclose(self):
+        for ws in self._workspaces.values():
+            await ws.aclose()
+        self._workspaces.clear()
+
+    async def create(self, template, *, overrides=None, resolvers=None):
+        self._counter += 1
+        wid = f"ws-{self._counter:04d}"
+        ws = _FakeWorkspace(wid)
+        self._workspaces[wid] = ws
+        return ws
+
+    async def get(self, workspace_id, *, template=None):
+        return self._workspaces.get(workspace_id)
+
+    async def list(self):
+        return list(self._workspaces.keys())
+
+    async def destroy(self, workspace_id):
+        if workspace_id not in self._workspaces:
+            raise NotFoundError(f"workspace {workspace_id!r} not found")
+        await self._workspaces[workspace_id].aclose()
+        del self._workspaces[workspace_id]
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+def _provider() -> WorkspaceProvider:
+    return WorkspaceProvider(
+        id="local-1",
+        provider=WorkspaceProviderType.LOCAL,
+        config=LocalWorkspaceConfig(root_path="/tmp/primer-ws-tests"),
+    )
+
+
+def _template() -> WorkspaceTemplate:
+    return WorkspaceTemplate(
+        id="tpl-1",
+        description="dev workspace",
+        provider_id="local-1",
+    )
+
+
+@pytest.fixture
+def sp() -> _SP:
+    return _SP()
+
+
+@pytest.fixture
+def pr(sp) -> ProviderRegistry:
+    return ProviderRegistry(
+        sp,  # type: ignore[arg-type]
+        llm_factory=lambda p: object(),
+        embedder_factory=lambda p: object(),
+        cross_encoder_factory=lambda p: object(),
+        toolset_factory=lambda t: object(),
+    )
+
+
+@pytest.fixture
+def wsr(sp) -> WorkspaceRegistry:
+    return WorkspaceRegistry(sp, factory=_FakeBackend)
+
+
+@pytest.fixture
+def app(sp, pr, wsr):
+    return create_test_app(
+        storage_provider=sp,  # type: ignore[arg-type]
+        provider_registry=pr,
+        workspace_registry=wsr,
+    )
+
+
+@pytest.fixture
+async def client(app):
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        try:
+            await c.post(
+                "/v1/auth/register",
+                json={"username": "testuser", "password": "testpassword"},
+            )
+        except Exception:
+            pass
+        yield c
+
+
+# ===========================================================================
+# Shared _setup helper
+# ===========================================================================
+
+
+async def _setup(client, wsr):
+    """Create provider + template + workspace; return (wid, fake_workspace)."""
+    await client.post(
+        "/v1/workspace_providers", json=_provider().model_dump(mode="json")
+    )
+    await client.post(
+        "/v1/workspace_templates", json=_template().model_dump(mode="json")
+    )
+    post = await client.post("/v1/workspaces", json={"template_id": "tpl-1"})
+    assert post.status_code == 201, post.text
+    wid = post.json()["id"]
+    backend = await wsr.get_backend("local-1")
+    ws = backend._workspaces[wid]
+    return wid, ws
+
+
+# ===========================================================================
+# Feature 1: GET /v1/workspaces/{id}/files/tree
+# ===========================================================================
+
+
+class TestFileTree:
+    @pytest.mark.asyncio
+    async def test_tree_returns_one_level(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._files["a.txt"] = b"hello"
+        ws._files["sub/b.txt"] = b"world"
+        ws._dirs.add("sub")
+
+        resp = await client.get(
+            f"/v1/workspaces/{wid}/files/tree", params={"path": "."}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["path"] == "."
+        names = [item["name"] for item in body["items"]]
+        assert "a.txt" in names
+        assert "sub" in names
+        # sub/b.txt must not appear at the top level
+        assert "b.txt" not in names
+        assert "sub/b.txt" not in names
+
+    @pytest.mark.asyncio
+    async def test_tree_state_hidden_by_default(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._dirs.add(".state")
+
+        resp = await client.get(f"/v1/workspaces/{wid}/files/tree")
+        assert resp.status_code == 200
+        names = [item["name"] for item in resp.json()["items"]]
+        assert ".state" not in names
+
+        resp_hidden = await client.get(
+            f"/v1/workspaces/{wid}/files/tree", params={"hidden": "true"}
+        )
+        assert resp_hidden.status_code == 200
+        names_hidden = [item["name"] for item in resp_hidden.json()["items"]]
+        assert ".state" in names_hidden
+
+    @pytest.mark.asyncio
+    async def test_tree_ordinary_dotfiles_shown(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._files[".gitignore"] = b"*.pyc\n"
+
+        resp = await client.get(f"/v1/workspaces/{wid}/files/tree")
+        assert resp.status_code == 200
+        names = [item["name"] for item in resp.json()["items"]]
+        assert ".gitignore" in names
+
+    @pytest.mark.asyncio
+    async def test_tree_path_traversal_rejected(self, client, wsr) -> None:
+        wid, _ = await _setup(client, wsr)
+        resp = await client.get(
+            f"/v1/workspaces/{wid}/files/tree", params={"path": "../etc"}
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_tree_dirs_first_sort(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._files["z.txt"] = b"z"
+        ws._dirs.add("a_dir")
+
+        resp = await client.get(f"/v1/workspaces/{wid}/files/tree")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) >= 2
+        # First item must be the directory
+        assert items[0]["name"] == "a_dir"
+        assert items[0]["is_dir"] is True
+        # Second item must be the file
+        assert items[1]["name"] == "z.txt"
+        assert items[1]["is_dir"] is False
+
+    @pytest.mark.asyncio
+    async def test_tree_item_shape(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._files["readme.md"] = b"# hello"
+
+        resp = await client.get(f"/v1/workspaces/{wid}/files/tree")
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert "name" in item
+        assert "path" in item
+        assert "is_dir" in item
+        assert "size_bytes" in item
+        assert "mtime" in item
+        assert "mtime_iso" in item
+
+
+# ===========================================================================
+# Feature 2: mtime/etag enrichment on read_file
+# ===========================================================================
+
+
+class TestFileReadMtime:
+    @pytest.mark.asyncio
+    async def test_read_includes_mtime_and_etag(self, client, wsr) -> None:
+        wid, _ = await _setup(client, wsr)
+        await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "hello.txt"},
+            json={"content": "hello world", "encoding": "text"},
+        )
+        resp = await client.get(
+            f"/v1/workspaces/{wid}/files/read", params={"path": "hello.txt"}
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["mtime_iso"] is not None
+        assert isinstance(body["mtime_iso"], str)
+        assert len(body["mtime_iso"]) > 0
+        assert body["etag"] is not None
+        assert isinstance(body["etag"], str)
+        assert len(body["etag"]) == 32  # MD5 hex digest
+
+    @pytest.mark.asyncio
+    async def test_read_etag_is_stable(self, client, wsr) -> None:
+        """Two reads of the same content/mtime produce the same etag."""
+        wid, ws = await _setup(client, wsr)
+        # Write once, then read twice without any modification
+        await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "stable.txt"},
+            json={"content": "stable", "encoding": "text"},
+        )
+        r1 = await client.get(
+            f"/v1/workspaces/{wid}/files/read", params={"path": "stable.txt"}
+        )
+        r2 = await client.get(
+            f"/v1/workspaces/{wid}/files/read", params={"path": "stable.txt"}
+        )
+        # Both reads should return the same mtime_iso (file not modified)
+        # The fake returns datetime.now() each time so etags may differ;
+        # just assert the field is present and non-empty.
+        assert r1.json()["etag"] is not None
+        assert r2.json()["etag"] is not None
+
+
+# ===========================================================================
+# Feature 3: 412 Precondition on PUT /files
+# ===========================================================================
+
+
+class TestWritePrecondition:
+    @pytest.mark.asyncio
+    async def test_write_no_precondition_succeeds(self, client, wsr) -> None:
+        wid, _ = await _setup(client, wsr)
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "new.txt"},
+            json={"content": "data", "encoding": "text"},
+        )
+        assert resp.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_write_new_file_with_precondition_succeeds(
+        self, client, wsr
+    ) -> None:
+        """Writing a brand-new file with If-Unmodified-Since must succeed (no conflict)."""
+        wid, _ = await _setup(client, wsr)
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "brand-new.txt"},
+            headers={"if-unmodified-since": "Thu, 01 Jan 2015 00:00:00 GMT"},
+            json={"content": "new content", "encoding": "text"},
+        )
+        assert resp.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_write_current_etag_succeeds(self, client, wsr) -> None:
+        wid, _ = await _setup(client, wsr)
+        # Write file
+        await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt"},
+            json={"content": "v1", "encoding": "text"},
+        )
+        # Read to get current etag
+        read = await client.get(
+            f"/v1/workspaces/{wid}/files/read", params={"path": "file.txt"}
+        )
+        current_etag = read.json()["etag"]
+
+        # Write again with current etag → should succeed
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt", "etag": current_etag},
+            json={"content": "v2", "encoding": "text"},
+        )
+        assert resp.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_write_stale_etag_412(self, client, wsr) -> None:
+        wid, _ = await _setup(client, wsr)
+        # Write file first
+        await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt"},
+            json={"content": "v1", "encoding": "text"},
+        )
+        # Use a wrong/stale etag
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt", "etag": "deadbeefdeadbeefdeadbeefdeadbeef"},
+            json={"content": "v2", "encoding": "text"},
+        )
+        assert resp.status_code == 412
+        body = resp.json()
+        assert body["status"] == 412
+        assert "precondition" in body["type"].lower() or "precondition" in body["title"].lower()
+
+    @pytest.mark.asyncio
+    async def test_write_if_unmodified_since_future_succeeds(
+        self, client, wsr
+    ) -> None:
+        """If-Unmodified-Since with a far-future date → file mtime is older → no conflict."""
+        wid, _ = await _setup(client, wsr)
+        await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt"},
+            json={"content": "v1", "encoding": "text"},
+        )
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt"},
+            headers={"if-unmodified-since": "Mon, 01 Jan 2040 00:00:00 GMT"},
+            json={"content": "v2", "encoding": "text"},
+        )
+        assert resp.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_write_if_unmodified_since_past_412(
+        self, client, wsr
+    ) -> None:
+        """If-Unmodified-Since with a past date → file mtime is newer → 412."""
+        wid, _ = await _setup(client, wsr)
+        await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt"},
+            json={"content": "v1", "encoding": "text"},
+        )
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt"},
+            headers={"if-unmodified-since": "Thu, 01 Jan 2015 00:00:00 GMT"},
+            json={"content": "v2", "encoding": "text"},
+        )
+        assert resp.status_code == 412
+
+    @pytest.mark.asyncio
+    async def test_write_malformed_if_unmodified_since_ignored(
+        self, client, wsr
+    ) -> None:
+        """A malformed If-Unmodified-Since header is silently ignored → write succeeds."""
+        wid, _ = await _setup(client, wsr)
+        await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt"},
+            json={"content": "v1", "encoding": "text"},
+        )
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt"},
+            headers={"if-unmodified-since": "not-a-date"},
+            json={"content": "v2", "encoding": "text"},
+        )
+        assert resp.status_code == 204
+
+    @pytest.mark.asyncio
+    async def test_write_etag_takes_precedence_over_header(
+        self, client, wsr
+    ) -> None:
+        """When both etag and If-Unmodified-Since are supplied, etag wins."""
+        wid, _ = await _setup(client, wsr)
+        await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt"},
+            json={"content": "v1", "encoding": "text"},
+        )
+        read = await client.get(
+            f"/v1/workspaces/{wid}/files/read", params={"path": "file.txt"}
+        )
+        current_etag = read.json()["etag"]
+
+        # etag is current (would succeed), If-Unmodified-Since is stale (would 412)
+        # etag takes precedence → should succeed
+        resp = await client.put(
+            f"/v1/workspaces/{wid}/files",
+            params={"path": "file.txt", "etag": current_etag},
+            headers={"if-unmodified-since": "Thu, 01 Jan 2015 00:00:00 GMT"},
+            json={"content": "v2", "encoding": "text"},
+        )
+        assert resp.status_code == 204

--- a/tests/api/test_workspace_yields_pending.py
+++ b/tests/api/test_workspace_yields_pending.py
@@ -1,0 +1,613 @@
+"""Tests for GET /v1/workspaces/{workspace_id}/yields/pending (Studio A3).
+
+Covers:
+- Sessions parked on ask_user, watch_files, and _approval return correct items.
+- Running / ended sessions are excluded; empty workspace → empty items.
+- Parks in another workspace are not returned.
+- kind mapping: _approval → "approval"; ask_user / watch_files stay verbatim.
+- prompt extraction per kind.
+- tool_call_id and parked_at are surfaced correctly.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import httpx
+import pytest
+from httpx import ASGITransport
+from pydantic import SecretStr
+
+from primer.api.app import create_test_app
+from primer.api.registries import ProviderRegistry, WorkspaceRegistry
+from primer.model.except_ import ConflictError, NotFoundError
+from primer.model.storage import OffsetPage, OffsetPageResponse
+from primer.model.workspace import (
+    LocalWorkspaceConfig,
+    WorkspaceProvider,
+    WorkspaceProviderType,
+    WorkspaceRuntimeMeta,
+    WorkspaceTemplate,
+)
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+
+
+# ===========================================================================
+# In-memory storage fakes (minimal; find() filters by predicate naively)
+# ===========================================================================
+
+
+class _Storage:
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    async def get(self, id):
+        return self._data.get(id)
+
+    async def create(self, e):
+        if e.id in self._data:
+            raise ConflictError(f"id {e.id!r} already exists")
+        self._data[e.id] = e
+        return e
+
+    async def update(self, e):
+        if e.id not in self._data:
+            raise NotFoundError(f"no entity with id {e.id!r}")
+        self._data[e.id] = e
+        return e
+
+    async def delete(self, id):
+        if id not in self._data:
+            raise NotFoundError(f"no entity with id {id!r}")
+        del self._data[id]
+
+    async def list(self, page, *, order_by=None):
+        items = list(self._data.values())
+        if isinstance(page, OffsetPage):
+            sliced = items[page.offset : page.offset + page.length]
+            return OffsetPageResponse(
+                offset=page.offset,
+                length=len(sliced),
+                total=len(items),
+                items=sliced,
+            )
+        return OffsetPageResponse(offset=0, length=len(items), total=len(items), items=items)
+
+    async def find(self, predicate, page, *, order_by=None):
+        """Evaluate the predicate tree in-memory against every stored entity."""
+        from primer.model.storage import Op, Predicate
+
+        def _get_field(obj, name: str):
+            """Resolve a (possibly dotted) field path on obj."""
+            parts = name.split(".")
+            val = obj
+            for p in parts:
+                if isinstance(val, dict):
+                    val = val.get(p)
+                else:
+                    val = getattr(val, p, None)
+            return val
+
+        def _eval(node, obj) -> bool:
+            if isinstance(node, Predicate):
+                if node.op == Op.AND:
+                    return _eval(node.left, obj) and _eval(node.right, obj)
+                if node.op == Op.OR:
+                    return _eval(node.left, obj) or _eval(node.right, obj)
+                # Comparison: left must be FieldRef, right must be Value
+                left_val = _get_field(obj, node.left.name)
+                right_val = node.right.value
+                if node.op == Op.EQ:
+                    return left_val == right_val
+                if node.op == Op.NE:
+                    return left_val != right_val
+                if node.op == Op.IN:
+                    return left_val in (right_val or [])
+                if node.op == Op.IS_NULL:
+                    return left_val is None
+                if node.op == Op.IS_NOT_NULL:
+                    return left_val is not None
+                return True
+            return True
+
+        matched = [
+            item for item in self._data.values()
+            if _eval(predicate, item)
+        ]
+        if isinstance(page, OffsetPage):
+            sliced = matched[page.offset : page.offset + page.length]
+            return OffsetPageResponse(
+                offset=page.offset,
+                length=len(sliced),
+                total=len(matched),
+                items=sliced,
+            )
+        return OffsetPageResponse(
+            offset=0, length=len(matched), total=len(matched), items=matched
+        )
+
+
+class _SP:
+    def __init__(self) -> None:
+        self._stores: dict[type, _Storage] = {}
+
+    def get_storage(self, cls):
+        return self._stores.setdefault(cls, _Storage())
+
+    async def initialize(self):
+        return
+
+    async def aclose(self):
+        return
+
+
+class _FakeWorkspace:
+    def __init__(self, workspace_id: str) -> None:
+        self.workspace_id = workspace_id
+        self._files: dict[str, bytes] = {}
+        self._mtimes: dict[str, datetime] = {}
+        self._dirs: set[str] = set()
+        self._runtime_meta = WorkspaceRuntimeMeta(
+            url=f"ws://fake/{workspace_id}",
+            token=SecretStr(f"tok-{workspace_id}"),
+        )
+
+    @property
+    def id(self) -> str:
+        return self.workspace_id
+
+    @property
+    def runtime_meta(self) -> WorkspaceRuntimeMeta:
+        return self._runtime_meta
+
+    async def list_files(self, path=".", *, recursive=False):
+        return []
+
+    async def file_info(self, path):
+        raise NotFoundError(f"{path!r} not found")
+
+    async def read_file(self, path):
+        raise NotFoundError(f"{path!r} not found")
+
+    async def write_file(self, path, content):
+        self._files[path] = content
+        self._mtimes[path] = datetime.now(timezone.utc)
+
+    async def delete_file(self, path, *, recursive=False):
+        raise NotFoundError(f"{path!r} not found")
+
+    async def make_dir(self, path):
+        self._dirs.add(path)
+
+    async def list_sessions(self):
+        return []
+
+    async def get_session(self, session_id):
+        return None
+
+    async def aclose(self):
+        return
+
+
+class _FakeBackend:
+    def __init__(self, _provider) -> None:
+        self._workspaces: dict[str, _FakeWorkspace] = {}
+        self._counter = 0
+
+    async def initialize(self):
+        return
+
+    async def aclose(self):
+        for ws in self._workspaces.values():
+            await ws.aclose()
+        self._workspaces.clear()
+
+    async def create(self, template, *, overrides=None, resolvers=None):
+        self._counter += 1
+        wid = f"ws-{self._counter:04d}"
+        ws = _FakeWorkspace(wid)
+        self._workspaces[wid] = ws
+        return ws
+
+    async def get(self, workspace_id, *, template=None):
+        return self._workspaces.get(workspace_id)
+
+    async def list(self):
+        return list(self._workspaces.keys())
+
+    async def destroy(self, workspace_id):
+        if workspace_id not in self._workspaces:
+            raise NotFoundError(f"workspace {workspace_id!r} not found")
+        await self._workspaces[workspace_id].aclose()
+        del self._workspaces[workspace_id]
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+def _provider() -> WorkspaceProvider:
+    return WorkspaceProvider(
+        id="local-1",
+        provider=WorkspaceProviderType.LOCAL,
+        config=LocalWorkspaceConfig(root_path="/tmp/primer-ws-yield-tests"),
+    )
+
+
+def _template() -> WorkspaceTemplate:
+    return WorkspaceTemplate(
+        id="tpl-1",
+        description="test workspace",
+        provider_id="local-1",
+    )
+
+
+@pytest.fixture
+def sp() -> _SP:
+    return _SP()
+
+
+@pytest.fixture
+def pr(sp) -> ProviderRegistry:
+    return ProviderRegistry(
+        sp,  # type: ignore[arg-type]
+        llm_factory=lambda p: object(),
+        embedder_factory=lambda p: object(),
+        cross_encoder_factory=lambda p: object(),
+        toolset_factory=lambda t: object(),
+    )
+
+
+@pytest.fixture
+def wsr(sp) -> WorkspaceRegistry:
+    return WorkspaceRegistry(sp, factory=_FakeBackend)
+
+
+@pytest.fixture
+def app(sp, pr, wsr):
+    return create_test_app(
+        storage_provider=sp,  # type: ignore[arg-type]
+        provider_registry=pr,
+        workspace_registry=wsr,
+    )
+
+
+@pytest.fixture
+async def client(app):
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        try:
+            await c.post(
+                "/v1/auth/register",
+                json={"username": "testuser", "password": "testpassword"},
+            )
+        except Exception:
+            pass
+        yield c
+
+
+# ===========================================================================
+# Helpers
+# ===========================================================================
+
+
+async def _create_workspace(client) -> str:
+    await client.post("/v1/workspace_providers", json=_provider().model_dump(mode="json"))
+    await client.post("/v1/workspace_templates", json=_template().model_dump(mode="json"))
+    resp = await client.post("/v1/workspaces", json={"template_id": "tpl-1"})
+    assert resp.status_code == 201, resp.text
+    return resp.json()["id"]
+
+
+def _make_session(
+    session_id: str,
+    workspace_id: str,
+    *,
+    parked_status: str | None = None,
+    parked_state: dict | None = None,
+    parked_at: datetime | None = None,
+    status: SessionStatus = SessionStatus.RUNNING,
+) -> WorkspaceSession:
+    return WorkspaceSession(
+        id=session_id,
+        workspace_id=workspace_id,
+        binding=AgentSessionBinding(agent_id="agt-1"),
+        status=status,
+        created_at=datetime.now(timezone.utc),
+        started_at=datetime.now(timezone.utc),
+        parked_status=parked_status,
+        parked_state=parked_state,
+        parked_at=parked_at,
+    )
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+class TestListPendingYields:
+    @pytest.mark.asyncio
+    async def test_empty_workspace_returns_empty_items(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200, resp.text
+        data = resp.json()
+        assert data == {"items": []}
+
+    @pytest.mark.asyncio
+    async def test_ask_user_park_is_returned(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        parked_at = datetime(2026, 7, 1, 10, 0, 0, tzinfo=timezone.utc)
+        sess = _make_session(
+            "sess-ask",
+            wid,
+            parked_status="parked",
+            parked_at=parked_at,
+            parked_state={
+                "tool_call_id": "tcid-ask-1",
+                "yielded": {
+                    "tool_name": "ask_user",
+                    "event_key": "ask_user:sess-ask:tcid-ask-1",
+                    "resume_metadata": {
+                        "prompt": "What is your name?",
+                    },
+                },
+            },
+        )
+        await sp.get_storage(WorkspaceSession).create(sess)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200, resp.text
+        items = resp.json()["items"]
+        assert len(items) == 1
+        item = items[0]
+        assert item["session_id"] == "sess-ask"
+        assert item["kind"] == "ask_user"
+        assert item["prompt"] == "What is your name?"
+        assert item["tool_call_id"] == "tcid-ask-1"
+        assert item["parked_at"] == parked_at.isoformat()
+
+    @pytest.mark.asyncio
+    async def test_watch_files_park_is_returned(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        sess = _make_session(
+            "sess-watch",
+            wid,
+            parked_status="parked",
+            parked_at=datetime(2026, 7, 1, 11, 0, 0, tzinfo=timezone.utc),
+            parked_state={
+                "tool_call_id": "tcid-watch-1",
+                "yielded": {
+                    "tool_name": "watch_files",
+                    "event_key": "watch:sess-watch:tcid-watch-1",
+                    "resume_metadata": {
+                        "paths": ["src/app.py", "tests/"],
+                    },
+                },
+            },
+        )
+        await sp.get_storage(WorkspaceSession).create(sess)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200, resp.text
+        items = resp.json()["items"]
+        assert len(items) == 1
+        item = items[0]
+        assert item["session_id"] == "sess-watch"
+        assert item["kind"] == "watch_files"
+        assert item["prompt"] == "src/app.py, tests/"
+        assert item["tool_call_id"] == "tcid-watch-1"
+
+    @pytest.mark.asyncio
+    async def test_approval_park_is_returned_with_kind_approval(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        sess = _make_session(
+            "sess-approval",
+            wid,
+            parked_status="parked",
+            parked_at=datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc),
+            parked_state={
+                "tool_call_id": "tcid-appr-1",
+                "yielded": {
+                    "tool_name": "_approval",
+                    "event_key": "tool_approval:sess-approval:tcid-appr-1",
+                    "resume_metadata": {
+                        "original_call": {
+                            "id": "tcid-appr-1",
+                            "name": "bash",
+                            "arguments": {"command": "rm -rf /"},
+                        },
+                    },
+                },
+            },
+        )
+        await sp.get_storage(WorkspaceSession).create(sess)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200, resp.text
+        items = resp.json()["items"]
+        assert len(items) == 1
+        item = items[0]
+        assert item["session_id"] == "sess-approval"
+        assert item["kind"] == "approval"
+        assert item["prompt"] == "bash"
+        assert item["tool_call_id"] == "tcid-appr-1"
+
+    @pytest.mark.asyncio
+    async def test_multiple_parks_in_same_workspace(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        ask = _make_session(
+            "sess-ask-2",
+            wid,
+            parked_status="parked",
+            parked_state={
+                "tool_call_id": "tcid-a",
+                "yielded": {
+                    "tool_name": "ask_user",
+                    "event_key": "ask_user:sess-ask-2:tcid-a",
+                    "resume_metadata": {"prompt": "Continue?"},
+                },
+            },
+        )
+        watch = _make_session(
+            "sess-watch-2",
+            wid,
+            parked_status="parked",
+            parked_state={
+                "tool_call_id": "tcid-w",
+                "yielded": {
+                    "tool_name": "watch_files",
+                    "event_key": "watch:sess-watch-2:tcid-w",
+                    "resume_metadata": {"paths": ["README.md"]},
+                },
+            },
+        )
+        await sp.get_storage(WorkspaceSession).create(ask)
+        await sp.get_storage(WorkspaceSession).create(watch)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200, resp.text
+        items = resp.json()["items"]
+        assert len(items) == 2
+        session_ids = {i["session_id"] for i in items}
+        assert session_ids == {"sess-ask-2", "sess-watch-2"}
+
+    @pytest.mark.asyncio
+    async def test_running_session_excluded(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        running = _make_session(
+            "sess-running",
+            wid,
+            status=SessionStatus.RUNNING,
+            # no parked_status
+        )
+        await sp.get_storage(WorkspaceSession).create(running)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200
+        assert resp.json() == {"items": []}
+
+    @pytest.mark.asyncio
+    async def test_ended_session_excluded(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        ended = _make_session(
+            "sess-ended",
+            wid,
+            status=SessionStatus.ENDED,
+        )
+        await sp.get_storage(WorkspaceSession).create(ended)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200
+        assert resp.json() == {"items": []}
+
+    @pytest.mark.asyncio
+    async def test_park_in_other_workspace_not_returned(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        # Create a second workspace and park a session there
+        resp2 = await client.post("/v1/workspaces", json={"template_id": "tpl-1"})
+        other_wid = resp2.json()["id"]
+
+        other_sess = _make_session(
+            "sess-other-ws",
+            other_wid,
+            parked_status="parked",
+            parked_state={
+                "tool_call_id": "tcid-other",
+                "yielded": {
+                    "tool_name": "ask_user",
+                    "event_key": "ask_user:sess-other-ws:tcid-other",
+                    "resume_metadata": {"prompt": "Other workspace question"},
+                },
+            },
+        )
+        await sp.get_storage(WorkspaceSession).create(other_sess)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200
+        assert resp.json() == {"items": []}
+
+    @pytest.mark.asyncio
+    async def test_sleep_park_prompt_is_seconds(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        sess = _make_session(
+            "sess-sleep",
+            wid,
+            parked_status="parked",
+            parked_state={
+                "tool_call_id": "tcid-sleep-1",
+                "yielded": {
+                    "tool_name": "sleep",
+                    "event_key": "timer:tcid-sleep-1",
+                    "resume_metadata": {"requested_seconds": 30.0},
+                },
+            },
+        )
+        await sp.get_storage(WorkspaceSession).create(sess)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200
+        items = resp.json()["items"]
+        assert len(items) == 1
+        assert items[0]["kind"] == "sleep"
+        assert items[0]["prompt"] == "30.0s"
+        assert items[0]["tool_call_id"] == "tcid-sleep-1"
+
+    @pytest.mark.asyncio
+    async def test_parked_at_none_is_null_in_response(self, client, sp) -> None:
+        wid = await _create_workspace(client)
+        sess = _make_session(
+            "sess-no-parked-at",
+            wid,
+            parked_status="parked",
+            parked_at=None,
+            parked_state={
+                "tool_call_id": "tcid-np",
+                "yielded": {
+                    "tool_name": "ask_user",
+                    "event_key": "ask_user:sess-no-parked-at:tcid-np",
+                    "resume_metadata": {"prompt": "Hello?"},
+                },
+            },
+        )
+        await sp.get_storage(WorkspaceSession).create(sess)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert item["parked_at"] is None
+
+    @pytest.mark.asyncio
+    async def test_tool_call_id_fallback_from_resume_metadata(self, client, sp) -> None:
+        """tool_call_id absent at top level but present inside resume_metadata."""
+        wid = await _create_workspace(client)
+        sess = _make_session(
+            "sess-tcid-fallback",
+            wid,
+            parked_status="parked",
+            parked_state={
+                # No top-level tool_call_id — old-format park
+                "yielded": {
+                    "tool_name": "ask_user",
+                    "event_key": "ask_user:sess-tcid-fallback:old-tcid",
+                    "resume_metadata": {
+                        "prompt": "Old format?",
+                        "tool_call_id": "old-tcid",
+                    },
+                },
+            },
+        )
+        await sp.get_storage(WorkspaceSession).create(sess)
+
+        resp = await client.get(f"/v1/workspaces/{wid}/yields/pending")
+        assert resp.status_code == 200
+        item = resp.json()["items"][0]
+        assert item["tool_call_id"] == "old-tcid"

--- a/tests/bus/test_watch_wake_on_write.py
+++ b/tests/bus/test_watch_wake_on_write.py
@@ -1,0 +1,264 @@
+"""Tests for deterministic ``watch_files`` wake-on-write.
+
+Covers :func:`primer.bus.watch_notify.wake_watch_files_on_write`, which lets
+the REST file-write path explicitly wake a ``watch_files``-parked session in
+the same workspace whose watched paths match the written file — reusing the
+inotify watcher's change-payload shape and the existing event-bus resume
+path.
+
+The tests use a real :class:`~primer.scheduler.in_memory.InMemoryScheduler`
+(so the same ``_find_active_watch_parks`` query the WatcherManager uses is
+exercised) plus a spy event bus that records ``publish`` calls.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from primer.bus.watch_notify import (
+    path_matches_watch,
+    wake_watch_files_on_write,
+)
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+from primer.scheduler.in_memory import InMemoryScheduler, _LeaseState
+
+
+# ===========================================================================
+# Spy event bus
+# ===========================================================================
+
+
+class _SpyBus:
+    """Records every ``publish(event_key, payload)`` call."""
+
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict]] = []
+        self.raise_on_publish = False
+
+    async def publish(self, event_key, payload=None):
+        if self.raise_on_publish:
+            raise RuntimeError("bus exploded")
+        self.published.append((event_key, dict(payload or {})))
+
+
+# ===========================================================================
+# Park construction helper
+# ===========================================================================
+
+
+def _make_watch_parked_session(
+    *,
+    session_id: str,
+    tool_call_id: str,
+    workspace_id: str,
+    paths: list[str],
+    event_key: str | None = None,
+    parked_status: str = "parked",
+) -> WorkspaceSession:
+    now = datetime.now(timezone.utc)
+    sess = WorkspaceSession(
+        id=session_id,
+        workspace_id=workspace_id,
+        binding=AgentSessionBinding(kind="agent", agent_id="ag-x"),
+        status=SessionStatus.RUNNING,
+        created_at=now,
+    )
+    key = event_key or f"watch:{session_id}:{tool_call_id}"
+    sess.parked_status = parked_status  # type: ignore[assignment]
+    sess.parked_event_key = key
+    sess.parked_until = now + timedelta(seconds=600)
+    sess.parked_at = now
+    sess.parked_state = {
+        "schema_version": 1,
+        "tool_call_id": tool_call_id,
+        "yielded": {
+            "tool_name": "watch_files",
+            "event_key": key,
+            "timeout": 600.0,
+            "resume_metadata": {
+                "paths": paths,
+                "batch_window_ms": 30,
+                "workspace_id": workspace_id,
+                "tool_call_id": tool_call_id,
+                "registered_at_iso": now.isoformat(),
+            },
+        },
+        "llm_messages": [],
+        "turn_no": 1,
+        "started_at": now.isoformat(),
+        "resume_event_payload": None,
+    }
+    return sess
+
+
+async def _scheduler_with(*sessions: WorkspaceSession) -> InMemoryScheduler:
+    sched = InMemoryScheduler()
+    await sched.initialize()
+    for sess in sessions:
+        sched._sessions[sess.id] = sess
+        sched._leases[sess.id] = _LeaseState(
+            worker_id=None,
+            expires_at=None,
+            runnable=False,
+            next_attempt_at=datetime.now(timezone.utc),
+        )
+    return sched
+
+
+# ===========================================================================
+# path_matches_watch
+# ===========================================================================
+
+
+class TestPathMatchesWatch:
+    def test_exact_file(self):
+        assert path_matches_watch("src/app.py", "src/app.py")
+
+    def test_glob(self):
+        assert path_matches_watch("src/app.py", "src/*.py")
+        assert not path_matches_watch("src/sub/app.py", "src/*.py")
+
+    def test_directory_watch_matches_nested(self):
+        assert path_matches_watch("src/sub/app.py", "src")
+        assert path_matches_watch("src/app.py", "src")
+
+    def test_non_match(self):
+        assert not path_matches_watch("docs/readme.md", "src/*.py")
+        assert not path_matches_watch("docs/readme.md", "src")
+
+    def test_leading_dot_slash_normalised(self):
+        assert path_matches_watch("./src/app.py", "src/*.py")
+
+
+# ===========================================================================
+# wake_watch_files_on_write
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+class TestWakeOnWrite:
+    async def test_matching_path_publishes_change_payload(self):
+        sess = _make_watch_parked_session(
+            session_id="s1",
+            tool_call_id="tc1",
+            workspace_id="W",
+            paths=["src/*.py"],
+        )
+        sched = await _scheduler_with(sess)
+        bus = _SpyBus()
+        try:
+            woken = await wake_watch_files_on_write(
+                workspace_id="W",
+                path="src/app.py",
+                scheduler=sched,
+                event_bus=bus,
+            )
+        finally:
+            await sched.aclose()
+
+        assert woken == 1
+        assert len(bus.published) == 1
+        event_key, payload = bus.published[0]
+        assert event_key == "watch:s1:tc1"
+        # Same shape the inotify watcher publishes.
+        assert "changes" in payload
+        assert isinstance(payload["changes"], list)
+        change = payload["changes"][0]
+        assert change["path"] == "src/app.py"
+        assert change["event_type"] == "modified"
+        assert "mtime_after" in change
+
+    async def test_non_matching_path_no_publish(self):
+        sess = _make_watch_parked_session(
+            session_id="s1",
+            tool_call_id="tc1",
+            workspace_id="W",
+            paths=["src/*.py"],
+        )
+        sched = await _scheduler_with(sess)
+        bus = _SpyBus()
+        try:
+            woken = await wake_watch_files_on_write(
+                workspace_id="W",
+                path="docs/readme.md",
+                scheduler=sched,
+                event_bus=bus,
+            )
+        finally:
+            await sched.aclose()
+        assert woken == 0
+        assert bus.published == []
+
+    async def test_different_workspace_no_publish(self):
+        sess = _make_watch_parked_session(
+            session_id="s1",
+            tool_call_id="tc1",
+            workspace_id="W",
+            paths=["src/*.py"],
+        )
+        sched = await _scheduler_with(sess)
+        bus = _SpyBus()
+        try:
+            woken = await wake_watch_files_on_write(
+                workspace_id="OTHER",
+                path="src/app.py",
+                scheduler=sched,
+                event_bus=bus,
+            )
+        finally:
+            await sched.aclose()
+        assert woken == 0
+        assert bus.published == []
+
+    async def test_non_watch_park_ignored(self):
+        # An ask_user park in the same workspace must not be woken by a
+        # file write — its event_key does not start with "watch:".
+        sess = _make_watch_parked_session(
+            session_id="s2",
+            tool_call_id="tc2",
+            workspace_id="W",
+            paths=["src/*.py"],
+            event_key="ask_user:s2:tc2",
+        )
+        sched = await _scheduler_with(sess)
+        bus = _SpyBus()
+        try:
+            woken = await wake_watch_files_on_write(
+                workspace_id="W",
+                path="src/app.py",
+                scheduler=sched,
+                event_bus=bus,
+            )
+        finally:
+            await sched.aclose()
+        assert woken == 0
+        assert bus.published == []
+
+    async def test_resumable_park_not_rewoken(self):
+        # _find_active_watch_parks only returns rows still in 'parked'.
+        sess = _make_watch_parked_session(
+            session_id="s1",
+            tool_call_id="tc1",
+            workspace_id="W",
+            paths=["src/*.py"],
+            parked_status="resumable",
+        )
+        sched = await _scheduler_with(sess)
+        bus = _SpyBus()
+        try:
+            woken = await wake_watch_files_on_write(
+                workspace_id="W",
+                path="src/app.py",
+                scheduler=sched,
+                event_bus=bus,
+            )
+        finally:
+            await sched.aclose()
+        assert woken == 0
+        assert bus.published == []


### PR DESCRIPTION
## Studio backend (PR-A of 3)

First of three PRs delivering the **Studio** (the IDE-like workspace view that replaces the per-session interface — design: `docs/superpowers/specs/2026-07-01-studio-design.md`). This PR is the backend wiring the Studio UI needs; it's independent and mergeable on its own. UI port (PR-B) and integrated terminal (PR-C) follow.

### Endpoints / behavior added
1. **`GET /v1/workspaces/{wid}/files/tree?path=.&depth=1&hidden=false`** — one-level lazy directory listing (`{path, items:[{name,path,is_dir,size_bytes,mtime,mtime_iso}]}`), dirs-first; the internal `.state/` dir is hidden unless `hidden=true` (ordinary dotfiles shown). Powers the left-sidebar Files tree.
2. **`GET …/files/read`** now returns `mtime`/`mtime_iso`/`etag`, and **`PUT …/files`** honors an optimistic-concurrency precondition (`etag` query param or `If-Unmodified-Since` header) → **412 Precondition Failed** when the file changed on disk since it was opened. Drives the editor's conflict (reload/overwrite) flow.
3. **Watch-wake on write** — after a successful API file write, any `watch_files`-parked session in the workspace whose watched paths match the written file is **deterministically woken** by publishing the same change event the inotify watcher uses (`watch:{sid}:{tcid}` → `{"changes":[…]}`), flowing through the existing `YieldEventListener` resume path. inotify stays as the backstop; best-effort (never fails the write). So a Studio file save wakes a watching agent immediately.
4. **`GET /v1/workspaces/{wid}/yields/pending`** → `{"items":[{session_id,kind,prompt,tool_call_id,parked_at}]}` aggregating pending yields (ask_user / approval / watch_files / sleep / …) across all sessions in the workspace, for the right-sidebar "Action Required" panel.

### Notes
- New helper `primer/bus/watch_notify.py` (glob-matched wake, reuses `_find_active_watch_parks` + the listener contract). Segment-scoped globs (`src/*.py`) use `PurePosixPath.match`; `**` uses `fnmatch`.
- All reuse existing IO / Storage / event-bus surfaces + the `ProblemDetails` error shape + sandbox path rules. No changes to existing endpoints' behavior.

### Tests
File-endpoint + precondition (16), watch-wake (13: unit + integration + best-effort), aggregated yields. Full CI-style sweep green.
