### PR TITLE
feat(ui): Studio — IDE-like workspace view replacing the session interface

### DIFF
--- a/tests/ui/test_studio_activity.py
+++ b/tests/ui/test_studio_activity.py
@@ -1,0 +1,194 @@
+"""Structural-presence checks for StudioActivity (PR-B / B4).
+
+Verifies:
+  - window.StudioActivity / ActionRequired / WorkspaceActivity are exported
+  - WorkspaceTap is reused (not reimplemented)
+  - region-activity placeholder is gone from studio.jsx
+  - all required data-testids are present in studio-activity.jsx
+  - the file transpiles cleanly in the full bundle
+
+These are static-source checks only (no React rendering), matching the
+approach used in test_studio_shell.py / test_studio_sidebar.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+ACTIVITY = UI / "components" / "studio-activity.jsx"
+STUDIO = UI / "components" / "studio.jsx"
+INDEX = UI / "index.html"
+
+
+def _activity_src() -> str:
+    return ACTIVITY.read_text(encoding="utf-8")
+
+
+def _studio_src() -> str:
+    return STUDIO.read_text(encoding="utf-8")
+
+
+def _index_order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            start = line.index('src="') + len('src="')
+            end = line.index('"', start)
+            out.append(line[start:end])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Component existence + window exports
+# ---------------------------------------------------------------------------
+
+def test_studio_activity_file_exists_and_exports() -> None:
+    assert ACTIVITY.exists(), "studio-activity.jsx missing"
+    src = _activity_src()
+    assert "function StudioActivity(" in src
+    assert "function ActionRequired(" in src
+    assert "function WorkspaceActivity(" in src
+    assert "window.StudioActivity = StudioActivity;" in src
+    assert "window.ActionRequired = ActionRequired;" in src
+    assert "window.WorkspaceActivity = WorkspaceActivity;" in src
+
+
+# ---------------------------------------------------------------------------
+# WorkspaceTap reuse — must delegate; must NOT reimplement
+# ---------------------------------------------------------------------------
+
+def test_workspace_tap_reused_not_reimplemented() -> None:
+    src = _activity_src()
+    # Must reference window.WorkspaceTap (the existing component)
+    assert "window.WorkspaceTap" in src, "WorkspaceTap not reused"
+    # Must NOT reimplement the SSE connection for the activity feed (no new
+    # EventSource inside WorkspaceActivity — only ActionRequired's reconcile ES)
+    # We check the WorkspaceActivity function body doesn't contain its own ES open.
+    # Strategy: the word "WorkspaceActivity" appears as a function header
+    # before WorkspaceTap is referenced; there should be no "new EventSource"
+    # inside WorkspaceActivity's definition. We extract its approximate body.
+    wa_start = src.index("function WorkspaceActivity(")
+    # Find the next top-level function after WorkspaceActivity
+    sa_start = src.index("function StudioActivity(", wa_start)
+    wa_body = src[wa_start:sa_start]
+    assert "new EventSource" not in wa_body, "WorkspaceActivity must not open its own EventSource"
+
+
+# ---------------------------------------------------------------------------
+# region-activity placeholder replaced in studio.jsx
+# ---------------------------------------------------------------------------
+
+def test_region_activity_placeholder_gone() -> None:
+    src = _studio_src()
+    assert 'testid="region-activity"' not in src, "B4 placeholder still present in studio.jsx"
+    assert "<StudioActivity wid={wid}" in src, "StudioActivity not wired into studio.jsx"
+
+
+# ---------------------------------------------------------------------------
+# data-testids (port-map §4.5)
+# ---------------------------------------------------------------------------
+
+def test_action_required_testids() -> None:
+    src = _activity_src()
+    for testid in (
+        "action-required",
+        "action-required-list",
+        "action-required-count",
+        "action-item",
+        "action-session-link",
+        "approve",
+        "reject",
+        "respond",
+        "cancel-yield",
+        "action-approval-controls",
+        "action-ask-controls",
+        "action-cancel-controls",
+    ):
+        assert f'data-testid="{testid}"' in src, f"Missing data-testid: {testid}"
+
+
+def test_workspace_activity_testid() -> None:
+    src = _activity_src()
+    assert 'data-testid="workspace-activity"' in src
+    assert 'data-testid="studio-activity-root"' in src
+
+
+# ---------------------------------------------------------------------------
+# Endpoint calls (verified against session-detail.jsx + approvals.jsx)
+# ---------------------------------------------------------------------------
+
+def test_approval_endpoints_present() -> None:
+    src = _activity_src()
+    # Approve / reject: POST /sessions/{sid}/tool_approval/respond
+    assert "tool_approval/respond" in src
+    assert 'decision: "approved"' in src
+    assert 'decision: "rejected"' in src
+
+
+def test_ask_user_respond_endpoint_present() -> None:
+    src = _activity_src()
+    # ask_user respond: POST /sessions/{sid}/ask_user/respond
+    assert "ask_user/respond" in src
+
+
+def test_cancel_yield_endpoint_present() -> None:
+    src = _activity_src()
+    # cancel: POST /sessions/{sid}/yields/{tcid}/cancel
+    assert "/yields/" in src
+    assert "/cancel" in src
+
+
+# ---------------------------------------------------------------------------
+# Live-reconcile strategy: EventSource on tap + debounce refetch
+# ---------------------------------------------------------------------------
+
+def test_live_reconcile_uses_tap_eventsource() -> None:
+    src = _activity_src()
+    # ActionRequired opens an EventSource for live reconciliation
+    assert "new EventSource" in src
+    assert "/tap" in src
+    # Reconcile triggers on yielded/done events
+    assert '"yielded"' in src
+    assert '"done"' in src
+    # Debounce prevents burst re-fetches
+    assert "debounce" in src or "setTimeout" in src
+
+
+def test_pending_yields_endpoint() -> None:
+    src = _activity_src()
+    assert "yields/pending" in src
+
+
+# ---------------------------------------------------------------------------
+# Bundle order: studio-activity.jsx must appear after workspace-tap.jsx
+# and before studio.jsx
+# ---------------------------------------------------------------------------
+
+def test_studio_activity_registered_in_index() -> None:
+    order = _index_order()
+    assert "components/studio-activity.jsx" in order, "studio-activity.jsx not in index.html"
+
+
+def test_studio_activity_load_order() -> None:
+    order = _index_order()
+    tap_idx = order.index("components/workspace-tap.jsx")
+    act_idx = order.index("components/studio-activity.jsx")
+    stu_idx = order.index("components/studio.jsx")
+    assert tap_idx < act_idx, "studio-activity.jsx must load after workspace-tap.jsx"
+    assert act_idx < stu_idx, "studio-activity.jsx must load before studio.jsx"
+
+
+# ---------------------------------------------------------------------------
+# Full bundle transpile gate (whole bundle must still parse cleanly)
+# ---------------------------------------------------------------------------
+
+def test_bundle_transpiles_with_studio_activity() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio-activity.jsx === */" in text
+    assert "/* === components/studio.jsx === */" in text

--- a/tests/ui/test_studio_center.py
+++ b/tests/ui/test_studio_center.py
@@ -1,0 +1,232 @@
+"""Structural-presence checks for the Studio center region (PR-B / B3).
+
+The center region is the tab bar + the active document panel. B3 builds:
+  - CenterTabs        — tab bar over studio.state.openTabs
+  - SessionAgentPanel — agent transcript (reuses SessionLiveStream)
+  - SessionGraphPanel — graph run-view (reuses SD_GraphRunView)
+  - FilePanel         — file preview/edit + 412-conflict save flow
+  - StudioCenter      — wires CenterTabs + the active panel into the shell
+
+Asserts the seams + data-testids exist, the reused components are referenced
+(NOT reimplemented), StudioCenter replaces the region-center placeholder, and
+the whole bundle (incl. studio-center.jsx) transpiles cleanly. Mirrors the
+static-source + bundle-build style of test_studio_sidebar.py — no React render.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+CENTER = UI / "components" / "studio-center.jsx"
+STUDIO = UI / "components" / "studio.jsx"
+INDEX = UI / "index.html"
+
+
+def _center_src() -> str:
+    return CENTER.read_text(encoding="utf-8")
+
+
+def _studio_src() -> str:
+    return STUDIO.read_text(encoding="utf-8")
+
+
+def _index_order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            start = line.index('src="') + len('src="')
+            end = line.index('"', start)
+            out.append(line[start:end])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# File existence + window exports
+# ---------------------------------------------------------------------------
+
+
+def test_center_file_exists() -> None:
+    assert CENTER.exists(), "studio-center.jsx must exist"
+
+
+def test_center_exports_all_required_symbols() -> None:
+    src = _center_src()
+    for sym in (
+        "window.StudioCenter = StudioCenter",
+        "window.CenterTabs = CenterTabs",
+        "window.SessionAgentPanel = SessionAgentPanel",
+        "window.SessionGraphPanel = SessionGraphPanel",
+        "window.FilePanel = FilePanel",
+    ):
+        assert sym in src, f"Missing export: {sym}"
+
+
+def test_center_defines_components() -> None:
+    src = _center_src()
+    for fn in (
+        "function StudioCenter(",
+        "function CenterTabs(",
+        "function SessionAgentPanel(",
+        "function SessionGraphPanel(",
+        "function FilePanel(",
+    ):
+        assert fn in src, f"Missing component: {fn}"
+
+
+# ---------------------------------------------------------------------------
+# REUSE — the agent transcript + graph run-view are the production components
+# from session-detail.jsx, reached as window globals (NOT reimplemented).
+# ---------------------------------------------------------------------------
+
+
+def test_reuses_session_live_stream() -> None:
+    src = _center_src()
+    assert "window.SessionLiveStream" in src, "must reuse SessionLiveStream, not rebuild it"
+    # Passed the props it already expects.
+    for prop in ("sid={sid}", "wid={wid}", "session={session}"):
+        assert prop in src, f"SessionLiveStream prop missing: {prop}"
+
+
+def test_reuses_sd_graph_run_view() -> None:
+    src = _center_src()
+    assert "window.SD_GraphRunView" in src, "must reuse SD_GraphRunView, not rebuild it"
+    # gid from the binding, rid = session id.
+    assert "gid={gid}" in src
+    assert "rid={sid}" in src
+
+
+def test_reuses_markdown_and_highlighter() -> None:
+    src = _center_src()
+    assert "window.renderMarkdown" in src, "markdown preview must reuse vendor renderMarkdown"
+    assert "highlightPython" in src, "code preview must reuse the vendored highlighter"
+
+
+def test_does_not_reimplement_reused_components() -> None:
+    src = _center_src()
+    # We must not define our own copies of the reused components.
+    assert "function SessionLiveStream(" not in src
+    assert "function SD_GraphRunView(" not in src
+    assert "function GR_Canvas(" not in src
+    assert "function renderMarkdown(" not in src
+
+
+# ---------------------------------------------------------------------------
+# Session panel routing: fetch the session, branch on binding.kind.
+# ---------------------------------------------------------------------------
+
+
+def test_session_panel_fetches_and_branches_on_binding_kind() -> None:
+    src = _center_src()
+    assert "/sessions/" in src, "must GET /v1/sessions/{ref}"
+    assert "useResource" in src
+    # Branch agent vs graph off binding.kind (with the defensive binding_kind alias).
+    assert "binding.kind" in src
+    assert "graph" in src and "agent" in src
+
+
+# ---------------------------------------------------------------------------
+# File panel: read holds etag, PUT with etag, 412 → conflict banner.
+# ---------------------------------------------------------------------------
+
+
+def test_file_panel_read_and_save_with_etag() -> None:
+    src = _center_src()
+    assert "files/read?path=" in src, "FilePanel must GET files/read"
+    assert "files?path=" in src, "FilePanel must PUT files?path"
+    assert "etag=" in src, "save must send the held etag for optimistic concurrency"
+    assert 'encoding: "text"' in src or "encoding:\"text\"" in src
+
+
+def test_file_panel_handles_412_conflict() -> None:
+    src = _center_src()
+    assert "412" in src, "save must detect the 412 stale-write status"
+    # Reload re-reads + clears dirty; Overwrite re-PUTs without the etag.
+    assert "reloadConflict" in src
+    assert "overwriteConflict" in src
+
+
+def test_file_panel_preview_branches() -> None:
+    src = _center_src()
+    # Image preview via files/download; markdown + code + text branches.
+    assert "files/download?path=" in src
+    assert "markdown" in src
+    assert "<img" in src
+
+
+def test_file_panel_dirty_via_patch() -> None:
+    src = _center_src()
+    # Dirty state mirrors into openTabs via the patch() escape hatch.
+    assert "studio.patch" in src
+    assert "dirty" in src
+
+
+# ---------------------------------------------------------------------------
+# data-testids (port-map §4.4)
+# ---------------------------------------------------------------------------
+
+
+def test_center_testids() -> None:
+    src = _center_src()
+    required = [
+        'data-testid="center-tabs"',
+        'data-testid="center-tab"',
+        'data-testid="center-tab-close"',
+        'data-testid="panel-agent"',
+        'data-testid="panel-graph"',
+        'data-testid="panel-file"',
+        'data-testid="file-mode-preview"',
+        'data-testid="file-mode-edit"',
+        'data-testid="file-save"',
+        'data-testid="file-editor"',
+        'data-testid="file-conflict-banner"',
+    ]
+    for tid in required:
+        assert tid in src, f"Missing data-testid: {tid}"
+
+
+# ---------------------------------------------------------------------------
+# Studio shell wires in StudioCenter (no more placeholder in the center region)
+# ---------------------------------------------------------------------------
+
+
+def test_studio_center_wired_into_studio_shell() -> None:
+    src = _studio_src()
+    assert 'testid="region-center"' not in src, (
+        "ST_RegionPlaceholder for region-center must be replaced by <StudioCenter>"
+    )
+    assert "<StudioCenter wid={wid}" in src
+
+
+# ---------------------------------------------------------------------------
+# index.html load order: studio-center.jsx after session-detail (for the reused
+# components) and before studio.jsx.
+# ---------------------------------------------------------------------------
+
+
+def test_index_loads_center_in_order() -> None:
+    order = _index_order()
+    assert "components/studio-center.jsx" in order, "studio-center.jsx not in index.html"
+    # Must load after session-detail.jsx (SessionLiveStream/SD_GraphRunView)
+    # and after markdown + shared, before studio.jsx.
+    assert order.index("components/session-detail.jsx") < order.index("components/studio-center.jsx")
+    assert order.index("components/shared.jsx") < order.index("components/studio-center.jsx")
+    assert order.index("vendor/markdown.jsx") < order.index("components/studio-center.jsx")
+    assert order.index("components/studio-center.jsx") < order.index("components/studio.jsx")
+
+
+# ---------------------------------------------------------------------------
+# Bundle transpile (the hard gate: the whole bundle incl. studio*.jsx compiles)
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_transpiles_with_studio_center() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio-center.jsx === */" in text
+    assert "/* === components/studio.jsx === */" in text
+    assert "/* === components/studio-sidebar.jsx === */" in text

--- a/tests/ui/test_studio_palette.py
+++ b/tests/ui/test_studio_palette.py
@@ -1,0 +1,238 @@
+"""Structural-presence checks for studio-palette.jsx (PR-B / B5).
+
+Verifies:
+  - window.CommandPalette and window.QuickOpen are exported
+  - required data-testids are present
+  - StudioHeader trigger buttons are wired (not no-ops) in studio.jsx
+  - the global keydown listener is registered in Studio
+  - pushToast is threaded from app.jsx into <Studio>
+  - studio-palette.jsx loads before studio.jsx in index.html
+  - the full bundle transpiles cleanly
+
+Static-source checks only (no React rendering), matching the approach used
+in test_studio_shell.py / test_studio_sidebar.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+PALETTE = UI / "components" / "studio-palette.jsx"
+STUDIO = UI / "components" / "studio.jsx"
+APP = UI / "app.jsx"
+INDEX = UI / "index.html"
+
+
+def _palette_src() -> str:
+    return PALETTE.read_text(encoding="utf-8")
+
+
+def _studio_src() -> str:
+    return STUDIO.read_text(encoding="utf-8")
+
+
+def _app_src() -> str:
+    return APP.read_text(encoding="utf-8")
+
+
+def _index_order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            start = line.index('src="') + len('src="')
+            end = line.index('"', start)
+            out.append(line[start:end])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# studio-palette.jsx presence + exports
+# ---------------------------------------------------------------------------
+
+def test_palette_file_exists() -> None:
+    assert PALETTE.exists(), "studio-palette.jsx is missing"
+
+
+def test_palette_exports_command_palette() -> None:
+    src = _palette_src()
+    assert "function CommandPalette(" in src
+    assert "window.CommandPalette = CommandPalette;" in src
+
+
+def test_palette_exports_quick_open() -> None:
+    src = _palette_src()
+    assert "function QuickOpen(" in src
+    assert "window.QuickOpen = QuickOpen;" in src
+
+
+# ---------------------------------------------------------------------------
+# Required data-testids
+# ---------------------------------------------------------------------------
+
+def test_command_palette_testid() -> None:
+    src = _palette_src()
+    assert 'data-testid="command-palette"' in src
+
+
+def test_palette_input_testid() -> None:
+    src = _palette_src()
+    assert 'data-testid="palette-input"' in src
+
+
+def test_palette_item_testid() -> None:
+    src = _palette_src()
+    assert 'data-testid="palette-item"' in src
+
+
+def test_quick_open_testid() -> None:
+    src = _palette_src()
+    assert 'data-testid="quick-open"' in src
+
+
+def test_quick_open_input_testid() -> None:
+    src = _palette_src()
+    assert 'data-testid="quick-open-input"' in src
+
+
+def test_quick_open_item_testid() -> None:
+    src = _palette_src()
+    assert 'data-testid="quick-open-item"' in src
+
+
+# ---------------------------------------------------------------------------
+# Fuzzy match helper present
+# ---------------------------------------------------------------------------
+
+def test_fuzzy_match_helper_present() -> None:
+    src = _palette_src()
+    assert "STP_fuzzy" in src
+
+
+# ---------------------------------------------------------------------------
+# StudioHeader trigger buttons wired (not no-ops) in studio.jsx
+# ---------------------------------------------------------------------------
+
+def test_header_palette_trigger_wired() -> None:
+    src = _studio_src()
+    # onTogglePalette must be wired to studio.togglePalette, not a no-op lambda
+    assert "onTogglePalette={studio.togglePalette}" in src
+
+
+def test_header_quickopen_trigger_wired() -> None:
+    src = _studio_src()
+    # onOpenQuick must call studio.openPalette("quickopen")
+    assert 'studio.openPalette("quickopen")' in src
+
+
+# ---------------------------------------------------------------------------
+# Global keydown effect in Studio
+# ---------------------------------------------------------------------------
+
+def test_studio_has_keydown_effect() -> None:
+    src = _studio_src()
+    # The useEffect that registers the keydown listener must be present
+    assert "addEventListener" in src and "keydown" in src
+
+
+def test_keydown_handles_cmd_k() -> None:
+    src = _studio_src()
+    assert 'e.key === "k"' in src or "e.key === 'k'" in src
+
+
+def test_keydown_handles_cmd_p() -> None:
+    src = _studio_src()
+    assert 'e.key === "p"' in src or "e.key === 'p'" in src
+
+
+def test_keydown_handles_ctrl_backtick() -> None:
+    src = _studio_src()
+    assert 'e.key === "`"' in src or 'e.key === \'`\'' in src
+
+
+def test_keydown_handles_escape() -> None:
+    src = _studio_src()
+    assert 'e.key === "Escape"' in src
+
+
+# ---------------------------------------------------------------------------
+# Palette state in useStudioState + Studio renders the overlays
+# ---------------------------------------------------------------------------
+
+def test_studio_state_has_palette_fields() -> None:
+    src = _studio_src()
+    assert "paletteOpen" in src
+    assert "paletteMode" in src
+
+
+def test_studio_renders_command_palette() -> None:
+    src = _studio_src()
+    assert "<CommandPalette" in src
+
+
+def test_studio_renders_quick_open() -> None:
+    src = _studio_src()
+    assert "<QuickOpen" in src
+
+
+def test_studio_state_exposes_open_palette() -> None:
+    src = _studio_src()
+    assert "openPalette" in src
+    assert "closePalette" in src
+    assert "togglePalette" in src
+
+
+# ---------------------------------------------------------------------------
+# pushToast threaded from app.jsx into Studio
+# ---------------------------------------------------------------------------
+
+def test_app_passes_push_toast_to_studio() -> None:
+    src = _app_src()
+    assert "pushToast={pushToast}" in src
+    # Must appear on the Studio render line, not just another component
+    assert "<Studio wid={currentWorkspaceId} pushToast={pushToast} />" in src
+
+
+def test_studio_accepts_push_toast_prop() -> None:
+    src = _studio_src()
+    # Studio function signature accepts pushToast
+    assert "pushToast" in src
+    # It is stored on studio object for sub-components to consume
+    assert "studio.pushToast" in src
+
+
+# ---------------------------------------------------------------------------
+# Load order in index.html
+# ---------------------------------------------------------------------------
+
+def test_palette_registered_before_studio() -> None:
+    order = _index_order()
+    assert "components/studio-palette.jsx" in order, "studio-palette.jsx not in index.html"
+    palette_idx = order.index("components/studio-palette.jsx")
+    studio_idx = order.index("components/studio.jsx")
+    assert palette_idx < studio_idx, (
+        f"studio-palette.jsx (pos {palette_idx}) must come before "
+        f"studio.jsx (pos {studio_idx})"
+    )
+
+
+def test_palette_registered_after_studio_activity() -> None:
+    order = _index_order()
+    activity_idx = order.index("components/studio-activity.jsx")
+    palette_idx = order.index("components/studio-palette.jsx")
+    assert activity_idx < palette_idx
+
+
+# ---------------------------------------------------------------------------
+# Bundle transpiles cleanly
+# ---------------------------------------------------------------------------
+
+def test_bundle_transpiles_with_palette() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio-palette.jsx === */" in text
+    assert "/* === components/studio.jsx === */" in text

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -66,11 +66,9 @@ def test_studio_region_placeholders_present() -> None:
     # B3 (center) is now filled — StudioCenter replaced the placeholder.
     assert "<StudioCenter wid={wid}" in src, "B3 StudioCenter not wired in"
     assert 'testid="region-center"' not in src, "B3 placeholder should be gone"
-    # B4 placeholder still present (not yet built).
-    assert 'data-testid={testid}' in src  # ST_RegionPlaceholder still used by B4
-    assert 'testid="region-activity"' in src
-    # The remaining seam calls out its downstream sub-task for the next author.
-    assert "B4" in src
+    # B4 (right sidebar) is now filled — StudioActivity replaced the placeholder.
+    assert "<StudioActivity wid={wid}" in src, "B4 StudioActivity not wired in"
+    assert 'testid="region-activity"' not in src, "B4 placeholder should be gone"
 
 
 def test_use_studio_state_persistence_contract() -> None:

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -63,12 +63,14 @@ def test_studio_region_placeholders_present() -> None:
     # B2 (left sidebar) is now filled — StudioSidebar replaced the placeholder.
     assert "<StudioSidebar wid={wid}" in src, "B2 StudioSidebar not wired in"
     assert 'testid="region-sidebar"' not in src, "B2 placeholder should be gone"
-    # B3 and B4 placeholders still present (not yet built).
-    assert 'data-testid={testid}' in src  # ST_RegionPlaceholder still used by B3/B4
-    for testid in ("region-center", "region-activity"):
-        assert f'testid="{testid}"' in src, testid
-    # The seams call out their downstream sub-task for the next author.
-    assert "B3" in src and "B4" in src
+    # B3 (center) is now filled — StudioCenter replaced the placeholder.
+    assert "<StudioCenter wid={wid}" in src, "B3 StudioCenter not wired in"
+    assert 'testid="region-center"' not in src, "B3 placeholder should be gone"
+    # B4 placeholder still present (not yet built).
+    assert 'data-testid={testid}' in src  # ST_RegionPlaceholder still used by B4
+    assert 'testid="region-activity"' in src
+    # The remaining seam calls out its downstream sub-task for the next author.
+    assert "B4" in src
 
 
 def test_use_studio_state_persistence_contract() -> None:

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -1,0 +1,129 @@
+"""Structural-presence checks for the Studio shell (PR-B / B1 foundation).
+
+The Studio is the workspace-scoped IDE view that replaces the thin
+workspace-detail page at /workspaces/:wid. B1 lays down the route shell,
+the useStudioState model, and the persistence + URL-mirroring seams; the
+left/center/right regions are styled placeholders that B2-B4 fill.
+
+These tests assert the seams exist and the bundle still transpiles. They
+do NOT render React (the ui/ suite is static-source + bundle-build only,
+matching test_session_frame_extracted.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+STUDIO = UI / "components" / "studio.jsx"
+INDEX = UI / "index.html"
+STYLES = UI / "styles.css"
+APP = UI / "app.jsx"
+
+
+def _studio_src() -> str:
+    return STUDIO.read_text(encoding="utf-8")
+
+
+def _index_order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            start = line.index('src="') + len('src="')
+            end = line.index('"', start)
+            out.append(line[start:end])
+    return out
+
+
+def test_studio_file_exists_and_exports() -> None:
+    src = _studio_src()
+    assert "function Studio(" in src
+    assert "function StudioHeader(" in src
+    assert "function useStudioState(" in src
+    # No-build window exports so app.jsx + B2-B4 can reach them.
+    assert "window.Studio = Studio;" in src
+    assert "window.StudioHeader = StudioHeader;" in src
+    assert "window.useStudioState = useStudioState;" in src
+
+
+def test_studio_shell_root_and_header_testids() -> None:
+    src = _studio_src()
+    assert 'data-testid="studio-root"' in src
+    assert 'data-testid="studio-header"' in src
+    assert 'data-testid="workspace-selector"' in src
+
+
+def test_studio_region_placeholders_present() -> None:
+    src = _studio_src()
+    # Each of the three body regions B2-B4 will fill is stubbed with a
+    # clearly-marked placeholder carrying a stable data-testid.
+    for testid in ("studio-sidebar", "studio-center", "studio-activity"):
+        assert f'data-testid="{testid}"' in src, testid
+    # The placeholder boxes carry their testid via a prop (testid="region-*"),
+    # forwarded onto data-testid inside ST_RegionPlaceholder.
+    assert 'data-testid={testid}' in src
+    for testid in ("region-sidebar", "region-center", "region-activity"):
+        assert f'testid="{testid}"' in src, testid
+    # The seams call out their downstream sub-task for the next author.
+    assert "B2" in src and "B3" in src and "B4" in src
+
+
+def test_use_studio_state_persistence_contract() -> None:
+    src = _studio_src()
+    # localStorage key + the exact persistence + URL seams from
+    # STUDIO-INTEGRATION.md §3.
+    assert '"studio:" + wid' in src
+    assert "ST_loadPersisted" in src
+    assert "ST_savePersisted" in src
+    assert "ST_tabFromUrl" in src
+    assert "ST_syncUrl" in src
+    assert "history.replaceState" in src
+    # Active-tab URL mirror uses the ?open=session:/?open=file: contract.
+    assert "open" in src
+    # The tab model + sidebar toggles B2-B4 consume.
+    for action in ("openTab", "focusTab", "closeTab", "toggleSessions", "toggleFiles", "toggleHidden"):
+        assert action in src, action
+
+
+def test_workspace_selector_uses_workspaces_resource() -> None:
+    src = _studio_src()
+    # Selector lists GET /v1/workspaces and navigates on pick.
+    assert "/workspaces?limit=200" in src
+    assert "useResource" in src
+
+
+def test_studio_registered_in_index_after_workspace_tap() -> None:
+    order = _index_order()
+    assert "components/studio.jsx" in order
+    # studio.jsx reuses Icon (shared.jsx) + WorkspaceTap is its B4 neighbour.
+    assert order.index("components/shared.jsx") < order.index("components/studio.jsx")
+    assert order.index("components/studio.jsx") < order.index("app.jsx")
+
+
+def test_app_renders_studio_for_workspace_detail() -> None:
+    src = APP.read_text(encoding="utf-8")
+    # /workspaces/:wid now renders the Studio shell directly.
+    assert "<Studio wid={currentWorkspaceId} />" in src
+    # /sessions and /sessions/:id redirect into the Studio.
+    assert '"#/workspaces"' in src
+    assert "open=session:" in src
+    assert "workspace_id" in src
+
+
+def test_styles_has_studio_tokens_and_classes() -> None:
+    css = STYLES.read_text(encoding="utf-8")
+    assert "--teal:" in css
+    assert "--teal-dim:" in css
+    assert "--frow-h:" in css
+    for cls in (".st-root", ".st-body", ".st-topbar", ".st-section", ".st-tabbar"):
+        assert cls in css, cls
+
+
+def test_bundle_transpiles_with_studio() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio.jsx === */" in text

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -88,6 +88,25 @@ def test_use_studio_state_persistence_contract() -> None:
         assert action in src, action
 
 
+def test_deep_link_synthesizes_url_tab() -> None:
+    src = _studio_src()
+    # A fresh deep-link (#/workspaces/:wid?open=session:<sid>) with empty
+    # localStorage must still create + activate the tab, not mount empty.
+    # The synthesis helper turns the parsed ?open= id into a minimal tab.
+    assert "function ST_tabFromUrlId(" in src
+    # session:<id> → a session tab; file:<path> → a file tab.
+    assert 'kind: "session"' in src
+    assert 'kind: "file"' in src
+    # The helper is wired through ST_applyUrlTab, which both the lazy
+    # initializer and the wid-change effect call, so a missing url tab is
+    # appended (concat) and activated rather than ignored.
+    assert "ST_applyUrlTab" in src
+    assert "ST_tabFromUrlId(urlTab)" in src
+    # When the url tab isn't already open we append + activate it.
+    assert "base.openTabs = openTabs.concat([tab]);" in src
+    assert "base.activeTabId = urlTab;" in src
+
+
 def test_workspace_selector_uses_workspaces_resource() -> None:
     src = _studio_src()
     # Selector lists GET /v1/workspaces and navigates on pick.

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -56,17 +56,19 @@ def test_studio_shell_root_and_header_testids() -> None:
 
 def test_studio_region_placeholders_present() -> None:
     src = _studio_src()
-    # Each of the three body regions B2-B4 will fill is stubbed with a
-    # clearly-marked placeholder carrying a stable data-testid.
+    # All three body-region wrapper divs must still carry their stable testids
+    # (the wrappers are kept even after a region is filled).
     for testid in ("studio-sidebar", "studio-center", "studio-activity"):
         assert f'data-testid="{testid}"' in src, testid
-    # The placeholder boxes carry their testid via a prop (testid="region-*"),
-    # forwarded onto data-testid inside ST_RegionPlaceholder.
-    assert 'data-testid={testid}' in src
-    for testid in ("region-sidebar", "region-center", "region-activity"):
+    # B2 (left sidebar) is now filled — StudioSidebar replaced the placeholder.
+    assert "<StudioSidebar wid={wid}" in src, "B2 StudioSidebar not wired in"
+    assert 'testid="region-sidebar"' not in src, "B2 placeholder should be gone"
+    # B3 and B4 placeholders still present (not yet built).
+    assert 'data-testid={testid}' in src  # ST_RegionPlaceholder still used by B3/B4
+    for testid in ("region-center", "region-activity"):
         assert f'testid="{testid}"' in src, testid
     # The seams call out their downstream sub-task for the next author.
-    assert "B2" in src and "B3" in src and "B4" in src
+    assert "B3" in src and "B4" in src
 
 
 def test_use_studio_state_persistence_contract() -> None:

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -106,7 +106,8 @@ def test_studio_registered_in_index_after_workspace_tap() -> None:
 def test_app_renders_studio_for_workspace_detail() -> None:
     src = APP.read_text(encoding="utf-8")
     # /workspaces/:wid now renders the Studio shell directly.
-    assert "<Studio wid={currentWorkspaceId} />" in src
+    # B5 added pushToast prop; check the Studio render is present with wid.
+    assert "<Studio wid={currentWorkspaceId}" in src
     # /sessions and /sessions/:id redirect into the Studio.
     assert '"#/workspaces"' in src
     assert "open=session:" in src

--- a/tests/ui/test_studio_sidebar.py
+++ b/tests/ui/test_studio_sidebar.py
@@ -1,0 +1,185 @@
+"""Structural-presence checks for the Studio left sidebar (PR-B / B2).
+
+Asserts:
+  - studio-sidebar.jsx exists and exports the expected symbols via window.*
+  - sessionStatus helper covers every spec-§7 tone/badge combination
+  - StudioSidebar wires into studio.jsx (replaces the region-sidebar placeholder)
+  - index.html loads studio-sidebar.jsx before studio.jsx
+  - The whole bundle (incl. studio-sidebar.jsx) transpiles cleanly
+  - data-testids specified in the port-map are present in the source
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SIDEBAR = UI / "components" / "studio-sidebar.jsx"
+STUDIO = UI / "components" / "studio.jsx"
+INDEX = UI / "index.html"
+
+
+def _sidebar_src() -> str:
+    return SIDEBAR.read_text(encoding="utf-8")
+
+
+def _studio_src() -> str:
+    return STUDIO.read_text(encoding="utf-8")
+
+
+def _index_order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            start = line.index('src="') + len('src="')
+            end = line.index('"', start)
+            out.append(line[start:end])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# File existence + window exports
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_file_exists() -> None:
+    assert SIDEBAR.exists(), "studio-sidebar.jsx must exist"
+
+
+def test_sidebar_exports_all_required_symbols() -> None:
+    src = _sidebar_src()
+    for sym in (
+        "window.StudioSidebar = StudioSidebar",
+        "window.SessionsSection = SessionsSection",
+        "window.FilesTree = FilesTree",
+        "window.ST_sessionStatus = ST_sessionStatus",
+    ):
+        assert sym in src, f"Missing export: {sym}"
+
+
+# ---------------------------------------------------------------------------
+# sessionStatus logic (spec §7 mappings)
+# ---------------------------------------------------------------------------
+
+
+def test_session_status_running() -> None:
+    src = _sidebar_src()
+    # running + not parked → green-pulse
+    assert "green-pulse" in src
+    assert '"running"' in src
+
+
+def test_session_status_paused() -> None:
+    src = _sidebar_src()
+    assert "paused" in src
+    assert '"amber"' in src
+
+
+def test_session_status_approval_badge() -> None:
+    src = _sidebar_src()
+    assert '"approve"' in src
+
+
+def test_session_status_ask_user_badge() -> None:
+    src = _sidebar_src()
+    assert '"ask"' in src
+
+
+def test_session_status_watch_files_badge() -> None:
+    src = _sidebar_src()
+    assert '"watch"' in src
+
+
+def test_session_status_sleep_badge() -> None:
+    src = _sidebar_src()
+    assert '"sleep"' in src
+
+
+def test_session_status_ended_gray() -> None:
+    src = _sidebar_src()
+    assert '"gray"' in src
+    # ended / completed / cancelled → gray
+    assert '"ended"' in src or "ended" in src
+
+
+def test_session_status_failed_red() -> None:
+    src = _sidebar_src()
+    assert '"red"' in src
+    assert '"failed"' in src
+
+
+def test_session_status_created_dim() -> None:
+    src = _sidebar_src()
+    assert '"dim"' in src
+    assert '"created"' in src
+
+
+# ---------------------------------------------------------------------------
+# data-testids (port-map §4.3)
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_testids() -> None:
+    src = _sidebar_src()
+    required = [
+        'data-testid="sessions-header"',
+        'data-testid="session-row"',
+        'data-testid="session-status-dot"',
+        'data-testid="files-header"',
+        'data-testid="file-row"',
+        'data-testid="new-session-btn"',
+        'data-testid="hidden-toggle"',
+        'data-testid="new-session-form"',
+    ]
+    for tid in required:
+        assert tid in src, f"Missing data-testid: {tid}"
+
+
+# ---------------------------------------------------------------------------
+# Studio shell wires in StudioSidebar (no more placeholder in the left region)
+# ---------------------------------------------------------------------------
+
+
+def test_studio_sidebar_wired_into_studio_shell() -> None:
+    src = _studio_src()
+    # Placeholder must be gone from the left region.
+    assert 'testid="region-sidebar"' not in src, (
+        "ST_RegionPlaceholder for region-sidebar must be replaced by <StudioSidebar>"
+    )
+    # The real component is rendered.
+    assert "<StudioSidebar wid={wid}" in src
+
+
+# ---------------------------------------------------------------------------
+# index.html load order: studio-sidebar.jsx before studio.jsx
+# ---------------------------------------------------------------------------
+
+
+def test_index_loads_sidebar_before_studio() -> None:
+    order = _index_order()
+    assert "components/studio-sidebar.jsx" in order, "studio-sidebar.jsx not in index.html"
+    assert "components/studio.jsx" in order, "studio.jsx not in index.html"
+    assert order.index("components/studio-sidebar.jsx") < order.index("components/studio.jsx"), (
+        "studio-sidebar.jsx must be loaded before studio.jsx"
+    )
+
+
+def test_index_loads_shared_before_sidebar() -> None:
+    order = _index_order()
+    assert order.index("components/shared.jsx") < order.index("components/studio-sidebar.jsx")
+
+
+# ---------------------------------------------------------------------------
+# Bundle transpile (the hard gate: JSX must compile cleanly)
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_transpiles_with_studio_sidebar() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio-sidebar.jsx === */" in text
+    assert "/* === components/studio.jsx === */" in text

--- a/tests/ui/test_ui_polish_fixes.py
+++ b/tests/ui/test_ui_polish_fixes.py
@@ -74,20 +74,16 @@ def test_app_agents_subtitle_not_from_mock() -> None:
     )
 
 
-def test_app_sessions_page_header_uses_real_count() -> None:
+def test_app_sessions_page_does_not_read_mock_counts() -> None:
     src = _app()
-    # The sessions-page subtitle must use counts.sessions (live API total),
-    # not sessions.length (was mock array) or sessions.filter (was mock live count).
-    assert "counts.sessions" in src, (
-        "sessions-page header must derive total from counts.sessions (live API), "
-        "not the stale mock sessions array"
-    )
-    # The mock-derived expressions must be gone.
+    # B6 (PR-B): the /sessions route is retired into a Studio redirect — the
+    # old Sessions-list page header (which once derived its subtitle count) no
+    # longer renders. Whatever remains must never read the stale mock array.
     assert "sessions.length" not in src, (
-        "sessions.length in app.jsx header must be removed -- was reading mock data"
+        "sessions.length in app.jsx must be removed -- was reading mock data"
     )
     assert "sessions.filter" not in src, (
-        "sessions.filter in app.jsx header must be removed -- was reading mock data"
+        "sessions.filter in app.jsx must be removed -- was reading mock data"
     )
 
 

--- a/tests/ui_e2e/test_studio.py
+++ b/tests/ui_e2e/test_studio.py
@@ -1,0 +1,310 @@
+"""UI E2E: the workspace Studio (PR-B) — the IDE-style view at /workspaces/:wid.
+
+Gated: collected-then-ignored unless ``PRIMER_RUN_UI_E2E=1``, exactly
+like every other test in this directory (see conftest.py:collect_ignore_glob)
+and mirroring test_workspace_tap_events.py's explicit per-file gate too.
+
+The Studio (B1-B5) replaces the old Sessions list + session-detail pages.
+B6 retired the ``/sessions`` and ``/sessions/:id`` routes into redirects
+into the Studio. This module pins the load-bearing flows:
+
+  1. Navigating to a workspace renders the Studio shell — all three region
+     wrappers (``studio-sidebar`` / ``studio-center`` / ``studio-activity``)
+     mount.
+  2. The left sidebar lists the workspace's sessions (and, when a file was
+     seeded, its files).
+  3. Clicking a session row opens a center tab and the agent panel
+     (``panel-agent`` for an agent-bound session).
+  4. Opening a file row shows the file panel (``panel-file``) in preview.
+  5. ``⌘K`` opens the command palette (``command-palette``).
+  6. The redirect: navigating to ``#/sessions/<sid>`` lands in the Studio
+     with that session's tab open (``panel-agent``).
+
+Flows are driven via Playwright against a live server seeded through a
+sync httpx client (mirroring test_session_lifecycle_journey.py's ladder
+and test_workspace_file_download_journey.py's file PUT). Seeding is
+skip-soft on 5xx — the primer-app container may not reach the workspace
+provider's host path (U0072/U0080-class), in which case we skip rather
+than fail.
+
+Ladder: llm_provider → workspace_provider → workspace_template →
+        workspace → agent → session (auto_start=False so it parks in
+        CREATED) → optional file PUT.
+"""
+
+from __future__ import annotations
+
+import os
+
+import httpx
+import pytest
+from playwright.sync_api import expect
+
+
+from tests._support.smk import smk  # noqa: E402
+
+pytestmark = smk("SMK-UI-06")
+
+
+# ---------------------------------------------------------------------------
+# Gate — mirrors conftest.py's collect_ignore_glob mechanism
+# ---------------------------------------------------------------------------
+
+if os.environ.get("PRIMER_RUN_UI_E2E") != "1":
+    collect_ignore_glob = ["test_studio.py"]
+
+
+# ---------------------------------------------------------------------------
+# Container-internal workspace provider path — host tmp_path is not visible
+# from the primer-app container; /tmp/<suffix> inside the container avoids
+# the U0072/U0080-class host-path unreachability problem.
+# ---------------------------------------------------------------------------
+
+
+def _container_ws_root(suffix: str) -> str:
+    return f"/tmp/studio-{suffix}"
+
+
+def _seed_studio_ladder(base_url: str, suffix: str) -> dict[str, str]:
+    """Seed llm_provider → workspace_provider → template → workspace →
+    agent → session via the API. Returns the ids.
+
+    Session is created with auto_start=False so it parks in CREATED
+    indefinitely (no LM Studio dependency); the row is still listed and
+    openable in the Studio sidebar.
+    """
+    ids = {
+        "llm": f"st-llm-{suffix}",
+        "wp": f"st-wp-{suffix}",
+        "tpl": f"st-tpl-{suffix}",
+        "agent": f"st-ag-{suffix}",
+        "workspace": "",  # backend-assigned
+        "session": "",  # backend-assigned
+    }
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        r = c.post("/v1/llm_providers", json={
+            "id": ids["llm"],
+            "provider": "ollama",
+            "config": {"url": "http://127.0.0.1:9999"},
+            "models": [{"name": "fake-model", "context_length": 4096}],
+            "limits": {"max_concurrency": 1},
+        })
+        assert r.status_code == 201, f"seed llm failed: {r.text}"
+        r = c.post("/v1/workspace_providers", json={
+            "id": ids["wp"],
+            "provider": "local",
+            "config": {"kind": "local", "root_path": _container_ws_root(suffix)},
+        })
+        assert r.status_code == 201, f"seed wp failed: {r.text}"
+        r = c.post("/v1/workspace_templates", json={
+            "id": ids["tpl"],
+            "description": "studio template",
+            "provider_id": ids["wp"],
+            "backend": {"kind": "local"},
+        })
+        assert r.status_code == 201, f"seed tpl failed: {r.text}"
+        r = c.post("/v1/workspaces", json={"template_id": ids["tpl"]})
+        if r.status_code >= 500:
+            pytest.skip(
+                f"workspace create returned {r.status_code} — primer-app "
+                f"container likely can't reach host tmp (U0072/U0080-class)."
+            )
+        assert r.status_code == 201, f"seed workspace failed: {r.text}"
+        ids["workspace"] = r.json()["id"]
+        r = c.post("/v1/agents", json={
+            "id": ids["agent"],
+            "description": "studio agent",
+            "model": {"provider_id": ids["llm"], "model_name": "fake-model"},
+            "tools": [],
+            "system_prompt": ["probe"],
+        })
+        assert r.status_code == 201, f"seed agent failed: {r.text}"
+        r = c.post(
+            f"/v1/workspaces/{ids['workspace']}/sessions",
+            json={
+                "binding": {"kind": "agent", "agent_id": ids["agent"]},
+                "auto_start": False,
+            },
+        )
+        assert r.status_code == 201, f"seed session failed: {r.text}"
+        ids["session"] = r.json()["id"]
+    return ids
+
+
+def _seed_file(base_url: str, wid: str, name: str, content: str) -> bool:
+    """PUT one text file into the workspace. Returns True on success,
+    False if the container can't reach the provider path (skip-soft)."""
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        r = c.put(
+            f"/v1/workspaces/{wid}/files?path={name}",
+            json={"content": content, "encoding": "text"},
+        )
+        if r.status_code >= 500:
+            return False
+        assert r.status_code in (200, 201, 204), r.text
+        return True
+
+
+def _cleanup(base_url: str, ids: dict[str, str]) -> None:
+    """Best-effort unwind; ignore individual failures so one stale row
+    doesn't mask the rest."""
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        for url in (
+            f"/v1/workspaces/{ids['workspace']}/sessions/{ids['session']}/cancel"
+            if ids.get("session") else None,
+            f"/v1/workspaces/{ids['workspace']}" if ids.get("workspace") else None,
+            f"/v1/workspace_templates/{ids['tpl']}",
+            f"/v1/workspace_providers/{ids['wp']}",
+            f"/v1/agents/{ids['agent']}",
+            f"/v1/llm_providers/{ids['llm']}",
+        ):
+            if url is None:
+                continue
+            try:
+                c.delete(url)
+            except Exception:  # noqa: BLE001
+                pass
+
+
+# ===========================================================================
+# Studio shell + sidebar + center + palette
+# ===========================================================================
+
+
+@pytest.mark.skipif(
+    os.environ.get("PRIMER_RUN_UI_E2E") != "1",
+    reason="Set PRIMER_RUN_UI_E2E=1 to run UI e2e tests",
+)
+def test_studio_shell_sidebar_center_and_palette(
+    page,
+    base_url: str,
+    console_url: str,
+    unique_suffix: str,
+    console_messages: list[dict],
+) -> None:
+    """Navigate to a workspace → the Studio shell mounts (3 regions), the
+    sidebar lists the seeded session + file, clicking the session row opens
+    a center tab + the agent panel, opening the file row shows the file
+    panel in preview, and ⌘K opens the command palette."""
+
+    ids = _seed_studio_ladder(base_url, unique_suffix)
+    wid = ids["workspace"]
+    file_name = f"studio-{unique_suffix}.txt"
+    file_marker = f"studio-marker-{unique_suffix}"
+    have_file = _seed_file(
+        base_url, wid, file_name, f"{file_marker}\nline 2\nline 3\n",
+    )
+
+    try:
+        # --- 1. Studio shell: all three regions mount ------------------
+        page.goto(
+            f"{console_url}#/workspaces/{wid}",
+            wait_until="domcontentloaded",
+        )
+        expect(page.locator('[data-testid="studio-root"]')).to_be_visible(
+            timeout=20_000,
+        )
+        for region in ("studio-sidebar", "studio-center", "studio-activity"):
+            expect(page.locator(f'[data-testid="{region}"]')).to_be_visible(
+                timeout=10_000,
+            )
+
+        # --- 2. Left sidebar lists the seeded session ------------------
+        session_row = page.locator('[data-testid="session-row"]').first
+        expect(session_row).to_be_visible(timeout=20_000)
+
+        # --- 3. Click session row → center tab + agent panel ----------
+        session_row.click()
+        expect(page.locator('[data-testid="center-tab"]').first).to_be_visible(
+            timeout=15_000,
+        )
+        # The seeded session is agent-bound → the agent panel renders.
+        expect(page.locator('[data-testid="panel-agent"]')).to_be_visible(
+            timeout=15_000,
+        )
+
+        # --- 4. Open the file row → file panel in preview --------------
+        # The Files section defaults to open (studio.jsx filesOpen: true,
+        # no persisted state in a fresh browser context), so the seeded
+        # file surfaces directly as a file-row.
+        if have_file:
+            file_row = page.locator(
+                '[data-testid="file-row"]', has_text=file_name,
+            ).first
+            expect(file_row).to_be_visible(timeout=20_000)
+            file_row.click()
+            expect(page.locator('[data-testid="panel-file"]')).to_be_visible(
+                timeout=15_000,
+            )
+            # Preview is the default mode; the breadcrumb shows the path.
+            expect(
+                page.locator('[data-testid="file-breadcrumb"]')
+            ).to_contain_text(file_name, timeout=10_000)
+
+        # --- 5. ⌘K opens the command palette ---------------------------
+        # The Studio keydown handler binds `e.metaKey || e.ctrlKey` + "k";
+        # on Linux Chromium (the e2e browser) Control is the reliable
+        # modifier (Meta maps to the Super key).
+        page.keyboard.press("Control+k")
+        palette = page.locator('[data-testid="command-palette"]')
+        expect(palette).to_be_visible(timeout=10_000)
+        # Close it again so it doesn't swallow subsequent input.
+        page.keyboard.press("Escape")
+
+        # --- 6. No console errors across the whole flow ----------------
+        from tests.ui_e2e.conftest import assert_no_console_errors
+        assert_no_console_errors(
+            console_messages,
+            ignore_patterns=[r"net::ERR_ABORTED", r"favicon"],
+        )
+
+    finally:
+        _cleanup(base_url, ids)
+
+
+@pytest.mark.skipif(
+    os.environ.get("PRIMER_RUN_UI_E2E") != "1",
+    reason="Set PRIMER_RUN_UI_E2E=1 to run UI e2e tests",
+)
+def test_studio_session_redirect_lands_with_tab_open(
+    page,
+    base_url: str,
+    console_url: str,
+    unique_suffix: str,
+    console_messages: list[dict],
+) -> None:
+    """B6 redirect: navigating to the retired ``#/sessions/<sid>`` route
+    resolves the session's workspace and lands in the Studio with that
+    session's tab open (agent panel rendered)."""
+
+    ids = _seed_studio_ladder(base_url, "rdr-" + unique_suffix)
+    wid = ids["workspace"]
+    sid = ids["session"]
+
+    try:
+        # The old session-detail route now redirects into the Studio.
+        page.goto(
+            f"{console_url}#/sessions/{sid}",
+            wait_until="domcontentloaded",
+        )
+        # The redirect resolves the workspace and replaces the hash.
+        page.wait_for_url(f"**/console/#/workspaces/{wid}**", timeout=20_000)
+        # The Studio shell mounts with the session tab open → agent panel.
+        expect(page.locator('[data-testid="studio-root"]')).to_be_visible(
+            timeout=20_000,
+        )
+        expect(page.locator('[data-testid="center-tab"]').first).to_be_visible(
+            timeout=15_000,
+        )
+        expect(page.locator('[data-testid="panel-agent"]')).to_be_visible(
+            timeout=15_000,
+        )
+
+        from tests.ui_e2e.conftest import assert_no_console_errors
+        assert_no_console_errors(
+            console_messages,
+            ignore_patterns=[r"net::ERR_ABORTED", r"favicon"],
+        )
+
+    finally:
+        _cleanup(base_url, ids)

--- a/ui/app.jsx
+++ b/ui/app.jsx
@@ -362,6 +362,46 @@ function App() {
 
   const openSession = (id) => navigate("session-detail", id);
 
+  // PR-B redirects: the Studio (/workspaces/:wid) subsumes the session
+  // interface. /sessions → /workspaces; /sessions/:id resolves the
+  // session's workspace then deep-links into the Studio with that session
+  // open (?open=session:<sid>). Old links keep working.
+  const sessionRedirectRef = React.useRef(null);
+  React.useEffect(() => {
+    if (page === "sessions") {
+      window.location.replace("#/workspaces");
+      return;
+    }
+    if (page === "session-detail" && currentSessionId) {
+      // Guard against re-firing the resolve for the same sid across the
+      // re-renders that happen while the fetch is in flight.
+      if (sessionRedirectRef.current === currentSessionId) return;
+      sessionRedirectRef.current = currentSessionId;
+      let cancelled = false;
+      window.primerApi
+        .apiFetch("GET", `/sessions/${encodeURIComponent(currentSessionId)}`)
+        .then((sess) => {
+          if (cancelled) return;
+          const wsid = sess && sess.workspace_id;
+          if (wsid) {
+            window.location.replace(
+              `#/workspaces/${encodeURIComponent(wsid)}?open=session:${encodeURIComponent(currentSessionId)}`
+            );
+          } else {
+            // No workspace to land in — fall back to the workspaces list.
+            window.location.replace("#/workspaces");
+          }
+        })
+        .catch(() => {
+          if (cancelled) return;
+          window.location.replace("#/workspaces");
+        });
+      return () => {
+        cancelled = true;
+      };
+    }
+  }, [page, currentSessionId]);
+
   // Demo state shows error toast on mount
   React.useEffect(() => {
     if (tweaks.demoState === "rfc7807") {
@@ -766,32 +806,11 @@ function App() {
       />
     );
   } else if (page === "workspace-detail" && currentWorkspaceId) {
-    pageHeader = (
-      <>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div className="crumb">
-            <a onClick={() => navigate("workspaces")}>Workspaces</a>
-            <span className="sep">/</span>
-            <span className="mono" style={{ color: "var(--text)" }}>{currentWorkspaceId}</span>
-          </div>
-          <h1 className="page-title mono">{currentWorkspaceId}</h1>
-          <div className="page-sub">
-            <span className="muted">Materialised workspace</span>
-          </div>
-        </div>
-        <div className="page-actions">
-          <Btn icon="chevron-left" kind="ghost" onClick={() => navigate("workspaces")}>Back to list</Btn>
-        </div>
-      </>
-    );
-    pageBody = (
-      <WorkspaceDetail
-        workspaceId={currentWorkspaceId}
-        onOpenSession={(sid) => navigate("session-detail", sid)}
-        onNavigate={navigate}
-        pushToast={pushToast}
-      />
-    );
+    // /workspaces/:wid is the Studio (PR-B). Studio renders its own full
+    // header + 3-column shell, so we return it directly below — bypassing
+    // the standard page chrome (sidebar/topbar/page-header) the other
+    // pages share. See the early-return guard after the page switch.
+    return <Studio wid={currentWorkspaceId} />;
   } else if (page === "workspace-providers") {
     pageHeader = (
       <>

--- a/ui/app.jsx
+++ b/ui/app.jsx
@@ -810,7 +810,7 @@ function App() {
     // header + 3-column shell, so we return it directly below — bypassing
     // the standard page chrome (sidebar/topbar/page-header) the other
     // pages share. See the early-return guard after the page switch.
-    return <Studio wid={currentWorkspaceId} />;
+    return <Studio wid={currentWorkspaceId} pushToast={pushToast} />;
   } else if (page === "workspace-providers") {
     pageHeader = (
       <>

--- a/ui/app.jsx
+++ b/ui/app.jsx
@@ -421,28 +421,18 @@ function App() {
   let pageBody = null;
 
   if (page === "session-detail" && currentSessionId) {
-    pageHeader = (
-      <>
-        <div style={{ flex: 1, minWidth: 0 }}>
-          <div className="crumb">
-            <a onClick={() => navigate("sessions")} style={{ cursor: "pointer" }}>Sessions</a>
-            <span className="sep">/</span>
-            <span className="mono" style={{ color: "var(--text)" }}>{currentSessionId}</span>
-          </div>
-          <h1 className="page-title mono">{currentSessionId}</h1>
-          <SessionStatusCaption sid={currentSessionId} />
-        </div>
-        <div className="page-actions">
-          <Btn icon="chevron-left" kind="ghost" onClick={() => navigate("sessions")}>Back to list</Btn>
-        </div>
-      </>
-    );
+    // PR-B (B6): the Studio subsumes the session detail view. The redirect
+    // useEffect above resolves this session's workspace and navigates to
+    // #/workspaces/:wid?open=session:<sid>. Render a minimal placeholder
+    // while that resolve is in flight — SessionDetail is no longer mounted.
+    pageHeader = null;
     pageBody = (
-      <SessionDetail
-        sid={currentSessionId}
-        onBack={() => navigate("sessions")}
-        pushToast={pushToast}
-      />
+      <div className="panel">
+        <div className="empty">
+          <div className="head">Opening session…</div>
+          <div className="sub">Redirecting to the workspace Studio.</div>
+        </div>
+      </div>
     );
   } else if (page === "internal-collections") {
     pageHeader = (
@@ -1010,30 +1000,18 @@ function App() {
     const Comp = window.MC_McpPage;
     pageBody = Comp ? <Comp /> : null;
   } else if (page === "sessions") {
-    pageHeader = (
-      <>
-        <div>
-          <div className="crumb">
-            <a>Operations</a><span className="sep">/</span><span style={{ color: "var(--text)" }}>Sessions</span>
-          </div>
-          <h1 className="page-title">Sessions</h1>
-          <div className="page-sub tabular">
-            {counts.sessions != null ? counts.sessions : "..."} sessions ·
-            <span className="mono" style={{ marginLeft: 4, color: "var(--text-3)" }}>autorefresh every 3s</span>
-          </div>
-        </div>
-        <div className="page-actions">
-          <Btn icon="refresh" kind="ghost">Refresh</Btn>
-          <Btn icon="plus" kind="primary" onClick={() => setNewSessionOpen(true)}>New session</Btn>
-        </div>
-      </>
-    );
+    // PR-B (B6): the global Sessions list is subsumed by the Studio. The
+    // redirect useEffect above navigates #/sessions → #/workspaces.
+    // Render a minimal placeholder while that replace is in flight —
+    // SessionsList is no longer mounted.
+    pageHeader = null;
     pageBody = (
-      <SessionsList
-        onOpenSession={openSession}
-        onNewSession={() => setNewSessionOpen(true)}
-        demoState={tweaks.demoState === "empty" ? "empty" : tweaks.demoState === "loading" ? "loading" : tweaks.demoState === "error-list" ? "error" : null}
-      />
+      <div className="panel">
+        <div className="empty">
+          <div className="head">Redirecting…</div>
+          <div className="sub">Sessions now live in the workspace Studio.</div>
+        </div>
+      </div>
     );
   } else {
     // Stub pages for sidebar entries

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -1,0 +1,549 @@
+/* global React, Icon, Btn */
+// StudioActivity — right sidebar: Action Required + Workspace Activity feed.
+// PR-B / B4. Replaces the region-activity placeholder in studio.jsx.
+//
+// Components exported:
+//   window.StudioActivity  — outer shell; props: { wid, studio }
+//   window.ActionRequired  — pending-yields list with inline actions
+//   window.WorkspaceActivity — header wrapper around window.WorkspaceTap
+//
+// No-build scope rules (see workspace-tap.jsx):
+//   • top-level declarations use `var` (not const/let)
+//   • helpers are prefixed SA_ to avoid global collisions
+//   • every exported symbol is written to window.X = X
+//
+// Live-reconcile strategy (simplest correct):
+//   ActionRequired opens a lightweight EventSource to the workspace tap and
+//   calls refetch() on the /yields/pending resource whenever a "yielded" or
+//   "done" event arrives. A 300 ms debounce prevents burst re-fetches when
+//   multiple events land at once. This reuses the existing tap infrastructure
+//   (no extra connection object) and keeps the reconcile logic in < 20 lines.
+//
+// Endpoint shapes (verified in session-detail.jsx / approvals.jsx):
+//   • Approve :  POST /sessions/{sid}/tool_approval/respond
+//                body: { tool_call_id, decision: "approved" }
+//   • Reject  :  POST /sessions/{sid}/tool_approval/respond
+//                body: { tool_call_id, decision: "rejected", reason: "" }
+//   • Respond :  POST /sessions/{sid}/ask_user/respond
+//                body: { tool_call_id, response: <string> }
+//   • Cancel  :  POST /sessions/{sid}/yields/{tcid}/cancel
+//                body: { reason: "operator cancelled" }
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function SA_short(sid) {
+  if (!sid) return "—";
+  if (sid.length <= 20) return sid;
+  return sid.slice(0, 10) + "…" + sid.slice(-6);
+}
+
+// ---------------------------------------------------------------------------
+// ActionRequired
+// ---------------------------------------------------------------------------
+
+function ActionRequired({ wid, studio }) {
+  var apiFetch = window.primerApi.apiFetch;
+  var useResource = window.primerApi.useResource;
+
+  // Snapshot of pending yields for the whole workspace.
+  var pending = useResource(
+    "studio-yields-pending:" + wid,
+    function(signal) {
+      return apiFetch("GET", "/workspaces/" + encodeURIComponent(wid) + "/yields/pending", null, { signal: signal });
+    },
+    { pollMs: 15000, deps: [wid] }
+  );
+
+  var items = (pending.data && Array.isArray(pending.data.items)) ? pending.data.items : [];
+
+  // Live reconcile: subscribe to the workspace tap; refetch on yielded/done.
+  // We keep this EventSource independent of WorkspaceTap so it is always
+  // open regardless of the activity feed's filter state.
+  var debounceRef = React.useRef(null);
+  React.useEffect(function() {
+    if (!wid) return;
+    var url = "/v1/workspaces/" + encodeURIComponent(wid) + "/tap";
+    var es;
+    try {
+      es = new EventSource(url, { withCredentials: true });
+    } catch (_e) {
+      return;
+    }
+    es.onmessage = function(e) {
+      var ev;
+      try { ev = JSON.parse(e.data); } catch (_) { return; }
+      if (!ev || typeof ev !== "object") return;
+      var cls = ev.class;
+      if (cls === "yielded" || cls === "done") {
+        clearTimeout(debounceRef.current);
+        debounceRef.current = setTimeout(function() {
+          pending.refetch();
+        }, 300);
+      }
+    };
+    return function() {
+      clearTimeout(debounceRef.current);
+      try { es.close(); } catch (_) { /* no-op */ }
+    };
+  }, [wid]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Per-item respond state: { [item_id]: { draft, submitting, error } }
+  var [respondState, setRespondState] = React.useState({});
+
+  function getRespond(id) {
+    return respondState[id] || { draft: "", submitting: false, error: null };
+  }
+
+  function patchRespond(id, patch) {
+    setRespondState(function(prev) {
+      var cur = prev[id] || { draft: "", submitting: false, error: null };
+      var next = {};
+      for (var k in prev) next[k] = prev[k];
+      next[id] = Object.assign({}, cur, patch);
+      return next;
+    });
+  }
+
+  // Optimistically remove an item after a successful action, then re-confirm
+  // via the next reconcile refetch.
+  var [hidden, setHidden] = React.useState({});
+  function hide(id) {
+    setHidden(function(prev) {
+      var next = {};
+      for (var k in prev) next[k] = prev[k];
+      next[id] = true;
+      return next;
+    });
+    setTimeout(function() { pending.refetch(); }, 800);
+  }
+
+  // Action handlers
+  function handleApprove(item) {
+    apiFetch(
+      "POST",
+      "/sessions/" + encodeURIComponent(item.session_id) + "/tool_approval/respond",
+      { tool_call_id: item.tool_call_id, decision: "approved" }
+    ).then(function() {
+      hide(item.tool_call_id);
+    }).catch(function(err) {
+      // Surface error inline — stay visible so user can retry
+      patchRespond(item.tool_call_id, { error: (err && (err.detail || err.title || err.message)) || "Approve failed" });
+    });
+  }
+
+  function handleReject(item) {
+    apiFetch(
+      "POST",
+      "/sessions/" + encodeURIComponent(item.session_id) + "/tool_approval/respond",
+      { tool_call_id: item.tool_call_id, decision: "rejected", reason: "" }
+    ).then(function() {
+      hide(item.tool_call_id);
+    }).catch(function(err) {
+      patchRespond(item.tool_call_id, { error: (err && (err.detail || err.title || err.message)) || "Reject failed" });
+    });
+  }
+
+  function handleRespondSubmit(item) {
+    var rs = getRespond(item.tool_call_id);
+    if (!rs.draft.trim()) return;
+    patchRespond(item.tool_call_id, { submitting: true, error: null });
+    apiFetch(
+      "POST",
+      "/sessions/" + encodeURIComponent(item.session_id) + "/ask_user/respond",
+      { tool_call_id: item.tool_call_id, response: rs.draft.trim() }
+    ).then(function() {
+      hide(item.tool_call_id);
+    }).catch(function(err) {
+      patchRespond(item.tool_call_id, { submitting: false, error: (err && (err.detail || err.title || err.message)) || "Respond failed" });
+    });
+  }
+
+  function handleRespondKeyDown(item, e) {
+    if (e.key === "Enter" && !e.shiftKey) {
+      e.preventDefault();
+      handleRespondSubmit(item);
+    }
+  }
+
+  function handleCancel(item) {
+    apiFetch(
+      "POST",
+      "/sessions/" + encodeURIComponent(item.session_id) + "/yields/" + encodeURIComponent(item.tool_call_id) + "/cancel",
+      { reason: "operator cancelled" }
+    ).then(function() {
+      hide(item.tool_call_id);
+    }).catch(function(err) {
+      patchRespond(item.tool_call_id, { error: (err && (err.detail || err.title || err.message)) || "Cancel failed" });
+    });
+  }
+
+  function handleFocusSession(sessionId) {
+    if (!studio || !studio.openTab) return;
+    studio.openTab({
+      id: "session:" + sessionId,
+      kind: "session",
+      ref: sessionId,
+      title: sessionId,
+    });
+  }
+
+  var visibleItems = items.filter(function(it) { return !hidden[it.tool_call_id]; });
+  var count = visibleItems.length;
+
+  return (
+    <div
+      className="st-section"
+      style={{
+        borderBottom: "1px solid var(--border)",
+        display: "flex",
+        flexDirection: "column",
+        flexShrink: 0,
+        maxHeight: count > 0 ? 320 : 60,
+        overflow: "hidden",
+      }}
+      data-testid="action-required"
+    >
+      {/* Section header */}
+      <div
+        style={{
+          height: 34,
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "0 12px",
+          borderBottom: count > 0 ? "1px solid var(--border)" : "none",
+        }}
+      >
+        <span style={{ color: "var(--amber)", fontSize: 13 }}>⚠</span>
+        <span
+          style={{
+            fontSize: 10.5,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            fontWeight: 600,
+            color: "var(--text-2)",
+            flex: 1,
+          }}
+        >
+          Action Required
+        </span>
+        {count > 0 && (
+          <span
+            data-testid="action-required-count"
+            style={{
+              background: "var(--amber-dim)",
+              color: "var(--amber)",
+              borderRadius: 999,
+              padding: "1px 7px",
+              fontSize: 10.5,
+              fontWeight: 700,
+              fontFamily: "IBM Plex Mono, monospace",
+            }}
+          >
+            {count}
+          </span>
+        )}
+        {pending.loading && !pending.data && (
+          <span style={{ color: "var(--text-4)", fontSize: 10.5 }}>…</span>
+        )}
+      </div>
+
+      {/* Item list */}
+      <div
+        data-testid="action-required-list"
+        style={{ overflowY: "auto", flex: 1 }}
+      >
+        {count === 0 && !pending.loading && (
+          <div
+            style={{
+              padding: "14px 12px",
+              fontSize: 12,
+              color: "var(--text-4)",
+              textAlign: "center",
+              lineHeight: 1.5,
+            }}
+          >
+            No pending actions. Everything's running clean.
+          </div>
+        )}
+
+        {visibleItems.map(function(item) {
+          var rs = getRespond(item.tool_call_id);
+          var isApproval = item.kind === "approval";
+          var isAsk = item.kind === "ask_user";
+          var isCancelable = item.kind === "watch_files" || item.kind === "sleep";
+          var sidShort = SA_short(item.session_id);
+
+          return (
+            <div
+              key={item.tool_call_id}
+              data-testid="action-item"
+              style={{
+                padding: "10px 12px",
+                borderBottom: "1px solid var(--border)",
+                display: "flex",
+                flexDirection: "column",
+                gap: 6,
+              }}
+            >
+              {/* Session label + kind */}
+              <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+                <button
+                  type="button"
+                  data-testid="action-session-link"
+                  onClick={function() { handleFocusSession(item.session_id); }}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    cursor: "pointer",
+                    color: "var(--accent)",
+                    fontFamily: "IBM Plex Mono, monospace",
+                    fontSize: 11,
+                    textDecoration: "underline",
+                    textUnderlineOffset: 2,
+                  }}
+                  title={item.session_id}
+                >
+                  {sidShort}
+                </button>
+                <span
+                  style={{
+                    color: "var(--amber)",
+                    fontSize: 10,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                    fontWeight: 600,
+                  }}
+                >
+                  {item.kind}
+                </span>
+              </div>
+
+              {/* Prompt text */}
+              {item.prompt && (
+                <div
+                  style={{
+                    fontSize: 12,
+                    lineHeight: 1.5,
+                    color: "var(--text-2)",
+                    wordBreak: "break-word",
+                    whiteSpace: "pre-wrap",
+                    maxHeight: 72,
+                    overflowY: "auto",
+                  }}
+                >
+                  {item.prompt}
+                </div>
+              )}
+
+              {/* Inline error */}
+              {rs.error && (
+                <div style={{ color: "var(--red)", fontSize: 11 }}>{rs.error}</div>
+              )}
+
+              {/* Approval actions */}
+              {isApproval && (
+                <div
+                  data-testid="action-approval-controls"
+                  style={{ display: "flex", gap: 6 }}
+                >
+                  <button
+                    type="button"
+                    data-testid="approve"
+                    onClick={function() { handleApprove(item); }}
+                    style={{
+                      flex: 1,
+                      padding: "4px 0",
+                      borderRadius: 6,
+                      border: "1px solid oklch(0.82 0.18 145 / 0.4)",
+                      background: "var(--green-dim)",
+                      color: "var(--green)",
+                      cursor: "pointer",
+                      fontSize: 12,
+                      fontWeight: 600,
+                    }}
+                  >
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    data-testid="reject"
+                    onClick={function() { handleReject(item); }}
+                    style={{
+                      flex: 1,
+                      padding: "4px 0",
+                      borderRadius: 6,
+                      border: "1px solid oklch(0.75 0.18 25 / 0.4)",
+                      background: "var(--red-dim)",
+                      color: "var(--red)",
+                      cursor: "pointer",
+                      fontSize: 12,
+                      fontWeight: 600,
+                    }}
+                  >
+                    Reject
+                  </button>
+                </div>
+              )}
+
+              {/* Ask-user respond */}
+              {isAsk && (
+                <div
+                  data-testid="action-ask-controls"
+                  style={{ display: "flex", gap: 6 }}
+                >
+                  <input
+                    type="text"
+                    data-testid="respond"
+                    placeholder="Type a response… Enter to send"
+                    value={rs.draft}
+                    disabled={rs.submitting}
+                    onChange={function(e) { patchRespond(item.tool_call_id, { draft: e.target.value }); }}
+                    onKeyDown={function(e) { handleRespondKeyDown(item, e); }}
+                    style={{
+                      flex: 1,
+                      background: "var(--bg-2)",
+                      border: "1px solid var(--border)",
+                      borderRadius: 6,
+                      padding: "4px 8px",
+                      fontSize: 12,
+                      color: "var(--text)",
+                      fontFamily: "inherit",
+                      outline: "none",
+                    }}
+                  />
+                </div>
+              )}
+
+              {/* Cancel for watch_files / sleep */}
+              {isCancelable && (
+                <div data-testid="action-cancel-controls">
+                  <button
+                    type="button"
+                    data-testid="cancel-yield"
+                    onClick={function() { handleCancel(item); }}
+                    style={{
+                      padding: "4px 10px",
+                      borderRadius: 6,
+                      border: "1px solid var(--border)",
+                      background: "transparent",
+                      color: "var(--text-3)",
+                      cursor: "pointer",
+                      fontSize: 12,
+                    }}
+                  >
+                    Cancel
+                  </button>
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceActivity — thin header wrapper around the reused WorkspaceTap
+// ---------------------------------------------------------------------------
+
+function WorkspaceActivity({ wid }) {
+  return (
+    <div
+      data-testid="workspace-activity"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        flex: 1,
+        minHeight: 0,
+        overflow: "hidden",
+      }}
+    >
+      {/* Section header */}
+      <div
+        style={{
+          height: 34,
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          gap: 6,
+          padding: "0 12px",
+          borderBottom: "1px solid var(--border)",
+        }}
+      >
+        <span
+          className="dot"
+          style={{
+            width: 7,
+            height: 7,
+            borderRadius: "50%",
+            background: "var(--green)",
+            display: "inline-block",
+            flexShrink: 0,
+          }}
+        />
+        <span
+          style={{
+            fontSize: 10.5,
+            textTransform: "uppercase",
+            letterSpacing: "0.06em",
+            fontWeight: 600,
+            color: "var(--text-2)",
+            flex: 1,
+          }}
+        >
+          Workspace Activity
+        </span>
+        <span
+          style={{
+            fontSize: 10,
+            color: "var(--green)",
+            fontFamily: "IBM Plex Mono, monospace",
+          }}
+        >
+          live
+        </span>
+      </div>
+
+      {/* WorkspaceTap owns its filter chips + SSE connection + auto-scroll */}
+      <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
+        <window.WorkspaceTap wid={wid} />
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StudioActivity — right sidebar shell (B4)
+// Replaces <ST_RegionPlaceholder testid="region-activity" /> in studio.jsx
+// ---------------------------------------------------------------------------
+
+function StudioActivity({ wid, studio }) {
+  return (
+    <div
+      data-testid="studio-activity-root"
+      style={{
+        display: "flex",
+        flexDirection: "column",
+        height: "100%",
+        overflow: "hidden",
+        borderLeft: "1px solid var(--border)",
+      }}
+    >
+      <ActionRequired wid={wid} studio={studio} />
+      <WorkspaceActivity wid={wid} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// No-build window exports
+// ---------------------------------------------------------------------------
+window.StudioActivity = StudioActivity;
+window.ActionRequired = ActionRequired;
+window.WorkspaceActivity = WorkspaceActivity;

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -83,6 +83,10 @@ function ActionRequired({ wid, studio }) {
         }, 300);
       }
     };
+    // No-op on stream error: the 15s pollMs on the pending resource is the
+    // safety net, so a dropped/erroring tap still reconciles on the next poll
+    // (mirrors how WorkspaceTap tolerates stream errors).
+    es.onerror = function() { /* poll backstops a dropped tap */ };
     return function() {
       clearTimeout(debounceRef.current);
       try { es.close(); } catch (_) { /* no-op */ }
@@ -119,8 +123,12 @@ function ActionRequired({ wid, studio }) {
     setTimeout(function() { pending.refetch(); }, 800);
   }
 
-  // Action handlers
+  // Action handlers. Each guards on a falsy tool_call_id — the /yields/pending
+  // item shape allows tool_call_id: null (malformed/legacy parks), and every
+  // endpoint below embeds it in the URL/body. Bailing keeps us from POSTing
+  // e.g. /yields/null/cancel.
   function handleApprove(item) {
+    if (!item.tool_call_id) return;
     apiFetch(
       "POST",
       "/sessions/" + encodeURIComponent(item.session_id) + "/tool_approval/respond",
@@ -134,6 +142,7 @@ function ActionRequired({ wid, studio }) {
   }
 
   function handleReject(item) {
+    if (!item.tool_call_id) return;
     apiFetch(
       "POST",
       "/sessions/" + encodeURIComponent(item.session_id) + "/tool_approval/respond",
@@ -146,6 +155,7 @@ function ActionRequired({ wid, studio }) {
   }
 
   function handleRespondSubmit(item) {
+    if (!item.tool_call_id) return;
     var rs = getRespond(item.tool_call_id);
     if (!rs.draft.trim()) return;
     patchRespond(item.tool_call_id, { submitting: true, error: null });
@@ -168,6 +178,7 @@ function ActionRequired({ wid, studio }) {
   }
 
   function handleCancel(item) {
+    if (!item.tool_call_id) return;
     apiFetch(
       "POST",
       "/sessions/" + encodeURIComponent(item.session_id) + "/yields/" + encodeURIComponent(item.tool_call_id) + "/cancel",
@@ -270,16 +281,20 @@ function ActionRequired({ wid, studio }) {
           </div>
         )}
 
-        {visibleItems.map(function(item) {
+        {visibleItems.map(function(item, idx) {
           var rs = getRespond(item.tool_call_id);
           var isApproval = item.kind === "approval";
           var isAsk = item.kind === "ask_user";
           var isCancelable = item.kind === "watch_files" || item.kind === "sleep";
           var sidShort = SA_short(item.session_id);
+          // A park with no tool_call_id (the /yields/pending shape allows null)
+          // is still rendered, but its action controls are disabled so a
+          // malformed/legacy item can't POST e.g. /yields/null/cancel.
+          var actionable = !!item.tool_call_id;
 
           return (
             <div
-              key={item.tool_call_id}
+              key={(item.session_id || "") + ":" + (item.tool_call_id || idx)}
               data-testid="action-item"
               style={{
                 padding: "10px 12px",
@@ -354,6 +369,7 @@ function ActionRequired({ wid, studio }) {
                   <button
                     type="button"
                     data-testid="approve"
+                    disabled={!actionable}
                     onClick={function() { handleApprove(item); }}
                     style={{
                       flex: 1,
@@ -362,7 +378,8 @@ function ActionRequired({ wid, studio }) {
                       border: "1px solid oklch(0.82 0.18 145 / 0.4)",
                       background: "var(--green-dim)",
                       color: "var(--green)",
-                      cursor: "pointer",
+                      cursor: actionable ? "pointer" : "not-allowed",
+                      opacity: actionable ? 1 : 0.5,
                       fontSize: 12,
                       fontWeight: 600,
                     }}
@@ -372,6 +389,7 @@ function ActionRequired({ wid, studio }) {
                   <button
                     type="button"
                     data-testid="reject"
+                    disabled={!actionable}
                     onClick={function() { handleReject(item); }}
                     style={{
                       flex: 1,
@@ -380,7 +398,8 @@ function ActionRequired({ wid, studio }) {
                       border: "1px solid oklch(0.75 0.18 25 / 0.4)",
                       background: "var(--red-dim)",
                       color: "var(--red)",
-                      cursor: "pointer",
+                      cursor: actionable ? "pointer" : "not-allowed",
+                      opacity: actionable ? 1 : 0.5,
                       fontSize: 12,
                       fontWeight: 600,
                     }}
@@ -401,7 +420,7 @@ function ActionRequired({ wid, studio }) {
                     data-testid="respond"
                     placeholder="Type a response… Enter to send"
                     value={rs.draft}
-                    disabled={rs.submitting}
+                    disabled={rs.submitting || !actionable}
                     onChange={function(e) { patchRespond(item.tool_call_id, { draft: e.target.value }); }}
                     onKeyDown={function(e) { handleRespondKeyDown(item, e); }}
                     style={{
@@ -425,6 +444,7 @@ function ActionRequired({ wid, studio }) {
                   <button
                     type="button"
                     data-testid="cancel-yield"
+                    disabled={!actionable}
                     onClick={function() { handleCancel(item); }}
                     style={{
                       padding: "4px 10px",
@@ -432,7 +452,8 @@ function ActionRequired({ wid, studio }) {
                       border: "1px solid var(--border)",
                       background: "transparent",
                       color: "var(--text-3)",
-                      cursor: "pointer",
+                      cursor: actionable ? "pointer" : "not-allowed",
+                      opacity: actionable ? 1 : 0.5,
                       fontSize: 12,
                     }}
                   >

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -1,0 +1,885 @@
+/* global React, Icon, Btn, Banner */
+// StudioCenter — center region of the Studio IDE shell (PR-B / B3).
+//
+// Replaces the ST_RegionPlaceholder at data-testid="region-center" inside
+// the shell's data-testid="studio-center" column. Renders:
+//   CenterTabs        — the tab bar over studio.state.openTabs (glyph/title,
+//                        dirty dot, close ×; horizontal overflow; empty state).
+//   the active panel  — chosen by the active tab's kind:
+//     session(agent) → SessionAgentPanel  (header + controls + SessionLiveStream)
+//     session(graph) → SessionGraphPanel  (header + SD_GraphRunView)
+//     file           → FilePanel          (preview/edit toggle + Save + 412 flow)
+//
+// REUSE (do NOT rebuild): the agent transcript and the graph run-view are the
+// production components from session-detail.jsx, reached across files as the
+// no-build window globals:
+//   window.SessionLiveStream  ({ sid, wid, session, pushToast })
+//   window.SD_GraphRunView    ({ gid, rid, wid, session, pushToast })
+// Markdown preview reuses window.renderMarkdown; code highlight reuses
+// window.primerVendor.highlightPython.
+//
+// REUSE FRICTION (noted for B6): the per-session control mutations
+// (pause/resume/steer/cancel) live *inlined* inside SessionDetail in
+// session-detail.jsx — they are NOT exported as standalone helpers/hooks.
+// Rather than touch session-detail.jsx (out of scope for B3), this file
+// re-creates those mutations against the SAME workspace-scoped endpoints
+// (POST .../sessions/{sid}/{pause|resume|cancel|steer}). B6 will extract the
+// shared control surface and this panel can swap to it.
+//
+// No-build rules: top-level declarations use `var`; helpers prefixed ST_;
+// every exported symbol is assigned to window.X at the bottom.
+
+// ---------------------------------------------------------------------------
+// ST_basename — last path segment, for the file breadcrumb / tab title.
+// ---------------------------------------------------------------------------
+
+function ST_basename(path) {
+  if (!path) return "";
+  var parts = String(path).split("/");
+  return parts[parts.length - 1] || path;
+}
+
+// ---------------------------------------------------------------------------
+// ST_fileClassOf — coarse render-class for a path: "markdown"|"image"|"code"|"text".
+// Drives the preview branch + whether syntax highlighting applies.
+// ---------------------------------------------------------------------------
+
+var ST_IMAGE_EXTS = { png: 1, jpg: 1, jpeg: 1, gif: 1, svg: 1, webp: 1, bmp: 1, ico: 1, avif: 1 };
+var ST_MD_EXTS = { md: 1, markdown: 1, mdx: 1 };
+var ST_CODE_LANGS = {
+  py: "python", pyi: "python",
+  js: "javascript", jsx: "javascript", ts: "javascript", tsx: "javascript",
+  json: "json",
+  sh: "bash", bash: "bash", zsh: "bash",
+  yaml: "yaml", yml: "yaml", toml: "toml", ini: "ini",
+  css: "css", html: "html", sql: "sql", rs: "rust", go: "go", c: "c",
+};
+
+function ST_extOf(path) {
+  var name = ST_basename(path).toLowerCase();
+  var dot = name.lastIndexOf(".");
+  return dot >= 0 ? name.slice(dot + 1) : "";
+}
+
+function ST_fileClassOf(path) {
+  var ext = ST_extOf(path);
+  if (ST_MD_EXTS[ext]) return "markdown";
+  if (ST_IMAGE_EXTS[ext]) return "image";
+  if (ST_CODE_LANGS[ext]) return "code";
+  return "text";
+}
+
+function ST_fmtBytes(n) {
+  if (typeof n !== "number" || !isFinite(n)) return "";
+  if (n < 1024) return n + " B";
+  if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+  return (n / (1024 * 1024)).toFixed(1) + " MB";
+}
+
+// Files larger than this are preview/download-only (no edit toggle).
+var ST_EDIT_MAX_BYTES = 1024 * 1024;
+
+// ---------------------------------------------------------------------------
+// CenterTabs — the tab bar over studio.state.openTabs.
+//   Each tab: glyph + title + dirty ● (files) + close ×.
+//   Active = activeTabId; click → focusTab; × → closeTab (confirm if dirty file).
+//   Horizontal overflow scrolls (.st-tabbar { overflow-x:auto }). Empty state
+//   shown when there are no open tabs.
+// ---------------------------------------------------------------------------
+
+function CenterTabs({ openTabs, activeTabId, onFocus, onClose }) {
+  var tabs = openTabs || [];
+
+  if (tabs.length === 0) {
+    return (
+      <div className="st-tabbar" data-testid="center-tabs">
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            padding: "0 14px",
+            fontSize: 11.5,
+            color: "var(--text-4)",
+            fontStyle: "italic",
+          }}
+          data-testid="center-tabs-empty"
+        >
+          No open tabs — pick a session or file from the sidebar.
+        </div>
+      </div>
+    );
+  }
+
+  function handleClose(e, tab) {
+    e.stopPropagation();
+    // A dirty file tab carries unsaved edits — confirm before discarding.
+    if (tab.kind === "file" && tab.dirty) {
+      var ok = window.confirm(
+        "“" + (tab.title || tab.ref) + "” has unsaved changes. Close without saving?"
+      );
+      if (!ok) return;
+    }
+    onClose(tab.id);
+  }
+
+  return (
+    <div className="st-tabbar" data-testid="center-tabs">
+      {tabs.map(function (tab) {
+        var isActive = tab.id === activeTabId;
+        return (
+          <div
+            key={tab.id}
+            className={"st-tab" + (isActive ? " is-active" : "")}
+            data-testid="center-tab"
+            data-tab-id={tab.id}
+            data-active={isActive ? "true" : "false"}
+            title={tab.ref || tab.title}
+            onClick={function () { onFocus(tab.id); }}
+          >
+            {tab.glyph && (
+              <span style={{ color: isActive ? "var(--accent)" : "var(--text-4)", flexShrink: 0 }}>
+                {tab.glyph}
+              </span>
+            )}
+            <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {tab.title || ST_basename(tab.ref)}
+            </span>
+            {tab.kind === "file" && tab.dirty && (
+              <span
+                data-testid="tab-dirty"
+                style={{ width: 7, height: 7, borderRadius: "50%", background: "var(--blue)", flexShrink: 0 }}
+              />
+            )}
+            <span
+              className="st-tab-close"
+              data-testid="center-tab-close"
+              title="Close"
+              onClick={function (e) { handleClose(e, tab); }}
+            >×</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ST_SessionControls — pause/resume · steer · cancel inline control cluster.
+// Re-creates SessionDetail's signal mutations against the same workspace-scoped
+// endpoints (see REUSE FRICTION note at top). Shared by the agent + graph
+// header rows.
+// ---------------------------------------------------------------------------
+
+function ST_SessionControls({ wid, sid, session, pushToast }) {
+  var { useMutation, apiFetch } = window.primerApi;
+  var [steerOpen, setSteerOpen] = React.useState(false);
+  var [steerText, setSteerText] = React.useState("");
+
+  var status = session && session.status;
+  var isTerminal = !!(session && window.SESSION_TERMINAL && window.SESSION_TERMINAL.has(status));
+
+  function toastErr(title) {
+    return function (err) {
+      if (typeof pushToast !== "function") return;
+      pushToast({
+        kind: "error",
+        title: (err && err.title) || title,
+        detail: (err && err.detail) || (err && err.message),
+        requestId: err && err.requestId,
+      });
+    };
+  }
+
+  var invalidates = ["studio-session:" + sid, "session-detail:" + sid, "sessions:list"];
+
+  var pauseMut = useMutation(
+    function () { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/pause"); },
+    { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Session paused" }); }, onError: toastErr("Pause failed") }
+  );
+  var resumeMut = useMutation(
+    function () { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/resume"); },
+    { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Resume signal sent" }); }, onError: toastErr("Resume failed") }
+  );
+  var cancelMut = useMutation(
+    function () { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/cancel"); },
+    { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "warning", title: "Cancel signal sent" }); }, onError: toastErr("Cancel failed") }
+  );
+  var steerMut = useMutation(
+    function (instruction) { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/steer", { instruction: instruction }); },
+    {
+      invalidates: invalidates,
+      onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Steer queued" }); setSteerText(""); setSteerOpen(false); },
+      onError: toastErr("Steer failed"),
+    }
+  );
+
+  function submitSteer() {
+    var text = steerText.trim();
+    if (!text || !wid) return;
+    steerMut.mutate(text);
+  }
+
+  return (
+    <div style={{ display: "flex", alignItems: "center", gap: 6, position: "relative" }} data-testid="session-controls">
+      <Btn
+        size="sm"
+        icon="pause"
+        disabled={!wid || status !== "running" || pauseMut.loading}
+        onClick={function () { if (wid) pauseMut.mutate(); }}
+        data-testid="ctrl-pause"
+        title={status !== "running" ? "Enabled only when running" : "Pause after current turn"}
+      >Pause</Btn>
+      <Btn
+        size="sm"
+        icon="play"
+        disabled={!wid || isTerminal || resumeMut.loading}
+        onClick={function () { if (wid) resumeMut.mutate(); }}
+        data-testid="ctrl-resume"
+        title="Resume (idempotent)"
+      >Resume</Btn>
+      <Btn
+        size="sm"
+        icon="send"
+        disabled={!wid || isTerminal}
+        onClick={function () { setSteerOpen(function (o) { return !o; }); }}
+        data-testid="ctrl-steer"
+        title="Queue a steer instruction"
+      >Steer</Btn>
+      <Btn
+        size="sm"
+        kind="danger"
+        icon="stop"
+        disabled={!wid || isTerminal || cancelMut.loading}
+        onClick={function () { if (wid) cancelMut.mutate(); }}
+        data-testid="ctrl-cancel"
+        title="Cancel the run"
+      >Cancel</Btn>
+
+      {steerOpen && (
+        <div
+          style={{
+            position: "absolute",
+            top: 30,
+            right: 0,
+            zIndex: 30,
+            width: 320,
+            background: "var(--bg-elev)",
+            border: "1px solid var(--border-strong)",
+            borderRadius: 9,
+            boxShadow: "var(--shadow)",
+            padding: 10,
+          }}
+          data-testid="steer-popover"
+        >
+          <textarea
+            placeholder="Drop a hint or directive for the next turn…"
+            value={steerText}
+            onChange={function (e) { setSteerText(e.target.value); }}
+            rows={3}
+            autoFocus
+            style={{
+              width: "100%", padding: "6px 8px", fontSize: 12, background: "var(--bg-2)",
+              border: "1px solid var(--border)", borderRadius: 6, color: "var(--text)",
+              resize: "none", fontFamily: "IBM Plex Mono, monospace", outline: "none", marginBottom: 8,
+            }}
+          />
+          <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
+            <Btn size="sm" kind="ghost" onClick={function () { setSteerOpen(false); }}>Cancel</Btn>
+            <Btn size="sm" kind="primary" icon="send" disabled={!steerText.trim() || steerMut.loading} onClick={submitSteer}>Queue</Btn>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ST_TokenMeterInline — compact token meter for the agent header. Reuses the
+// shared window.TokenMeter when present; degrades to a plain count otherwise.
+// ---------------------------------------------------------------------------
+
+function ST_TokenMeterInline({ session }) {
+  var turns = (session && Array.isArray(session.turns)) ? session.turns : [];
+  var last = turns.length > 0 ? turns[turns.length - 1] : null;
+  var inputTokens = Number(last && last.tokens_in) || 0;
+  var contextLength = Number(session && session.context_length) || 0;
+  if (window.TokenMeter) {
+    return <window.TokenMeter inputTokens={inputTokens} contextLength={contextLength} onCompact={null} />;
+  }
+  return (
+    <span className="mono" style={{ fontSize: 11, color: "var(--text-3)" }}>{inputTokens} tok</span>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SessionAgentPanel — agent transcript panel.
+//   header: title · status pill · turn · token meter + inline controls
+//   body  : the reused SessionLiveStream (session-scoped tap + history)
+// ---------------------------------------------------------------------------
+
+function SessionAgentPanel({ wid, sid, session, pushToast }) {
+  var StatusPill = window.StatusPill;
+  var title = (session && (session.name || session.id)) || sid;
+  var turnNo = (session && (session.turn_no != null ? session.turn_no : session.turn_count)) || 0;
+
+  return (
+    <div
+      data-testid="panel-agent"
+      style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}
+    >
+      <div
+        style={{
+          display: "flex", alignItems: "center", gap: 10, padding: "8px 14px",
+          borderBottom: "1px solid var(--border)", flex: "0 0 auto", flexWrap: "wrap",
+        }}
+        data-testid="panel-agent-header"
+      >
+        <span style={{ color: "var(--accent)", flexShrink: 0 }}>◆</span>
+        <span className="mono" style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{title}</span>
+        {StatusPill && session && <StatusPill status={session.status} />}
+        <span className="mono" style={{ fontSize: 11, color: "var(--text-4)" }}>turn {turnNo}</span>
+        <div style={{ flex: 1 }} />
+        <ST_TokenMeterInline session={session} />
+        <ST_SessionControls wid={wid} sid={sid} session={session} pushToast={pushToast} />
+      </div>
+      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+        {wid && window.SessionLiveStream
+          ? <window.SessionLiveStream sid={sid} wid={wid} session={session} pushToast={pushToast} />
+          : (
+            <div className="muted text-sm" style={{ padding: 20, textAlign: "center", color: "var(--text-4)" }}>
+              Live stream unavailable — session has no workspace.
+            </div>
+          )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SessionGraphPanel — graph run-view panel.
+//   header: name · status · progress (superstep N · X/Y · current)
+//   body  : the reused SD_GraphRunView (graph canvas + node inspector)
+// ---------------------------------------------------------------------------
+
+function SessionGraphPanel({ wid, sid, session, pushToast }) {
+  var StatusPill = window.StatusPill;
+  var gid = session && session.binding && session.binding.graph_id
+    ? session.binding.graph_id
+    : (session && session.graph_id) || null;
+  var title = (session && (session.name || session.id)) || sid;
+  var superstep = (session && (session.turn_no != null ? session.turn_no : session.turn_count)) || 0;
+
+  // Progress summary if the row carries node counts (best-effort; the
+  // run-view itself owns the authoritative per-node state).
+  var done = session && (session.nodes_done != null ? session.nodes_done : null);
+  var total = session && (session.nodes_total != null ? session.nodes_total : null);
+  var current = session && (session.current_node || session.active_node) || null;
+
+  return (
+    <div
+      data-testid="panel-graph"
+      style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}
+    >
+      <div
+        style={{
+          display: "flex", alignItems: "center", gap: 10, padding: "8px 14px",
+          borderBottom: "1px solid var(--border)", flex: "0 0 auto", flexWrap: "wrap",
+        }}
+        data-testid="panel-graph-header"
+      >
+        <span style={{ color: "var(--violet)", flexShrink: 0 }}>◈</span>
+        <span className="mono" style={{ fontSize: 13, fontWeight: 600, color: "var(--text)" }}>{title}</span>
+        {StatusPill && session && <StatusPill status={session.status} />}
+        <span className="mono" style={{ fontSize: 11, color: "var(--text-4)" }}>
+          superstep {superstep}
+          {(done != null && total != null) ? " · " + done + "/" + total : ""}
+          {current ? " · " + current : ""}
+        </span>
+        <div style={{ flex: 1 }} />
+        <ST_SessionControls wid={wid} sid={sid} session={session} pushToast={pushToast} />
+      </div>
+      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+        {wid && gid && window.SD_GraphRunView
+          ? <window.SD_GraphRunView gid={gid} rid={sid} wid={wid} session={session} pushToast={pushToast} />
+          : (
+            <div className="muted text-sm" style={{ padding: 20, textAlign: "center", color: "var(--text-4)" }}>
+              Run view unavailable — graph binding or workspace missing.
+            </div>
+          )}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ST_SessionPanel — resolves a session tab to the agent or graph panel.
+//   Fetches GET /v1/sessions/{ref} (useResource) to read binding.kind.
+// ---------------------------------------------------------------------------
+
+function ST_SessionPanel({ wid, sid, pushToast }) {
+  var { useResource, apiFetch } = window.primerApi;
+
+  var detail = useResource(
+    "studio-session:" + sid,
+    function (signal) { return apiFetch("GET", "/sessions/" + encodeURIComponent(sid), null, { signal }); },
+    {
+      pollMs: 2000,
+      pauseWhile: function () {
+        // Once terminal, stop polling — nothing left to refresh at this level.
+        var st = detail && detail.data && detail.data.status;
+        return !!(window.SESSION_TERMINAL && window.SESSION_TERMINAL.has(st));
+      },
+      deps: [sid],
+    }
+  );
+
+  var session = detail.data;
+
+  if (detail.loading && !session) {
+    return (
+      <div className="muted text-sm" style={{ padding: 40, textAlign: "center", color: "var(--text-4)" }}>
+        Loading session {sid}…
+      </div>
+    );
+  }
+  if (detail.error && !session) {
+    return (
+      <div style={{ padding: 16 }}>
+        <Banner
+          kind="error"
+          title={(detail.error && detail.error.title) || "Couldn't load session"}
+          detail={(detail.error && (detail.error.detail || detail.error.message)) || sid}
+          actions={<Btn size="sm" icon="refresh" onClick={detail.refetch}>Retry</Btn>}
+        />
+      </div>
+    );
+  }
+  if (!session) return null;
+
+  // Resolve binding kind; mirror SessionLiveStream/SD_GraphRunView's defensive
+  // reads (binding.kind || binding_kind).
+  var kind = (session.binding && session.binding.kind) || session.binding_kind || "agent";
+  // The session's own workspace_id is authoritative; fall back to the route wid.
+  var effWid = session.workspace_id || wid;
+
+  if (kind === "graph") {
+    return <SessionGraphPanel wid={effWid} sid={sid} session={session} pushToast={pushToast} />;
+  }
+  return <SessionAgentPanel wid={effWid} sid={sid} session={session} pushToast={pushToast} />;
+}
+
+// ---------------------------------------------------------------------------
+// ST_FilePreview — render the held content per file class.
+//   markdown → renderMarkdown; code → highlighted line-numbered <pre>;
+//   image → <img> via files/download; else plain text.
+// ---------------------------------------------------------------------------
+
+function ST_FilePreview({ wid, path, content }) {
+  var cls = ST_fileClassOf(path);
+
+  if (cls === "image") {
+    var src = "/v1/workspaces/" + encodeURIComponent(wid) + "/files/download?path=" + encodeURIComponent(path);
+    return (
+      <div style={{ padding: 18, display: "grid", placeItems: "center" }} data-testid="file-preview-image">
+        <img src={src} alt={ST_basename(path)} style={{ maxWidth: "100%", maxHeight: "100%", objectFit: "contain" }} />
+      </div>
+    );
+  }
+
+  if (cls === "markdown" && typeof window.renderMarkdown === "function") {
+    return (
+      <div
+        className="md-body"
+        data-testid="file-preview-markdown"
+        style={{ maxWidth: 760, padding: "18px 22px", fontSize: 13.5, lineHeight: 1.65 }}
+      >
+        {window.renderMarkdown(content || "")}
+      </div>
+    );
+  }
+
+  if (cls === "code" && window.primerVendor && window.primerVendor.highlightPython) {
+    var lang = ST_CODE_LANGS[ST_extOf(path)] || "";
+    var htmlLines = window.primerVendor.highlightPython(content || "", lang);
+    return (
+      <div
+        data-testid="file-preview-code"
+        style={{ fontFamily: "IBM Plex Mono, monospace", fontSize: 12.5, lineHeight: 1.7, padding: "12px 14px" }}
+      >
+        {htmlLines.map(function (html, i) {
+          return (
+            <div key={i} style={{ display: "flex" }}>
+              <span style={{ color: "var(--text-4)", width: 34, textAlign: "right", marginRight: 14, userSelect: "none", flexShrink: 0 }}>{i + 1}</span>
+              <span style={{ whiteSpace: "pre-wrap", flex: 1 }} dangerouslySetInnerHTML={{ __html: html }} />
+            </div>
+          );
+        })}
+      </div>
+    );
+  }
+
+  // Plain text fallback.
+  return (
+    <pre
+      data-testid="file-preview-text"
+      style={{
+        fontFamily: "IBM Plex Mono, monospace", fontSize: 12.5, lineHeight: 1.7,
+        padding: "12px 14px", margin: 0, whiteSpace: "pre-wrap", color: "var(--text-2)",
+      }}
+    >{content || ""}</pre>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FilePanel — preview/edit a workspace file with optimistic-concurrency save.
+//   header: breadcrumb path + Preview/Edit toggle + Save (enabled when dirty)
+//   body  : preview (markdown/code/image/text) OR a <textarea> editor
+//   save  : PUT .../files?path=<ref>&etag=<held>; on 412 → conflict banner
+//           (Reload re-GETs + clears dirty; Overwrite re-PUTs without etag).
+//   binary/large(>~1MB): preview/download only (no edit toggle).
+// ---------------------------------------------------------------------------
+
+function FilePanel({ wid, tab, studio, pushToast }) {
+  var { useResource, apiFetch } = window.primerApi;
+  var path = tab.ref;
+  var tabId = tab.id;
+  var mode = (studio.state.fileModes && studio.state.fileModes[tabId]) || "preview";
+
+  // The held read: content + etag we opened the file at. The etag we PUT with
+  // is held in a ref so editing doesn't refetch and a successful save can
+  // refresh it without re-reading the file.
+  var fileRes = useResource(
+    "studio-file:" + wid + ":" + path,
+    function (signal) {
+      return apiFetch(
+        "GET",
+        "/workspaces/" + encodeURIComponent(wid) + "/files/read?path=" + encodeURIComponent(path) + "&encoding=text",
+        null,
+        { signal }
+      );
+    },
+    { pollMs: 0, deps: [wid, path] }
+  );
+
+  var heldEtagRef = React.useRef(null);
+  var [draft, setDraft] = React.useState(null);
+  var [conflict, setConflict] = React.useState(false);
+  var [saving, setSaving] = React.useState(false);
+
+  var data = fileRes.data || null;
+  var content = data && typeof data.content === "string" ? data.content : "";
+  var sizeBytes = data && typeof data.size_bytes === "number" ? data.size_bytes : (content ? content.length : 0);
+  var isImage = ST_fileClassOf(path) === "image";
+  var encoding = data && data.encoding;
+  var isBinary = encoding && encoding !== "text";
+  var tooLarge = sizeBytes > ST_EDIT_MAX_BYTES;
+  var editable = !isImage && !isBinary && !tooLarge;
+
+  // Seed the editor draft + held etag whenever a fresh read lands. Editing
+  // mutates `draft` locally; the held etag gates the next save.
+  React.useEffect(function () {
+    if (data && data.etag !== undefined) {
+      heldEtagRef.current = data.etag;
+    }
+    if (data && typeof data.content === "string") {
+      setDraft(data.content);
+    }
+  }, [data]);
+
+  // A dirty tab is one whose draft diverges from the held content. We mirror
+  // that into studio.state.openTabs[*].dirty via the patch() escape hatch so
+  // the tab bar + sidebar dirty dots reflect it.
+  function setTabDirty(dirty) {
+    var openTabs = (studio.state.openTabs || []).map(function (t) {
+      if (t.id !== tabId) return t;
+      if (!!t.dirty === !!dirty) return t;
+      return Object.assign({}, t, { dirty: !!dirty });
+    });
+    // Only patch when something actually changed (avoid render churn).
+    var changed = false;
+    for (var i = 0; i < openTabs.length; i++) {
+      if (openTabs[i] !== (studio.state.openTabs || [])[i]) { changed = true; break; }
+    }
+    if (changed) studio.patch({ openTabs: openTabs });
+  }
+
+  function onEditInput(e) {
+    var next = e.target.value;
+    setDraft(next);
+    setTabDirty(next !== content);
+  }
+
+  function setMode(m) {
+    // B1's useStudioState exposes only patch(); the per-tab file mode lives in
+    // state.fileModes keyed by tab id.
+    var nextModes = Object.assign({}, studio.state.fileModes);
+    nextModes[tabId] = m;
+    studio.patch({ fileModes: nextModes });
+  }
+
+  function toastErr(title, err) {
+    if (typeof pushToast !== "function") return;
+    pushToast({
+      kind: "error",
+      title: (err && err.title) || title,
+      detail: (err && (err.detail || err.message)),
+      requestId: err && err.requestId,
+    });
+  }
+
+  // PUT the draft. When `withEtag` is true we send the held etag so the server
+  // 412s on a stale write (someone else wrote the file since we opened it);
+  // when false we force-overwrite (the Overwrite conflict action).
+  async function doSave(withEtag) {
+    if (draft == null) return;
+    setSaving(true);
+    var url = "/workspaces/" + encodeURIComponent(wid) + "/files?path=" + encodeURIComponent(path);
+    if (withEtag && heldEtagRef.current) {
+      url += "&etag=" + encodeURIComponent(heldEtagRef.current);
+    }
+    try {
+      await apiFetch("PUT", url, { content: draft, encoding: "text" });
+      // Success: clear dirty + conflict, refresh the held etag from a re-read.
+      setConflict(false);
+      setTabDirty(false);
+      setSaving(false);
+      pushToast && pushToast({ kind: "success", title: "File saved", detail: path });
+      var fresh = await fileRes.refetch();
+      // refetch() resolves to the new data in this codebase's useResource; if
+      // it returns the body, adopt its etag immediately (the effect above also
+      // seeds it once the resource state commits).
+      if (fresh && fresh.etag !== undefined) heldEtagRef.current = fresh.etag;
+    } catch (err) {
+      setSaving(false);
+      if (err && err.status === 412) {
+        // Stale write — surface the conflict banner (Reload / Overwrite).
+        setConflict(true);
+        return;
+      }
+      toastErr("Save failed", err);
+    }
+  }
+
+  function onSave() { doSave(true); }
+
+  // Reload: discard local edits, re-GET (replaces content), clear dirty.
+  async function reloadConflict() {
+    setConflict(false);
+    setTabDirty(false);
+    var fresh = await fileRes.refetch();
+    if (fresh && typeof fresh.content === "string") setDraft(fresh.content);
+    if (fresh && fresh.etag !== undefined) heldEtagRef.current = fresh.etag;
+  }
+
+  // Overwrite: re-PUT WITHOUT the etag (force), keeping local edits.
+  function overwriteConflict() {
+    setConflict(false);
+    doSave(false);
+  }
+
+  var dirty = (draft != null) && (draft !== content);
+  var effMode = editable ? mode : "preview";
+
+  // ----- header -----
+  var header = (
+    <div
+      style={{
+        display: "flex", alignItems: "center", gap: 8, padding: "8px 14px",
+        borderBottom: "1px solid var(--border)", flex: "0 0 auto",
+        fontFamily: "IBM Plex Mono, monospace", fontSize: 12, color: "var(--text-3)",
+      }}
+      data-testid="panel-file-header"
+    >
+      <span style={{ color: "var(--text-2)", display: "grid", placeItems: "center", flexShrink: 0 }}>
+        <Icon name={isImage ? "image" : ST_fileClassOf(path) === "code" ? "code" : "doc"} size={13} />
+      </span>
+      <span data-testid="file-breadcrumb" style={{ color: "var(--text)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{path}</span>
+      {sizeBytes ? <span style={{ flexShrink: 0 }}>· {ST_fmtBytes(sizeBytes)}</span> : null}
+      <div style={{ flex: 1 }} />
+
+      {editable && (
+        <div style={{ display: "flex", border: "1px solid var(--border)", borderRadius: 7, overflow: "hidden", flexShrink: 0 }}>
+          <button
+            data-testid="file-mode-preview"
+            onClick={function () { setMode("preview"); }}
+            style={{
+              padding: "3px 9px", fontSize: 11.5, border: "none", cursor: "pointer",
+              background: effMode === "preview" ? "var(--accent-dim)" : "var(--bg-2)",
+              color: effMode === "preview" ? "var(--accent)" : "var(--text-3)",
+            }}
+          >◉ Preview</button>
+          <button
+            data-testid="file-mode-edit"
+            onClick={function () { setMode("edit"); }}
+            style={{
+              padding: "3px 9px", fontSize: 11.5, border: "none", cursor: "pointer",
+              borderLeft: "1px solid var(--border)",
+              background: effMode === "edit" ? "var(--accent-dim)" : "var(--bg-2)",
+              color: effMode === "edit" ? "var(--accent)" : "var(--text-3)",
+            }}
+          >✎ Edit</button>
+        </div>
+      )}
+
+      {editable && (
+        <button
+          data-testid="file-save"
+          onClick={onSave}
+          disabled={!dirty || saving}
+          title={dirty ? "Save (PUT with etag)" : "No unsaved changes"}
+          style={{
+            padding: "3px 10px", fontSize: 11.5, fontWeight: 600, borderRadius: 6,
+            border: "1px solid oklch(0.82 0.18 145 / 0.4)", cursor: dirty && !saving ? "pointer" : "default",
+            background: "var(--green-dim)", color: "var(--green)",
+            opacity: dirty && !saving ? 1 : 0.45, flexShrink: 0,
+          }}
+        >⤓ {saving ? "Saving…" : "Save"}</button>
+      )}
+
+      {!editable && (
+        <a
+          data-testid="file-download"
+          href={"/v1/workspaces/" + encodeURIComponent(wid) + "/files/download?path=" + encodeURIComponent(path)}
+          target="_blank"
+          rel="noreferrer noopener"
+          style={{ padding: "3px 10px", fontSize: 11.5, color: "var(--text-2)", textDecoration: "none", border: "1px solid var(--border)", borderRadius: 6, flexShrink: 0 }}
+        >↓ Download</a>
+      )}
+    </div>
+  );
+
+  // ----- body -----
+  var body;
+  if (fileRes.loading && !data) {
+    body = <div className="muted text-sm" style={{ padding: 24, textAlign: "center", color: "var(--text-4)" }}>Loading {path}…</div>;
+  } else if (fileRes.error && !data) {
+    body = (
+      <div style={{ padding: 16 }}>
+        <Banner
+          kind="error"
+          title={(fileRes.error && fileRes.error.title) || "Couldn't read file"}
+          detail={(fileRes.error && (fileRes.error.detail || fileRes.error.message)) || path}
+          actions={<Btn size="sm" icon="refresh" onClick={fileRes.refetch}>Retry</Btn>}
+        />
+      </div>
+    );
+  } else if (effMode === "edit") {
+    body = (
+      <div style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 0 }}>
+        {conflict && (
+          <div
+            data-testid="file-conflict-banner"
+            style={{
+              margin: "12px 14px 0", padding: "8px 12px", borderRadius: 7,
+              border: "1px solid oklch(0.82 0.16 75 / 0.4)", background: "var(--amber-dim)",
+              color: "var(--amber)", fontSize: 12, display: "flex", alignItems: "center", gap: 10,
+            }}
+          >
+            <span style={{ flex: 1 }}>⚠ This file changed on disk since you opened it.</span>
+            <b data-testid="file-conflict-reload" onClick={reloadConflict} style={{ cursor: "pointer", textDecoration: "underline" }}>Reload</b>
+            <b data-testid="file-conflict-overwrite" onClick={overwriteConflict} style={{ cursor: "pointer", textDecoration: "underline" }}>Overwrite</b>
+          </div>
+        )}
+        <textarea
+          data-testid="file-editor"
+          value={draft == null ? "" : draft}
+          onChange={onEditInput}
+          spellCheck={false}
+          style={{
+            flex: 1, minHeight: 320, width: "100%", background: "var(--bg)", border: 0,
+            color: "var(--text)", fontFamily: "IBM Plex Mono, monospace", fontSize: 12.5,
+            lineHeight: 1.7, padding: "14px 16px", resize: "none", tabSize: 2, outline: "none",
+          }}
+        />
+      </div>
+    );
+  } else {
+    body = <ST_FilePreview wid={wid} path={path} content={content} />;
+  }
+
+  return (
+    <div
+      data-testid="panel-file"
+      style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column" }}
+    >
+      {header}
+      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+        {body}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StudioCenter — center region: CenterTabs + the active panel.
+// Props: { wid, studio }  (studio = useStudioState(wid) bag)
+// ---------------------------------------------------------------------------
+
+function StudioCenter({ wid, studio }) {
+  var s = studio.state;
+  var openTabs = s.openTabs || [];
+  var activeTabId = s.activeTabId;
+  // pushToast threads down from app.jsx → Studio when wired; B1 renders Studio
+  // without it today, so every toast call below is guarded and simply no-ops
+  // until a later task passes it. The 412-conflict UX uses an inline banner
+  // (not a toast), so the critical flow does not depend on this.
+  var pushToast = studio.pushToast || (window.primerApi && window.primerApi.pushToast) || null;
+
+  var activeTab = null;
+  for (var i = 0; i < openTabs.length; i++) {
+    if (openTabs[i].id === activeTabId) { activeTab = openTabs[i]; break; }
+  }
+
+  var panel;
+  if (!activeTab) {
+    panel = (
+      <div
+        className="st-placeholder"
+        data-testid="center-empty"
+        style={{ flex: 1 }}
+      >
+        <div>
+          <div className="st-ph-kind">Studio</div>
+          <div style={{ marginTop: 6 }}>Open a session or file from the sidebar to begin.</div>
+        </div>
+      </div>
+    );
+  } else if (activeTab.kind === "session") {
+    // key by ref so switching session tabs remounts the resolver cleanly.
+    panel = <ST_SessionPanel key={"sess:" + activeTab.ref} wid={wid} sid={activeTab.ref} pushToast={pushToast} />;
+  } else if (activeTab.kind === "file") {
+    panel = <FilePanel key={"file:" + activeTab.ref} wid={wid} tab={activeTab} studio={studio} pushToast={pushToast} />;
+  } else {
+    panel = (
+      <div className="st-placeholder" data-testid="center-unknown" style={{ flex: 1 }}>
+        <div>Unknown tab kind: {String(activeTab.kind)}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      data-testid="studio-center-inner"
+      style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 0, overflow: "hidden" }}
+    >
+      <CenterTabs
+        openTabs={openTabs}
+        activeTabId={activeTabId}
+        onFocus={studio.focusTab}
+        onClose={studio.closeTab}
+      />
+      <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
+        {panel}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// No-build exports
+// ---------------------------------------------------------------------------
+window.StudioCenter = StudioCenter;
+window.CenterTabs = CenterTabs;
+window.SessionAgentPanel = SessionAgentPanel;
+window.SessionGraphPanel = SessionGraphPanel;
+window.FilePanel = FilePanel;

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -644,11 +644,10 @@ function FilePanel({ wid, tab, studio, pushToast }) {
       setTabDirty(false);
       setSaving(false);
       pushToast && pushToast({ kind: "success", title: "File saved", detail: path });
-      var fresh = await fileRes.refetch();
-      // refetch() resolves to the new data in this codebase's useResource; if
-      // it returns the body, adopt its etag immediately (the effect above also
-      // seeds it once the resource state commits).
-      if (fresh && fresh.etag !== undefined) heldEtagRef.current = fresh.etag;
+      // Trigger a re-read to refresh the held etag. refetch() returns undefined
+      // here (useResource), so adoption happens in the [data] effect above,
+      // which re-seeds heldEtagRef + draft once the new read commits.
+      await fileRes.refetch();
     } catch (err) {
       setSaving(false);
       if (err && err.status === 412) {
@@ -666,9 +665,10 @@ function FilePanel({ wid, tab, studio, pushToast }) {
   async function reloadConflict() {
     setConflict(false);
     setTabDirty(false);
-    var fresh = await fileRes.refetch();
-    if (fresh && typeof fresh.content === "string") setDraft(fresh.content);
-    if (fresh && fresh.etag !== undefined) heldEtagRef.current = fresh.etag;
+    // Trigger a re-read. refetch() returns undefined (useResource), so the
+    // [data] effect above performs the adoption: it replaces `draft` with the
+    // fresh content and re-seeds heldEtagRef once the new read commits.
+    await fileRes.refetch();
   }
 
   // Overwrite: re-PUT WITHOUT the etag (force), keeping local edits.
@@ -823,7 +823,7 @@ function StudioCenter({ wid, studio }) {
   // without it today, so every toast call below is guarded and simply no-ops
   // until a later task passes it. The 412-conflict UX uses an inline banner
   // (not a toast), so the critical flow does not depend on this.
-  var pushToast = studio.pushToast || (window.primerApi && window.primerApi.pushToast) || null;
+  var pushToast = studio.pushToast || (window.primerApi && window.primerApi.toastPush) || null;
 
   var activeTab = null;
   for (var i = 0; i < openTabs.length; i++) {

--- a/ui/components/studio-palette.jsx
+++ b/ui/components/studio-palette.jsx
@@ -1,0 +1,417 @@
+/* global React, Icon */
+// studio-palette.jsx — CommandPalette (⌘K) + QuickOpen (⌘P) overlays for Studio.
+//
+// Exports:
+//   window.CommandPalette  ({ wid, studio, open, onClose })
+//   window.QuickOpen       ({ wid, studio, open, onClose })
+//
+// No-build scope rules (see workspace-tap.jsx): top-level declarations use
+// `var`; helpers are prefixed STP_ to avoid global collisions.
+
+// ---------------------------------------------------------------------------
+// Fuzzy match — simple subsequence: every char of `query` appears in `text`
+// in order (case-insensitive). Returns true/false.
+// ---------------------------------------------------------------------------
+
+function STP_fuzzy(text, query) {
+  if (!query) return true;
+  var t = text.toLowerCase();
+  var q = query.toLowerCase();
+  var ti = 0;
+  for (var qi = 0; qi < q.length; qi++) {
+    var idx = t.indexOf(q[qi], ti);
+    if (idx < 0) return false;
+    ti = idx + 1;
+  }
+  return true;
+}
+
+// ---------------------------------------------------------------------------
+// CommandPalette — modal overlay; search input + fuzzy-filtered command list.
+//
+// Commands:
+//   - Each open session → studio.openTab(session)
+//   - Library nav shortcuts (/graphs, /agents, /chats, /knowledge)
+//   - Actions: New session, Toggle terminal, Toggle theme, Toggle density
+//
+// Props: { wid, studio, open, onClose }
+// ---------------------------------------------------------------------------
+
+function CommandPalette({ wid, studio, open, onClose }) {
+  var { apiFetch, useResource } = window.primerApi;
+  var [query, setQuery] = React.useState("");
+  var [cursor, setCursor] = React.useState(0);
+  var inputRef = React.useRef(null);
+
+  // Fetch sessions for this workspace so they appear as palette entries.
+  var sessionsRes = useResource(
+    "palette:sessions:" + wid,
+    function (signal) {
+      return apiFetch("GET", "/workspaces/" + encodeURIComponent(wid) + "/sessions?limit=200", null, { signal });
+    },
+    { pollMs: 0, deps: [wid] }
+  );
+  var sessions = Array.isArray(sessionsRes.data && sessionsRes.data.items) ? sessionsRes.data.items : [];
+
+  // Auto-focus the input when palette opens; clear query on open.
+  React.useEffect(function () {
+    if (!open) return;
+    setQuery("");
+    setCursor(0);
+    var t = setTimeout(function () {
+      if (inputRef.current) inputRef.current.focus();
+    }, 30);
+    return function () { clearTimeout(t); };
+  }, [open]);
+
+  // Build command items.
+  var allItems = React.useMemo(function () {
+    var items = [];
+
+    // Sessions
+    sessions.forEach(function (s) {
+      items.push({
+        id: "session:" + s.id,
+        label: s.name || s.id,
+        group: s.binding && s.binding.graph_id ? "graph" : "agent",
+        icon: s.binding && s.binding.graph_id ? "◈" : "◆",
+        run: function () {
+          studio.openTab({
+            id: "session:" + s.id,
+            kind: "session",
+            ref: s.id,
+            title: s.name || s.id,
+          });
+        },
+      });
+    });
+
+    // Library nav
+    var navItems = [
+      { id: "nav:graphs", label: "Open Graphs library", group: "nav", icon: "⊞", run: function () { window.location.hash = "#/graphs"; } },
+      { id: "nav:agents", label: "Open Agents library", group: "nav", icon: "⊞", run: function () { window.location.hash = "#/agents"; } },
+      { id: "nav:chats", label: "Open Chats", group: "nav", icon: "⊞", run: function () { window.location.hash = "#/chats"; } },
+      { id: "nav:knowledge", label: "Open Knowledge", group: "nav", icon: "⊞", run: function () { window.location.hash = "#/knowledge/collections"; } },
+    ];
+    navItems.forEach(function (n) { items.push(n); });
+
+    // Actions
+    var actionItems = [
+      {
+        id: "action:new-session",
+        label: "New session",
+        group: "action",
+        icon: "＋",
+        run: function () {
+          if (studio.pushToast) {
+            studio.pushToast({ kind: "info", title: "New session", detail: "Use the + button in the Sessions sidebar to create a session." });
+          }
+        },
+      },
+      {
+        id: "action:toggle-terminal",
+        label: "Toggle terminal",
+        group: "action",
+        icon: "⌥",
+        run: function () { studio.toggleTerminal(); },
+      },
+      {
+        id: "action:toggle-theme",
+        label: "Toggle theme",
+        group: "action",
+        icon: "◐",
+        run: function () { studio.toggleTheme(); },
+      },
+      {
+        id: "action:toggle-density",
+        label: "Toggle density",
+        group: "action",
+        icon: "☰",
+        run: function () { studio.toggleDensity(); },
+      },
+    ];
+    actionItems.forEach(function (a) { items.push(a); });
+
+    return items;
+  }, [sessions, studio]);
+
+  // Filter by query.
+  var filtered = React.useMemo(function () {
+    if (!query) return allItems.slice(0, 8);
+    var results = [];
+    for (var i = 0; i < allItems.length; i++) {
+      if (STP_fuzzy(allItems[i].label, query)) results.push(allItems[i]);
+      if (results.length >= 8) break;
+    }
+    return results;
+  }, [allItems, query]);
+
+  // Clamp cursor when list changes.
+  React.useEffect(function () {
+    setCursor(function (c) { return Math.min(c, Math.max(0, filtered.length - 1)); });
+  }, [filtered.length]);
+
+  function runItem(item) {
+    item.run();
+    onClose();
+  }
+
+  function onKeyDown(e) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setCursor(function (c) { return Math.min(c + 1, filtered.length - 1); });
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setCursor(function (c) { return Math.max(c - 1, 0); });
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (filtered[cursor]) runItem(filtered[cursor]);
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      onClose();
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed", inset: 0, background: "oklch(0 0 0 / 0.5)",
+        zIndex: 60, display: "flex", justifyContent: "center", paddingTop: "12vh",
+      }}
+      onClick={onClose}
+      data-testid="command-palette"
+    >
+      <div
+        style={{
+          width: 560, maxWidth: "calc(100vw - 32px)", height: "max-content",
+          maxHeight: "64vh", background: "var(--bg-1)", border: "1px solid var(--border-strong)",
+          borderRadius: 12, boxShadow: "var(--shadow)", display: "flex",
+          flexDirection: "column", overflow: "hidden",
+        }}
+        onClick={function (e) { e.stopPropagation(); }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 14px", borderBottom: "1px solid var(--border)" }}>
+          <span style={{ color: "var(--text-3)", fontSize: 15 }}>⌘</span>
+          <input
+            data-testid="palette-input"
+            ref={inputRef}
+            value={query}
+            onChange={function (e) { setQuery(e.target.value); setCursor(0); }}
+            onKeyDown={onKeyDown}
+            placeholder="Search sessions, files, actions…"
+            style={{
+              flex: 1, background: "transparent", border: 0, outline: "none",
+              color: "var(--text)", fontSize: 14,
+            }}
+          />
+          <kbd style={{ fontFamily: "'IBM Plex Mono',monospace", fontSize: 11, color: "var(--text-3)", background: "var(--bg-2)", border: "1px solid var(--border)", borderRadius: 4, padding: "1px 6px" }}>esc</kbd>
+        </div>
+        <div style={{ overflow: "auto", padding: 6, minHeight: 0 }}>
+          {filtered.length === 0 && (
+            <div style={{ padding: 20, textAlign: "center", color: "var(--text-4)", fontSize: 12 }}>No matches.</div>
+          )}
+          {filtered.map(function (item, idx) {
+            const active = idx === cursor;
+            return (
+              <div
+                key={item.id}
+                data-testid="palette-item"
+                onClick={function () { runItem(item); }}
+                onMouseEnter={function () { setCursor(idx); }}
+                style={{
+                  display: "flex", gap: 10, padding: "8px 10px", borderRadius: 7,
+                  cursor: "pointer",
+                  background: active ? "var(--bg-active)" : "transparent",
+                  alignItems: "center",
+                }}
+              >
+                <span style={{ width: 18, display: "grid", placeItems: "center", color: "var(--text-3)", flex: "0 0 auto", fontSize: 13 }}>{item.icon}</span>
+                <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: "var(--text)" }}>{item.label}</span>
+                <span style={{ fontSize: 10, fontFamily: "'IBM Plex Mono',monospace", color: "var(--text-4)", textTransform: "uppercase", letterSpacing: ".4px", flex: "0 0 auto" }}>{item.group}</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// QuickOpen — modal; fuzzy file open over GET …/files?recursive=true.
+//
+// Selecting a file calls:
+//   studio.openTab({ id:"file:"+path, kind:"file", ref:path, title:basename })
+//
+// Props: { wid, studio, open, onClose }
+// ---------------------------------------------------------------------------
+
+function QuickOpen({ wid, studio, open, onClose }) {
+  var { apiFetch, useResource } = window.primerApi;
+  var [query, setQuery] = React.useState("");
+  var [cursor, setCursor] = React.useState(0);
+  var inputRef = React.useRef(null);
+
+  // Fetch flat file list for this workspace.
+  var filesRes = useResource(
+    "quickopen:files:" + wid,
+    function (signal) {
+      return apiFetch("GET", "/workspaces/" + encodeURIComponent(wid) + "/files?recursive=true", null, { signal });
+    },
+    { pollMs: 0, deps: [wid] }
+  );
+  // The files endpoint may return { items: [...] } or an array directly.
+  var rawFiles = filesRes.data;
+  var allFiles = React.useMemo(function () {
+    if (!rawFiles) return [];
+    if (Array.isArray(rawFiles)) return rawFiles;
+    if (Array.isArray(rawFiles.items)) return rawFiles.items;
+    return [];
+  }, [rawFiles]);
+
+  // Auto-focus on open; clear state.
+  React.useEffect(function () {
+    if (!open) return;
+    setQuery("");
+    setCursor(0);
+    var t = setTimeout(function () {
+      if (inputRef.current) inputRef.current.focus();
+    }, 30);
+    return function () { clearTimeout(t); };
+  }, [open]);
+
+  // Filter files by query.
+  var filtered = React.useMemo(function () {
+    var results = [];
+    for (var i = 0; i < allFiles.length; i++) {
+      var f = allFiles[i];
+      // Skip directories
+      if (f.is_dir || f.isDir) continue;
+      var path = f.path || f.name || "";
+      if (STP_fuzzy(path, query)) {
+        results.push({ path: path, name: STP_basename(path) });
+      }
+      if (results.length >= 10) break;
+    }
+    return results;
+  }, [allFiles, query]);
+
+  // Clamp cursor.
+  React.useEffect(function () {
+    setCursor(function (c) { return Math.min(c, Math.max(0, filtered.length - 1)); });
+  }, [filtered.length]);
+
+  function openFile(path) {
+    var name = STP_basename(path);
+    studio.openTab({
+      id: "file:" + path,
+      kind: "file",
+      ref: path,
+      title: name,
+    });
+    onClose();
+  }
+
+  function onKeyDown(e) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setCursor(function (c) { return Math.min(c + 1, filtered.length - 1); });
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setCursor(function (c) { return Math.max(c - 1, 0); });
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (filtered[cursor]) openFile(filtered[cursor].path);
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      onClose();
+    }
+  }
+
+  if (!open) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed", inset: 0, background: "oklch(0 0 0 / 0.5)",
+        zIndex: 60, display: "flex", justifyContent: "center", paddingTop: "12vh",
+      }}
+      onClick={onClose}
+      data-testid="quick-open"
+    >
+      <div
+        style={{
+          width: 560, maxWidth: "calc(100vw - 32px)", height: "max-content",
+          maxHeight: "64vh", background: "var(--bg-1)", border: "1px solid var(--border-strong)",
+          borderRadius: 12, boxShadow: "var(--shadow)", display: "flex",
+          flexDirection: "column", overflow: "hidden",
+        }}
+        onClick={function (e) { e.stopPropagation(); }}
+      >
+        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "12px 14px", borderBottom: "1px solid var(--border)" }}>
+          <span style={{ color: "var(--text-3)", fontSize: 15 }}>⌕</span>
+          <input
+            data-testid="quick-open-input"
+            ref={inputRef}
+            value={query}
+            onChange={function (e) { setQuery(e.target.value); setCursor(0); }}
+            onKeyDown={onKeyDown}
+            placeholder="Go to file…"
+            style={{
+              flex: 1, background: "transparent", border: 0, outline: "none",
+              color: "var(--text)", fontSize: 14,
+            }}
+          />
+          <kbd style={{ fontFamily: "'IBM Plex Mono',monospace", fontSize: 11, color: "var(--text-3)", background: "var(--bg-2)", border: "1px solid var(--border)", borderRadius: 4, padding: "1px 6px" }}>esc</kbd>
+        </div>
+        <div style={{ overflow: "auto", padding: 6, minHeight: 0 }}>
+          {allFiles.length === 0 && filesRes.loading && (
+            <div style={{ padding: 20, textAlign: "center", color: "var(--text-4)", fontSize: 12 }}>Loading files…</div>
+          )}
+          {allFiles.length > 0 && filtered.length === 0 && (
+            <div style={{ padding: 20, textAlign: "center", color: "var(--text-4)", fontSize: 12 }}>No matches.</div>
+          )}
+          {filtered.map(function (f, idx) {
+            const active = idx === cursor;
+            return (
+              <div
+                key={f.path}
+                data-testid="quick-open-item"
+                onClick={function () { openFile(f.path); }}
+                onMouseEnter={function () { setCursor(idx); }}
+                style={{
+                  display: "flex", gap: 10, padding: "8px 10px", borderRadius: 7,
+                  cursor: "pointer",
+                  background: active ? "var(--bg-active)" : "transparent",
+                  alignItems: "center",
+                }}
+              >
+                <span style={{ width: 18, display: "grid", placeItems: "center", color: "var(--text-3)", flex: "0 0 auto", fontSize: 13 }}>◻</span>
+                <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", color: "var(--text)" }}>{f.path}</span>
+                <span style={{ fontSize: 10, fontFamily: "'IBM Plex Mono',monospace", color: "var(--text-4)", textTransform: "uppercase", letterSpacing: ".4px", flex: "0 0 auto" }}>file</span>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function STP_basename(path) {
+  if (!path) return "";
+  var parts = path.replace(/\\/g, "/").split("/");
+  return parts[parts.length - 1] || path;
+}
+
+// ---------------------------------------------------------------------------
+// No-build exports
+// ---------------------------------------------------------------------------
+window.CommandPalette = CommandPalette;
+window.QuickOpen = QuickOpen;

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -184,7 +184,11 @@ function NewSessionForm({ wid, onClose, onCreated }) {
   var [submitting, setSubmitting] = React.useState(false);
   var [error, setError] = React.useState(null);
 
-  // Default to first available option when items load.
+  // Single owner of the default selection: these effects default the first
+  // available option whenever items load OR the kind toggles to an as-yet
+  // unselected binding. The AGENT/GRAPH toggle buttons below only change
+  // `kind` — they do NOT set the id — so there is exactly one writer per id
+  // and no race between the effect and an imperative button handler.
   React.useEffect(function() {
     if (kind === "agent" && agentItems.length > 0 && !agentId) {
       setAgentId(agentItems[0].id);
@@ -258,7 +262,7 @@ function NewSessionForm({ wid, onClose, onCreated }) {
             color: kind === "agent" ? "var(--accent)" : "var(--text-3)",
             cursor: "pointer",
           }}
-          onClick={function() { setKind("agent"); setAgentId(agentItems.length > 0 ? agentItems[0].id : ""); }}
+          onClick={function() { setKind("agent"); }}
         >AGENT</button>
         <button
           style={{
@@ -272,7 +276,7 @@ function NewSessionForm({ wid, onClose, onCreated }) {
             color: kind === "graph" ? "var(--accent)" : "var(--text-3)",
             cursor: "pointer",
           }}
-          onClick={function() { setKind("graph"); setGraphId(graphItems.length > 0 ? graphItems[0].id : ""); }}
+          onClick={function() { setKind("graph"); }}
         >GRAPH</button>
       </div>
 

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -1,0 +1,829 @@
+/* global React, Icon */
+// StudioSidebar — left sidebar for the Studio IDE shell (PR-B / B2).
+//
+// Contains two collapsible sections:
+//   SessionsSection  — live session list with status dots; "+" new-session form.
+//   FilesTree        — lazy-expanding file tree; show-hidden toggle; refresh.
+//
+// Plugs into the Studio shell's left region (replaces the ST_RegionPlaceholder
+// at data-testid="region-sidebar" inside data-testid="studio-sidebar").
+// Receives the studio state-bag from Studio({ wid }) via the `studio` prop.
+//
+// No-build rules: top-level declarations use `var`; helpers prefixed ST_;
+// every exported symbol is assigned to window.X at the bottom.
+
+// ---------------------------------------------------------------------------
+// sessionStatus — shared status-derivation helper
+// Derives { tone, label, badge } from a session row returned by
+//   GET /v1/workspaces/{wid}/sessions
+// Fields inspected:
+//   session.status          : "created"|"running"|"paused"|"ended"|"failed"|...
+//   session.parked_status   : "parked"|"resumable"|undefined
+//   session.parked_state    : object with { yielded?: { tool_name }, tool_name? }
+//
+// Published as window.ST_sessionStatus for B3/B4 reuse.
+// ---------------------------------------------------------------------------
+
+function ST_sessionStatus(session) {
+  if (!session) return { tone: "dim", label: "unknown", badge: null };
+
+  var status = session.status || "created";
+
+  // Resolve the parked tool when session is parked/waiting.
+  var isParked = session.parked_status === "parked" || session.parked_status === "resumable";
+  var parkedTool = null;
+  if (isParked && session.parked_state) {
+    var ps = session.parked_state;
+    parkedTool = (ps.yielded && ps.yielded.tool_name) || ps.tool_name || null;
+  }
+
+  if (status === "running" && !isParked) {
+    return { tone: "green-pulse", label: "running", badge: null };
+  }
+  if (status === "paused") {
+    return { tone: "amber", label: "paused", badge: null };
+  }
+  if (isParked) {
+    if (parkedTool === "approval" || parkedTool === "ask_approval") {
+      return { tone: "amber", label: "waiting", badge: "approve" };
+    }
+    if (parkedTool === "ask_user") {
+      return { tone: "amber", label: "waiting", badge: "ask" };
+    }
+    if (parkedTool === "watch_files") {
+      return { tone: "amber", label: "waiting", badge: "watch" };
+    }
+    if (parkedTool === "sleep") {
+      return { tone: "amber", label: "waiting", badge: "sleep" };
+    }
+    // Generic waiting state.
+    return { tone: "amber", label: "waiting", badge: null };
+  }
+  if (status === "created") {
+    return { tone: "dim", label: "created", badge: null };
+  }
+  if (status === "ended" || status === "completed" || status === "cancelled") {
+    return { tone: "gray", label: status, badge: null };
+  }
+  if (status === "failed") {
+    return { tone: "red", label: "failed", badge: null };
+  }
+  // Fallback.
+  return { tone: "dim", label: status, badge: null };
+}
+
+// ---------------------------------------------------------------------------
+// ST_dotStyle — build an inline style object for the 8×8 status dot.
+// ---------------------------------------------------------------------------
+
+function ST_dotStyle(tone) {
+  var base = {
+    width: 8,
+    height: 8,
+    borderRadius: "50%",
+    flexShrink: 0,
+    display: "inline-block",
+  };
+  if (tone === "green-pulse") {
+    return Object.assign({}, base, {
+      background: "var(--green)",
+      animation: "pulse 1.8s ease-in-out infinite",
+    });
+  }
+  if (tone === "amber") {
+    return Object.assign({}, base, {
+      background: "var(--amber)",
+      boxShadow: "inset 0 0 0 2px var(--amber-dim)",
+    });
+  }
+  if (tone === "red") {
+    return Object.assign({}, base, { background: "var(--red)" });
+  }
+  if (tone === "gray") {
+    return Object.assign({}, base, { background: "var(--text-4)" });
+  }
+  // dim (created / unknown)
+  return Object.assign({}, base, { background: "var(--border-strong)" });
+}
+
+// ---------------------------------------------------------------------------
+// ST_sessionSort — active/waiting-first, then by id for stability.
+// ---------------------------------------------------------------------------
+
+function ST_sessionSort(sessions) {
+  var order = { "running": 0, "paused": 1, "created": 2 };
+  return sessions.slice().sort(function(a, b) {
+    var oa = order[a.status] !== undefined ? order[a.status] : 3;
+    var ob = order[b.status] !== undefined ? order[b.status] : 3;
+    if (oa !== ob) return oa - ob;
+    // Parked (waiting) sessions float up within their group.
+    var aParked = a.parked_status === "parked" || a.parked_status === "resumable" ? -1 : 0;
+    var bParked = b.parked_status === "parked" || b.parked_status === "resumable" ? -1 : 0;
+    if (aParked !== bParked) return aParked - bParked;
+    var aId = a.id || "";
+    var bId = b.id || "";
+    return aId < bId ? -1 : aId > bId ? 1 : 0;
+  });
+}
+
+// ---------------------------------------------------------------------------
+// ST_fileIconName — map a file extension / dir to an Icon name.
+// ---------------------------------------------------------------------------
+
+function ST_fileIconName(item) {
+  if (item.is_dir) return "box";
+  var ext = (item.name || "").split(".").pop().toLowerCase();
+  if (ext === "py" || ext === "js" || ext === "jsx" || ext === "ts" || ext === "tsx") return "code";
+  if (ext === "md" || ext === "txt" || ext === "rst") return "doc";
+  if (ext === "json" || ext === "yaml" || ext === "yml" || ext === "toml") return "code";
+  if (ext === "png" || ext === "jpg" || ext === "jpeg" || ext === "svg" || ext === "gif" || ext === "webp") return "image";
+  if (ext === "sh" || ext === "bash" || ext === "zsh") return "code";
+  return "file";
+}
+
+// ---------------------------------------------------------------------------
+// ST_fileIconColor — colour the icon based on extension.
+// ---------------------------------------------------------------------------
+
+function ST_fileIconColor(item) {
+  if (item.is_dir) return "var(--text-3)";
+  var ext = (item.name || "").split(".").pop().toLowerCase();
+  if (ext === "py") return "var(--blue)";
+  if (ext === "md" || ext === "txt" || ext === "rst") return "var(--text-2)";
+  return "var(--text-3)";
+}
+
+// ---------------------------------------------------------------------------
+// NewSessionForm — inline modal-style form for creating a session.
+// Renders as a positioned overlay inside the sessions section.
+// POST /v1/workspaces/{wid}/sessions with the SessionCreateBody shape:
+//   { binding: { kind, agent_id? | graph_id? }, auto_start, initial_instructions? }
+// ---------------------------------------------------------------------------
+
+function NewSessionForm({ wid, onClose, onCreated }) {
+  var { useResource, apiFetch } = window.primerApi;
+
+  var agents = useResource(
+    "new-session-form:agents",
+    function(signal) { return apiFetch("GET", "/agents?limit=200", null, { signal }); },
+    { pollMs: 0 }
+  );
+  var graphs = useResource(
+    "new-session-form:graphs",
+    function(signal) { return apiFetch("GET", "/graphs?limit=200", null, { signal }); },
+    { pollMs: 0 }
+  );
+
+  var agentItems = (agents.data && agents.data.items) ? agents.data.items : [];
+  var graphItems = (graphs.data && graphs.data.items) ? graphs.data.items : [];
+
+  var [kind, setKind] = React.useState("agent");
+  var [agentId, setAgentId] = React.useState("");
+  var [graphId, setGraphId] = React.useState("");
+  var [instructions, setInstructions] = React.useState("");
+  var [submitting, setSubmitting] = React.useState(false);
+  var [error, setError] = React.useState(null);
+
+  // Default to first available option when items load.
+  React.useEffect(function() {
+    if (kind === "agent" && agentItems.length > 0 && !agentId) {
+      setAgentId(agentItems[0].id);
+    }
+  }, [agentItems, kind]);
+  React.useEffect(function() {
+    if (kind === "graph" && graphItems.length > 0 && !graphId) {
+      setGraphId(graphItems[0].id);
+    }
+  }, [graphItems, kind]);
+
+  var loading = agents.loading || graphs.loading;
+  var canSubmit = !submitting && (kind === "agent" ? agentId : graphId);
+
+  async function onSubmit(e) {
+    e.preventDefault();
+    if (!canSubmit) return;
+    setSubmitting(true);
+    setError(null);
+    var binding = kind === "agent"
+      ? { kind: "agent", agent_id: agentId }
+      : { kind: "graph", graph_id: graphId };
+    var body = { binding: binding, auto_start: true };
+    if (instructions.trim()) body.initial_instructions = instructions.trim();
+    try {
+      var session = await apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions", body);
+      onCreated(session);
+    } catch (err) {
+      setError((err && err.detail) || (err && err.message) || "Failed to create session");
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      style={{
+        position: "absolute",
+        top: 32,
+        left: 0,
+        right: 0,
+        zIndex: 20,
+        background: "var(--bg-elev)",
+        border: "1px solid var(--border-strong)",
+        borderRadius: 9,
+        boxShadow: "var(--shadow)",
+        padding: "12px 12px 10px",
+        margin: "4px 6px",
+      }}
+      data-testid="new-session-form"
+    >
+      <div style={{ display: "flex", alignItems: "center", marginBottom: 10 }}>
+        <span style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--text-3)", flex: 1 }}>New session</span>
+        <button
+          style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-3)", fontSize: 14, padding: "0 2px", lineHeight: 1 }}
+          onClick={onClose}
+          title="Cancel"
+        >×</button>
+      </div>
+
+      {/* Binding kind toggle */}
+      <div style={{ display: "flex", gap: 4, marginBottom: 8 }}>
+        <button
+          style={{
+            flex: 1,
+            padding: "4px 0",
+            fontSize: 11,
+            fontWeight: 600,
+            border: "1px solid " + (kind === "agent" ? "var(--accent-border)" : "var(--border)"),
+            borderRadius: 5,
+            background: kind === "agent" ? "var(--accent-dim)" : "var(--bg-2)",
+            color: kind === "agent" ? "var(--accent)" : "var(--text-3)",
+            cursor: "pointer",
+          }}
+          onClick={function() { setKind("agent"); setAgentId(agentItems.length > 0 ? agentItems[0].id : ""); }}
+        >AGENT</button>
+        <button
+          style={{
+            flex: 1,
+            padding: "4px 0",
+            fontSize: 11,
+            fontWeight: 600,
+            border: "1px solid " + (kind === "graph" ? "var(--accent-border)" : "var(--border)"),
+            borderRadius: 5,
+            background: kind === "graph" ? "var(--accent-dim)" : "var(--bg-2)",
+            color: kind === "graph" ? "var(--accent)" : "var(--text-3)",
+            cursor: "pointer",
+          }}
+          onClick={function() { setKind("graph"); setGraphId(graphItems.length > 0 ? graphItems[0].id : ""); }}
+        >GRAPH</button>
+      </div>
+
+      {/* Binding selector */}
+      {kind === "agent" ? (
+        <select
+          style={{ width: "100%", padding: "5px 7px", fontSize: 12, background: "var(--bg-2)", border: "1px solid var(--border)", borderRadius: 5, color: "var(--text)", marginBottom: 8 }}
+          value={agentId}
+          onChange={function(e) { setAgentId(e.target.value); }}
+          disabled={loading || agentItems.length === 0}
+        >
+          {agentItems.length === 0 && <option value="">{loading ? "Loading…" : "No agents"}</option>}
+          {agentItems.map(function(a) { return <option key={a.id} value={a.id}>{a.id}</option>; })}
+        </select>
+      ) : (
+        <select
+          style={{ width: "100%", padding: "5px 7px", fontSize: 12, background: "var(--bg-2)", border: "1px solid var(--border)", borderRadius: 5, color: "var(--text)", marginBottom: 8 }}
+          value={graphId}
+          onChange={function(e) { setGraphId(e.target.value); }}
+          disabled={loading || graphItems.length === 0}
+        >
+          {graphItems.length === 0 && <option value="">{loading ? "Loading…" : "No graphs"}</option>}
+          {graphItems.map(function(g) { return <option key={g.id} value={g.id}>{g.id}</option>; })}
+        </select>
+      )}
+
+      {/* Instructions */}
+      <textarea
+        placeholder="Initial instructions (optional)"
+        value={instructions}
+        onChange={function(e) { setInstructions(e.target.value); }}
+        rows={3}
+        style={{
+          width: "100%",
+          padding: "5px 7px",
+          fontSize: 12,
+          background: "var(--bg-2)",
+          border: "1px solid var(--border)",
+          borderRadius: 5,
+          color: "var(--text)",
+          resize: "none",
+          fontFamily: "inherit",
+          marginBottom: 8,
+          outline: "none",
+        }}
+      />
+
+      {error && (
+        <div style={{ fontSize: 11, color: "var(--red)", marginBottom: 6 }}>{error}</div>
+      )}
+
+      <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
+        <button
+          style={{ padding: "4px 10px", fontSize: 12, border: "1px solid var(--border)", borderRadius: 5, background: "var(--bg-2)", color: "var(--text-2)", cursor: "pointer" }}
+          onClick={onClose}
+        >Cancel</button>
+        <button
+          style={{
+            padding: "4px 10px",
+            fontSize: 12,
+            fontWeight: 600,
+            border: "1px solid var(--accent-border)",
+            borderRadius: 5,
+            background: canSubmit ? "var(--accent-dim)" : "var(--bg-2)",
+            color: canSubmit ? "var(--accent)" : "var(--text-4)",
+            cursor: canSubmit ? "pointer" : "default",
+          }}
+          disabled={!canSubmit}
+          onClick={onSubmit}
+        >{submitting ? "Creating…" : "Create"}</button>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SessionsSection
+// ---------------------------------------------------------------------------
+
+function SessionsSection({ wid, studio }) {
+  var { useResource, apiFetch } = window.primerApi;
+  var s = studio.state;
+
+  var sessionsRes = useResource(
+    "studio-sessions:" + wid,
+    function(signal) { return apiFetch("GET", "/workspaces/" + encodeURIComponent(wid) + "/sessions", null, { signal }); },
+    { pollMs: 3000 }
+  );
+
+  var rawSessions = (sessionsRes.data && Array.isArray(sessionsRes.data.items))
+    ? sessionsRes.data.items
+    : (Array.isArray(sessionsRes.data) ? sessionsRes.data : []);
+
+  var sessions = ST_sessionSort(rawSessions);
+
+  var [showNewForm, setShowNewForm] = React.useState(false);
+
+  function openSession(session) {
+    var isGraph = (session.binding && session.binding.kind === "graph") ||
+                  session.binding_kind === "graph";
+    var title = session.name || session.id;
+    var glyph = isGraph ? "◈" : "◆";
+    studio.openTab({
+      id: "session:" + session.id,
+      kind: "session",
+      ref: session.id,
+      title: title,
+      glyph: glyph,
+    });
+  }
+
+  function onCreated(session) {
+    setShowNewForm(false);
+    // Invalidate the sessions resource so the new session appears.
+    sessionsRes.refetch && sessionsRes.refetch();
+    openSession(session);
+  }
+
+  var chevStyle = {
+    display: "inline-block",
+    transition: "transform 0.15s",
+    transform: s.sessionsOpen ? "rotate(0deg)" : "rotate(-90deg)",
+    color: "var(--text-4)",
+  };
+
+  return (
+    <div
+      className="st-section"
+      style={{ flex: s.sessionsOpen ? "0 0 auto" : "0 0 auto", maxHeight: s.sessionsOpen ? "46%" : "32px", minHeight: 0, position: "relative" }}
+      data-testid="sessions-section"
+    >
+      {/* Section header */}
+      <div
+        className="st-section-h"
+        data-testid="sessions-header"
+        onClick={studio.toggleSessions}
+      >
+        <span style={chevStyle}>▾</span>
+        Sessions
+        <span className="st-section-count">{sessions.length > 0 ? sessions.length : ""}</span>
+        <button
+          style={{
+            width: 20,
+            height: 20,
+            display: "grid",
+            placeItems: "center",
+            borderRadius: 5,
+            border: "none",
+            background: "none",
+            color: "var(--text-3)",
+            fontSize: 14,
+            cursor: "pointer",
+            flexShrink: 0,
+          }}
+          title="New session"
+          data-testid="new-session-btn"
+          onClick={function(e) {
+            e.stopPropagation();
+            setShowNewForm(function(v) { return !v; });
+          }}
+        >＋</button>
+      </div>
+
+      {/* New session form overlay */}
+      {showNewForm && (
+        <NewSessionForm
+          wid={wid}
+          onClose={function() { setShowNewForm(false); }}
+          onCreated={onCreated}
+        />
+      )}
+
+      {/* Session list */}
+      {s.sessionsOpen && (
+        <div className="st-section-body">
+          {sessionsRes.loading && sessions.length === 0 && (
+            <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-4)" }}>Loading…</div>
+          )}
+          {!sessionsRes.loading && sessions.length === 0 && (
+            <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-4)" }}>No sessions yet.</div>
+          )}
+          {sessions.map(function(session) {
+            var st = ST_sessionStatus(session);
+            var isGraph = (session.binding && session.binding.kind === "graph") ||
+                          session.binding_kind === "graph";
+            var tabId = "session:" + session.id;
+            var isActive = s.activeTabId === tabId;
+            var title = session.name || session.id;
+
+            return (
+              <div
+                key={session.id}
+                className="st-session-row"
+                data-testid="session-row"
+                onClick={function() { openSession(session); }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  gap: 7,
+                  height: "var(--row-h, 34px)",
+                  padding: "0 10px 0 10px",
+                  cursor: "pointer",
+                  borderLeft: "2px solid " + (isActive ? "var(--accent)" : "transparent"),
+                  background: isActive ? "var(--bg-active)" : "transparent",
+                }}
+              >
+                <span
+                  className="st-session-dot"
+                  data-testid="session-status-dot"
+                  style={ST_dotStyle(st.tone)}
+                />
+                <span style={{
+                  flex: 1,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  color: (st.tone === "gray") ? "var(--text-3)" : "var(--text)",
+                  fontSize: 12,
+                }}>
+                  {title}
+                </span>
+                {st.badge && (
+                  <span style={{
+                    fontSize: 9,
+                    fontWeight: 700,
+                    padding: "1px 5px",
+                    borderRadius: 999,
+                    background: "var(--amber-dim)",
+                    color: "var(--amber)",
+                    flexShrink: 0,
+                  }}>
+                    {st.badge}
+                  </span>
+                )}
+                <span style={{
+                  fontSize: 9,
+                  fontWeight: 700,
+                  letterSpacing: "0.05em",
+                  color: "var(--text-4)",
+                  border: "1px solid var(--border)",
+                  borderRadius: 4,
+                  padding: "0 4px",
+                  flexShrink: 0,
+                }}>
+                  {isGraph ? "GRAPH" : "AGENT"}
+                </span>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// FilesTree
+// ---------------------------------------------------------------------------
+
+function FilesTree({ wid, studio }) {
+  var { useResource, apiFetch } = window.primerApi;
+  var s = studio.state;
+
+  // Root-level tree fetch. Refetches when showHidden changes.
+  var rootRes = useResource(
+    "studio-files-root:" + wid + ":" + s.showHidden,
+    function(signal) {
+      return apiFetch(
+        "GET",
+        "/workspaces/" + encodeURIComponent(wid) + "/files/tree?path=.&hidden=" + s.showHidden,
+        null,
+        { signal }
+      );
+    },
+    { pollMs: 0 }
+  );
+
+  // Per-folder lazy-fetch cache keyed by path. Map: path → { loading, items, loaded }.
+  var [folderCache, setFolderCache] = React.useState({});
+
+  // When showHidden changes, clear the folder cache so child expansions
+  // re-fetch with the updated hidden flag.
+  var prevHiddenRef = React.useRef(s.showHidden);
+  React.useEffect(function() {
+    if (prevHiddenRef.current !== s.showHidden) {
+      prevHiddenRef.current = s.showHidden;
+      setFolderCache({});
+    }
+  }, [s.showHidden]);
+
+  function fetchFolder(path) {
+    // Only fetch once per path (or if not yet started).
+    if (folderCache[path]) return;
+    // Mark loading.
+    setFolderCache(function(c) {
+      var next = Object.assign({}, c);
+      next[path] = { loading: true, items: [], loaded: false };
+      return next;
+    });
+    apiFetch(
+      "GET",
+      "/workspaces/" + encodeURIComponent(wid) + "/files/tree?path=" + encodeURIComponent(path) + "&hidden=" + s.showHidden
+    ).then(function(data) {
+      var items = (data && data.items) ? data.items : [];
+      setFolderCache(function(c) {
+        var next = Object.assign({}, c);
+        next[path] = { loading: false, items: items, loaded: true };
+        return next;
+      });
+    }).catch(function() {
+      setFolderCache(function(c) {
+        var next = Object.assign({}, c);
+        next[path] = { loading: false, items: [], loaded: true, error: true };
+        return next;
+      });
+    });
+  }
+
+  function handleFolderClick(item) {
+    // Toggle the expanded state in studio state.
+    studio.toggleFolder(item.path);
+    // Lazily fetch on first expand.
+    if (!s.expanded[item.path] && !folderCache[item.path]) {
+      fetchFolder(item.path);
+    }
+  }
+
+  function handleFileClick(item) {
+    var parts = item.path.split("/");
+    var basename = parts[parts.length - 1];
+    studio.openTab({
+      id: "file:" + item.path,
+      kind: "file",
+      ref: item.path,
+      title: basename,
+    });
+  }
+
+  function handleRefresh() {
+    // Clear folder cache and re-request root.
+    setFolderCache({});
+    rootRes.refetch && rootRes.refetch();
+  }
+
+  // Flatten the tree into a list of rows for rendering, respecting expansion.
+  function ST_flattenItems(items, depth) {
+    var rows = [];
+    if (!items) return rows;
+    items.forEach(function(item) {
+      rows.push({ item: item, depth: depth });
+      if (item.is_dir && s.expanded[item.path]) {
+        var cached = folderCache[item.path];
+        if (cached && cached.loaded) {
+          var childRows = ST_flattenItems(cached.items, depth + 1);
+          childRows.forEach(function(r) { rows.push(r); });
+        } else if (cached && cached.loading) {
+          rows.push({ spinner: true, path: item.path, depth: depth + 1 });
+        }
+      }
+    });
+    return rows;
+  }
+
+  var rootItems = (rootRes.data && rootRes.data.items) ? rootRes.data.items : [];
+  var flatRows = ST_flattenItems(rootItems, 0);
+
+  var chevStyle = {
+    display: "inline-block",
+    transition: "transform 0.15s",
+    transform: s.filesOpen ? "rotate(0deg)" : "rotate(-90deg)",
+    color: "var(--text-4)",
+  };
+
+  return (
+    <div
+      className="st-section"
+      style={{ flex: "1 1 auto", minHeight: 0 }}
+      data-testid="files-section"
+    >
+      {/* Section header */}
+      <div
+        className="st-section-h"
+        data-testid="files-header"
+        onClick={studio.toggleFiles}
+      >
+        <span style={chevStyle}>▾</span>
+        Files
+        <span style={{ flex: 1 }} />
+        <button
+          style={{
+            width: 20,
+            height: 20,
+            display: "grid",
+            placeItems: "center",
+            borderRadius: 5,
+            border: "none",
+            background: "none",
+            color: "var(--text-3)",
+            fontSize: 14,
+            cursor: "pointer",
+            flexShrink: 0,
+          }}
+          title="Refresh"
+          onClick={function(e) {
+            e.stopPropagation();
+            handleRefresh();
+          }}
+        >⟳</button>
+        <button
+          style={{
+            width: 20,
+            height: 20,
+            display: "grid",
+            placeItems: "center",
+            borderRadius: 5,
+            border: "none",
+            background: s.showHidden ? "var(--accent-dim)" : "none",
+            color: s.showHidden ? "var(--accent)" : "var(--text-3)",
+            fontSize: 14,
+            cursor: "pointer",
+            flexShrink: 0,
+          }}
+          data-testid="hidden-toggle"
+          title="Show hidden files"
+          onClick={function(e) {
+            e.stopPropagation();
+            studio.toggleHidden();
+          }}
+        >⊘</button>
+      </div>
+
+      {/* File tree */}
+      {s.filesOpen && (
+        <div className="st-section-body" style={{ paddingBottom: 6 }}>
+          {rootRes.loading && flatRows.length === 0 && (
+            <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-4)" }}>Loading…</div>
+          )}
+          {!rootRes.loading && flatRows.length === 0 && (
+            <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-4)" }}>No files.</div>
+          )}
+          {flatRows.map(function(row, idx) {
+            if (row.spinner) {
+              return (
+                <div
+                  key={"spin:" + row.path + ":" + idx}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    height: "var(--frow-h, 30px)",
+                    paddingLeft: (row.depth * 16 + 8) + "px",
+                    color: "var(--text-4)",
+                    fontSize: 11,
+                  }}
+                >
+                  ···
+                </div>
+              );
+            }
+            var item = row.item;
+            var depth = row.depth;
+            var tabId = "file:" + item.path;
+            var isActive = s.activeTabId === tabId;
+            var isDirty = false; // dirty state lives in studio.state.openTabs
+            var openTabs = s.openTabs || [];
+            for (var ti = 0; ti < openTabs.length; ti++) {
+              if (openTabs[ti].id === tabId && openTabs[ti].dirty) {
+                isDirty = true;
+                break;
+              }
+            }
+            var isExpanded = !!s.expanded[item.path];
+            var iconColor = ST_fileIconColor(item);
+            var iconName = ST_fileIconName(item);
+
+            return (
+              <div
+                key={item.path}
+                className="st-file-row"
+                data-testid="file-row"
+                onClick={function() {
+                  if (item.is_dir) {
+                    handleFolderClick(item);
+                  } else {
+                    handleFileClick(item);
+                  }
+                }}
+                style={{
+                  display: "flex",
+                  alignItems: "center",
+                  height: "var(--frow-h, 30px)",
+                  paddingLeft: (depth * 16 + 8) + "px",
+                  paddingRight: 8,
+                  cursor: "pointer",
+                  background: isActive ? "var(--bg-active)" : "transparent",
+                }}
+              >
+                {/* Chevron column */}
+                <span style={{ width: 12, color: "var(--text-4)", fontSize: 9, textAlign: "center", flexShrink: 0 }}>
+                  {item.is_dir ? (isExpanded ? "▾" : "▸") : ""}
+                </span>
+                {/* Icon column */}
+                <span style={{ width: 15, display: "grid", placeItems: "center", flexShrink: 0, color: iconColor }}>
+                  <Icon name={iconName} size={12} />
+                </span>
+                {/* Name */}
+                <span style={{
+                  flex: 1,
+                  overflow: "hidden",
+                  textOverflow: "ellipsis",
+                  whiteSpace: "nowrap",
+                  fontSize: 12,
+                  fontWeight: item.is_dir ? 500 : 400,
+                  color: isActive ? "var(--text)" : "var(--text-2)",
+                  marginLeft: 4,
+                }}>
+                  {item.name}
+                </span>
+                {/* Dirty dot */}
+                {isDirty && (
+                  <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--blue)", marginLeft: 4, flexShrink: 0 }} />
+                )}
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StudioSidebar — top-level component that replaces region-sidebar.
+// Props: { wid, studio }  (studio = useStudioState(wid) bag)
+// ---------------------------------------------------------------------------
+
+function StudioSidebar({ wid, studio }) {
+  return (
+    <div
+      style={{ display: "flex", flexDirection: "column", height: "100%", overflow: "hidden" }}
+      data-testid="studio-sidebar-inner"
+    >
+      <SessionsSection wid={wid} studio={studio} />
+      <FilesTree wid={wid} studio={studio} />
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// No-build exports
+// ---------------------------------------------------------------------------
+window.StudioSidebar = StudioSidebar;
+window.SessionsSection = SessionsSection;
+window.FilesTree = FilesTree;
+window.ST_sessionStatus = ST_sessionStatus;

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -91,6 +91,47 @@ function ST_tabFromUrl() {
   }
 }
 
+// Synthesize a minimal tab from a parsed url tab id (the ?open= value).
+// Returns { id, kind, ref, title, glyph } or null. Used by the initializer
+// and the wid-change effect so a fresh deep-link (empty localStorage) still
+// creates + activates the tab — the center/right panels self-fetch their
+// detail from `ref`, so a minimal synthesized tab renders correctly.
+function ST_tabFromUrlId(urlTab) {
+  if (!urlTab || typeof urlTab !== "string") return null;
+  if (urlTab.indexOf("session:") === 0) {
+    var sid = urlTab.slice("session:".length);
+    return { id: urlTab, kind: "session", ref: sid, title: sid, glyph: "◆" };
+  }
+  if (urlTab.indexOf("file:") === 0) {
+    var fpath = urlTab.slice("file:".length);
+    var parts = String(fpath).split("/");
+    var base = parts[parts.length - 1] || fpath;
+    return { id: urlTab, kind: "file", ref: fpath, title: base };
+  }
+  return null;
+}
+
+// Reconcile a freshly-built base state with the current ?open= deep-link.
+// If the url tab is already an open tab, just activate it; otherwise
+// synthesize a minimal tab, append it, and activate it. With activeTabId set
+// on mount, the first persist effect's ST_syncUrl re-writes the same ?open=
+// value instead of deleting it (so deep-links survive the mount).
+function ST_applyUrlTab(base) {
+  var urlTab = ST_tabFromUrl();
+  if (!urlTab) return base;
+  var openTabs = base.openTabs || [];
+  var present = openTabs.some(function (t) { return t.id === urlTab; });
+  if (present) {
+    base.activeTabId = urlTab;
+    return base;
+  }
+  var tab = ST_tabFromUrlId(urlTab);
+  if (!tab) return base;
+  base.openTabs = openTabs.concat([tab]);
+  base.activeTabId = urlTab;
+  return base;
+}
+
 // Mirror the active tab to the URL query via replaceState — no history
 // entry per tab switch. activeTabId is already in `session:<id>` /
 // `file:<path>` form so it maps straight onto ?open=.
@@ -158,12 +199,7 @@ function useStudioState(wid) {
   // Initial state: defaults <- persisted(wid) <- url(?open=). Computed once
   // per wid via the lazy initialiser; re-keyed below when wid changes.
   var [state, setState] = React.useState(function () {
-    var base = Object.assign(ST_defaultState(), ST_loadPersisted(wid));
-    var urlTab = ST_tabFromUrl();
-    if (urlTab && (base.openTabs || []).some(function (t) { return t.id === urlTab; })) {
-      base.activeTabId = urlTab;
-    }
-    return base;
+    return ST_applyUrlTab(Object.assign(ST_defaultState(), ST_loadPersisted(wid)));
   });
 
   // Re-hydrate when switching workspace (wid changes): swap to that
@@ -173,12 +209,7 @@ function useStudioState(wid) {
   React.useEffect(function () {
     if (widRef.current === wid) return;
     widRef.current = wid;
-    var base = Object.assign(ST_defaultState(), ST_loadPersisted(wid));
-    var urlTab = ST_tabFromUrl();
-    if (urlTab && (base.openTabs || []).some(function (t) { return t.id === urlTab; })) {
-      base.activeTabId = urlTab;
-    }
-    setState(base);
+    setState(ST_applyUrlTab(Object.assign(ST_defaultState(), ST_loadPersisted(wid))));
   }, [wid]);
 
   // Persist + URL-mirror after every committed state change.
@@ -223,11 +254,21 @@ function useStudioState(wid) {
 
   var closeTab = React.useCallback(function (id) {
     setState(function (s) {
-      var idx = (s.openTabs || []).findIndex(function (t) { return t.id === id; });
-      var openTabs = s.openTabs.filter(function (t) { return t.id !== id; });
+      var prev = s.openTabs || [];
+      var idx = prev.findIndex(function (t) { return t.id === id; });
+      var openTabs = prev.filter(function (t) { return t.id !== id; });
       var activeTabId = s.activeTabId;
       if (activeTabId === id) {
-        activeTabId = openTabs.length ? openTabs[Math.max(0, idx - 1)].id : null;
+        // Activate the left neighbour in the POST-filter array. The closed
+        // tab sat at `idx`, so its left neighbour is now at `idx - 1` (clamped
+        // into the filtered array's bounds); compute against one consistent
+        // array to avoid an off-by-one.
+        if (!openTabs.length) {
+          activeTabId = null;
+        } else {
+          var nextIdx = Math.min(Math.max(0, idx - 1), openTabs.length - 1);
+          activeTabId = openTabs[nextIdx].id;
+        }
       }
       return Object.assign({}, s, { openTabs: openTabs, activeTabId: activeTabId });
     });

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -488,7 +488,7 @@ function Studio({ wid }) {
       <div className="st-body">
         {/* ---- LEFT: B2 StudioSidebar (sessions + files tree) ---- */}
         <div className="st-col st-col-left" data-testid="studio-sidebar">
-          <ST_RegionPlaceholder kind="B2 · left sidebar" label="Sessions + Files tree" testid="region-sidebar" />
+          <StudioSidebar wid={wid} studio={studio} />
         </div>
 
         <div className="st-resize" onMouseDown={function (e) { startResize("left", e); }} data-testid="studio-resize-left" />

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -1,0 +1,517 @@
+/* global React, Icon, Btn */
+// Studio — the workspace-scoped IDE shell (PR-B / B1 foundation).
+//
+// Route component for /workspaces/:wid. Owns useStudioState(wid): the
+// open-tab model, sidebar layout, theme/density, and the persistence +
+// URL-mirroring seams ported from studio/Studio.dc.html. The three body
+// regions (left sidebar / center / right) are STUBBED here as styled
+// placeholder boxes; later sub-tasks fill them:
+//   B2 → StudioSidebar   (left)
+//   B3 → StudioCenter    (center)
+//   B4 → StudioActivity  (right)
+//   B5 → CommandPalette + ⌘K/⌘P wiring + enrichments
+//
+// No-build scope rules (see workspace-tap.jsx): top-level declarations use
+// `var`; helpers are prefixed ST_ to avoid global collisions; every
+// component/hook is exported via `window.X = X`.
+
+// ---------------------------------------------------------------------------
+// Persistence contract (STUDIO-INTEGRATION.md §3)
+// ---------------------------------------------------------------------------
+
+// The exact key set round-tripped through localStorage["studio:<wid>"].
+var ST_PERSIST_KEYS = [
+  "openTabs",
+  "activeTabId",
+  "sessionsOpen",
+  "filesOpen",
+  "showHidden",
+  "expanded",
+  "fileModes",
+  "terminalOpen",
+  "activeTermId",
+  "termTabs",
+  "density",
+  "theme",
+  "activeChips",
+  "leftWidth",
+  "rightWidth",
+];
+
+function ST_storageKey(wid) {
+  return "studio:" + wid;
+}
+
+// Read the persisted partial state for a workspace; returns {} on any
+// miss / parse error. Only whitelisted keys survive.
+function ST_loadPersisted(wid) {
+  try {
+    var raw = window.localStorage.getItem(ST_storageKey(wid));
+    if (!raw) return {};
+    var parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") return {};
+    var keep = {};
+    ST_PERSIST_KEYS.forEach(function (k) {
+      if (parsed[k] !== undefined) keep[k] = parsed[k];
+    });
+    return keep;
+  } catch (_e) {
+    return {};
+  }
+}
+
+// Serialise the persisted slice of state under studio:<wid>.
+function ST_savePersisted(wid, state) {
+  try {
+    var snap = {};
+    ST_PERSIST_KEYS.forEach(function (k) {
+      snap[k] = state[k];
+    });
+    window.localStorage.setItem(ST_storageKey(wid), JSON.stringify(snap));
+  } catch (_e) {
+    /* quota / disabled storage — non-fatal */
+  }
+}
+
+// Parse ?open=session:<id> / ?open=file:<path> into a tab id string, or
+// null. The Studio uses a hash router (see foundation/router.js), so the
+// query lives in the hash fragment, not window.location.search.
+function ST_tabFromUrl() {
+  try {
+    var hash = window.location.hash || "";
+    var qIdx = hash.indexOf("?");
+    if (qIdx < 0) return null;
+    var open = new URLSearchParams(hash.slice(qIdx + 1)).get("open");
+    if (!open) return null;
+    if (open.indexOf("session:") === 0) return open;
+    if (open.indexOf("file:") === 0) return open;
+    return null;
+  } catch (_e) {
+    return null;
+  }
+}
+
+// Mirror the active tab to the URL query via replaceState — no history
+// entry per tab switch. activeTabId is already in `session:<id>` /
+// `file:<path>` form so it maps straight onto ?open=.
+function ST_syncUrl(activeTabId) {
+  try {
+    var url = new URL(window.location.href);
+    var hash = url.hash || "#/";
+    var qIdx = hash.indexOf("?");
+    var path = qIdx >= 0 ? hash.slice(0, qIdx) : hash;
+    var params = new URLSearchParams(qIdx >= 0 ? hash.slice(qIdx + 1) : "");
+    if (activeTabId) params.set("open", activeTabId);
+    else params.delete("open");
+    var qs = params.toString();
+    url.hash = qs ? path + "?" + qs : path;
+    window.history.replaceState(null, "", url.toString());
+  } catch (_e) {
+    /* malformed URL — skip */
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Default (un-persisted) state shape
+// ---------------------------------------------------------------------------
+
+function ST_defaultState() {
+  return {
+    // Layout / appearance
+    theme: "dark",
+    density: "comfortable",
+    leftWidth: 248,
+    rightWidth: 332,
+    // Left sidebar
+    sessionsOpen: true,
+    filesOpen: true,
+    showHidden: false,
+    expanded: {},
+    // Center tabs — [{ id, kind:'session'|'file', ref, title, dirty }]
+    openTabs: [],
+    activeTabId: null,
+    fileModes: {},
+    // Terminal placeholders (P7)
+    terminalOpen: false,
+    termTabs: [{ id: "bash", title: "bash" }],
+    activeTermId: "bash",
+    // Right sidebar activity-feed chip filter
+    activeChips: { tool: true, gt: true, asst: true, yield: true, done: true, err: true },
+    // Last sidebar selection (ephemeral-ish; persisted for restore)
+    lastSelection: null,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// useStudioState(wid) — the single state owner for the Studio shell.
+//
+// Returns { state, ...actions }. Persists the whitelisted slice to
+// localStorage on every change and mirrors the active tab into the URL.
+// B2–B4 consume the action callbacks (openTab/focusTab/closeTab/toggle*).
+// ---------------------------------------------------------------------------
+
+function useStudioState(wid) {
+  // Initial state: defaults <- persisted(wid) <- url(?open=). Computed once
+  // per wid via the lazy initialiser; re-keyed below when wid changes.
+  var [state, setState] = React.useState(function () {
+    var base = Object.assign(ST_defaultState(), ST_loadPersisted(wid));
+    var urlTab = ST_tabFromUrl();
+    if (urlTab && (base.openTabs || []).some(function (t) { return t.id === urlTab; })) {
+      base.activeTabId = urlTab;
+    }
+    return base;
+  });
+
+  // Re-hydrate when switching workspace (wid changes): swap to that
+  // workspace's persisted layout. switchWorkspace() in the header navigates
+  // the route, which remounts/keys this hook via the wid dependency.
+  var widRef = React.useRef(wid);
+  React.useEffect(function () {
+    if (widRef.current === wid) return;
+    widRef.current = wid;
+    var base = Object.assign(ST_defaultState(), ST_loadPersisted(wid));
+    var urlTab = ST_tabFromUrl();
+    if (urlTab && (base.openTabs || []).some(function (t) { return t.id === urlTab; })) {
+      base.activeTabId = urlTab;
+    }
+    setState(base);
+  }, [wid]);
+
+  // Persist + URL-mirror after every committed state change.
+  React.useEffect(function () {
+    ST_savePersisted(wid, state);
+    ST_syncUrl(state.activeTabId);
+  }, [wid, state]);
+
+  // Apply theme/density attrs to <html> so the design tokens resolve. The
+  // Studio root <div> also carries them (see render) for scoped reads.
+  React.useEffect(function () {
+    var html = document.documentElement;
+    var prevTheme = html.getAttribute("data-theme");
+    var prevDensity = html.getAttribute("data-density");
+    html.setAttribute("data-theme", state.theme);
+    html.setAttribute("data-density", state.density);
+    return function () {
+      // Restore prior attrs on unmount so leaving the Studio doesn't strand
+      // the rest of the console in Studio's density.
+      if (prevTheme) html.setAttribute("data-theme", prevTheme);
+      if (prevDensity) html.setAttribute("data-density", prevDensity);
+    };
+  }, [state.theme, state.density]);
+
+  // ---- tab management (consumed by B2/B3) ----
+  var openTab = React.useCallback(function (tab) {
+    setState(function (s) {
+      var exists = (s.openTabs || []).some(function (t) { return t.id === tab.id; });
+      var openTabs = exists ? s.openTabs : s.openTabs.concat([tab]);
+      var fileModes = s.fileModes;
+      if (tab.kind === "file" && fileModes[tab.id] === undefined) {
+        fileModes = Object.assign({}, fileModes);
+        fileModes[tab.id] = tab.mode || "preview";
+      }
+      return Object.assign({}, s, { openTabs: openTabs, activeTabId: tab.id, fileModes: fileModes });
+    });
+  }, []);
+
+  var focusTab = React.useCallback(function (id) {
+    setState(function (s) { return Object.assign({}, s, { activeTabId: id }); });
+  }, []);
+
+  var closeTab = React.useCallback(function (id) {
+    setState(function (s) {
+      var idx = (s.openTabs || []).findIndex(function (t) { return t.id === id; });
+      var openTabs = s.openTabs.filter(function (t) { return t.id !== id; });
+      var activeTabId = s.activeTabId;
+      if (activeTabId === id) {
+        activeTabId = openTabs.length ? openTabs[Math.max(0, idx - 1)].id : null;
+      }
+      return Object.assign({}, s, { openTabs: openTabs, activeTabId: activeTabId });
+    });
+  }, []);
+
+  // ---- left sidebar toggles ----
+  var toggleSessions = React.useCallback(function () {
+    setState(function (s) { return Object.assign({}, s, { sessionsOpen: !s.sessionsOpen }); });
+  }, []);
+  var toggleFiles = React.useCallback(function () {
+    setState(function (s) { return Object.assign({}, s, { filesOpen: !s.filesOpen }); });
+  }, []);
+  var toggleHidden = React.useCallback(function () {
+    setState(function (s) { return Object.assign({}, s, { showHidden: !s.showHidden }); });
+  }, []);
+  var toggleFolder = React.useCallback(function (path) {
+    setState(function (s) {
+      var expanded = Object.assign({}, s.expanded);
+      expanded[path] = !expanded[path];
+      return Object.assign({}, s, { expanded: expanded });
+    });
+  }, []);
+
+  // ---- appearance ----
+  var toggleTheme = React.useCallback(function () {
+    setState(function (s) { return Object.assign({}, s, { theme: s.theme === "dark" ? "light" : "dark" }); });
+  }, []);
+  var toggleDensity = React.useCallback(function () {
+    setState(function (s) {
+      return Object.assign({}, s, { density: s.density === "comfortable" ? "compact" : "comfortable" });
+    });
+  }, []);
+
+  // ---- terminal (P7 placeholder) ----
+  var toggleTerminal = React.useCallback(function () {
+    setState(function (s) { return Object.assign({}, s, { terminalOpen: !s.terminalOpen }); });
+  }, []);
+
+  // ---- activity chips (B4) ----
+  var toggleChip = React.useCallback(function (cl) {
+    setState(function (s) {
+      var activeChips = Object.assign({}, s.activeChips);
+      activeChips[cl] = !activeChips[cl];
+      return Object.assign({}, s, { activeChips: activeChips });
+    });
+  }, []);
+
+  // ---- column resize (persisted) ----
+  var setLeftWidth = React.useCallback(function (w) {
+    setState(function (s) { return Object.assign({}, s, { leftWidth: w }); });
+  }, []);
+  var setRightWidth = React.useCallback(function (w) {
+    setState(function (s) { return Object.assign({}, s, { rightWidth: w }); });
+  }, []);
+
+  // Generic patch escape hatch for B2–B4 to set fields not covered above
+  // (fileModes, lastSelection, etc.) without re-plumbing the hook each time.
+  var patch = React.useCallback(function (partial) {
+    setState(function (s) { return Object.assign({}, s, partial); });
+  }, []);
+
+  return {
+    state: state,
+    openTab: openTab,
+    focusTab: focusTab,
+    closeTab: closeTab,
+    toggleSessions: toggleSessions,
+    toggleFiles: toggleFiles,
+    toggleHidden: toggleHidden,
+    toggleFolder: toggleFolder,
+    toggleTheme: toggleTheme,
+    toggleDensity: toggleDensity,
+    toggleTerminal: toggleTerminal,
+    toggleChip: toggleChip,
+    setLeftWidth: setLeftWidth,
+    setRightWidth: setRightWidth,
+    patch: patch,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Brand logo — faceted diamond from the prototype (renderVals.logo).
+// ---------------------------------------------------------------------------
+
+function ST_Logo() {
+  return (
+    <svg width={22} height={22} viewBox="0 0 24 24">
+      <polygon points="12,3 21,12 12,21 3,12" fill="var(--text)" fillOpacity={0.16} />
+      <polygon points="12,3 16.5,7.5 12,12 7.5,7.5" fill="var(--text)" />
+      <polygon points="16.5,7.5 21,12 16.5,16.5 12,12" fill="var(--text)" fillOpacity={0.4} />
+      <polygon points="12,12 16.5,16.5 12,21 7.5,16.5" fill="var(--accent)" />
+      <polygon points="7.5,7.5 12,12 7.5,16.5 3,12" fill="var(--text)" fillOpacity={0.4} />
+    </svg>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// StudioHeader — brand · workspace selector ▾ · ⌘K / ⌘P / density / theme
+// ---------------------------------------------------------------------------
+
+function StudioHeader({ wid, theme, density, onToggleTheme, onToggleDensity, onTogglePalette, onOpenQuick, onSelectWorkspace }) {
+  var { useResource, apiFetch } = window.primerApi;
+  var [menuOpen, setMenuOpen] = React.useState(false);
+
+  // Workspace list for the selector dropdown. Reuse the same cache key the
+  // app already polls so we ride on its data instead of a second roundtrip.
+  var workspaces = useResource(
+    "topbar:workspaces",
+    function (signal) { return apiFetch("GET", "/workspaces?limit=200", null, { signal }); },
+    { pollMs: 5000 }
+  );
+  var items = Array.isArray(workspaces.data && workspaces.data.items) ? workspaces.data.items : [];
+
+  // Close the dropdown on Escape or outside click.
+  React.useEffect(function () {
+    if (!menuOpen) return;
+    function onKey(e) { if (e.key === "Escape") setMenuOpen(false); }
+    function onDoc() { setMenuOpen(false); }
+    window.addEventListener("keydown", onKey);
+    // defer so the opening click doesn't immediately close it
+    var t = setTimeout(function () { document.addEventListener("click", onDoc); }, 0);
+    return function () {
+      window.removeEventListener("keydown", onKey);
+      clearTimeout(t);
+      document.removeEventListener("click", onDoc);
+    };
+  }, [menuOpen]);
+
+  function pick(id) {
+    setMenuOpen(false);
+    if (id !== wid) onSelectWorkspace(id);
+  }
+
+  return (
+    <div className="st-topbar" data-testid="studio-header">
+      <div className="st-brand">
+        <span style={{ width: 22, height: 22, display: "grid", placeItems: "center" }}><ST_Logo /></span>
+        Primer <span style={{ color: "var(--text-3)", fontWeight: 500, fontSize: 12 }}>Studio</span>
+      </div>
+
+      <div
+        className="st-ws-btn"
+        data-testid="workspace-selector"
+        onClick={function (e) { e.stopPropagation(); setMenuOpen(function (o) { return !o; }); }}
+      >
+        <span style={{ width: 14, height: 14, borderRadius: 4, background: "var(--accent-dim)", border: "1px solid var(--accent-border)" }} />
+        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 180 }}>{wid}</span>
+        <span style={{ color: "var(--text-3)" }}>▾</span>
+        {menuOpen && (
+          <div className="st-ws-menu" data-testid="workspace-menu" onClick={function (e) { e.stopPropagation(); }}>
+            {items.length === 0 && (
+              <div className="st-ws-menu-row" style={{ color: "var(--text-3)", cursor: "default" }}>
+                {workspaces.loading ? "Loading…" : "No workspaces"}
+              </div>
+            )}
+            {items.map(function (w) {
+              return (
+                <div key={w.id} className="st-ws-menu-row" onClick={function () { pick(w.id); }}>
+                  <span style={{ width: 8, height: 8, borderRadius: "50%", background: "var(--green)", flex: "0 0 auto" }} />
+                  <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{w.name || w.id}</span>
+                  {w.id === wid && <span style={{ color: "var(--accent)" }}>✓</span>}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+
+      <div style={{ flex: 1 }} />
+
+      {/* ⌘K palette trigger — inert stub until B5 wires the palette. */}
+      <div className="st-palette-trigger" data-testid="palette-trigger" onClick={onTogglePalette}>
+        <span style={{ opacity: 0.8 }}>Search · run · jump</span>
+        <kbd>⌘K</kbd>
+      </div>
+      {/* ⌘P quick-open — inert stub until B5. */}
+      <div className="st-hbtn" data-testid="quickopen-trigger" title="Quick open (⌘P)" onClick={onOpenQuick}>⌕</div>
+      <div className="st-hbtn" data-testid="density-toggle" title="Density" onClick={onToggleDensity}>☰</div>
+      <div className="st-hbtn" data-testid="theme-toggle" title="Theme" onClick={onToggleTheme}>
+        {theme === "dark" ? "◐" : "○"}
+      </div>
+      <div className="st-avatar" title="User">DK</div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ST_RegionPlaceholder — styled empty box for a not-yet-built region.
+// ---------------------------------------------------------------------------
+
+function ST_RegionPlaceholder({ kind, label, testid }) {
+  return (
+    <div className="st-placeholder" data-testid={testid}>
+      <div>
+        <div className="st-ph-kind">{kind}</div>
+        <div style={{ marginTop: 6 }}>{label}</div>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Studio — route shell. Header + 3-column resizable body with placeholders.
+// ---------------------------------------------------------------------------
+
+function Studio({ wid }) {
+  var studio = useStudioState(wid);
+  var s = studio.state;
+
+  // Column resize: drag the handle, write width into state (persisted).
+  // We clamp to sane bounds so a column can't be dragged off-screen.
+  var dragRef = React.useRef(null);
+  function startResize(side, e) {
+    e.preventDefault();
+    dragRef.current = { side: side, startX: e.clientX, startW: side === "left" ? s.leftWidth : s.rightWidth };
+    function onMove(ev) {
+      var d = dragRef.current;
+      if (!d) return;
+      var delta = ev.clientX - d.startX;
+      if (d.side === "left") {
+        var lw = Math.max(180, Math.min(480, d.startW + delta));
+        studio.setLeftWidth(lw);
+      } else {
+        var rw = Math.max(220, Math.min(560, d.startW - delta));
+        studio.setRightWidth(rw);
+      }
+    }
+    function onUp() {
+      dragRef.current = null;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    }
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
+  function selectWorkspace(newWid) {
+    // Navigate to the new workspace route; the hook re-hydrates from that
+    // wid's persisted layout. Drop any stale ?open= from the previous ws.
+    window.location.hash = "#/workspaces/" + encodeURIComponent(newWid);
+  }
+
+  return (
+    <div
+      className="st-root"
+      data-theme={s.theme}
+      data-density={s.density}
+      data-testid="studio-root"
+      style={{ "--st-left-w": s.leftWidth + "px", "--st-right-w": s.rightWidth + "px" }}
+    >
+      <StudioHeader
+        wid={wid}
+        theme={s.theme}
+        density={s.density}
+        onToggleTheme={studio.toggleTheme}
+        onToggleDensity={studio.toggleDensity}
+        onTogglePalette={function () { /* B5: open command palette */ }}
+        onOpenQuick={function () { /* B5: open quick-open */ }}
+        onSelectWorkspace={selectWorkspace}
+      />
+
+      <div className="st-body">
+        {/* ---- LEFT: B2 StudioSidebar (sessions + files tree) ---- */}
+        <div className="st-col st-col-left" data-testid="studio-sidebar">
+          <ST_RegionPlaceholder kind="B2 · left sidebar" label="Sessions + Files tree" testid="region-sidebar" />
+        </div>
+
+        <div className="st-resize" onMouseDown={function (e) { startResize("left", e); }} data-testid="studio-resize-left" />
+
+        {/* ---- CENTER: B3 StudioCenter (tabs + active panel + terminal) ---- */}
+        <div className="st-col st-col-center" data-testid="studio-center">
+          <ST_RegionPlaceholder kind="B3 · center" label="Tab bar + active document panel" testid="region-center" />
+        </div>
+
+        <div className="st-resize" onMouseDown={function (e) { startResize("right", e); }} data-testid="studio-resize-right" />
+
+        {/* ---- RIGHT: B4 StudioActivity (action required + workspace tap) ---- */}
+        <div className="st-col st-col-right" data-testid="studio-activity">
+          <ST_RegionPlaceholder kind="B4 · right sidebar" label="Action Required + Workspace Activity" testid="region-activity" />
+        </div>
+      </div>
+
+      {/* B5: {paletteOpen && <CommandPalette … />} mounts here. */}
+    </div>
+  );
+}
+
+// No-build exports — every component/hook reachable from app.jsx + B2–B4.
+window.Studio = Studio;
+window.StudioHeader = StudioHeader;
+window.useStudioState = useStudioState;

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -493,9 +493,9 @@ function Studio({ wid }) {
 
         <div className="st-resize" onMouseDown={function (e) { startResize("left", e); }} data-testid="studio-resize-left" />
 
-        {/* ---- CENTER: B3 StudioCenter (tabs + active panel + terminal) ---- */}
+        {/* ---- CENTER: B3 StudioCenter (tabs + active panel) ---- */}
         <div className="st-col st-col-center" data-testid="studio-center">
-          <ST_RegionPlaceholder kind="B3 · center" label="Tab bar + active document panel" testid="region-center" />
+          <StudioCenter wid={wid} studio={studio} />
         </div>
 
         <div className="st-resize" onMouseDown={function (e) { startResize("right", e); }} data-testid="studio-resize-right" />

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -502,7 +502,7 @@ function Studio({ wid }) {
 
         {/* ---- RIGHT: B4 StudioActivity (action required + workspace tap) ---- */}
         <div className="st-col st-col-right" data-testid="studio-activity">
-          <ST_RegionPlaceholder kind="B4 · right sidebar" label="Action Required + Workspace Activity" testid="region-activity" />
+          <StudioActivity wid={wid} studio={studio} />
         </div>
       </div>
 

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -139,6 +139,10 @@ function ST_defaultState() {
     activeChips: { tool: true, gt: true, asst: true, yield: true, done: true, err: true },
     // Last sidebar selection (ephemeral-ish; persisted for restore)
     lastSelection: null,
+    // Command palette / quick-open (B5) — ephemeral, not persisted.
+    paletteOpen: false,
+    paletteMode: "command",
+    paletteQuery: "",
   };
 }
 
@@ -262,6 +266,20 @@ function useStudioState(wid) {
     setState(function (s) { return Object.assign({}, s, { terminalOpen: !s.terminalOpen }); });
   }, []);
 
+  // ---- command palette / quick-open (B5) ----
+  var openPalette = React.useCallback(function (mode) {
+    setState(function (s) { return Object.assign({}, s, { paletteOpen: true, paletteMode: mode || "command", paletteQuery: "" }); });
+  }, []);
+  var closePalette = React.useCallback(function () {
+    setState(function (s) { return Object.assign({}, s, { paletteOpen: false }); });
+  }, []);
+  var togglePalette = React.useCallback(function () {
+    setState(function (s) {
+      if (s.paletteOpen) return Object.assign({}, s, { paletteOpen: false });
+      return Object.assign({}, s, { paletteOpen: true, paletteMode: "command", paletteQuery: "" });
+    });
+  }, []);
+
   // ---- activity chips (B4) ----
   var toggleChip = React.useCallback(function (cl) {
     setState(function (s) {
@@ -301,6 +319,10 @@ function useStudioState(wid) {
     setLeftWidth: setLeftWidth,
     setRightWidth: setRightWidth,
     patch: patch,
+    // B5: palette / quick-open
+    openPalette: openPalette,
+    closePalette: closePalette,
+    togglePalette: togglePalette,
   };
 }
 
@@ -429,9 +451,15 @@ function ST_RegionPlaceholder({ kind, label, testid }) {
 // Studio — route shell. Header + 3-column resizable body with placeholders.
 // ---------------------------------------------------------------------------
 
-function Studio({ wid }) {
+function Studio({ wid, pushToast }) {
   var studio = useStudioState(wid);
   var s = studio.state;
+
+  // Thread pushToast into the studio object so StudioCenter / StudioActivity
+  // can reach it via studio.pushToast without re-plumbing every sub-component.
+  // Falls back to the module-level primerApi.toastPush so non-nil calls always
+  // work even when app.jsx hasn't passed the prop yet.
+  studio.pushToast = pushToast || (window.primerApi && window.primerApi.toastPush) || null;
 
   // Column resize: drag the handle, write width into state (persisted).
   // We clamp to sane bounds so a column can't be dragged off-screen.
@@ -466,6 +494,30 @@ function Studio({ wid }) {
     window.location.hash = "#/workspaces/" + encodeURIComponent(newWid);
   }
 
+  // B5: Global keydown — ⌘K/Ctrl-K → toggle palette; ⌘P/Ctrl-P → quick-open;
+  // Ctrl-` → toggleTerminal; Escape → close whichever overlay is open.
+  // Registered on the window (not just the Studio div) so it fires regardless
+  // of focus position within the IDE shell.
+  React.useEffect(function () {
+    function onKeyDown(e) {
+      var mod = e.metaKey || e.ctrlKey;
+      if (mod && (e.key === "k" || e.key === "K")) {
+        e.preventDefault();
+        studio.togglePalette();
+      } else if (mod && (e.key === "p" || e.key === "P")) {
+        e.preventDefault();
+        studio.openPalette("quickopen");
+      } else if (e.ctrlKey && e.key === "`") {
+        e.preventDefault();
+        studio.toggleTerminal();
+      } else if (e.key === "Escape") {
+        if (s.paletteOpen) studio.closePalette();
+      }
+    }
+    window.addEventListener("keydown", onKeyDown);
+    return function () { window.removeEventListener("keydown", onKeyDown); };
+  }, [s.paletteOpen, studio.togglePalette, studio.openPalette, studio.closePalette, studio.toggleTerminal]);
+
   return (
     <div
       className="st-root"
@@ -480,8 +532,8 @@ function Studio({ wid }) {
         density={s.density}
         onToggleTheme={studio.toggleTheme}
         onToggleDensity={studio.toggleDensity}
-        onTogglePalette={function () { /* B5: open command palette */ }}
-        onOpenQuick={function () { /* B5: open quick-open */ }}
+        onTogglePalette={studio.togglePalette}
+        onOpenQuick={function () { studio.openPalette("quickopen"); }}
         onSelectWorkspace={selectWorkspace}
       />
 
@@ -506,7 +558,25 @@ function Studio({ wid }) {
         </div>
       </div>
 
-      {/* B5: {paletteOpen && <CommandPalette … />} mounts here. */}
+      {/* B5: Command palette overlay (⌘K). Rendered at Studio root so it sits
+          above all three columns. paletteMode "command" vs "quickopen" selects
+          which component renders; both share the same open/close state. */}
+      {s.paletteOpen && s.paletteMode === "command" && (
+        <CommandPalette
+          wid={wid}
+          studio={studio}
+          open={s.paletteOpen}
+          onClose={studio.closePalette}
+        />
+      )}
+      {s.paletteOpen && s.paletteMode === "quickopen" && (
+        <QuickOpen
+          wid={wid}
+          studio={studio}
+          open={s.paletteOpen}
+          onClose={studio.closePalette}
+        />
+      )}
     </div>
   );
 }

--- a/ui/index.html
+++ b/ui/index.html
@@ -90,6 +90,7 @@
 <script type="text/babel" src="components/workspaces/templates.jsx"></script>
 <script type="text/babel" src="components/workspace-tap.jsx"></script>
 <script type="text/babel" src="components/studio-sidebar.jsx"></script>
+<script type="text/babel" src="components/studio-center.jsx"></script>
 <script type="text/babel" src="components/studio.jsx"></script>
 <script type="text/babel" src="components/workspaces.jsx"></script>
 <script type="text/babel" src="components/agents.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -91,6 +91,7 @@
 <script type="text/babel" src="components/workspace-tap.jsx"></script>
 <script type="text/babel" src="components/studio-sidebar.jsx"></script>
 <script type="text/babel" src="components/studio-center.jsx"></script>
+<script type="text/babel" src="components/studio-activity.jsx"></script>
 <script type="text/babel" src="components/studio.jsx"></script>
 <script type="text/babel" src="components/workspaces.jsx"></script>
 <script type="text/babel" src="components/agents.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -89,6 +89,7 @@
 <script type="text/babel" src="components/workspaces/providers.jsx"></script>
 <script type="text/babel" src="components/workspaces/templates.jsx"></script>
 <script type="text/babel" src="components/workspace-tap.jsx"></script>
+<script type="text/babel" src="components/studio-sidebar.jsx"></script>
 <script type="text/babel" src="components/studio.jsx"></script>
 <script type="text/babel" src="components/workspaces.jsx"></script>
 <script type="text/babel" src="components/agents.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -92,6 +92,7 @@
 <script type="text/babel" src="components/studio-sidebar.jsx"></script>
 <script type="text/babel" src="components/studio-center.jsx"></script>
 <script type="text/babel" src="components/studio-activity.jsx"></script>
+<script type="text/babel" src="components/studio-palette.jsx"></script>
 <script type="text/babel" src="components/studio.jsx"></script>
 <script type="text/babel" src="components/workspaces.jsx"></script>
 <script type="text/babel" src="components/agents.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -89,6 +89,7 @@
 <script type="text/babel" src="components/workspaces/providers.jsx"></script>
 <script type="text/babel" src="components/workspaces/templates.jsx"></script>
 <script type="text/babel" src="components/workspace-tap.jsx"></script>
+<script type="text/babel" src="components/studio.jsx"></script>
 <script type="text/babel" src="components/workspaces.jsx"></script>
 <script type="text/babel" src="components/agents.jsx"></script>
 <script type="text/babel" src="components/graphs.jsx"></script>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -83,6 +83,263 @@
 :root[data-density="compact"] { --row-h: 30px; }
 :root[data-density="comfortable"] { --row-h: 40px; }
 
+/* ---------------------------------------------------------------------------
+   Studio additions (PR-B). Three tokens the port-map identifies as missing,
+   plus the Studio-scoped layout classes (st-*). The colour/spacing token set
+   is otherwise pixel-identical to the prototype, so we reuse the existing
+   tokens above rather than duplicating them.
+
+   --teal / --teal-dim     : graph_transition activity chip colour.
+   --frow-h                : file-tree row height (tighter than --row-h).
+   Because the Studio mounts data-density on its OWN root <div> (not :root),
+   --frow-h is declared on both :root and the [data-density] attribute so it
+   resolves whether the attribute lands on <html> or on .st-root.
+--------------------------------------------------------------------------- */
+:root { --teal: oklch(0.78 0.12 195); --teal-dim: oklch(0.78 0.12 195 / 0.14); --frow-h: 30px; }
+:root[data-density="compact"],
+[data-density="compact"] { --frow-h: 24px; }
+:root[data-density="comfortable"],
+[data-density="comfortable"] { --frow-h: 30px; }
+
+/* Studio root shell: header row + body. Owns its own data-theme/-density. */
+.st-root {
+  display: grid;
+  grid-template-rows: var(--topbar-h, 48px) 1fr;
+  height: 100dvh;
+  width: 100%;
+  background: var(--bg);
+  color: var(--text);
+  font-family: "IBM Plex Sans", system-ui, -apple-system, sans-serif;
+  font-size: 13px;
+  line-height: 1.45;
+  -webkit-font-smoothing: antialiased;
+  overflow: hidden;
+}
+
+/* Header (top row). */
+.st-topbar {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  padding: 0 12px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border);
+  position: relative;
+  z-index: 30;
+}
+.st-brand {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  font-weight: 600;
+  letter-spacing: -0.01em;
+  padding-right: 14px;
+  border-right: 1px solid var(--border);
+  height: var(--topbar-h, 48px);
+}
+.st-ws-btn {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 10px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  background: var(--bg-2);
+  cursor: pointer;
+  font-weight: 600;
+}
+.st-ws-btn:hover { border-color: var(--accent-border); }
+.st-ws-menu {
+  position: absolute;
+  top: 38px;
+  left: 0;
+  width: 230px;
+  background: var(--bg-1);
+  border: 1px solid var(--border-strong);
+  border-radius: 9px;
+  box-shadow: var(--shadow);
+  padding: 5px;
+  z-index: 40;
+}
+.st-ws-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 6px 8px;
+  border-radius: 6px;
+  cursor: pointer;
+}
+.st-ws-menu-row:hover { background: var(--bg-hover); }
+.st-palette-trigger {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 5px 9px 5px 11px;
+  border: 1px solid var(--border);
+  border-radius: 7px;
+  color: var(--text-3);
+  background: var(--bg-2);
+  font-size: 12px;
+  cursor: pointer;
+  min-width: 190px;
+}
+.st-palette-trigger:hover { border-color: var(--border-strong); color: var(--text-2); }
+.st-palette-trigger kbd {
+  margin-left: auto;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  color: var(--text-2);
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 5px;
+}
+.st-hbtn {
+  width: 30px;
+  height: 30px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  background: var(--bg-2);
+  border-radius: 6px;
+  color: var(--text-2);
+  cursor: pointer;
+}
+.st-hbtn:hover { border-color: var(--border-strong); color: var(--text); }
+.st-avatar {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  display: grid;
+  place-items: center;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  color: var(--text-2);
+}
+
+/* Body: 3 columns. Widths are CSS custom props so the resize handles can
+   write --st-left-w / --st-right-w inline on the grid element. */
+.st-body {
+  display: grid;
+  grid-template-columns: var(--st-left-w, 248px) minmax(0, 1fr) var(--st-right-w, 332px);
+  min-height: 0;
+}
+.st-col {
+  min-height: 0;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.st-col-left { background: var(--bg-1); border-right: 1px solid var(--border); }
+.st-col-center { background: var(--bg); }
+.st-col-right { background: var(--bg-1); border-left: 1px solid var(--border); }
+
+/* Column resize handles (left/right). 5px hit area straddling the border. */
+.st-resize {
+  position: relative;
+  z-index: 5;
+  width: 5px;
+  margin: 0 -3px;
+  cursor: col-resize;
+  background: transparent;
+}
+.st-resize:hover, .st-resize.is-active { background: var(--accent-border); }
+
+/* Collapsible sidebar sections (VS Code style). */
+.st-section { display: flex; flex-direction: column; min-height: 0; }
+.st-section + .st-section { border-top: 1px solid var(--border); }
+.st-section-h {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  height: 32px;
+  padding: 0 8px 0 10px;
+  text-transform: uppercase;
+  font-size: 10.5px;
+  letter-spacing: 0.07em;
+  font-weight: 700;
+  color: var(--text-3);
+  cursor: pointer;
+  user-select: none;
+  flex: 0 0 auto;
+}
+.st-section-h:hover { color: var(--text); }
+.st-section-count {
+  margin-left: auto;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  color: var(--text-4);
+}
+.st-section-body { overflow: auto; flex: 1; min-height: 0; }
+
+/* Center tab bar. */
+.st-tabbar {
+  display: flex;
+  align-items: stretch;
+  height: 36px;
+  background: var(--bg-1);
+  border-bottom: 1px solid var(--border);
+  overflow-x: auto;
+  flex: 0 0 auto;
+}
+.st-tab {
+  position: relative;
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  max-width: 220px;
+  padding: 0 8px 0 12px;
+  border-right: 1px solid var(--border);
+  background: transparent;
+  color: var(--text-3);
+  cursor: pointer;
+  white-space: nowrap;
+  font-size: 12px;
+}
+.st-tab:hover { background: var(--bg-2); }
+.st-tab.is-active { background: var(--bg); color: var(--text); }
+.st-tab.is-active::before {
+  content: "";
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 2px;
+  background: var(--accent);
+}
+.st-tab-close {
+  width: 16px;
+  height: 16px;
+  display: grid;
+  place-items: center;
+  border-radius: 4px;
+  color: var(--text-4);
+}
+.st-tab-close:hover { background: var(--bg-active); color: var(--text); }
+
+/* Region placeholder (B2/B3/B4 fill these). */
+.st-placeholder {
+  flex: 1;
+  min-height: 0;
+  display: grid;
+  place-items: center;
+  text-align: center;
+  padding: 24px;
+  color: var(--text-4);
+  font-size: 12px;
+}
+.st-placeholder .st-ph-kind {
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--text-3);
+  text-transform: uppercase;
+}
+
 * { box-sizing: border-box; }
 
 html, body, #root { height: 100%; }


### PR DESCRIPTION
## Studio UI (PR-B of 3)

The **Studio** — an IDE-like, single-view workspace console that replaces the per-session interface (design: `docs/superpowers/specs/2026-07-01-studio-design.md`). Opening a workspace lands here: a header (workspace selector) over three columns + (later) a terminal. Builds on the merged backend (PR-A); the integrated terminal is PR-C.

### Layout
- **Left sidebar** — collapsible **Sessions** (live status dots, new-session) + lazy **Files tree** (show-hidden toggle).
- **Center** — multi-doc **tabs**; the active panel renders the selected session (agent → live conversation, graph → run-view canvas + node inspector) or a file (**Preview/Edit** with conflict-checked save).
- **Right sidebar** (workspace-wide) — **Action Required** (aggregated pending yields, inline approve/reject/respond, live-reconciled) over the live **Workspace Activity** feed.
- **Enrichments** — ⌘K command palette, ⌘P quick-open, persisted layout (localStorage per workspace), deep-linkable tabs (`?open=…` in the hash).

### Reuse (not rebuilt)
The graph run-view (`SD_GraphRunView` + AntV G6 canvas), the live transcript (`SessionLiveStream`), and the activity feed (`WorkspaceTap`) are re-housed from the existing console. All Action-Required actions hit the existing yield/approval endpoints; new-session reuses the existing create body.

### Routing
`/workspaces/:wid` now renders the Studio. `/sessions/:id` redirects into it with that session's tab open (deep-link); `/sessions` redirects to `/workspaces`. Library pages (graphs/agents/chats/knowledge) are untouched.

### Built in 6 reviewed sub-tasks (B1 shell+state+routing → B6 route-retirement + e2e), then a whole-branch review pass.
A final review (REQUEST CHANGES) caught a real deep-link bug (a redirect mounting an empty Studio) — fixed by synthesizing the tab from the URL — plus 3 Important + 4 Minor fixes (commit `2b2fcf29`).

### Tests
`tests/ui` **446 passed** (whole bundle transpiles, structural-presence per region + the deep-link synthesis). Gated `tests/ui_e2e/test_studio.py` (shell/sidebar/center/palette + the session-redirect deep-link) runs in CI. Full backend sweep green (unchanged).

### Tracked follow-ups (not in this PR)
- Extract the two reused views into a shared file and delete the now-dead `SessionDetail`/`SessionsList` page code (kept intact here so the Studio's reuse doesn't break).
- **PR-C:** the integrated terminal (runtime PTY + `WS /terminal` + xterm.js).
