### PR TITLE
fix(ui): Studio as an in-shell page (nav entry, app chrome, mobile)

### DIFF
--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -20,6 +20,7 @@ STUDIO = UI / "components" / "studio.jsx"
 INDEX = UI / "index.html"
 STYLES = UI / "styles.css"
 APP = UI / "app.jsx"
+CHROME = UI / "components" / "chrome.jsx"
 
 
 def _studio_src() -> str:
@@ -131,6 +132,68 @@ def test_app_renders_studio_for_workspace_detail() -> None:
     assert '"#/workspaces"' in src
     assert "open=session:" in src
     assert "workspace_id" in src
+
+
+def test_studio_renders_in_shell_not_as_takeover() -> None:
+    """The Studio is now ordinary page CONTENT inside the shared shell — it no
+    longer early-returns to bypass the app Topbar / Sidebar. It is assigned to
+    pageBody (which the shell wraps), not `return`ed."""
+    src = APP.read_text(encoding="utf-8")
+    # Wired as page content for the workspace-detail branch.
+    assert "pageBody = <Studio wid={currentWorkspaceId} pushToast={pushToast} />" in src
+    # The old full-screen takeover early-return must be gone.
+    assert "return <Studio wid={currentWorkspaceId} pushToast={pushToast} />;" not in src
+    # The shell flags the Studio page so CSS can reset the page chrome padding.
+    assert "studio-page" in src
+
+
+def test_nav_has_studio_and_no_sessions_item() -> None:
+    """FIX 1: the NAV exposes a top-level "Studio" entry next to Dashboard and
+    the old "Sessions" nav item is removed (Sessions live inside the Studio)."""
+    src = CHROME.read_text(encoding="utf-8")
+    # New Studio nav item present.
+    assert '{ id: "studio", label: "Studio"' in src
+    # The old Sessions nav item is gone (the dict literal — not substrings that
+    # appear in comments or the palette session-hit code).
+    assert '{ id: "sessions", label: "Sessions"' not in src
+
+
+def test_app_navigate_studio_uses_last_wid() -> None:
+    """navigate("studio") opens the last-opened workspace's Studio, persisted by
+    the Studio under localStorage["studio:lastWid"]."""
+    app = APP.read_text(encoding="utf-8")
+    assert 'target === "studio"' in app
+    assert 'studio:lastWid' in app
+    # The Studio writes the key on mount.
+    studio = _studio_src()
+    assert 'window.localStorage.setItem("studio:lastWid", wid)' in studio
+
+
+def test_studio_header_is_slim_no_brand() -> None:
+    """FIX 2: the slim sub-header dropped the 'Primer · Studio' brand/logo and
+    keeps just the workspace selector + ⌘K palette + terminal toggle."""
+    src = _studio_src()
+    # Brand / logo removed.
+    assert "st-brand" not in src
+    assert "function ST_Logo(" not in src
+    # Slim triggers retained.
+    assert 'data-testid="workspace-selector"' in src
+    assert 'data-testid="palette-trigger"' in src
+    assert 'data-testid="terminal-toggle"' in src
+
+
+def test_studio_mobile_panel_toggles_and_drawers() -> None:
+    """FIX 3: phone layout exposes left/right panel-drawer toggles in the
+    sub-header and the columns slide in as overlay sheets."""
+    src = _studio_src()
+    assert 'data-testid="studio-left-toggle"' in src
+    assert 'data-testid="studio-right-toggle"' in src
+    assert "is-drawer-open" in src
+    assert "st-panel-overlay" in src
+    css = STYLES.read_text(encoding="utf-8")
+    # Single column at the mobile breakpoint + off-canvas drawer transforms.
+    assert ".st-body { grid-template-columns: 1fr; }" in css
+    assert ".st-panel-overlay" in css
 
 
 def test_styles_has_studio_tokens_and_classes() -> None:

--- a/ui/app.jsx
+++ b/ui/app.jsx
@@ -308,7 +308,38 @@ function App() {
   };
   const removeToast = (id) => setToasts((arr) => arr.filter((x) => x.id !== id));
 
+  // Open the Studio for the last-opened workspace. The Studio persists
+  // localStorage["studio:lastWid"] whenever it mounts (see the effect in the
+  // workspace-detail render path); read it back here. Falls back to the first
+  // workspace from the already-polled topbar:workspaces resource, and finally
+  // to a one-shot GET /v1/workspaces if that cache is still cold. When nothing
+  // resolves we land on the workspaces list so the nav item never dead-ends.
+  const openStudio = () => {
+    let wid = null;
+    try { wid = window.localStorage.getItem("studio:lastWid") || null; } catch { wid = null; }
+    if (!wid) {
+      const items = realWorkspaces.data && realWorkspaces.data.items;
+      if (Array.isArray(items) && items.length) wid = items[0].id;
+    }
+    if (wid) {
+      window.location.hash = "#/workspaces/" + encodeURIComponent(wid);
+      return;
+    }
+    window.primerApi
+      .apiFetch("GET", "/workspaces?limit=1")
+      .then((r) => {
+        const first = r && Array.isArray(r.items) && r.items[0];
+        if (first && first.id) {
+          window.location.hash = "#/workspaces/" + encodeURIComponent(first.id);
+        } else {
+          window.location.hash = "#/workspaces";
+        }
+      })
+      .catch(() => { window.location.hash = "#/workspaces"; });
+  };
+
   const navigate = (target, extra) => {
+    if (target === "studio") { openStudio(); return; }
     // Designer's API: navigate(page, extra?). Map to URL paths.
     const ROUTES = {
       dashboard: "/",
@@ -796,11 +827,13 @@ function App() {
       />
     );
   } else if (page === "workspace-detail" && currentWorkspaceId) {
-    // /workspaces/:wid is the Studio (PR-B). Studio renders its own full
-    // header + 3-column shell, so we return it directly below — bypassing
-    // the standard page chrome (sidebar/topbar/page-header) the other
-    // pages share. See the early-return guard after the page switch.
-    return <Studio wid={currentWorkspaceId} pushToast={pushToast} />;
+    // /workspaces/:wid is the Studio (PR-B). It now renders as ordinary PAGE
+    // CONTENT inside the shared shell (app Topbar + Sidebar stay mounted) —
+    // no header takeover. The Studio supplies its own slim sub-header (the
+    // workspace selector + ⌘K palette + terminal toggle). pageHeader is left
+    // null so the standard .page-header bar collapses out of the way.
+    pageHeader = null;
+    pageBody = <Studio wid={currentWorkspaceId} pushToast={pushToast} />;
   } else if (page === "workspace-providers") {
     pageHeader = (
       <>
@@ -1042,12 +1075,12 @@ function App() {
   }
 
   return (
-    <div className={`app ${sidebarCollapsed ? "sidebar-collapsed" : ""}`}>
+    <div className={`app ${sidebarCollapsed ? "sidebar-collapsed" : ""} ${page === "workspace-detail" ? "studio-page" : ""}`}>
       <Topbar workerStats={workerStats} onNavigate={navigate} onOpenPalette={() => setPaletteOpen(true)} onOpenDrawer={() => setDrawerOpen(true)} />
       {(() => {
         const sidebarPage = (
-          page === "session-detail" ? "sessions"
-          : page === "workspace-detail" ? "workspaces"
+          page === "session-detail" ? "studio"
+          : page === "workspace-detail" ? "studio"
           : page === "workspace-provider-detail" ? "workspace-providers"
           : page === "workspace-template-detail" ? "workspace-templates"
           : page === "agent-detail" ? "agents"

--- a/ui/components/chrome.jsx
+++ b/ui/components/chrome.jsx
@@ -5,12 +5,12 @@ const NAV = [
     group: null,
     items: [
       { id: "dashboard", label: "Dashboard", icon: "home" },
+      { id: "studio", label: "Studio", icon: "panel-left" },
     ],
   },
   {
     group: "Compute",
     items: [
-      { id: "sessions", label: "Sessions", icon: "zap", countKey: "sessions" },
       { id: "agents", label: "Agents", icon: "agent" },
       { id: "graphs", label: "Graphs", icon: "graph" },
       { id: "chats", label: "Chats", icon: "send", countKey: "chats" },

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -368,26 +368,17 @@ function useStudioState(wid) {
 }
 
 // ---------------------------------------------------------------------------
-// Brand logo — faceted diamond from the prototype (renderVals.logo).
+// StudioHeader — SLIM in-shell content sub-header.
+//
+// The Studio renders as an ordinary page inside the app shell (the app Topbar
+// owns brand / global search / theme / user — see chrome.jsx Topbar), so this
+// row is intentionally minimal: workspace selector ▾ · ⌘K palette ·
+// terminal toggle. On phones it also carries the two panel-drawer toggles
+// (left = Sessions+Files, right = Action Required+Activity) since the columns
+// collapse to a single document there.
 // ---------------------------------------------------------------------------
 
-function ST_Logo() {
-  return (
-    <svg width={22} height={22} viewBox="0 0 24 24">
-      <polygon points="12,3 21,12 12,21 3,12" fill="var(--text)" fillOpacity={0.16} />
-      <polygon points="12,3 16.5,7.5 12,12 7.5,7.5" fill="var(--text)" />
-      <polygon points="16.5,7.5 21,12 16.5,16.5 12,12" fill="var(--text)" fillOpacity={0.4} />
-      <polygon points="12,12 16.5,16.5 12,21 7.5,16.5" fill="var(--accent)" />
-      <polygon points="7.5,7.5 12,12 7.5,16.5 3,12" fill="var(--text)" fillOpacity={0.4} />
-    </svg>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// StudioHeader — brand · workspace selector ▾ · ⌘K / ⌘P / density / theme
-// ---------------------------------------------------------------------------
-
-function StudioHeader({ wid, theme, density, onToggleTheme, onToggleDensity, onTogglePalette, onOpenQuick, onSelectWorkspace }) {
+function StudioHeader({ wid, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, onToggleLeftPanel, onToggleRightPanel }) {
   var { useResource, apiFetch } = window.primerApi;
   var [menuOpen, setMenuOpen] = React.useState(false);
 
@@ -422,10 +413,16 @@ function StudioHeader({ wid, theme, density, onToggleTheme, onToggleDensity, onT
 
   return (
     <div className="st-topbar" data-testid="studio-header">
-      <div className="st-brand">
-        <span style={{ width: 22, height: 22, display: "grid", placeItems: "center" }}><ST_Logo /></span>
-        Primer <span style={{ color: "var(--text-3)", fontWeight: 500, fontSize: 12 }}>Studio</span>
-      </div>
+      {/* Mobile-only panel-drawer toggle (left: Sessions + Files). */}
+      <button
+        className="st-hbtn mobile-only touch-target"
+        data-testid="studio-left-toggle"
+        title="Sessions & Files"
+        aria-label="Toggle sessions and files panel"
+        onClick={onToggleLeftPanel}
+      >
+        <Icon name="panel-left" size={15} />
+      </button>
 
       <div
         className="st-ws-btn"
@@ -457,18 +454,46 @@ function StudioHeader({ wid, theme, density, onToggleTheme, onToggleDensity, onT
 
       <div style={{ flex: 1 }} />
 
-      {/* ⌘K palette trigger — inert stub until B5 wires the palette. */}
+      {/* ⌘K command palette (run · jump · search within the workspace). The
+          wide trigger is hidden on phones (see .st-palette-trigger in the
+          mobile block); a compact search button replaces it there. */}
       <div className="st-palette-trigger" data-testid="palette-trigger" onClick={onTogglePalette}>
         <span style={{ opacity: 0.8 }}>Search · run · jump</span>
         <kbd>⌘K</kbd>
       </div>
-      {/* ⌘P quick-open — inert stub until B5. */}
-      <div className="st-hbtn" data-testid="quickopen-trigger" title="Quick open (⌘P)" onClick={onOpenQuick}>⌕</div>
-      <div className="st-hbtn" data-testid="density-toggle" title="Density" onClick={onToggleDensity}>☰</div>
-      <div className="st-hbtn" data-testid="theme-toggle" title="Theme" onClick={onToggleTheme}>
-        {theme === "dark" ? "◐" : "○"}
-      </div>
-      <div className="st-avatar" title="User">DK</div>
+      {/* Compact ⌘K affordance for phones (the wide trigger is desktop-only). */}
+      <button
+        className="st-hbtn mobile-only touch-target"
+        data-testid="palette-trigger-mobile"
+        title="Command palette (⌘K)"
+        aria-label="Open command palette"
+        onClick={onTogglePalette}
+      >
+        <Icon name="search" size={15} />
+      </button>
+
+      {/* Terminal toggle (Ctrl-`). */}
+      <button
+        className={"st-hbtn touch-target" + (terminalOpen ? " is-active" : "")}
+        data-testid="terminal-toggle"
+        title="Toggle terminal (Ctrl-`)"
+        aria-label="Toggle terminal"
+        aria-pressed={terminalOpen ? "true" : "false"}
+        onClick={onToggleTerminal}
+      >
+        <Icon name="code" size={15} />
+      </button>
+
+      {/* Mobile-only panel-drawer toggle (right: Action Required + Activity). */}
+      <button
+        className="st-hbtn mobile-only touch-target"
+        data-testid="studio-right-toggle"
+        title="Action required & activity"
+        aria-label="Toggle action-required and activity panel"
+        onClick={onToggleRightPanel}
+      >
+        <Icon name="bell" size={15} />
+      </button>
     </div>
   );
 }
@@ -501,6 +526,37 @@ function Studio({ wid, pushToast }) {
   // Falls back to the module-level primerApi.toastPush so non-nil calls always
   // work even when app.jsx hasn't passed the prop yet.
   studio.pushToast = pushToast || (window.primerApi && window.primerApi.toastPush) || null;
+
+  // Remember the last workspace whose Studio was opened so the global "Studio"
+  // nav item (chrome.jsx) can re-open it without a workspace picker. Written on
+  // every mount / wid change; read in app.jsx's openStudio().
+  React.useEffect(function () {
+    if (!wid) return;
+    try { window.localStorage.setItem("studio:lastWid", wid); } catch (_e) { /* storage disabled */ }
+  }, [wid]);
+
+  // Mobile-only panel drawers. On phones st-body collapses to the single
+  // center document (CSS); the left (Sessions+Files) and right (Action
+  // Required+Activity) columns become slide-over sheets toggled from the slim
+  // sub-header. Desktop ignores this state entirely (the columns are static).
+  var [leftPanelOpen, setLeftPanelOpen] = React.useState(false);
+  var [rightPanelOpen, setRightPanelOpen] = React.useState(false);
+  var closePanels = React.useCallback(function () { setLeftPanelOpen(false); setRightPanelOpen(false); }, []);
+
+  // Close the drawers when the workspace changes (route switch) and lock body
+  // scroll + wire Escape while either is open — mirrors chrome.jsx MobileNav.
+  React.useEffect(function () { closePanels(); }, [wid, closePanels]);
+  React.useEffect(function () {
+    if (!leftPanelOpen && !rightPanelOpen) return undefined;
+    function onKey(e) { if (e.key === "Escape") closePanels(); }
+    window.addEventListener("keydown", onKey);
+    var prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return function () {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [leftPanelOpen, rightPanelOpen, closePanels]);
 
   // Column resize: drag the handle, write width into state (persisted).
   // We clamp to sane bounds so a column can't be dragged off-screen.
@@ -569,32 +625,45 @@ function Studio({ wid, pushToast }) {
     >
       <StudioHeader
         wid={wid}
-        theme={s.theme}
-        density={s.density}
-        onToggleTheme={studio.toggleTheme}
-        onToggleDensity={studio.toggleDensity}
         onTogglePalette={studio.togglePalette}
-        onOpenQuick={function () { studio.openPalette("quickopen"); }}
         onSelectWorkspace={selectWorkspace}
+        terminalOpen={s.terminalOpen}
+        onToggleTerminal={studio.toggleTerminal}
+        onToggleLeftPanel={function () { setRightPanelOpen(false); setLeftPanelOpen(function (o) { return !o; }); }}
+        onToggleRightPanel={function () { setLeftPanelOpen(false); setRightPanelOpen(function (o) { return !o; }); }}
       />
 
       <div className="st-body">
-        {/* ---- LEFT: B2 StudioSidebar (sessions + files tree) ---- */}
-        <div className="st-col st-col-left" data-testid="studio-sidebar">
+        {/* Mobile backdrop: dims the center doc while a panel drawer is open.
+            Desktop never shows this (st-panel-overlay is mobile-only in CSS). */}
+        {(leftPanelOpen || rightPanelOpen) && (
+          <div className="st-panel-overlay mobile-only" data-testid="studio-panel-overlay" onClick={closePanels} />
+        )}
+
+        {/* ---- LEFT: B2 StudioSidebar (sessions + files tree) ---- On phones
+            this column is an off-canvas sheet toggled from the sub-header. ---- */}
+        <div
+          className={"st-col st-col-left" + (leftPanelOpen ? " is-drawer-open" : "")}
+          data-testid="studio-sidebar"
+        >
           <StudioSidebar wid={wid} studio={studio} />
         </div>
 
-        <div className="st-resize" onMouseDown={function (e) { startResize("left", e); }} data-testid="studio-resize-left" />
+        <div className="st-resize desktop-only" onMouseDown={function (e) { startResize("left", e); }} data-testid="studio-resize-left" />
 
         {/* ---- CENTER: B3 StudioCenter (tabs + active panel) ---- */}
         <div className="st-col st-col-center" data-testid="studio-center">
           <StudioCenter wid={wid} studio={studio} />
         </div>
 
-        <div className="st-resize" onMouseDown={function (e) { startResize("right", e); }} data-testid="studio-resize-right" />
+        <div className="st-resize desktop-only" onMouseDown={function (e) { startResize("right", e); }} data-testid="studio-resize-right" />
 
-        {/* ---- RIGHT: B4 StudioActivity (action required + workspace tap) ---- */}
-        <div className="st-col st-col-right" data-testid="studio-activity">
+        {/* ---- RIGHT: B4 StudioActivity (action required + workspace tap) ----
+            Off-canvas sheet on phones (right edge); static column on desktop. */}
+        <div
+          className={"st-col st-col-right" + (rightPanelOpen ? " is-drawer-open" : "")}
+          data-testid="studio-activity"
+        >
           <StudioActivity wid={wid} studio={studio} />
         </div>
       </div>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -101,11 +101,15 @@
 :root[data-density="comfortable"],
 [data-density="comfortable"] { --frow-h: 30px; }
 
-/* Studio root shell: header row + body. Owns its own data-theme/-density. */
+/* Studio root shell: slim sub-header row + body. Renders as IN-SHELL page
+   content (inside the app .main / .page-body), so it fills its container
+   rather than the whole viewport. The .studio-page chrome reset below strips
+   the empty page-header + page-body padding so this can size to 100%. Owns its
+   own data-theme/-density. */
 .st-root {
   display: grid;
-  grid-template-rows: var(--topbar-h, 48px) 1fr;
-  height: 100dvh;
+  grid-template-rows: var(--st-subhead-h, 44px) 1fr;
+  height: 100%;
   width: 100%;
   background: var(--bg);
   color: var(--text);
@@ -116,26 +120,23 @@
   overflow: hidden;
 }
 
-/* Header (top row). */
+/* In-shell chrome reset: when the Studio is the active page, collapse the
+   shared empty page-header and drop the page-body padding so the Studio fills
+   the scroll area edge-to-edge under the app Topbar. */
+.app.studio-page .main { overflow: hidden; }
+.app.studio-page .page-header { display: none; }
+.app.studio-page .page-body { padding: 0; height: 100%; min-height: 0; }
+
+/* Slim content sub-header (top row). */
 .st-topbar {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 10px;
   padding: 0 12px;
   background: var(--bg-1);
   border-bottom: 1px solid var(--border);
   position: relative;
   z-index: 30;
-}
-.st-brand {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  padding-right: 14px;
-  border-right: 1px solid var(--border);
-  height: var(--topbar-h, 48px);
 }
 .st-ws-btn {
   position: relative;
@@ -1720,6 +1721,43 @@ input, textarea, select { font: inherit; color: inherit; }
   /* Hide existing sidebar in favor of slide-over drawer. */
   .app { grid-template-columns: 1fr; }
   .sidebar { display: none; }
+
+  /* ---- Studio: collapse the 3-column body to the single center document.
+     The left (Sessions+Files) and right (Action Required+Activity) columns
+     become slide-over sheets toggled from the slim sub-header. ---- */
+  /* The wide ⌘K trigger gives way to the compact mobile search button. */
+  .st-palette-trigger { display: none; }
+  /* Re-assert grid centering on the mobile-only sub-header buttons — the
+     generic `.mobile-only { display: revert }` above would otherwise drop
+     `.st-hbtn`'s `display: grid` back to the UA inline-block default. */
+  .st-topbar .st-hbtn.mobile-only { display: grid; }
+  .st-body { grid-template-columns: 1fr; }
+  .st-col-left,
+  .st-col-right {
+    position: fixed;
+    top: 0; bottom: 0;
+    width: 85vw; max-width: 340px;
+    z-index: 51;
+    box-shadow: var(--shadow);
+    transition: transform 0.18s ease;
+  }
+  .st-col-left {
+    left: 0;
+    border-right: 1px solid var(--border);
+    transform: translateX(-100%);
+  }
+  .st-col-right {
+    right: 0;
+    border-left: 1px solid var(--border);
+    transform: translateX(100%);
+  }
+  .st-col-left.is-drawer-open,
+  .st-col-right.is-drawer-open { transform: translateX(0); }
+  .st-panel-overlay {
+    position: fixed; inset: 0;
+    background: oklch(0 0 0 / 0.5);
+    z-index: 50;
+  }
 
   /* Topbar: hamburger left, brand + theme toggle right. */
   .topbar-brand { padding-left: 8px; }


### PR DESCRIPTION
## Studio: in-shell page, not a full-screen takeover

Fixes three issues reported on the merged Studio (it had shipped as a full-screen takeover with its own header):

1. **Nav** — the left nav's "Sessions" entry is replaced with a **"Studio"** entry next to Dashboard (`panel-left` icon). "Studio" opens the last-opened workspace's Studio (`localStorage["studio:lastWid"]` → first workspace → workspaces list). `/sessions` + `/sessions/:id` still redirect into the Studio; the Studio now highlights the **Studio** nav item.
2. **No header takeover** — the Studio renders as a normal page **inside the app shell**: the standard Topbar + nav Sidebar stay mounted (no `◆ Primer · Studio` brand, no duplicated search/density/theme affordances). The workspace selector + ⌘K + terminal-toggle live in a slim **sub-header** within the Studio content.
3. **Mobile** — at the existing `≤639px` breakpoint the 3 columns collapse to a single center column; the Sessions/Files and Action-Required/Activity panels become **slide-over drawers** (reusing the app's drawer/`.sheet` style) toggled from the sub-header. Desktop keeps the 3-column layout.

### Tests
`tests/ui` **451 passed** (+5 structural: in-shell render, NAV has `studio` not `sessions`, `studio:lastWid` resolution, slim header, mobile drawers). Whole bundle transpiles. UI-only; backend untouched.

### Worth a look (not blocking)
On a **mid-width desktop** the app nav Sidebar (248px) + the Studio's own left column (248px) is ~500px of chrome before the document (the app Sidebar auto-shrinks to 56px below 900px). If you'd prefer, I can auto-collapse the app Sidebar to its icon rail while in the Studio (VS Code-style). Since these are visual changes, a quick look on a deploy is recommended.
