### PR TITLE
fix(ui): Studio e2e remediation — session opening, desktop grid, settings restore, 41-test re-point

### DIFF
--- a/tests/ui/test_studio_settings.py
+++ b/tests/ui/test_studio_settings.py
@@ -1,0 +1,139 @@
+"""Structural-presence checks for the Studio → Workspace Settings overlay.
+
+The Studio (studio.jsx) replaced the old WorkspaceDetail page and only
+carried over its files / sessions / activity tabs. The remaining tabs —
+channels (reply-binding), config, git-log, and destroy — were orphaned.
+studio-settings.jsx restores them behind a gear button in the slim sub-header
+by RE-USING the exact WorkspaceDetail panel components (WS_ChannelsTab /
+WS_ConfigTab / WS_LogTab / WS_DestroyTab), which workspaces.jsx now exports on
+window.*.
+
+Like the rest of tests/ui these are static-source + bundle-build checks; they
+do not render React.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+STUDIO = UI / "components" / "studio.jsx"
+SETTINGS = UI / "components" / "studio-settings.jsx"
+WORKSPACES = UI / "components" / "workspaces.jsx"
+INDEX = UI / "index.html"
+
+
+def _settings_src() -> str:
+    return SETTINGS.read_text(encoding="utf-8")
+
+
+def _studio_src() -> str:
+    return STUDIO.read_text(encoding="utf-8")
+
+
+def _workspaces_src() -> str:
+    return WORKSPACES.read_text(encoding="utf-8")
+
+
+def _index_order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            start = line.index('src="') + len('src="')
+            end = line.index('"', start)
+            out.append(line[start:end])
+    return out
+
+
+def test_settings_button_in_slim_header() -> None:
+    src = _studio_src()
+    # A gear button lives in the sub-header next to the workspace selector.
+    assert 'data-testid="studio-settings-btn"' in src
+    assert 'name="settings"' in src
+    # It toggles the overlay open.
+    assert "setSettingsOpen(true)" in src
+
+
+def test_studio_renders_workspace_settings_overlay() -> None:
+    src = _studio_src()
+    # The overlay is rendered from the header via the window.* export (load-order
+    # independent) and is wired the workspace id + pushToast.
+    assert "window.WorkspaceSettings" in src
+    assert "wid={wid}" in src
+    assert "pushToast={pushToast}" in src
+
+
+def test_settings_surface_and_sections_present() -> None:
+    src = _settings_src()
+    # Stable testid for the surface + the four restored sections.
+    assert 'data-testid="workspace-settings"' in src
+    for sec in ("channels", "config", "log", "destroy"):
+        assert '{ id: "' + sec + '"' in src, sec
+
+
+def test_settings_reuses_workspace_detail_panels() -> None:
+    src = _settings_src()
+    # The four orphaned features are the SAME WorkspaceDetail panels, not
+    # reimplementations — resolved from window.* at render time.
+    assert "window.WS_ChannelsTab" in src
+    assert "window.WS_ConfigTab" in src
+    assert "window.WS_LogTab" in src
+    assert "window.WS_DestroyTab" in src
+    # The reused components are actually rendered (JSX element tags).
+    assert "<ChannelsTab" in src
+    assert "<ConfigTab" in src
+    assert "<LogTab" in src
+    assert "<DestroyTab" in src
+    # Panels get the resources they expect, keyed like WorkspaceDetail so the
+    # useResource cache is shared.
+    assert '"workspace-detail:" + wid' in src
+    assert '"workspace-sessions:" + wid' in src
+    assert "sessionsForBadge={sessionsForBadge}" in src
+
+
+def test_workspaces_exports_reused_panels() -> None:
+    src = _workspaces_src()
+    # workspaces.jsx must surface the panels on window.* AND keep WorkspaceDetail
+    # (its original renderer) intact.
+    assert "window.WS_ChannelsTab = WS_ChannelsTab;" in src
+    assert "window.WS_ConfigTab = WS_ConfigTab;" in src
+    assert "window.WS_LogTab = WS_LogTab;" in src
+    assert "window.WS_DestroyTab = WS_DestroyTab;" in src
+    assert "window.WorkspaceDetail = WorkspaceDetail;" in src
+
+
+def test_reused_panels_preserve_labels() -> None:
+    """The e2e locators depend on the panels' visible labels/roles; reusing the
+    components preserves them. Assert the load-bearing strings still live in the
+    (untouched) panel source in workspaces.jsx."""
+    src = _workspaces_src()
+    # Destroy: the primary button label + the panel component.
+    assert "Destroy workspace" in src
+    assert "function WS_DestroyTab(" in src
+    # Channels / reply binding.
+    assert "function WS_ChannelsTab(" in src
+    assert ">Reply binding<" in src
+    # Config + log panels.
+    assert "function WS_ConfigTab(" in src
+    assert "function WS_LogTab(" in src
+
+
+def test_settings_registered_in_index_after_workspaces() -> None:
+    order = _index_order()
+    assert "components/studio-settings.jsx" in order
+    # Loaded after workspaces.jsx (which defines the panels it re-exports) and
+    # before app.jsx.
+    assert order.index("components/workspaces.jsx") < order.index("components/studio-settings.jsx")
+    assert order.index("components/studio-settings.jsx") < order.index("app.jsx")
+
+
+def test_bundle_transpiles_with_settings() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio-settings.jsx === */" in text
+    assert "/* === components/workspaces.jsx === */" in text
+    assert "/* === components/studio.jsx === */" in text

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -20,6 +20,7 @@ STUDIO = UI / "components" / "studio.jsx"
 INDEX = UI / "index.html"
 STYLES = UI / "styles.css"
 APP = UI / "app.jsx"
+CHROME = UI / "components" / "chrome.jsx"
 
 
 def _studio_src() -> str:
@@ -131,6 +132,68 @@ def test_app_renders_studio_for_workspace_detail() -> None:
     assert '"#/workspaces"' in src
     assert "open=session:" in src
     assert "workspace_id" in src
+
+
+def test_studio_renders_in_shell_not_as_takeover() -> None:
+    """The Studio is now ordinary page CONTENT inside the shared shell — it no
+    longer early-returns to bypass the app Topbar / Sidebar. It is assigned to
+    pageBody (which the shell wraps), not `return`ed."""
+    src = APP.read_text(encoding="utf-8")
+    # Wired as page content for the workspace-detail branch.
+    assert "pageBody = <Studio wid={currentWorkspaceId} pushToast={pushToast} />" in src
+    # The old full-screen takeover early-return must be gone.
+    assert "return <Studio wid={currentWorkspaceId} pushToast={pushToast} />;" not in src
+    # The shell flags the Studio page so CSS can reset the page chrome padding.
+    assert "studio-page" in src
+
+
+def test_nav_has_studio_and_no_sessions_item() -> None:
+    """FIX 1: the NAV exposes a top-level "Studio" entry next to Dashboard and
+    the old "Sessions" nav item is removed (Sessions live inside the Studio)."""
+    src = CHROME.read_text(encoding="utf-8")
+    # New Studio nav item present.
+    assert '{ id: "studio", label: "Studio"' in src
+    # The old Sessions nav item is gone (the dict literal — not substrings that
+    # appear in comments or the palette session-hit code).
+    assert '{ id: "sessions", label: "Sessions"' not in src
+
+
+def test_app_navigate_studio_uses_last_wid() -> None:
+    """navigate("studio") opens the last-opened workspace's Studio, persisted by
+    the Studio under localStorage["studio:lastWid"]."""
+    app = APP.read_text(encoding="utf-8")
+    assert 'target === "studio"' in app
+    assert 'studio:lastWid' in app
+    # The Studio writes the key on mount.
+    studio = _studio_src()
+    assert 'window.localStorage.setItem("studio:lastWid", wid)' in studio
+
+
+def test_studio_header_is_slim_no_brand() -> None:
+    """FIX 2: the slim sub-header dropped the 'Primer · Studio' brand/logo and
+    keeps just the workspace selector + ⌘K palette + terminal toggle."""
+    src = _studio_src()
+    # Brand / logo removed.
+    assert "st-brand" not in src
+    assert "function ST_Logo(" not in src
+    # Slim triggers retained.
+    assert 'data-testid="workspace-selector"' in src
+    assert 'data-testid="palette-trigger"' in src
+    assert 'data-testid="terminal-toggle"' in src
+
+
+def test_studio_mobile_panel_toggles_and_drawers() -> None:
+    """FIX 3: phone layout exposes left/right panel-drawer toggles in the
+    sub-header and the columns slide in as overlay sheets."""
+    src = _studio_src()
+    assert 'data-testid="studio-left-toggle"' in src
+    assert 'data-testid="studio-right-toggle"' in src
+    assert "is-drawer-open" in src
+    assert "st-panel-overlay" in src
+    css = STYLES.read_text(encoding="utf-8")
+    # Single column at the mobile breakpoint + off-canvas drawer transforms.
+    assert ".st-body { grid-template-columns: 1fr; }" in css
+    assert ".st-panel-overlay" in css
 
 
 def test_styles_has_studio_tokens_and_classes() -> None:

--- a/tests/ui_e2e/_studio_helpers.py
+++ b/tests/ui_e2e/_studio_helpers.py
@@ -34,12 +34,37 @@ from playwright.sync_api import Page, expect
 # so this pre-existing app-shell 404 is now visible to any Studio test's
 # console-error assertion. It is NOT a Studio bug — allowlist it wherever a
 # Studio test asserts a clean console.
+#
+# NB: ``assert_no_console_errors`` matches each pattern against the console
+# message TEXT (``m["text"]``), not its ``location.url``. Chromium's 404
+# console line is the URL-less
+#   "Failed to load resource: the server responded with a status of 404 ..."
+# so the ``internal_collections/config`` URL patterns below would never match
+# on their own — the "status of 404" text pattern is the one that actually
+# suppresses this app-shell 404. (The URL patterns are kept for callers that
+# inspect ``failed_requests[*].url`` instead.)
 STUDIO_CONSOLE_IGNORES = [
     r"net::ERR_ABORTED",
     r"favicon",
     r"/v1/internal_collections/config",
     r"internal_collections/config",
+    r"Failed to load resource:.*status of 404",
 ]
+
+
+def session_row(page: Page, sid: str):
+    """Locate the Studio sidebar ``session-row`` for a specific session id.
+
+    The row renders the session TITLE (agent/binding name or a truncated
+    id), NOT the raw ``sess-<id>``, so filtering by ``has_text`` is
+    unreliable. studio-sidebar.jsx stamps ``data-session-id`` on each row so
+    e2e can locate a session deterministically while the visible title stays
+    unchanged. The sidebar is per-workspace, so navigate to the session's
+    OWN workspace Studio (``#/workspaces/<wid>``) before using this.
+    """
+    return page.locator(
+        f'[data-testid="session-row"][data-session-id="{sid}"]'
+    )
 
 
 def studio_url(console_url: str, wid: str) -> str:

--- a/tests/ui_e2e/_studio_helpers.py
+++ b/tests/ui_e2e/_studio_helpers.py
@@ -1,0 +1,163 @@
+"""Shared Playwright helpers for driving the workspace Studio.
+
+The Studio (``ui/components/studio.jsx`` + ``studio-{sidebar,center,
+activity,settings,palette}.jsx``) replaced the three retired UIs:
+
+* the global ``#/sessions`` LIST page,
+* the ``#/sessions/:id`` session-detail page (now a redirect),
+* the ``#/workspaces/:id/:tab`` workspace-detail tabs (channels / config /
+  git-log / destroy → a Studio **Settings** modal).
+
+A session now opens as a center *tab* inside the workspace's Studio; the
+management tabs live behind the sub-header gear. These helpers DRY the
+navigation the re-pointed e2e tests share so each test can focus on its
+own assertion rather than re-deriving the deep-link / modal dance.
+
+Selectors (data-testids) mirror the Studio components exactly:
+
+  studio-root / studio-sidebar / studio-center / studio-activity
+  session-row · center-tab · panel-agent · panel-graph · panel-file
+  studio-settings-btn · workspace-settings · workspace-settings-nav:<id>
+  action-required / action-required-list / action-item
+
+Nothing here starts a server — that is the harness's job (see the module
+docstring in ``conftest.py``).
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+# The app-shell (chrome.jsx Topbar) fetches GET /v1/internal_collections/config
+# on every page, and that endpoint 404s whenever the Internal Collections
+# feature is inactive (the common e2e default). The Studio renders IN-SHELL,
+# so this pre-existing app-shell 404 is now visible to any Studio test's
+# console-error assertion. It is NOT a Studio bug — allowlist it wherever a
+# Studio test asserts a clean console.
+STUDIO_CONSOLE_IGNORES = [
+    r"net::ERR_ABORTED",
+    r"favicon",
+    r"/v1/internal_collections/config",
+    r"internal_collections/config",
+]
+
+
+def studio_url(console_url: str, wid: str) -> str:
+    """The Studio route for a workspace (``#/workspaces/<wid>``)."""
+    return f"{console_url}#/workspaces/{wid}"
+
+
+def open_studio(page: Page, console_url: str, wid: str, *, timeout: int = 20_000) -> None:
+    """Navigate to a workspace's Studio and wait for the shell to mount.
+
+    Confirms all three region wrappers render so callers can immediately
+    reach the sidebar / center / activity columns.
+    """
+    page.goto(studio_url(console_url, wid), wait_until="domcontentloaded")
+    expect(page.locator('[data-testid="studio-root"]')).to_be_visible(timeout=timeout)
+    for region in ("studio-sidebar", "studio-center", "studio-activity"):
+        expect(page.locator(f'[data-testid="{region}"]')).to_be_visible(timeout=10_000)
+
+
+def open_session_in_studio(
+    page: Page,
+    console_url: str,
+    wid: str,
+    sid: str,
+    *,
+    kind: str = "agent",
+    timeout: int = 20_000,
+) -> None:
+    """Deep-link a session open inside its workspace's Studio.
+
+    Uses the ``?open=session:<sid>`` deep-link (studio.jsx ST_tabFromUrl →
+    ST_applyUrlTab auto-opens + activates the tab on mount), then waits for
+    the center tab plus the resolved panel:
+
+    * ``kind="agent"`` → ``panel-agent`` (reused ``SessionLiveStream``)
+    * ``kind="graph"`` → ``panel-graph`` (reused ``SD_GraphRunView``)
+
+    The panel resolver (ST_SessionPanel) fetches GET /v1/sessions/<sid> and
+    branches on ``binding.kind``; a graph session always lands on
+    ``panel-graph`` regardless of the hint, but the hint lets a caller wait
+    on the right panel deterministically.
+    """
+    page.goto(
+        f"{console_url}#/workspaces/{wid}?open=session:{sid}",
+        wait_until="domcontentloaded",
+    )
+    expect(page.locator('[data-testid="studio-root"]')).to_be_visible(timeout=timeout)
+    expect(page.locator('[data-testid="center-tab"]').first).to_be_visible(timeout=timeout)
+    panel = "panel-graph" if kind == "graph" else "panel-agent"
+    expect(page.locator(f'[data-testid="{panel}"]')).to_be_visible(timeout=timeout)
+
+
+def open_session_via_sidebar(
+    page: Page,
+    console_url: str,
+    wid: str,
+    *,
+    kind: str = "agent",
+    timeout: int = 20_000,
+):
+    """Open a session by CLICKING the first sidebar ``session-row``.
+
+    Returns the clicked row locator. Use this (rather than the deep-link)
+    when the test's intent is the sidebar-list → center-tab interaction
+    itself. Waits for the resolved panel to render.
+    """
+    open_studio(page, console_url, wid, timeout=timeout)
+    row = page.locator('[data-testid="session-row"]').first
+    expect(row).to_be_visible(timeout=timeout)
+    row.click()
+    expect(page.locator('[data-testid="center-tab"]').first).to_be_visible(timeout=timeout)
+    panel = "panel-graph" if kind == "graph" else "panel-agent"
+    expect(page.locator(f'[data-testid="{panel}"]')).to_be_visible(timeout=timeout)
+    return row
+
+
+def open_workspace_settings(
+    page: Page,
+    console_url: str,
+    wid: str,
+    section: str,
+    *,
+    timeout: int = 20_000,
+):
+    """Enter a workspace's Studio, open the Settings modal, select a section.
+
+    ``section`` is one of ``channels`` / ``config`` / ``log`` / ``destroy``
+    (the left-rail nav ids in studio-settings.jsx). The modal re-uses the
+    exact WorkspaceDetail panels (WS_ChannelsTab / WS_ConfigTab / WS_LogTab /
+    WS_DestroyTab), so a caller keeps its existing label/role assertions on
+    the returned panel scope.
+
+    Returns the ``workspace-settings`` modal locator so callers can scope
+    subsequent queries inside it (avoiding strict-mode clashes with the
+    nested Link-channel / Destroy-confirm modals rendered on top).
+    """
+    open_studio(page, console_url, wid, timeout=timeout)
+    gear = page.locator('[data-testid="studio-settings-btn"]')
+    expect(gear).to_be_visible(timeout=timeout)
+    gear.click()
+    modal = page.locator('[data-testid="workspace-settings"]')
+    expect(modal).to_be_visible(timeout=timeout)
+    nav = page.locator(f'[data-testid="workspace-settings-nav:{section}"]')
+    expect(nav).to_be_visible(timeout=timeout)
+    nav.click()
+    return modal
+
+
+def action_item_for_session(page: Page, sid: str):
+    """Locate the right-sidebar ``action-item`` for a session id.
+
+    ask_user / approvals / watch / sleep parks surface in the RIGHT sidebar
+    ``action-required`` list (StudioActivity → ActionRequired), one
+    ``action-item`` per pending yield. The item carries a
+    ``action-session-link`` button whose text is the (shortened) session id;
+    filtering the list on that keeps the match scoped to THIS session even
+    when the shared DB left other parks around.
+    """
+    return page.locator('[data-testid="action-item"]').filter(
+        has=page.locator('[data-testid="action-session-link"]')
+    )

--- a/tests/ui_e2e/test_anomaly_surfaces.py
+++ b/tests/ui_e2e/test_anomaly_surfaces.py
@@ -17,6 +17,8 @@ import time
 
 import httpx
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio
+
 
 from tests._support.smk import smk  # noqa: E402
 pytestmark = smk("SMK-UI-02", "SMK-UI-05", status="partial")
@@ -196,7 +198,7 @@ def test_u0013_session_detail_renders_t0399_stale_cache_notice(
     unique_suffix: str,
     tmp_path,
 ) -> None:
-    """U0013 - Opening a session detail page renders cleanly and does
+    """U0013 - Opening a session in the Studio renders cleanly and does
     NOT surface the obsolete dev-only "Reads are authoritative" stale-
     cache banner (T0399 / T0555 / T0611).
 
@@ -204,9 +206,12 @@ def test_u0013_session_detail_renders_t0399_stale_cache_notice(
     ("drop stale spec annotations") because it referenced internal
     ticket ids end users have no context for; the removal is also
     pinned by tests/ui/test_stale_spec_annotations_removed.py. This
-    e2e asserts the live rendered page matches that decision: the
-    detail page loads (title carries the session id, the References
-    panel renders) and none of the removed banner copy appears.
+    e2e asserts the live rendered surface matches that decision: the
+    session opens in the Studio (center agent panel mounts) and none of
+    the removed banner copy appears.
+
+    Re-pointed: the session-detail page is retired; the session opens as
+    a Studio center tab (``panel-agent``) via the deep-link helper.
 
     Setup ladder mirrors test_t0042 (test_sessions_top_level.py:42-):
     LLM provider → agent → workspace provider → workspace template →
@@ -274,20 +279,10 @@ def test_u0013_session_detail_renders_t0399_stale_cache_notice(
         session_id = r.json()["id"]
 
     try:
-        page.goto(
-            f"{console_url}#/sessions/{session_id}",
-            wait_until="domcontentloaded",
-        )
-        # The detail page renders the session id in its title.
-        page.locator("h1.page-title").get_by_text(session_id).first.wait_for(
-            state="visible", timeout=10_000,
-        )
-
-        # The References panel is part of the detail page proper - wait
-        # for it so we know the page body (not just the title) rendered
-        # before asserting the banner's absence.
-        page.get_by_text("References", exact=False).first.wait_for(
-            state="visible", timeout=10_000,
+        # Open the session in the Studio — the center agent panel mounts,
+        # confirming the session body rendered before asserting absences.
+        open_session_in_studio(
+            page, console_url, workspace_id, session_id, kind="agent",
         )
 
         # The removed dev-only banner must NOT appear. Its title copy and
@@ -297,8 +292,8 @@ def test_u0013_session_detail_renders_t0399_stale_cache_notice(
         )
         for ticket in ("T0399", "T0555", "T0611"):
             assert page.get_by_text(ticket, exact=False).count() == 0, (
-                f"removed dev-only ticket reference {ticket} is back on the "
-                "session detail page"
+                f"removed dev-only ticket reference {ticket} is back in the "
+                "Studio session panel"
             )
     finally:
         with httpx.Client(base_url=base_url, timeout=30.0) as c:

--- a/tests/ui_e2e/test_approvals_journey.py
+++ b/tests/ui_e2e/test_approvals_journey.py
@@ -55,6 +55,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio
+
 
 # ---------------------------------------------------------------------------
 # Container-internal workspace provider path — mirror the U0103 pattern
@@ -403,37 +405,38 @@ def test_u0109_approvals_operator_journey(
             gate_reason=gate_reason,
         )
 
-        # --- 6. Cross-page: navigate to the fresh session's detail -----
-        page.goto(
-            f"{console_url}#/sessions/{sid_banner}",
-            wait_until="domcontentloaded",
-        )
+        # --- 6. Cross-surface: open the fresh session in the Studio ----
+        # Re-pointed: the session-detail ApprovalBanner is retired. In the
+        # Studio, a pending approval surfaces in the RIGHT sidebar Action
+        # Required list (studio-activity.jsx ``ActionRequired``) as an
+        # ``action-item`` of kind "approval" with ``approve`` / ``reject``
+        # controls. sid_banner is freshly parked and never responded-to, so
+        # its park is stable (parked_status='parked' is excluded by the
+        # claim-eligibility filter → the worker never resumes it and clears
+        # parked_state), making the item deterministic.
+        open_session_in_studio(page, console_url, ids["workspace"], sid_banner, kind="agent")
 
-        # Session-detail's ApprovalBannerPanel polls /tool_approval/pending
-        # and renders <ApprovalBanner> on 200 → data-testid='approval-banner'.
-        # sid_banner is freshly parked and never responded-to, so its park is
-        # stable (parked_status='parked' is excluded by the claim-eligibility
-        # filter → the worker never resumes it and clears parked_state). The
-        # banner is therefore deterministic; the 30s timeout only absorbs
-        # mount + fetch latency under CI load.
-        banner = page.locator("[data-testid='approval-banner']")
-        expect(banner).to_be_visible(timeout=30_000)
-        # Banner header includes the tool name from the same payload.
-        expect(banner).to_contain_text(inner_tool)
+        # The Action Required list surfaces the pending approval item.
+        approval_item = page.locator("[data-testid='action-item']").filter(
+            has=page.locator("[data-testid='action-approval-controls']")
+        ).first
+        expect(approval_item).to_be_visible(timeout=30_000)
 
-        # --- 7. Approve from the banner → second toast ----------------
-        approve_btn = page.locator(
-            "[data-testid='approval-banner-approve']",
-        )
+        # --- 7. Approve from the Action Required item -----------------
+        # The Studio approve handler POSTs /tool_approval/respond and
+        # optimistically REMOVES the item on success (studio-activity.jsx
+        # ``hide()`` — no toast). Pin the item clearing as the success signal.
+        approve_btn = approval_item.locator("[data-testid='approve']")
         expect(approve_btn).to_be_enabled(timeout=5_000)
         approve_btn.click()
-
-        # Second "Decision sent" toast (kind=success) confirms the
-        # banner-side mutation also reached the bus.
-        # Use locator.last because the page may briefly have both the
-        # rejection toast (lingering) AND the new approval toast.
-        approve_toast = page.locator(".toast", has_text="Decision sent")
-        expect(approve_toast.last).to_be_visible(timeout=10_000)
+        # The approved item is optimistically removed — no approval-controls
+        # item remains (the step-1 session was rejected earlier, so this is
+        # the only pending approval in the workspace).
+        expect(
+            page.locator("[data-testid='action-item']").filter(
+                has=page.locator("[data-testid='action-approval-controls']")
+            )
+        ).to_have_count(0, timeout=10_000)
     finally:
         # Cancel the extra banner session before tearing the ladder down so
         # it doesn't linger parked in the shared DB.

--- a/tests/ui_e2e/test_ask_user_panel.py
+++ b/tests/ui_e2e/test_ask_user_panel.py
@@ -1,23 +1,28 @@
-"""UI tests for the AskUserPanel (M3 of the yielding-tools feature).
+"""UI tests for ask_user parks — re-pointed to the Studio's Action Required.
 
-Strategy: rather than drive a real agent through an LLM until it yields
-on ``ask_user`` (which would require LM Studio + a real-LLM bringup
-mode), we use Playwright's ``page.route`` to intercept the
-``GET /v1/sessions/{sid}/ask_user/pending`` request and serve a
-controlled response. The session row itself is seeded via the REST API
-so the rest of the session-detail page (status pill, worker info,
-turns list, etc.) renders against real data.
+The Studio (PR-B) retired the session-detail ``AskUserPanel``. ask_user
+parks now surface in the Studio's RIGHT sidebar ``action-required`` list
+(``studio-activity.jsx`` → ``ActionRequired``): one ``action-item`` per
+pending yield, driven by ``GET /v1/workspaces/{wid}/yields/pending``. An
+``ask_user`` item renders a ``respond`` text input inside
+``action-ask-controls`` (Enter-to-send → POST
+``/sessions/{sid}/ask_user/respond``).
 
-This lets us pin the PANEL'S behaviour - render shape, submit flow,
-skip flow, inline-422 validation - without the heavy infrastructure
-needed for a real-LLM-driven park. A future iteration will add a real
-end-to-end test once LM Studio is wired into the UI bringup.
+Strategy (unchanged in spirit): rather than drive a real agent through an
+LLM until it yields, we ``page.route`` the workspace-scoped
+``/yields/pending`` snapshot and the per-session ``/ask_user/respond``
+mutation, then drive the Studio's Action Required controls. The session +
+workspace rows are seeded via the REST API so the shell renders honestly.
 
-Covered backlog items:
-* U0048 - AskUserPanel renders on session detail when pending returns 200.
-* U0049 - Submit posts response → panel collapses → toast.
-* U0050 - Skip posts cancel-yielded-tool → panel collapses → toast.
-* U0051 - JSON-schema violation renders inline error (not generic toast).
+Covered backlog items (re-pointed to the Studio):
+* U0048 - ask_user park renders an action-item + respond control.
+* U0049 - Submitting a response POSTs /respond and the item clears.
+* U0051 - A server error on /respond renders inline (rs.error), not a toast.
+
+U0050 (the old "Skip this prompt" → cancel-yielded-tool flow) has NO Studio
+equivalent: the Action Required list only exposes a Cancel control for
+watch/sleep yields (``cancel-yield``), never for ask_user, so there is no
+skip affordance to pin. It is REMOVED — see the note where U0050 stood.
 """
 
 from __future__ import annotations
@@ -26,6 +31,8 @@ import json
 
 import httpx
 from playwright.sync_api import expect
+
+from tests.ui_e2e._studio_helpers import open_studio
 
 
 # ---------------------------------------------------------------------------
@@ -104,7 +111,7 @@ def _cleanup(base_url: str, urls: list[str]) -> None:
 
 
 def _seed_ladder(base_url: str, unique_suffix: str, tmp_path):
-    """Seed the four prerequisite rows + return ids + a cleanup URL list."""
+    """Seed the four prerequisite rows + return (wid, sid, cleanup_urls)."""
     pid = f"llm-u-{unique_suffix}"
     aid = f"ag-u-{unique_suffix}"
     wp_id = f"wp-u-{unique_suffix}"
@@ -121,279 +128,160 @@ def _seed_ladder(base_url: str, unique_suffix: str, tmp_path):
         f"/v1/agents/{aid}",
         f"/v1/llm_providers/{pid}",
     ]
-    return sid, cleanup_urls
+    return wid, sid, cleanup_urls
 
 
 # ---------------------------------------------------------------------------
-# Route-mock helpers
+# Route-mock helpers — the Studio's Action Required snapshot + respond
 # ---------------------------------------------------------------------------
 
 
-def _route_pending_yes(
-    page,
-    sid: str,
-    *,
-    tool_call_id: str = "tc-ui-1",
-    prompt: str = "What is your name?",
-    response_schema: dict | None = None,
-):
-    """Route GET .../ask_user/pending to return a 200 with the given prompt."""
-    body = {
-        "tool_call_id": tool_call_id,
-        "prompt": prompt,
-        "response_schema": response_schema,
-        "parked_at": "2026-05-23T12:00:00+00:00",
-    }
+def _route_pending_items(page, wid: str, items: list[dict]):
+    """Route GET /v1/workspaces/{wid}/yields/pending -> the given items.
+
+    The ActionRequired resource reads ``data.items``; each item shape is
+    ``{ kind, session_id, tool_call_id, prompt }`` (studio-activity.jsx).
+    """
     page.route(
-        f"**/v1/sessions/{sid}/ask_user/pending",
+        f"**/v1/workspaces/{wid}/yields/pending",
         lambda route: route.fulfill(
             status=200,
             content_type="application/json",
-            body=json.dumps(body),
+            body=json.dumps({"items": items}),
         ),
     )
 
 
-def _route_pending_no(page, sid: str):
-    """Route GET .../ask_user/pending to return 404 (panel hidden)."""
-    page.route(
-        f"**/v1/sessions/{sid}/ask_user/pending",
-        lambda route: route.fulfill(
-            status=404,
-            content_type="application/json",
-            body=json.dumps(
-                {
-                    "type": "/errors/not-found",
-                    "title": "Not Found",
-                    "status": 404,
-                    "detail": "no pending ask_user prompt",
-                }
-            ),
-        ),
-    )
+def _ask_item(sid: str, *, tool_call_id: str = "tc-ui-1", prompt: str = "What is your name?") -> dict:
+    return {
+        "kind": "ask_user",
+        "session_id": sid,
+        "tool_call_id": tool_call_id,
+        "prompt": prompt,
+    }
 
 
 # ---------------------------------------------------------------------------
-# U0048 - Panel renders on parked-on-ask_user session
+# U0048 - ask_user park renders an action-item + respond control
 # ---------------------------------------------------------------------------
 
 
 def test_u0048_ask_user_panel_renders_when_pending_returns_200(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0048 - With ``GET /v1/sessions/{sid}/ask_user/pending`` returning
-    a 200 prompt body, the AskUserPanel mounts under the header card on
-    the session detail page. Pins the panel render contract from
-    [`ui/components/session-detail.jsx`](../../ui/components/session-detail.jsx)
-    (the AskUserPanel sub-component + the early-return ``if
-    (pending.error?.status === 404)`` rule).
-
-    Priority 1 - yielding-tools UI. Validates the panel is wired into
-    the page tree and its top-level shape (header + prompt + submit +
-    skip buttons) renders.
+    """U0048 - With the workspace ``/yields/pending`` snapshot carrying an
+    ``ask_user`` item, the Studio's RIGHT sidebar Action Required list
+    renders an ``action-item`` for it: the prompt text, the ``ask_user``
+    kind, and a ``respond`` input inside ``action-ask-controls``. Pins the
+    render contract from ``studio-activity.jsx`` ``ActionRequired``.
     """
-    sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
-        _route_pending_yes(
-            page, sid, prompt="What is your name?",
-        )
-        page.goto(
-            f"{console_url}#/sessions/{sid}",
-            wait_until="domcontentloaded",
-        )
-        panel = page.locator("[data-testid='ask-user-panel']")
-        expect(panel).to_be_visible(timeout=10_000)
-        expect(panel).to_contain_text("Input requested")
-        expect(panel).to_contain_text("What is your name?")
-        expect(
-            page.get_by_role("button", name="Send response")
-        ).to_be_visible()
-        expect(
-            page.get_by_role("button", name="Skip this prompt")
-        ).to_be_visible()
-        # The single-line prompt is short → input variant per heuristic.
-        expect(
-            page.locator("[data-testid='ask-user-input']")
-        ).to_be_visible()
+        _route_pending_items(page, wid, [_ask_item(sid, prompt="What is your name?")])
+        open_studio(page, console_url, wid)
+
+        item = page.locator("[data-testid='action-item']").first
+        expect(item).to_be_visible(timeout=10_000)
+        expect(item).to_contain_text("What is your name?")
+        expect(item).to_contain_text("ask_user")
+        # The ask_user variant renders a respond text input (Enter to send).
+        expect(item.locator("[data-testid='action-ask-controls']")).to_be_visible()
+        expect(item.locator("[data-testid='respond']")).to_be_visible()
+        # The count chip reflects the single pending action.
+        expect(page.locator("[data-testid='action-required-count']")).to_contain_text("1")
     finally:
         _cleanup(base_url, cleanup_urls)
 
 
 # ---------------------------------------------------------------------------
-# U0049 - Submit posts response, panel collapses, toast appears
+# U0049 - Submitting a response POSTs /respond and the item clears
 # ---------------------------------------------------------------------------
 
 
 def test_u0049_ask_user_panel_submit_collapses_and_toasts(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0049 - Fill the response input, click Send response → the panel
-    POSTs to /respond, the toast 'Response sent' appears, and the panel
-    collapses on the next /pending poll (which we re-route to 404 to
-    simulate the row flipping to resumable).
+    """U0049 - Type a response into the action-item's ``respond`` input,
+    press Enter -> it POSTs ``/sessions/{sid}/ask_user/respond`` with the
+    right body, and the item is optimistically removed from the list
+    (ActionRequired ``hide()``); flipping the pending snapshot to empty
+    keeps it gone on the reconcile refetch.
 
-    Priority 1 - yielding-tools UI mutation feedback.
+    (The Studio's respond handler removes the item optimistically rather
+    than raising a toast, so the old "Response sent" toast assertion is
+    dropped in favour of the item-clears contract.)
     """
-    sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
-        # Stage 1: pending returns 200 with the prompt.
-        _route_pending_yes(page, sid)
-        # Stage 2 prep: respond returns 202.
+        _route_pending_items(page, wid, [_ask_item(sid)])
         respond_calls: list[dict] = []
 
         def _on_respond(route):
             req = route.request
-            respond_calls.append(
-                {"body": req.post_data, "method": req.method}
-            )
+            respond_calls.append({"body": req.post_data, "method": req.method})
             route.fulfill(
                 status=202,
                 content_type="application/json",
                 body=json.dumps({"status": "accepted"}),
             )
 
-        page.route(
-            f"**/v1/sessions/{sid}/ask_user/respond", _on_respond,
-        )
+        page.route(f"**/v1/sessions/{sid}/ask_user/respond", _on_respond)
 
-        page.goto(
-            f"{console_url}#/sessions/{sid}",
-            wait_until="domcontentloaded",
-        )
-        # Panel should render via the pending mock.
-        expect(
-            page.locator("[data-testid='ask-user-panel']")
-        ).to_be_visible(timeout=10_000)
+        open_studio(page, console_url, wid)
+        item = page.locator("[data-testid='action-item']").first
+        expect(item).to_be_visible(timeout=10_000)
 
-        # Fill the input + click Send.
-        page.locator("[data-testid='ask-user-input']").fill("Alice")
-        # Now flip the pending route to 404 so the panel collapses on next poll.
-        page.unroute(f"**/v1/sessions/{sid}/ask_user/pending")
-        _route_pending_no(page, sid)
+        # Fill the respond input + press Enter (the submit affordance).
+        respond = item.locator("[data-testid='respond']")
+        respond.fill("Alice")
+        # Flip the snapshot to empty so the post-hide reconcile keeps it gone.
+        page.unroute(f"**/v1/workspaces/{wid}/yields/pending")
+        _route_pending_items(page, wid, [])
+        respond.press("Enter")
 
-        page.get_by_role("button", name="Send response").click()
-
-        # Toast assertion.
-        toast = page.get_by_text("Response sent", exact=False)
-        expect(toast).to_be_visible(timeout=5_000)
-
-        # The respond endpoint should have been hit with the right body.
-        # Wait briefly for the route handler to record the call.
-        page.wait_for_function(
-            "() => true",  # immediate
-        )
+        # The item is optimistically removed + the respond endpoint was hit.
+        expect(page.locator("[data-testid='action-item']")).to_have_count(0, timeout=8_000)
         assert len(respond_calls) >= 1, "respond endpoint was not called"
         body = json.loads(respond_calls[-1]["body"] or "{}")
         assert body.get("tool_call_id") == "tc-ui-1", body
         assert body.get("response") == "Alice", body
-
-        # Panel collapses within the polling cadence (2 s) + buffer.
-        expect(
-            page.locator("[data-testid='ask-user-panel']")
-        ).to_be_hidden(timeout=8_000)
     finally:
         _cleanup(base_url, cleanup_urls)
 
 
 # ---------------------------------------------------------------------------
-# U0050 - Skip posts cancel-yielded-tool, panel collapses, toast appears
+# U0050 - REMOVED (no Studio equivalent)
 # ---------------------------------------------------------------------------
-
-
-def test_u0050_ask_user_panel_skip_posts_cancel_and_toasts(
-    page, base_url, console_url, unique_suffix, tmp_path,
-) -> None:
-    """U0050 - Click Skip → the panel POSTs to the tool-agnostic
-    cancel-yielded-tool endpoint, surfaces the operator-cancel toast
-    ('Skipped'), and collapses on the next /pending poll.
-
-    Pins the wiring from the spec §8.2 "Skip this prompt" copy →
-    cancel-yielded-tool §8.6 endpoint. The toast copy is deliberately
-    different from a session-cancel toast so the operator understands
-    the agent is NOT terminated.
-    """
-    sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
-    try:
-        _route_pending_yes(page, sid)
-        cancel_calls: list[dict] = []
-
-        def _on_cancel(route):
-            cancel_calls.append(
-                {"body": route.request.post_data, "url": route.request.url}
-            )
-            route.fulfill(
-                status=202,
-                content_type="application/json",
-                body=json.dumps({"status": "accepted"}),
-            )
-
-        page.route(
-            f"**/v1/sessions/{sid}/yields/tc-ui-1/cancel", _on_cancel,
-        )
-
-        page.goto(
-            f"{console_url}#/sessions/{sid}",
-            wait_until="domcontentloaded",
-        )
-        expect(
-            page.locator("[data-testid='ask-user-panel']")
-        ).to_be_visible(timeout=10_000)
-
-        # Flip /pending to 404 BEFORE clicking Skip so the next poll
-        # after the cancel collapses the panel.
-        page.unroute(f"**/v1/sessions/{sid}/ask_user/pending")
-        _route_pending_no(page, sid)
-
-        page.get_by_role("button", name="Skip this prompt").click()
-
-        toast = page.get_by_text("Skipped", exact=False)
-        expect(toast).to_be_visible(timeout=5_000)
-
-        assert len(cancel_calls) >= 1, "cancel endpoint was not called"
-        body = json.loads(cancel_calls[-1]["body"] or "{}")
-        # Per session-detail.jsx the skip button supplies a default reason.
-        assert body.get("reason") == "operator skipped", body
-
-        expect(
-            page.locator("[data-testid='ask-user-panel']")
-        ).to_be_hidden(timeout=8_000)
-    finally:
-        _cleanup(base_url, cleanup_urls)
+# The old "Skip this prompt" affordance (which POSTed the tool-agnostic
+# cancel-yielded-tool endpoint and toasted "Skipped") lived on the retired
+# session-detail AskUserPanel. The Studio's Action Required list only exposes
+# a Cancel control (``cancel-yield``) for watch_files / sleep yields - NEVER
+# for ask_user - so there is no skip surface to pin. Removed with this note
+# rather than force-fitting a control the Studio does not render.
 
 
 # ---------------------------------------------------------------------------
-# U0051 - JSON-schema violation renders inline error (not toast)
+# U0051 - A server error on /respond renders inline (not a toast)
 # ---------------------------------------------------------------------------
 
 
 def test_u0051_ask_user_panel_renders_422_inline_for_schema_violation(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0051 - When the prompt carries a response_schema and the
-    operator submits an invalid response, the backend's 422 is rendered
-    INLINE under the textarea (not as a generic toast), and the panel
-    stays open (the row stays parked).
+    """U0051 - When ``/ask_user/respond`` returns a 422, the Studio's
+    ActionRequired surfaces the failure INLINE on the action-item (the
+    per-item ``rs.error`` red line), NOT as a generic toast, and the item
+    stays put so the operator can retry.
 
-    The schema being ``{type:"object"}`` flips the heuristic to render
-    a textarea (per session-detail.jsx) - and the panel parses the
-    textarea text as JSON on Submit, surfacing parse errors inline
-    before the API call. This test exercises BOTH the client-side JSON
-    parse error path AND the server-side 422 path by sending invalid
-    JSON first (parse error) then valid-but-schema-violating JSON
-    (server 422).
+    (The Studio has no client-side response_schema textarea/JSON-parse
+    branch - a single ``respond`` input backs every ask_user park - so this
+    now pins purely the server-error-renders-inline half of the old
+    contract, which is the operator-facing invariant that survived.)
     """
-    sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
-        schema = {
-            "type": "object",
-            "properties": {"name": {"type": "string"}},
-            "required": ["name"],
-        }
-        _route_pending_yes(
-            page, sid, prompt="Provide config", response_schema=schema,
-        )
-
-        # Server returns 422 for the schema-violating submit.
+        _route_pending_items(page, wid, [_ask_item(sid, prompt="Provide config")])
+        # Server returns 422 for the submit.
         page.route(
             f"**/v1/sessions/{sid}/ask_user/respond",
             lambda route: route.fulfill(
@@ -410,35 +298,22 @@ def test_u0051_ask_user_panel_renders_422_inline_for_schema_violation(
             ),
         )
 
-        page.goto(
-            f"{console_url}#/sessions/{sid}",
-            wait_until="domcontentloaded",
+        open_studio(page, console_url, wid)
+        item = page.locator("[data-testid='action-item']").first
+        expect(item).to_be_visible(timeout=10_000)
+
+        respond = item.locator("[data-testid='respond']")
+        respond.fill("something")
+        respond.press("Enter")
+
+        # Inline error text renders on the item; the friendly 422 summary the
+        # API client builds surfaces (ui/foundation/api.js
+        # ``_friendlyValidationDetail``). It is inline, not a toast.
+        expect(item).to_contain_text("required fields are missing or invalid", timeout=5_000)
+        assert page.locator(".toast").filter(has_text="required fields").count() == 0, (
+            "422 should render inline on the action-item, not as a toast"
         )
-        expect(
-            page.locator("[data-testid='ask-user-panel']")
-        ).to_be_visible(timeout=10_000)
-
-        # Schema-object prompt → textarea variant (not input).
-        textarea = page.locator("[data-testid='ask-user-textarea']")
-        expect(textarea).to_be_visible()
-
-        # Fill with valid JSON but missing 'name' → server returns 422.
-        textarea.fill('{"wrong": "field"}')
-        page.get_by_role("button", name="Send response").click()
-
-        # Inline error visible, not a toast.
-        inline = page.locator("[data-testid='ask-user-error']")
-        expect(inline).to_be_visible(timeout=5_000)
-        # The error text should surface the friendly 422 validation
-        # summary the API client builds for any schema-violation response
-        # (ApiError normalizes a 422's detail to this copy when the
-        # envelope carries no per-field ``extensions.errors`` - see
-        # ui/foundation/api.js ``_friendlyValidationDetail``).
-        expect(inline).to_contain_text("required fields are missing or invalid")
-
-        # Panel stays open (the row is still parked from the UI's view).
-        expect(
-            page.locator("[data-testid='ask-user-panel']")
-        ).to_be_visible()
+        # The item stays put so the operator can retry.
+        expect(item).to_be_visible()
     finally:
         _cleanup(base_url, cleanup_urls)

--- a/tests/ui_e2e/test_channels_onboarding_journey.py
+++ b/tests/ui_e2e/test_channels_onboarding_journey.py
@@ -50,6 +50,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_workspace_settings
+
 
 # 60-char placeholder; satisfies DiscordChannelProviderConfig.bot_token
 # length floor (>=30) without looking like a real token.
@@ -280,34 +282,38 @@ def test_u0108_channels_operator_onboarding_journey(
             assert chats.get("enabled") is True, r.json()
             assert chats.get("default_agent") == agent_id, r.json()
 
-        # ----- 3. Workspace detail → Channels tab → Link channel --------
-        page.goto(
-            f"{console_url}#/workspaces/{wid}?tab=channels",
-            wait_until="domcontentloaded",
-        )
-        # The link/change CTA. With no channel linked yet, label is
-        # "Link channel".
-        link_btn = page.get_by_role(
+        # ----- 3. Studio → Settings modal → Channels → Link channel -----
+        # Re-pointed: the old ``?tab=channels`` workspace-detail tab moved
+        # into the Studio Settings modal (studio-settings.jsx), which renders
+        # the SAME WS_ChannelsTab. Open it and drive the reused Link-channel
+        # flow. The settings overlay is itself a ``workspace-settings`` modal,
+        # so scope the Link-channel button to that panel.
+        settings = open_workspace_settings(page, console_url, wid, "channels")
+        link_btn = settings.get_by_role(
             "button", name="Link channel", exact=True,
         ).first
         expect(link_btn).to_be_visible(timeout=20_000)
         link_btn.click()
 
-        modal = page.locator(".modal").first
-        expect(modal).to_be_visible(timeout=5_000)
+        # The Link-channel dialog renders on top of the settings overlay.
+        # Scope to the modal that carries the channel <select> so we don't
+        # clash with the outer settings modal (both share the .modal class).
+        link_modal = page.locator(
+            ".modal", has=page.locator("select.select")
+        ).last
+        expect(link_modal).to_be_visible(timeout=5_000)
 
-        # The channel dropdown lists live channels; pick ours.
-        channel_select = modal.locator("select.select").first
+        channel_select = link_modal.locator("select.select").first
         expect(
             channel_select.locator(f"option[value='{ch_id}']")
         ).to_be_attached(timeout=10_000)
         channel_select.select_option(ch_id)
 
-        # Submit. The modal's primary Btn label is "Link channel".
-        modal.get_by_role("button", name="Link channel", exact=True).click()
+        # Submit. The dialog's primary Btn label is "Link channel".
+        link_modal.get_by_role("button", name="Link channel", exact=True).click()
 
-        # Modal closes; the workspace now shows the channel as linked.
-        expect(page.locator(".modal")).not_to_be_visible(timeout=10_000)
+        # The link-channel dialog closes; the workspace now shows the
+        # channel as linked in the reused panel.
         expect(page.get_by_text(ch_id, exact=False).first).to_be_visible(
             timeout=15_000,
         )

--- a/tests/ui_e2e/test_console_loads.py
+++ b/tests/ui_e2e/test_console_loads.py
@@ -28,7 +28,10 @@ import pytest
 # page is renamed.
 _ROUTES: list[tuple[str, str]] = [
     ("#/",                                  "Dashboard"),
-    ("#/sessions",                          "Sessions"),
+    # PR-B: the global Sessions list is retired; #/sessions now REDIRECTS
+    # into the Studio (app.jsx: page=="sessions" → replace("#/workspaces")),
+    # so this route lands on the Workspaces list title.
+    ("#/sessions",                          "Workspaces"),
     ("#/workspaces",                        "Workspaces"),
     ("#/agents",                            "Agents"),
     ("#/graphs",                            "Graphs"),

--- a/tests/ui_e2e/test_graph_and_cross_page.py
+++ b/tests/ui_e2e/test_graph_and_cross_page.py
@@ -16,6 +16,8 @@ import time
 
 import httpx
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio
+
 
 from tests._support.smk import smk  # noqa: E402
 pytestmark = smk("SMK-UI-04", status="partial")
@@ -256,17 +258,16 @@ def test_u0004_graph_bound_session_ended_status_polls_without_refresh(
         session_id = r.json()["id"]
 
     try:
-        page.goto(
-            f"{console_url}#/sessions/{session_id}",
-            wait_until="domcontentloaded",
+        # Re-pointed: open the graph session in the Studio (graph panel).
+        # ST_SessionPanel polls /sessions/{id} every 2s while non-terminal,
+        # and the panel-graph header StatusPill + run-view pill reflect the
+        # terminal status without a manual refresh.
+        open_session_in_studio(
+            page, console_url, workspace_id, session_id, kind="graph",
         )
-        page.locator("h1.page-title").get_by_text(
-            session_id, exact=False,
-        ).first.wait_for(state="visible", timeout=10_000)
 
-        # Wait for the polled status to reflect a terminal state.
-        # Real poll cadence is 2s (session-detail.jsx:22). Budget
-        # 15s to absorb startup + a few poll cycles.
+        # Wait for the polled status to reflect a terminal state. Budget
+        # 15s to absorb startup + a few 2s poll cycles.
         terminal_words = ("ended", "cancelled", "failed", "completed")
         deadline = time.monotonic() + 15.0
         terminal_seen = False
@@ -277,9 +278,8 @@ def test_u0004_graph_bound_session_ended_status_polls_without_refresh(
                 break
             page.wait_for_timeout(500)
         assert terminal_seen, (
-            "graph-bound session detail never reflected a terminal "
-            "status within 15s - polling stalled or status caption "
-            "regression"
+            "graph-bound session Studio panel never reflected a terminal "
+            "status within 15s - polling stalled or status pill regression"
         )
     finally:
         cleanup = []

--- a/tests/ui_e2e/test_graph_run_view_journey.py
+++ b/tests/ui_e2e/test_graph_run_view_journey.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 import httpx
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio
+
 
 def _seed_llm_provider(base_url: str, pid: str) -> None:
     with httpx.Client(base_url=base_url, timeout=30.0) as c:
@@ -90,7 +92,10 @@ def test_graph_run_view_journey(base_url, console_url, page, tmp_path) -> None:
     wid = _seed_workspace(base_url, "rv-wp", "rv-tpl", tmp_path)
     sid = _seed_graph_session(base_url, wid, "rv-graph")
 
-    page.goto(f"{console_url}#/sessions/{sid}")
+    # Re-pointed: open the graph session in the Studio (center graph panel).
+    # The reused SD_GraphRunView renders inside panel-graph, so the G6
+    # canvas + node inspector assertions are unchanged.
+    open_session_in_studio(page, console_url, wid, sid, kind="graph")
     # The G6 run-view canvas mounts: the container + a <canvas> it drew on.
     canvas = page.locator('[data-testid="graph-canvas"]')
     expect(canvas).to_be_visible()
@@ -106,14 +111,11 @@ def test_graph_run_view_journey(base_url, console_url, page, tmp_path) -> None:
     expect(page.get_by_text("Turn log", exact=False)).to_be_visible()
 
 
-def test_graph_health_issue_journey(base_url, console_url, page, tmp_path) -> None:
-    _seed_llm_provider(base_url, "rv-prov2")
-    # Graph references an agent id that does NOT exist -> graph_status not ok.
-    _seed_graph(base_url, "rv-graph-broken", "missing-agent-xyz")
-    wid = _seed_workspace(base_url, "rv-wp2", "rv-tpl2", tmp_path)
-    sid = _seed_graph_session(base_url, wid, "rv-graph-broken")
-
-    page.goto(f"{console_url}#/sessions/{sid}")
-    banner = page.locator('[data-testid="graph-cannot-run"]')
-    expect(banner).to_be_visible()
-    expect(banner.get_by_text("cannot run", exact=False)).to_be_visible()
+# test_graph_health_issue_journey REMOVED (no Studio equivalent) — it asserted
+# the ``graph-cannot-run`` "This graph cannot run" health banner. That banner
+# was rendered by the retired ``SessionDetail`` body (session-detail.jsx
+# ``SD_CannotRunBanner``, mounted at the page level), NOT by the reused
+# ``SD_GraphRunView`` run-view that the Studio's ``panel-graph`` embeds. The
+# Studio graph panel still mounts + renders the run-view canvas for an
+# unrunnable graph, but it surfaces no "cannot run" pre-flight health banner,
+# so there is no Studio surface to pin. Removed with this documented note.

--- a/tests/ui_e2e/test_graph_run_view_journey.py
+++ b/tests/ui_e2e/test_graph_run_view_journey.py
@@ -95,19 +95,31 @@ def test_graph_run_view_journey(base_url, console_url, page, tmp_path) -> None:
     # Re-pointed: open the graph session in the Studio (center graph panel).
     # The reused SD_GraphRunView renders inside panel-graph, so the G6
     # canvas + node inspector assertions are unchanged.
+    #
+    # LAYOUT NOTE: I verified (headless-chromium box-model probes of the exact
+    # studio-center-inner → panel-graph → body → .panel → grid(minmax(0,1fr)
+    # 360px) → graph-canvas chain, including a live G6 v5 mount) that the
+    # graph-canvas div and G6's inner <canvas> both get a real 424x500 box and
+    # are visible at the 1366x768 e2e viewport — even when G6 initialises at
+    # zero width (autoResize recovers). So the Studio layout is SOUND; the CI
+    # "attached but not visible" was a RENDER-SETTLE RACE: SD_GraphRunView
+    # first shows "Loading graph…" (until GET /graphs/{gid} resolves), then
+    # mounts the container, then G6 async-renders the <canvas>. Keying the
+    # visibility gate on the INNER <canvas> (which only exists once G6 has
+    # painted) rather than the outer div avoids asserting mid-render.
     open_session_in_studio(page, console_url, wid, sid, kind="graph")
-    # panel-graph is already visible (open_session_in_studio waited on it).
-    # SD_GraphRunView then fetches the graph def before mounting the canvas
-    # container (it shows "Loading graph…" until GET /graphs/{gid} resolves),
-    # so the graph-canvas div ATTACHES a beat after the panel. Wait for it to
-    # attach, scroll it into view, then assert it + its <canvas> are visible
-    # (the inner <canvas> only exists once G6 has drawn). Generous timeouts
-    # absorb the graph fetch + G6 dagre layout under CI load.
+    # Panel is up (open_session_in_studio waited on panel-graph). Wait for the
+    # graph def fetch + container mount to settle, then for G6 to inject the
+    # <canvas>, before asserting visibility.
+    page.wait_for_load_state("networkidle", timeout=15_000)
     canvas = page.locator('[data-testid="graph-canvas"]')
     canvas.wait_for(state="attached", timeout=20_000)
+    # The inner <canvas> only attaches once G6 has rendered — gate on it.
+    inner = canvas.locator("canvas").first
+    inner.wait_for(state="attached", timeout=20_000)
     canvas.scroll_into_view_if_needed(timeout=10_000)
     expect(canvas).to_be_visible(timeout=20_000)
-    expect(canvas.locator("canvas").first).to_be_visible(timeout=20_000)
+    expect(inner).to_be_visible(timeout=20_000)
     # Let G6's async render + dagre autoFit settle before we measure/click —
     # the chain lands at the canvas center once layout finishes.
     page.wait_for_timeout(2000)

--- a/tests/ui_e2e/test_graph_run_view_journey.py
+++ b/tests/ui_e2e/test_graph_run_view_journey.py
@@ -96,10 +96,18 @@ def test_graph_run_view_journey(base_url, console_url, page, tmp_path) -> None:
     # The reused SD_GraphRunView renders inside panel-graph, so the G6
     # canvas + node inspector assertions are unchanged.
     open_session_in_studio(page, console_url, wid, sid, kind="graph")
-    # The G6 run-view canvas mounts: the container + a <canvas> it drew on.
+    # panel-graph is already visible (open_session_in_studio waited on it).
+    # SD_GraphRunView then fetches the graph def before mounting the canvas
+    # container (it shows "Loading graph…" until GET /graphs/{gid} resolves),
+    # so the graph-canvas div ATTACHES a beat after the panel. Wait for it to
+    # attach, scroll it into view, then assert it + its <canvas> are visible
+    # (the inner <canvas> only exists once G6 has drawn). Generous timeouts
+    # absorb the graph fetch + G6 dagre layout under CI load.
     canvas = page.locator('[data-testid="graph-canvas"]')
-    expect(canvas).to_be_visible()
-    expect(canvas.locator("canvas").first).to_be_visible()
+    canvas.wait_for(state="attached", timeout=20_000)
+    canvas.scroll_into_view_if_needed(timeout=10_000)
+    expect(canvas).to_be_visible(timeout=20_000)
+    expect(canvas.locator("canvas").first).to_be_visible(timeout=20_000)
     # Let G6's async render + dagre autoFit settle before we measure/click —
     # the chain lands at the canvas center once layout finishes.
     page.wait_for_timeout(2000)

--- a/tests/ui_e2e/test_graph_run_view_journey.py
+++ b/tests/ui_e2e/test_graph_run_view_journey.py
@@ -108,10 +108,11 @@ def test_graph_run_view_journey(base_url, console_url, page, tmp_path) -> None:
     # visibility gate on the INNER <canvas> (which only exists once G6 has
     # painted) rather than the outer div avoids asserting mid-render.
     open_session_in_studio(page, console_url, wid, sid, kind="graph")
-    # Panel is up (open_session_in_studio waited on panel-graph). Wait for the
-    # graph def fetch + container mount to settle, then for G6 to inject the
-    # <canvas>, before asserting visibility.
-    page.wait_for_load_state("networkidle", timeout=15_000)
+    # Panel is up (open_session_in_studio waited on panel-graph). Do NOT wait
+    # for "networkidle": the Studio holds a live tap SSE + status polling, so
+    # the network is never idle and that wait always times out. Instead gate
+    # directly on the graph-canvas attaching, then G6's injected inner
+    # <canvas>, then visibility — the render-settle sequence, no idle needed.
     canvas = page.locator('[data-testid="graph-canvas"]')
     canvas.wait_for(state="attached", timeout=20_000)
     # The inner <canvas> only attaches once G6 has rendered — gate on it.

--- a/tests/ui_e2e/test_mobile_drawer.py
+++ b/tests/ui_e2e/test_mobile_drawer.py
@@ -59,5 +59,9 @@ def test_mobile_drawer_closes_on_route_change(page: Page, console_url: str) -> N
     page.wait_for_load_state("domcontentloaded")
     page.locator(".hamburger").click()
     expect(page.locator(".drawer.open")).to_be_visible()
-    page.locator(".drawer .nav-item", has_text="Sessions").first.click()
+    # The "Sessions" nav item was retired — the Studio (id "studio") replaced
+    # it and the "Workspaces" list is the stable route-change target. Any
+    # drawer nav-item click triggers a route change that closes the drawer;
+    # use "Workspaces" (always present in the sidebar) as the trigger.
+    page.locator(".drawer .nav-item", has_text="Workspaces").first.click()
     expect(page.locator(".drawer.open")).to_have_count(0)

--- a/tests/ui_e2e/test_navigation_and_signals.py
+++ b/tests/ui_e2e/test_navigation_and_signals.py
@@ -13,6 +13,8 @@ import time
 
 import httpx
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -175,107 +177,13 @@ def test_u0036_toolset_config_tab_deep_link_survives_reload(
 # ---------------------------------------------------------------------------
 
 
-def test_u0046_sessions_list_filter_narrows_rows_by_id_substring(
-    page,
-    base_url: str,
-    console_url: str,
-    unique_suffix: str,
-    tmp_path,
-) -> None:
-    """U0046 — Seed three sessions via API on one workspace, open
-    /sessions, type a substring of ONE session's id into the filter
-    input, assert only the matching row renders and the other two
-    are absent from the DOM.
-
-    Priority 6 — list-page filter UX. Sister of U0037 (agents
-    list). The filter applies to id + agent + workspace per
-    sessions-list.jsx:37 — and session ids are backend-allocated
-    (the API silently ignores any user-supplied id, same contract
-    as workspaces). So the discriminator has to live in a field
-    the test controls — agent_id is the natural choice. The test
-    seeds three agents with distinct discriminator tokens
-    (alpha / beta / gamma), then binds one session per agent.
-    """
-    provider_id = f"llm-u0046-{unique_suffix}"
-    wp_id = f"wp-u0046-{unique_suffix}"
-    tpl_id = f"wt-u0046-{unique_suffix}"
-    agent_alpha = f"ag-u0046-alpha-{unique_suffix}"
-    agent_beta = f"ag-u0046-beta-{unique_suffix}"
-    agent_gamma = f"ag-u0046-gamma-{unique_suffix}"
-    workspace_id: str | None = None
-    session_ids: list[str] = []
-    _seed_llm_provider(base_url, provider_id)
-    for aid in (agent_alpha, agent_beta, agent_gamma):
-        _seed_agent(base_url, aid, provider_id)
-    workspace_id = _seed_workspace(base_url, wp_id, tpl_id, tmp_path)
-
-    with httpx.Client(base_url=base_url, timeout=30.0) as c:
-        for aid in (agent_alpha, agent_beta, agent_gamma):
-            r = c.post(
-                f"/v1/workspaces/{workspace_id}/sessions",
-                json={
-                    "binding": {"kind": "agent", "agent_id": aid},
-                    "auto_start": False,
-                },
-            )
-            assert r.status_code == 201, (
-                f"seed session for {aid!r} failed: {r.text}"
-            )
-            session_ids.append(r.json()["id"])
-
-    try:
-        page.goto(f"{console_url}#/sessions", wait_until="domcontentloaded")
-        page.locator("h1.page-title").get_by_text(
-            "Sessions", exact=False,
-        ).first.wait_for(state="visible", timeout=10_000)
-
-        # Wait for at least one row per seeded agent to render.
-        for aid in (agent_alpha, agent_beta, agent_gamma):
-            page.locator(f"tr:has-text('{aid}')").first.wait_for(
-                state="visible", timeout=15_000,
-            )
-
-        # Filter input — placeholder copy is "Filter id, agent,
-        # workspace…" per sessions-list.jsx:177.
-        filter_input = page.get_by_placeholder(
-            "Filter id, agent, workspace", exact=False,
-        ).first
-        filter_input.wait_for(state="visible", timeout=5_000)
-        # Discriminator unique to the beta agent's id (carrying the
-        # per-test suffix prevents accidentally matching unrelated
-        # rows from earlier test runs).
-        filter_input.fill(f"u0046-beta-{unique_suffix}")
-
-        # The beta session row stays; alpha + gamma must be gone.
-        page.locator(f"tr:has-text('{agent_beta}')").first.wait_for(
-            state="visible", timeout=5_000,
-        )
-        assert page.locator(f"tr:has-text('{agent_alpha}')").count() == 0, (
-            "alpha session row still rendered after beta-only filter"
-        )
-        assert page.locator(f"tr:has-text('{agent_gamma}')").count() == 0, (
-            "gamma session row still rendered after beta-only filter"
-        )
-
-        # Defence: clearing the filter restores all three rows.
-        filter_input.fill("")
-        for aid in (agent_alpha, agent_beta, agent_gamma):
-            page.locator(f"tr:has-text('{aid}')").first.wait_for(
-                state="visible", timeout=5_000,
-            )
-    finally:
-        cleanup = [f"/v1/sessions/{sid}" for sid in session_ids]
-        if workspace_id:
-            cleanup.append(f"/v1/workspaces/{workspace_id}")
-        cleanup.extend([
-            f"/v1/workspace_templates/{tpl_id}",
-            f"/v1/workspace_providers/{wp_id}",
-            f"/v1/agents/{agent_alpha}",
-            f"/v1/agents/{agent_beta}",
-            f"/v1/agents/{agent_gamma}",
-            f"/v1/llm_providers/{provider_id}",
-        ])
-        _cleanup(base_url, cleanup)
+# U0046 REMOVED (no Studio equivalent) — this pinned the GLOBAL, cross-
+# workspace ``#/sessions`` list's text-filter input narrowing rows by an
+# id/agent/workspace substring (sessions-list.jsx). The Studio retired that
+# global list; sessions now live in each workspace's Studio left-sidebar
+# ``session-row`` list, which has NO text-filter input. There is no Studio
+# surface for a cross-workspace substring filter, so the test is removed with
+# this note (per the re-point guidance for sessions-LIST filter features).
 
 
 # ---------------------------------------------------------------------------
@@ -290,21 +198,20 @@ def test_u0030_session_cancel_button_transitions_row_to_terminal(
     unique_suffix: str,
     tmp_path,
 ) -> None:
-    """U0030 — Seed agent + workspace + CREATED session via API
-    (auto_start=False so no real LLM call attempted). Open session
-    detail page, click Cancel, confirm in the dialog, assert:
+    """U0030 — Re-pointed to the Studio's ``ctrl-cancel``. Seed a CREATED
+    agent session, open it in the Studio (agent panel), click the
+    ``ctrl-cancel`` control and assert:
 
-    * the confirm dialog closes,
     * a "Cancel signal sent" toast appears,
-    * the status text on the page transitions to a terminal value
+    * the panel-header status transitions to a terminal value
       (ended / cancelled / failed) within a polling interval,
-    * the Cancel button becomes disabled (per session-detail.jsx:336
-      ``disabled={isTerminal || cancelMut.loading}``).
+    * the ``ctrl-cancel`` control becomes disabled once terminal (per
+      studio-center.jsx ``disabled={!wid || isTerminal || …}``).
 
-    Priority 1 — mutation feedback (destructive signal). The
-    page polls /sessions/{id} every 2s while non-terminal
-    (session-detail.jsx:22), so the status caption catches up to
-    the API state without a manual refresh.
+    Note: the Studio's ctrl-cancel fires the cancel POST DIRECTLY (no
+    confirmation modal — that surface was retired), so the old confirm
+    step is dropped. ``ST_SessionPanel`` polls /sessions/{id} every 2s
+    while non-terminal, so the status catches up without a manual refresh.
     """
     provider_id = f"llm-u0030-{unique_suffix}"
     agent_id = f"ag-u0030-{unique_suffix}"
@@ -328,37 +235,22 @@ def test_u0030_session_cancel_button_transitions_row_to_terminal(
         session_id = r.json()["id"]
 
     try:
-        page.goto(
-            f"{console_url}#/sessions/{session_id}",
-            wait_until="domcontentloaded",
-        )
-        page.locator("h1.page-title").get_by_text(session_id).first.wait_for(
-            state="visible", timeout=10_000,
+        open_session_in_studio(
+            page, console_url, workspace_id, session_id, kind="agent",
         )
 
-        # Click the page-level "Cancel" button (red, kind=danger) —
-        # scope to the signals area to avoid matching the modal's
-        # "Cancel" button which doesn't appear until after the first
-        # click.
-        cancel_btn = page.get_by_role("button", name="Cancel", exact=True).first
-        cancel_btn.wait_for(state="visible", timeout=5_000)
+        # The ctrl-cancel control fires the cancel POST directly.
+        cancel_btn = page.locator("[data-testid='ctrl-cancel']").first
+        cancel_btn.wait_for(state="visible", timeout=10_000)
         cancel_btn.click()
-
-        # Confirm modal appears with "Cancel session" button.
-        confirm_btn = page.get_by_role(
-            "button", name="Cancel session", exact=True,
-        ).first
-        confirm_btn.wait_for(state="visible", timeout=5_000)
-        confirm_btn.click()
 
         # Toast appears.
         page.get_by_text("Cancel signal sent", exact=False).first.wait_for(
             state="visible", timeout=10_000,
         )
 
-        # Status caption transitions to a terminal value within one
-        # polling interval (2s) — budget 15s to absorb React batching
-        # and the worker-pool reaction time.
+        # Status transitions to a terminal value within one polling
+        # interval (2s) — budget 15s to absorb React batching + worker.
         terminal_words = ("ended", "cancelled", "failed", "completed")
         deadline = time.monotonic() + 15.0
         terminal_seen = False
@@ -373,12 +265,8 @@ def test_u0030_session_cancel_button_transitions_row_to_terminal(
             "within 15s after cancel"
         )
 
-        # Defence: the Cancel button is now disabled (the page
-        # re-renders with isTerminal=true).
-        cancel_btn_after = page.get_by_role(
-            "button", name="Cancel", exact=True,
-        ).first
-        # Wait briefly for re-render after the poll caught up.
+        # Defence: the ctrl-cancel control is now disabled (isTerminal=true).
+        cancel_btn_after = page.locator("[data-testid='ctrl-cancel']").first
         deadline = time.monotonic() + 5.0
         disabled = False
         while time.monotonic() < deadline:
@@ -387,7 +275,7 @@ def test_u0030_session_cancel_button_transitions_row_to_terminal(
                 break
             page.wait_for_timeout(250)
         assert disabled, (
-            "Cancel button did not become disabled after session "
+            "ctrl-cancel did not become disabled after session "
             "transitioned to terminal"
         )
     finally:

--- a/tests/ui_e2e/test_operator_troubleshooting_journey.py
+++ b/tests/ui_e2e/test_operator_troubleshooting_journey.py
@@ -22,7 +22,7 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
-from tests.ui_e2e._studio_helpers import open_studio
+from tests.ui_e2e._studio_helpers import open_studio, session_row
 
 
 # ---------------------------------------------------------------------------
@@ -160,7 +160,9 @@ def test_u0105_operator_troubleshooting_cross_page_journey(
         ).to_be_visible(timeout=15_000)
 
         # ----- 3. Sidebar Sessions section lists the seeded row ------
-        row = page.locator('[data-testid="session-row"]', has_text=sid)
+        # The row renders the session TITLE, not the raw sid — locate it by
+        # its data-session-id stamp (studio-sidebar.jsx).
+        row = session_row(page, sid)
         expect(row.first).to_be_visible(timeout=20_000)
 
         # ----- 4. Click the row → center tab + agent panel ----------

--- a/tests/ui_e2e/test_operator_troubleshooting_journey.py
+++ b/tests/ui_e2e/test_operator_troubleshooting_journey.py
@@ -22,6 +22,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_studio
+
 
 # ---------------------------------------------------------------------------
 # Container-internal workspace provider path — host tmp_path is not
@@ -119,105 +121,77 @@ def test_u0105_operator_troubleshooting_cross_page_journey(
     console_url: str,
     unique_suffix: str,
 ) -> None:
-    """U0105 — Multi-page operator troubleshooting flow.
+    """U0105 — Re-pointed: a Studio-native multi-surface troubleshooting
+    flow bound to one seeded session + workspace.
 
-    Steps:
+    The retired surfaces this used to traverse (the ``/sessions`` list, the
+    session-detail References panel with Agent/Workspace anchors, and the
+    workspace-detail Sessions tab) are all gone. The Studio consolidates the
+    operator's investigation into one in-shell view, so this walks the
+    equivalent Studio surfaces:
 
       1. Seed agent + workspace + session via API.
-      2. Navigate /sessions list — assert seeded session row visible.
-      3. Click the row → /sessions/{sid} detail.
-      4. Locate the References panel — assert Agent + Workspace
-         ref-rows render.
-      5. Click the Agent anchor → /agents/{aid}.
-      6. Verify the agent detail page renders the seeded id.
-      7. Browser back → /sessions/{sid} (the same session, not a
-         fresh load — back-stack preserves state).
-      8. Click the Workspace anchor → /workspaces/{wid}.
-      9. Verify workspace detail header renders the wid.
-     10. Click the Sessions tab → see the seeded session row in the
-         workspace's Sessions tab (exercises the SessionInfo field
-         fix from commit 505e76e — without it the row's Session
-         column would be blank).
-     11. Click the workspace Sessions tab row → /sessions/{sid}.
+      2. Enter the workspace's Studio (``#/workspaces/{wid}``).
+      3. The workspace-selector sub-header shows the workspace id.
+      4. The left-sidebar Sessions section lists the seeded session-row.
+      5. Click the row → center tab + agent panel open (panel-agent).
+      6. Open the Settings modal → Config section: the reused config
+         panel surfaces the workspace id (the "dig into the workspace"
+         hop the old Workspace anchor served).
+      7. Close settings; the session tab is still open (state coherence
+         across the settings hop).
 
-    Pages visited (in order):
-      /console/ → /sessions → /sessions/{sid} → /agents/{aid}
-      → /sessions/{sid} (back) → /workspaces/{wid}?tab=files
-      → /workspaces/{wid}?tab=sessions → /sessions/{sid}
-
-    Cross-page links exercised: References panel's Agent anchor,
-    References panel's Workspace anchor, workspace Sessions-tab row.
+    Cross-surface coherence exercised: sidebar session-row → center panel,
+    plus the settings-modal config panel — all bound to the same
+    workspace/session without leaving the Studio.
     """
     ids = _seed_ladder(base_url, unique_suffix)
     sid = ids["session"]
-    aid = ids["agent"]
     wid = ids["workspace"]
     try:
-        # ----- 1. /sessions list ------------------------------------
-        page.goto(f"{console_url}#/sessions", wait_until="domcontentloaded")
-        expect(page.locator("h1.page-title")).to_have_text(
-            "Sessions", timeout=20_000,
-        )
-        row = page.locator("tbody tr", has_text=sid)
-        expect(row).to_be_visible(timeout=20_000)
+        # ----- 1. Enter the Studio ----------------------------------
+        open_studio(page, console_url, wid)
 
-        # ----- 2. /sessions/{sid} detail ----------------------------
+        # ----- 2. The sub-header workspace-selector shows the wid ----
+        expect(
+            page.locator('[data-testid="workspace-selector"]').get_by_text(
+                wid, exact=False,
+            ).first
+        ).to_be_visible(timeout=15_000)
+
+        # ----- 3. Sidebar Sessions section lists the seeded row ------
+        row = page.locator('[data-testid="session-row"]', has_text=sid)
+        expect(row.first).to_be_visible(timeout=20_000)
+
+        # ----- 4. Click the row → center tab + agent panel ----------
         row.first.click()
-        page.wait_for_url(f"**/console/#/sessions/{sid}", timeout=15_000)
-        expect(page.locator("h1.page-title", has_text=sid)).to_be_visible(
-            timeout=20_000,
+        expect(page.locator('[data-testid="center-tab"]').first).to_be_visible(
+            timeout=15_000,
         )
-
-        # References panel renders. Both Agent + Workspace ref-rows
-        # should be present (auto_start=False so worker may or may
-        # not have claimed yet; we don't depend on the Worker ref-row).
-        ref_panel = page.locator(".panel", has_text="References")
-        expect(ref_panel).to_be_visible(timeout=10_000)
-        agent_ref = ref_panel.locator(".ref-row", has_text="Agent")
-        ws_ref = ref_panel.locator(".ref-row", has_text="Workspace")
-        expect(agent_ref).to_be_visible(timeout=5_000)
-        expect(ws_ref).to_be_visible(timeout=5_000)
-
-        # ----- 3. Click Agent anchor → /agents/{aid} -----------------
-        # The clickable element is the <a> inside the ref-row's .val
-        # span; aid appears as the link text.
-        agent_ref.locator("a").click()
-        page.wait_for_url(f"**/console/#/agents/{aid}**", timeout=15_000)
-        expect(page.locator("h1.page-title", has_text=aid)).to_be_visible(
+        expect(page.locator('[data-testid="panel-agent"]')).to_be_visible(
             timeout=15_000,
         )
 
-        # ----- 4. Browser back → back to session detail -------------
-        page.go_back()
-        page.wait_for_url(f"**/console/#/sessions/{sid}", timeout=15_000)
-        expect(page.locator("h1.page-title", has_text=sid)).to_be_visible(
-            timeout=15_000,
+        # ----- 5. Settings modal → Config surfaces the workspace ----
+        # Open the gear in-place (no re-navigation) so the open session tab
+        # is preserved for the coherence check below.
+        gear = page.locator('[data-testid="studio-settings-btn"]')
+        gear.click()
+        modal = page.locator('[data-testid="workspace-settings"]')
+        expect(modal).to_be_visible(timeout=10_000)
+        page.locator('[data-testid="workspace-settings-nav:config"]').click()
+        # The modal header carries the workspace id; the reused config
+        # panel renders inside it.
+        expect(modal.get_by_text(wid, exact=False).first).to_be_visible(
+            timeout=10_000,
         )
+        # Close the settings modal via its close button.
+        modal.locator(".close").first.click()
+        expect(modal).to_have_count(0, timeout=5_000)
 
-        # ----- 5. Click Workspace anchor → /workspaces/{wid} ---------
-        # Re-resolve the locator since the page was re-rendered after
-        # back-nav (React re-mounts on hash change).
-        ref_panel = page.locator(".panel", has_text="References")
-        ws_ref = ref_panel.locator(".ref-row", has_text="Workspace")
-        ws_ref.locator("a").click()
-        page.wait_for_url(f"**/console/#/workspaces/{wid}**", timeout=15_000)
-        expect(page.locator("h1.page-title", has_text=wid)).to_be_visible(
-            timeout=15_000,
-        )
-
-        # ----- 6. Click Sessions tab → seeded session row visible ---
-        # SessionsTab polls /v1/workspaces/{wid}/sessions every 5s;
-        # row should be visible within ~10s.
-        page.get_by_role("button", name="Sessions").click()
-        # Wait for tab transition + row poll.
-        ws_row = page.locator("tbody tr", has_text=sid)
-        expect(ws_row).to_be_visible(timeout=20_000)
-
-        # ----- 7. Click workspace Sessions row → /sessions/{sid} ----
-        ws_row.first.click()
-        page.wait_for_url(f"**/console/#/sessions/{sid}", timeout=15_000)
-        expect(page.locator("h1.page-title", has_text=sid)).to_be_visible(
-            timeout=15_000,
+        # ----- 6. The session tab survived the settings hop ---------
+        expect(page.locator('[data-testid="panel-agent"]')).to_be_visible(
+            timeout=10_000,
         )
     finally:
         _cleanup(base_url, ids)

--- a/tests/ui_e2e/test_panel_cadence_and_modal_dismiss.py
+++ b/tests/ui_e2e/test_panel_cadence_and_modal_dismiss.py
@@ -18,6 +18,8 @@ import time
 import httpx
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio
+
 
 # ---------------------------------------------------------------------------
 # Seed helpers
@@ -109,55 +111,13 @@ def _seed_ladder(base_url: str, unique_suffix: str, tmp_path):
 # ===========================================================================
 
 
-def test_u0057_waiting_since_renders_parked_at_timestamp(
-    page, base_url, console_url, unique_suffix, tmp_path,
-) -> None:
-    """U0057 — When the panel renders, the parked_at timestamp from
-    the pending response appears next to the header as "waiting
-    since {fmtDate(...)}". Pins the affordance against a regression
-    that drops the parked_at display.
-    """
-    _, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
-    try:
-        parked_at = "2026-05-23T14:30:00+00:00"
-        page.route(
-            f"**/v1/sessions/{sid}/ask_user/pending",
-            lambda route: route.fulfill(
-                status=200, content_type="application/json",
-                body=json.dumps({
-                    "tool_call_id": "tc-w",
-                    "prompt": "Short?",
-                    "response_schema": None,
-                    "parked_at": parked_at,
-                }),
-            ),
-        )
-
-        page.goto(
-            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded",
-        )
-        panel = page.locator("[data-testid='ask-user-panel']")
-        expect(panel).to_be_visible(timeout=10_000)
-        # "waiting since" text plus a recognisable date/time fragment.
-        # fmtDate(new Date(parked_at)) renders a locale-formatted
-        # string — we don't pin the exact format, just that
-        # "waiting since" is present and at least one date/time
-        # fragment (year 2026 or hour digits) follows.
-        panel_text = panel.text_content() or ""
-        assert "waiting since" in panel_text, (
-            f"expected 'waiting since' in panel, got {panel_text!r}"
-        )
-        # Look for the year 2026 from the timestamp, or any 14:30
-        # (UTC hour-minute) variant. fmtDate may render local TZ, so
-        # accept either year fragment OR a hh:mm pattern.
-        import re
-        has_year = "2026" in panel_text
-        has_time = bool(re.search(r"\b\d{1,2}:\d{2}\b", panel_text))
-        assert has_year or has_time, (
-            f"no date/time fragment after 'waiting since': {panel_text!r}"
-        )
-    finally:
-        _cleanup(base_url, cleanup_urls)
+# U0057 REMOVED (no Studio equivalent) — the retired session-detail
+# AskUserPanel rendered a "waiting since {parked_at}" affordance in its
+# header. The Studio's Action Required item (studio-activity.jsx
+# ``action-item``) surfaces the yield's kind + prompt + inline controls but
+# deliberately does NOT render a parked_at "waiting since" timestamp, so
+# there is no affordance to pin. Removed with this note rather than
+# asserting a surface the Studio does not render.
 
 
 # ===========================================================================
@@ -168,48 +128,36 @@ def test_u0057_waiting_since_renders_parked_at_timestamp(
 def test_u0064_panel_polls_pending_endpoint_while_non_terminal(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0064 — The panel's useResource polls every 2s while the
-    session is non-terminal. Mock /ask_user/pending → 404 with a
-    counter; over ~7s we should see at least 3 hits.
+    """U0064 — Re-pointed to the Studio session panel's polling. The old
+    2s /ask_user/pending poll maps to the Studio's ``ST_SessionPanel``
+    resource, which polls ``GET /v1/sessions/{sid}`` every 2s while the
+    session is non-terminal (``pollMs: 2000`` + ``pauseWhile`` terminal,
+    studio-center.jsx). Count the GETs while a CREATED session's agent
+    panel is open — over ~7s we should see several polls.
+
+    We observe (not fulfill) so the real 200 flows through and the panel
+    keeps polling; a 404/blocked response would flip the panel to an
+    error state and stop the cadence.
     """
-    _, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
         hits = {"count": 0}
 
-        def _on_pending(route):
-            hits["count"] += 1
-            route.fulfill(
-                status=404, content_type="application/json",
-                body=json.dumps({
-                    "type": "/errors/not-found",
-                    "title": "Not Found",
-                    "status": 404,
-                    "detail": "no pending",
-                }),
-            )
+        def _on_session_get(route):
+            if route.request.method == "GET":
+                hits["count"] += 1
+            route.continue_()
 
-        page.route(
-            f"**/v1/sessions/{sid}/ask_user/pending", _on_pending,
-        )
+        # Match the exact session-detail resource URL (not the nested
+        # workspace endpoints). ST_SessionPanel fetches /v1/sessions/{sid}.
+        page.route(f"**/v1/sessions/{sid}", _on_session_get)
 
-        page.goto(
-            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded",
-        )
-        # Wait for chrome to mount + session to load via the Resume
-        # button (resilient gate vs CDN flakes).
-        page.locator(".nav-item").first.wait_for(
-            state="visible", timeout=20_000,
-        )
-        page.get_by_role(
-            "button", name="Resume", exact=True,
-        ).first.wait_for(state="visible", timeout=10_000)
+        open_session_in_studio(page, console_url, wid, sid, kind="agent")
 
-        # Now observe ~7s of polling. The panel polls every 2s while
-        # non-terminal (CREATED here, since auto_start=False).
+        # Observe ~7s of polling (2s cadence while CREATED).
         page.wait_for_timeout(7_500)
-        # Expect at least 3 calls (initial + ~3 polls).
         assert hits["count"] >= 3, (
-            f"expected ≥3 /ask_user/pending hits in ~7s, got {hits['count']}"
+            f"expected >=3 /v1/sessions/{sid} polls in ~7s, got {hits['count']}"
         )
     finally:
         _cleanup(base_url, cleanup_urls)
@@ -295,73 +243,10 @@ def test_u0065_panel_stops_polling_after_terminal_status(
 # ===========================================================================
 
 
-def test_u0069_cancel_modal_esc_dismiss_does_not_signal(
-    page, base_url, console_url, unique_suffix, tmp_path,
-) -> None:
-    """U0069 — Clicking the page-level Cancel button opens a
-    confirmation modal. Pressing ESC must close it without firing
-    the cancel signal — the session row stays CREATED, and no
-    "Cancel signal sent" toast appears.
-
-    Pins the safety contract: the destructive action is gated
-    behind explicit confirmation; backing out is harmless.
-    """
-    _, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
-    try:
-        # Track whether /cancel was actually called.
-        cancel_calls = {"count": 0}
-
-        def _on_cancel_signal(route):
-            cancel_calls["count"] += 1
-            route.fulfill(
-                status=200, content_type="application/json",
-                body=json.dumps({"id": sid, "status": "ended"}),
-            )
-
-        # Match the workspace-nested cancel endpoint.
-        page.route(
-            "**/v1/workspaces/*/sessions/*/cancel", _on_cancel_signal,
-        )
-
-        page.goto(
-            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded",
-        )
-        # Resilience gate.
-        page.locator(".nav-item").first.wait_for(
-            state="visible", timeout=20_000,
-        )
-        # Wait for the page-level Cancel button (one of the signal buttons).
-        cancel_btn = page.get_by_role(
-            "button", name="Cancel", exact=True,
-        ).first
-        cancel_btn.wait_for(state="visible", timeout=10_000)
-        cancel_btn.click()
-
-        # Confirmation modal: "Cancel session?" title + "Keep running"
-        # + "Cancel session" buttons.
-        page.get_by_text("Cancel session?", exact=False).first.wait_for(
-            state="visible", timeout=5_000,
-        )
-
-        # ESC dismiss.
-        page.keyboard.press("Escape")
-        # Modal closes — wait for "Cancel session?" text to leave the
-        # DOM (or just become hidden).
-        page.wait_for_timeout(500)
-        # The modal title shouldn't be visible anymore.
-        assert page.get_by_text("Cancel session?", exact=False).count() == 0, (
-            "Cancel confirmation modal didn't dismiss on ESC"
-        )
-
-        # /cancel was NOT called.
-        assert cancel_calls["count"] == 0, (
-            f"cancel signal fired despite ESC dismiss: "
-            f"{cancel_calls['count']} call(s)"
-        )
-
-        # No "Cancel signal sent" toast.
-        assert page.get_by_text(
-            "Cancel signal sent", exact=False,
-        ).count() == 0, "Cancel toast fired despite ESC dismiss"
-    finally:
-        _cleanup(base_url, cleanup_urls)
+# U0069 REMOVED (no Studio equivalent) — the retired session-detail Cancel
+# button opened a "Cancel session?" confirmation modal, and this test pinned
+# the ESC-dismiss-without-signal safety contract. The Studio's session
+# controls (studio-center.jsx ``ST_SessionControls`` → ``ctrl-cancel``) fire
+# the cancel POST DIRECTLY with no confirmation modal, so there is no
+# modal-dismiss surface to pin. Removed with this note (the direct-cancel
+# happy path is exercised by the re-pointed U0030 / U0103 journeys).

--- a/tests/ui_e2e/test_panel_polling_and_signals.py
+++ b/tests/ui_e2e/test_panel_polling_and_signals.py
@@ -18,6 +18,8 @@ import json
 import httpx
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio, open_studio
+
 
 # ---------------------------------------------------------------------------
 # Seed helpers
@@ -111,101 +113,89 @@ def _seed_ladder(base_url: str, unique_suffix: str, tmp_path):
     return wid, sid, cleanup_urls
 
 
-def _pending_body(*, tool_call_id, prompt, response_schema=None) -> str:
-    return json.dumps({
-        "tool_call_id": tool_call_id,
-        "prompt": prompt,
-        "response_schema": response_schema,
-        "parked_at": "2026-05-23T12:00:00+00:00",
-    })
+def _ask_item(sid, *, tool_call_id, prompt):
+    return {"kind": "ask_user", "session_id": sid, "tool_call_id": tool_call_id, "prompt": prompt}
+
+
+def _route_pending_items(page, wid, items):
+    """Route GET /v1/workspaces/{wid}/yields/pending → {items}."""
+    page.route(
+        f"**/v1/workspaces/{wid}/yields/pending",
+        lambda route: route.fulfill(
+            status=200, content_type="application/json",
+            body=json.dumps({"items": items}),
+        ),
+    )
 
 
 # ===========================================================================
-# U0058 — Panel clears draft when a new tool_call_id arrives across polls
+# U0058 — Per-item respond draft is isolated across pending items
 # ===========================================================================
 
 
 def test_u0058_draft_clears_when_new_tool_call_id_arrives(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0058 — The panel's useEffect on tcid resets draft + inline
-    error to empty when the polled tool_call_id changes. Pins that
-    cross-prompt isolation against stale draft contamination.
+    """U0058 — Re-pointed to the Studio's Action Required. The old
+    single-panel "draft resets when the polled tool_call_id changes"
+    invariant maps to the Studio's per-item respond state: each pending
+    yield is its own ``action-item`` keyed by tool_call_id
+    (studio-activity.jsx ``respondState``), so a draft typed into item A
+    never bleeds into item B when the pending snapshot swaps.
     """
-    _, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
-        # Mutable state so we can swap the response mid-test.
-        state = {"tcid": "tc-A", "prompt": "What is your name?"}
+        state = {"items": [_ask_item(sid, tool_call_id="tc-A", prompt="What is your name?")]}
 
         def _on_pending(route):
             route.fulfill(
                 status=200, content_type="application/json",
-                body=_pending_body(
-                    tool_call_id=state["tcid"], prompt=state["prompt"],
-                ),
+                body=json.dumps({"items": state["items"]}),
             )
 
-        page.route(
-            f"**/v1/sessions/{sid}/ask_user/pending", _on_pending,
-        )
+        page.route(f"**/v1/workspaces/{wid}/yields/pending", _on_pending)
 
-        page.goto(
-            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded",
-        )
-        panel = page.locator("[data-testid='ask-user-panel']")
-        expect(panel).to_be_visible(timeout=10_000)
+        open_studio(page, console_url, wid)
+        item = page.locator("[data-testid='action-item']").first
+        expect(item).to_be_visible(timeout=10_000)
+        expect(item).to_contain_text("What is your name?")
 
-        # Type a draft.
-        inp = page.locator("[data-testid='ask-user-input']")
+        # Type a draft into item A's respond input.
+        inp = item.locator("[data-testid='respond']")
         inp.fill("partial draft text")
-        # Assert the draft is what we typed.
         assert (inp.input_value() or "") == "partial draft text"
 
-        # Swap tcid + prompt — next poll will show a different tcid
-        # which triggers the useEffect that clears the draft.
-        state["tcid"] = "tc-B"
-        state["prompt"] = "Pick a color?"
-        # Wait for the new prompt text to land (polling ~2s).
-        expect(panel).to_contain_text("Pick a color?", timeout=6_000)
-        # And the input is now empty.
-        # Refetch the locator since the panel may have re-rendered.
-        inp_new = page.locator("[data-testid='ask-user-input']")
-        # If the prompt is still short, the variant remains input.
-        # Assert input is present + empty.
-        assert inp_new.count() == 1
-        assert (inp_new.input_value() or "") == "", (
-            f"draft was not cleared when tcid changed: "
-            f"{inp_new.input_value()!r}"
+        # Swap the pending snapshot to a DIFFERENT yield (new tcid + prompt);
+        # the next reconcile poll (15s) or a manual wait surfaces item B.
+        state["items"] = [_ask_item(sid, tool_call_id="tc-B", prompt="Pick a color?")]
+        item_b = page.locator("[data-testid='action-item']").filter(has_text="Pick a color?").first
+        expect(item_b).to_be_visible(timeout=20_000)
+        # Item B's respond input is empty — the draft was scoped to item A.
+        inp_b = item_b.locator("[data-testid='respond']")
+        assert (inp_b.input_value() or "") == "", (
+            f"draft bled into the new pending item: {inp_b.input_value()!r}"
         )
     finally:
         _cleanup(base_url, cleanup_urls)
 
 
 # ===========================================================================
-# U0060 — /respond 500 → inline error (not generic toast)
+# U0060 — /respond error → inline on the action-item (not a toast)
 # ===========================================================================
 
 
 def test_u0060_respond_500_renders_inline_error_not_toast(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0060 — A server 500 from /ask_user/respond is rendered INLINE
-    under the textarea/input (ask-user-error data-testid), NOT as
-    a generic error toast. Defends the panel's localised error
-    surface so the operator sees the failure exactly where the
-    submission happened.
+    """U0060 — Re-pointed to the Studio's Action Required. A server 500
+    from ``/ask_user/respond`` renders INLINE on the action-item (the
+    per-item ``rs.error`` red line), NOT as a generic toast — the
+    operator sees the failure exactly where the submission happened and
+    the item stays put to retry.
     """
-    _, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
-        page.route(
-            f"**/v1/sessions/{sid}/ask_user/pending",
-            lambda route: route.fulfill(
-                status=200, content_type="application/json",
-                body=_pending_body(
-                    tool_call_id="tc-500", prompt="Short?",
-                ),
-            ),
-        )
+        _route_pending_items(page, wid, [_ask_item(sid, tool_call_id="tc-500", prompt="Short?")])
         page.route(
             f"**/v1/sessions/{sid}/ask_user/respond",
             lambda route: route.fulfill(
@@ -219,33 +209,28 @@ def test_u0060_respond_500_renders_inline_error_not_toast(
             ),
         )
 
-        page.goto(
-            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded",
-        )
-        expect(
-            page.locator("[data-testid='ask-user-panel']")
-        ).to_be_visible(timeout=10_000)
+        open_studio(page, console_url, wid)
+        item = page.locator("[data-testid='action-item']").first
+        expect(item).to_be_visible(timeout=10_000)
 
-        page.locator("[data-testid='ask-user-input']").fill("Alice")
-        page.get_by_role("button", name="Send response").click()
+        respond = item.locator("[data-testid='respond']")
+        respond.fill("Alice")
+        respond.press("Enter")
 
-        # Inline error visible.
-        inline = page.locator("[data-testid='ask-user-error']")
-        expect(inline).to_be_visible(timeout=5_000)
-        # Error text references the 500 detail or generic submit-failure.
-        text = (inline.text_content() or "").lower()
-        assert "500" in text or "synthetic" in text or "submit" in text, (
-            f"inline error text doesn't reference the failure: {text!r}"
+        # An inline error line renders on the item (studio-activity.jsx sets
+        # rs.error to the failure's detail/title/message, else "Respond
+        # failed"). Wait for the red line to appear, then confirm it carries
+        # a failure marker — and that it is inline, NOT a toast.
+        page.wait_for_timeout(1_000)
+        item_text = (item.text_content() or "").lower()
+        assert any(m in item_text for m in ("synthetic 500", "internal error", "respond failed", "500")), (
+            f"no inline error marker on the action-item: {item_text!r}"
         )
-
-        # No "Response sent" success toast.
-        assert page.get_by_text("Response sent", exact=False).count() == 0, (
-            "success toast appeared despite the 500 — error path leaked"
+        assert page.locator(".toast").filter(has_text="Respond failed").count() == 0, (
+            "respond error should render inline on the item, not as a toast"
         )
-        # Panel stays open for the operator to retry.
-        expect(
-            page.locator("[data-testid='ask-user-panel']")
-        ).to_be_visible()
+        # The item stays put for a retry.
+        expect(item).to_be_visible()
     finally:
         _cleanup(base_url, cleanup_urls)
 
@@ -258,35 +243,22 @@ def test_u0060_respond_500_renders_inline_error_not_toast(
 def test_u0070_pause_button_disabled_when_status_not_running(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0070 — Per session-detail.jsx the Pause button is
-    ``disabled={s.status !== "running" || pauseMut.loading}`` with
-    a title attribute "Enabled only when status = running" when
-    disabled. Pins both the disabled attr AND the title affordance.
+    """U0070 — Re-pointed to the Studio's ``ctrl-pause``. Per
+    studio-center.jsx ``ST_SessionControls`` the Pause button is
+    ``disabled={!wid || status !== "running" || pauseMut.loading}`` with
+    a title "Enabled only when running" for a non-running (CREATED)
+    session. Pins both the disabled attr AND the title affordance.
     """
-    _, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
-        page.goto(
-            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded",
-        )
-        # Resilience: unpkg / Google-Fonts can ERR_CONNECTION_RESET on
-        # individual tests, leaving the page blank because React never
-        # loaded. Gate on the sidebar (.nav-item) being rendered — it
-        # only appears once chrome.jsx has mounted. Generous timeout to
-        # absorb a CDN slow-cache.
-        page.locator(".nav-item").first.wait_for(
-            state="visible", timeout=20_000,
-        )
-        # Now wait for the session detail's right-rail signals area
-        # via the Resume button (only mounted after session.data lands).
-        page.get_by_role(
-            "button", name="Resume", exact=True,
-        ).first.wait_for(state="visible", timeout=10_000)
+        open_session_in_studio(page, console_url, wid, sid, kind="agent")
 
-        pause = page.get_by_role("button", name="Pause", exact=True).first
+        pause = page.locator("[data-testid='ctrl-pause']").first
+        expect(pause).to_be_visible(timeout=10_000)
         expect(pause).to_be_disabled()
         # Title affordance explains why.
         title = pause.get_attribute("title") or ""
-        assert "Enabled only when status = running" in title, (
+        assert "Enabled only when running" in title, (
             f"expected disabled-reason title, got {title!r}"
         )
     finally:
@@ -308,17 +280,10 @@ def test_u0067_resume_re_toasts_on_repeat_click(
     even if the row was already running by the time the second
     click landed.
     """
-    _, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
-        page.goto(
-            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded",
-        )
-        page.locator("h1.page-title").get_by_text(sid).first.wait_for(
-            state="visible", timeout=10_000,
-        )
-        resume = page.get_by_role(
-            "button", name="Resume", exact=True,
-        ).first
+        open_session_in_studio(page, console_url, wid, sid, kind="agent")
+        resume = page.locator("[data-testid='ctrl-resume']").first
         resume.wait_for(state="visible", timeout=10_000)
 
         # First click → toast.

--- a/tests/ui_e2e/test_polling_cadences.py
+++ b/tests/ui_e2e/test_polling_cadences.py
@@ -28,7 +28,7 @@ import time
 import httpx
 import pytest
 
-from tests.ui_e2e._studio_helpers import open_studio
+from tests.ui_e2e._studio_helpers import open_studio, session_row
 
 
 def test_u0002_sessions_sidebar_count_polls_after_api_create(
@@ -140,9 +140,11 @@ def test_u0002_sessions_sidebar_count_polls_after_api_create(
             f"state within 15s: baseline={baseline} expected>={target} "
             f"final={final}"
         )
-        # The new row is the seeded session.
-        expect_row = page.locator('[data-testid="session-row"]', has_text=session_id)
-        assert expect_row.count() >= 1, "seeded session row not found in sidebar"
+        # The new row is the seeded session (located by data-session-id;
+        # the row shows the title, not the raw sid).
+        assert session_row(page, session_id).count() >= 1, (
+            "seeded session row not found in sidebar"
+        )
     finally:
         with httpx.Client(base_url=base_url, timeout=30.0) as c:
             for url in (

--- a/tests/ui_e2e/test_polling_cadences.py
+++ b/tests/ui_e2e/test_polling_cadences.py
@@ -28,6 +28,8 @@ import time
 import httpx
 import pytest
 
+from tests.ui_e2e._studio_helpers import open_studio
+
 
 def test_u0002_sessions_sidebar_count_polls_after_api_create(
     page,
@@ -36,21 +38,21 @@ def test_u0002_sessions_sidebar_count_polls_after_api_create(
     unique_suffix: str,
     tmp_path,
 ) -> None:
-    """U0002 — POST a session via the API to a fresh workspace and
-    assert the sidebar Sessions counter increments to reflect the new
-    row within one polling interval (≤12s budget, real cadence ≤5s).
+    """U0002 — Re-pointed to the Studio sidebar's per-workspace Sessions
+    count. POST a session via the API to a fresh workspace and assert the
+    Studio left-sidebar Sessions-section count increments to reflect the
+    new row within one polling interval (≤15s budget, real cadence ~3s).
 
-    Priority 4 — polling cadence. The Sessions sidebar count is the
-    sum of three sub-counts (CREATED + RUNNING + PAUSED) — each its
-    own poll (chrome.jsx:94-102). The combined number renders only
-    once all three have a value, so a fresh page needs one full
-    interval to display a number at all.
+    Priority 4 — polling cadence. The old GLOBAL sidebar "Sessions" nav
+    count was removed with the sessions list (the ``studio`` nav item
+    carries no count). The Studio's SessionsSection instead polls
+    ``/workspaces/{wid}/sessions`` every 3s and renders the row count in
+    its ``sessions-header`` (studio-sidebar.jsx ``st-section-count``); a
+    new API-created row surfaces there without a manual refresh.
 
-    Setup ladder mirrors U0013 (anomaly): LLM provider → agent →
-    workspace provider → template → workspace. Then we open the
-    console, capture the baseline Sessions count, POST a session via
-    API with auto_start=false (no real LLM call), and poll the
-    sidebar until the count is baseline+1.
+    Setup ladder: LLM provider → agent → workspace provider → template →
+    workspace. Open the Studio, capture the baseline session-row count,
+    POST a session (auto_start=false), poll until a new row appears.
     """
     provider_id = f"llm-u0002-{unique_suffix}"
     agent_id = f"ag-u0002-{unique_suffix}"
@@ -96,40 +98,21 @@ def test_u0002_sessions_sidebar_count_polls_after_api_create(
         workspace_id = r.json()["id"]
 
     try:
-        # Open the dashboard (sidebar renders on any page).
-        page.goto(f"{console_url}#/", wait_until="domcontentloaded")
-        # The Sessions nav item carries a .count span when the three
-        # status polls have all loaded. Find it via the label.
-        sessions_nav = page.locator(
-            ".nav-item:has(.label:text('Sessions'))"
-        ).first
-        sessions_nav.wait_for(state="visible", timeout=10_000)
+        # Open the Studio for the fresh workspace; the sidebar Sessions
+        # section polls this workspace's sessions every 3s.
+        open_studio(page, console_url, workspace_id)
 
-        def _read_count() -> int | None:
-            """Return the integer rendered in the Sessions .count, or
-            None if the count hasn't loaded yet (no .count element
-            present means the polls are still in flight)."""
-            count_el = sessions_nav.locator(".count").first
-            if count_el.count() == 0:
-                return None
-            txt = (count_el.text_content() or "").strip()
-            try:
-                return int(txt)
-            except ValueError:
-                return None
+        def _row_count() -> int:
+            """Number of session-row entries currently rendered."""
+            return page.locator('[data-testid="session-row"]').count()
 
-        # Wait until the baseline is rendered (first poll cycle).
-        baseline: int | None = None
-        deadline = time.monotonic() + 12.0
-        while time.monotonic() < deadline:
-            baseline = _read_count()
-            if baseline is not None:
-                break
-            page.wait_for_timeout(250)
-        assert baseline is not None, (
-            "Sessions sidebar count never rendered within 12s — "
-            "polls aren't loading at all on the freshly opened page"
+        # Baseline: a brand-new workspace has zero session rows. Wait for
+        # the Sessions section to have finished its first poll (the empty
+        # "No sessions yet." copy is present).
+        page.locator('[data-testid="sessions-section"]').wait_for(
+            state="visible", timeout=15_000,
         )
+        baseline = _row_count()
 
         # POST the session via API to drive the increment.
         with httpx.Client(base_url=base_url, timeout=30.0) as c:
@@ -143,22 +126,23 @@ def test_u0002_sessions_sidebar_count_polls_after_api_create(
             assert r.status_code == 201, f"seed session failed: {r.text}"
             session_id = r.json()["id"]
 
-        # Wait for the sidebar to catch up. Real poll cadence is 5s
-        # — budget 15s to absorb the worst-case overlap between
-        # request firing and React batching.
+        # Wait for the sidebar to catch up (3s poll) — budget 15s.
         target = baseline + 1
         deadline = time.monotonic() + 15.0
+        final = baseline
         while time.monotonic() < deadline:
-            now = _read_count()
-            if now is not None and now >= target:
+            final = _row_count()
+            if final >= target:
                 break
             page.wait_for_timeout(250)
-        final = _read_count()
-        assert final is not None and final >= target, (
-            f"Sessions sidebar count did not catch up to API state "
-            f"within 15s: baseline={baseline} expected≥{target} "
+        assert final >= target, (
+            f"Studio sidebar session-row count did not catch up to API "
+            f"state within 15s: baseline={baseline} expected>={target} "
             f"final={final}"
         )
+        # The new row is the seeded session.
+        expect_row = page.locator('[data-testid="session-row"]', has_text=session_id)
+        assert expect_row.count() >= 1, "seeded session row not found in sidebar"
     finally:
         with httpx.Client(base_url=base_url, timeout=30.0) as c:
             for url in (

--- a/tests/ui_e2e/test_routing_and_mutations.py
+++ b/tests/ui_e2e/test_routing_and_mutations.py
@@ -72,9 +72,13 @@ def test_u0023_new_workspace_modal_creates_row_toasts_and_navigates(
 ) -> None:
     """U0023 — Open the Workspaces list, click "New workspace", pick
     the seeded template from the dropdown, submit. The modal must
-    close, a success toast must appear, the URL must navigate to
-    ``#/workspaces/<new-id>``, and the detail-page title must render
-    the new id.
+    close, a success toast must appear, and the URL must navigate to
+    ``#/workspaces/<new-id>``.
+
+    Re-pointed: ``#/workspaces/<id>`` now renders the Studio (not the old
+    workspace-detail page), so the post-create assertion pins the Studio
+    shell mounting for the new workspace (studio-root + the workspace
+    selector showing the new id) instead of an ``h1.page-title``.
 
     Priority 1 — mutation feedback. Sister to U0006 (agents) for the
     workspace-create flow. The backend allocates the id (workspace
@@ -136,8 +140,12 @@ def test_u0023_new_workspace_modal_creates_row_toasts_and_navigates(
             f"unexpected workspace id format in URL: {url}"
         )
 
-        # Detail title carries the new id.
-        page.locator("h1.page-title").get_by_text(
+        # The new workspace's Studio shell mounts (studio-root), and its
+        # sub-header workspace selector shows the new id.
+        page.locator('[data-testid="studio-root"]').wait_for(
+            state="visible", timeout=15_000,
+        )
+        page.locator('[data-testid="workspace-selector"]').get_by_text(
             created_ws_id, exact=False,
         ).first.wait_for(state="visible", timeout=10_000)
 

--- a/tests/ui_e2e/test_session_files_toast_lasterr.py
+++ b/tests/ui_e2e/test_session_files_toast_lasterr.py
@@ -312,106 +312,15 @@ def test_u0080_workspace_files_dir_drilldown_renders_children(
 # ===========================================================================
 
 
-def test_u0083_session_detail_last_error_panel_renders(
-    page, base_url, console_url, unique_suffix, tmp_path,
-) -> None:
-    """U0083 - Mock GET /v1/sessions/{sid} to return a row whose
-    ``last_error`` payload is populated (RFC 7807 envelope shape).
-    Navigate to ``#/sessions/<id>`` → the "Last error" panel
-    (session-detail.jsx:262) renders with the literal "Last error"
-    header + type subscript + the title/detail copy when expanded.
-
-    Pins the documented session-detail last_error render - the
-    only operator-facing surface for the session's failure
-    payload. Using page.route here (instead of relying on the
-    worker to actually populate last_error on a fast-fail path)
-    keeps the test deterministic across container/native dispatch
-    differences; the field's POPULATION is exercised end-to-end
-    in T0739 / T0737 from the API loop.
-    """
-    pid = f"llm-83-{unique_suffix}"
-    aid = f"ag-83-{unique_suffix}"
-    wp_id = f"wp-83-{unique_suffix}"
-    tpl_id = f"tpl-83-{unique_suffix}"
-    _seed_llm_provider(base_url, pid)
-    _seed_agent(base_url, aid, pid)
-    wid = _seed_workspace(base_url, wp_id, tpl_id, tmp_path)
-    cleanup_urls = [
-        f"/v1/workspaces/{wid}",
-        f"/v1/workspace_templates/{tpl_id}",
-        f"/v1/workspace_providers/{wp_id}",
-        f"/v1/agents/{aid}",
-        f"/v1/llm_providers/{pid}",
-    ]
-    sid: str | None = None
-    try:
-        # Real session row (so the rest of the page renders honestly);
-        # we'll only mock the last_error payload in flight.
-        with httpx.Client(base_url=base_url, timeout=30.0) as c:
-            r = c.post(
-                f"/v1/workspaces/{wid}/sessions",
-                json={
-                    "binding": {"kind": "agent", "agent_id": aid},
-                    "auto_start": False,
-                },
-            )
-            assert r.status_code == 201, r.text
-            sid = r.json()["id"]
-            cleanup_urls.insert(
-                0, f"/v1/workspaces/{wid}/sessions/{sid}/cancel",
-            )
-            # Fetch the real row so we can return it back with
-            # last_error injected.
-            gr = c.get(f"/v1/sessions/{sid}")
-            assert gr.status_code == 200, gr.text
-            real_row = gr.json()
-            real_row["last_error"] = {
-                "type": "/errors/internal",
-                "title": "Synthetic last_error for U0083",
-                "status": 500,
-                "detail": "page.route-injected payload",
-                "extensions": {"request_id": f"req-{unique_suffix}"},
-            }
-
-        # Mock the GET /v1/sessions/{sid} response so the UI sees
-        # last_error populated.
-        body_json = json.dumps(real_row)
-
-        def _on_session_get(route):
-            if route.request.method == "GET":
-                route.fulfill(
-                    status=200,
-                    content_type="application/json",
-                    body=body_json,
-                )
-            else:
-                route.continue_()
-
-        page.route(f"**/v1/sessions/{sid}", _on_session_get)
-
-        try:
-            page.goto(
-                f"{console_url}#/sessions/{sid}",
-                wait_until="domcontentloaded",
-            )
-            page.locator(".nav-item").first.wait_for(
-                state="visible", timeout=20_000,
-            )
-
-            # Last error panel header carries the literal "Last error"
-            # span (session-detail.jsx:267). Renders unconditionally
-            # when last_error is truthy; body is collapsed by default.
-            expect(
-                page.get_by_text("Last error", exact=True).first
-            ).to_be_visible(timeout=10_000)
-            # And the type subscript renders next to the header.
-            expect(
-                page.get_by_text("/errors/internal", exact=False).first
-            ).to_be_visible(timeout=3_000)
-        finally:
-            page.unroute(f"**/v1/sessions/{sid}")
-    finally:
-        _cleanup(base_url, cleanup_urls)
+# U0083 REMOVED (no Studio equivalent) — this pinned the session-detail
+# "Last error" panel (session-detail.jsx ``lastError`` block, header + RFC
+# 7807 type subscript). That panel lived in the retired ``SessionDetail``
+# body; the Studio's center session panel reuses ``SessionLiveStream``, which
+# renders the live frame stream + a terminal "Session ended" notice but does
+# NOT surface a session-level ``last_error`` panel (there is no equivalent
+# data-testid or copy in studio-center.jsx). With no Studio surface to pin,
+# the test is removed with this documented note (last_error POPULATION stays
+# covered end-to-end by the API loop's T0739 / T0737).
 
 
 # ===========================================================================
@@ -419,81 +328,14 @@ def test_u0083_session_detail_last_error_panel_renders(
 # ===========================================================================
 
 
-def test_u0084_session_detail_turns_panel_header_toggles(
-    page, base_url, console_url, unique_suffix, tmp_path,
-) -> None:
-    """U0084 - Session detail turn-log surface renders + responds to
-    selection.
-
-    The turn-log view moved from an inline collapsible "Turns timeline"
-    panel to a dedicated "Turn log" tab on the session detail page
-    (session-detail.jsx ``tabs`` + ``TurnLogTab``). The tab surface is
-    rendered through ``MobileTabs`` at the mobile breakpoint, so this
-    test drives it at a mobile viewport: select the "Turn log" tab → the
-    empty-state copy ("No turn-log entries yet") for a CREATED session
-    becomes visible; switch away to "Overview" → it hides; switch back →
-    it reappears. This is the current testable contract on every session
-    regardless of dispatch outcome (the placeholder-LLM session never
-    populates a turn row).
-    """
-    pid = f"llm-84-{unique_suffix}"
-    aid = f"ag-84-{unique_suffix}"
-    wp_id = f"wp-84-{unique_suffix}"
-    tpl_id = f"tpl-84-{unique_suffix}"
-    _seed_llm_provider(base_url, pid)
-    _seed_agent(base_url, aid, pid)
-    wid = _seed_workspace(base_url, wp_id, tpl_id, tmp_path)
-    cleanup_urls = [
-        f"/v1/workspaces/{wid}",
-        f"/v1/workspace_templates/{tpl_id}",
-        f"/v1/workspace_providers/{wp_id}",
-        f"/v1/agents/{aid}",
-        f"/v1/llm_providers/{pid}",
-    ]
-    sid: str | None = None
-    try:
-        with httpx.Client(base_url=base_url, timeout=30.0) as c:
-            r = c.post(
-                f"/v1/workspaces/{wid}/sessions",
-                json={
-                    "binding": {"kind": "agent", "agent_id": aid},
-                    "auto_start": False,
-                },
-            )
-            assert r.status_code == 201, r.text
-            sid = r.json()["id"]
-            cleanup_urls.insert(
-                0, f"/v1/workspaces/{wid}/sessions/{sid}/cancel",
-            )
-
-        # Drive the tabbed session-detail at the mobile breakpoint so the
-        # MobileTabs surface (which hosts the Turn log tab) renders.
-        page.set_viewport_size({"width": 375, "height": 812})
-        page.goto(
-            f"{console_url}#/sessions/{sid}",
-            wait_until="domcontentloaded",
-        )
-        # At the mobile breakpoint the sidebar nav is collapsed behind a
-        # drawer; wait directly on the tab strip the detail page renders.
-        turn_log_tab = page.get_by_role("tab", name="Turn log").first
-        turn_log_tab.wait_for(state="visible", timeout=20_000)
-
-        empty_copy = page.get_by_text("No turn-log entries yet", exact=False).first
-
-        # Select the Turn log tab → empty-state copy for a CREATED
-        # session becomes visible.
-        turn_log_tab.click()
-        expect(empty_copy).to_be_visible(timeout=10_000)
-
-        # Switch to the Overview tab → the turn-log content is no longer
-        # mounted (tab panels swap their content).
-        page.get_by_role("tab", name="Overview").first.click()
-        expect(empty_copy).to_have_count(0, timeout=5_000)
-
-        # Switch back to Turn log → the empty-state copy reappears.
-        page.get_by_role("tab", name="Turn log").first.click()
-        expect(
-            page.get_by_text("No turn-log entries yet", exact=False).first
-        ).to_be_visible(timeout=10_000)
-    finally:
-        _cleanup(base_url, cleanup_urls)
+# U0084 REMOVED (no Studio equivalent) — this pinned the session-detail
+# "Turn log" tab (session-detail.jsx ``tabs`` + ``TurnLogTab``) and its
+# empty-state "No turn-log entries yet" copy, driven through the mobile
+# ``MobileTabs`` surface. Both the tabbed session-detail page and its Turn
+# log tab were retired with the Studio. The Studio's center session panel
+# reuses ``SessionLiveStream`` (a live frame stream), not a per-turn "Turn
+# log" tab — there is no equivalent tab/empty-state surface in
+# studio-center.jsx — so the test is removed with this documented note.
+# (Graph sessions DO keep a "Turn log" section inside the reused
+# SD_GraphRunView node inspector, exercised by test_graph_run_view_journey,
+# but that is the graph node inspector, not this agent-session turn tab.)

--- a/tests/ui_e2e/test_session_graph_liveness_pill.py
+++ b/tests/ui_e2e/test_session_graph_liveness_pill.py
@@ -23,6 +23,7 @@ import httpx
 from playwright.sync_api import expect
 
 from tests._support.smk import smk  # noqa: E402
+from tests.ui_e2e._studio_helpers import open_session_in_studio
 
 pytestmark = smk("SMK-UI-02")
 
@@ -98,7 +99,7 @@ def _seed(base_url: str, suffix: str, tmp_path):
         f"/v1/workspace_providers/{wp_id}",
         f"/v1/agents/{aid}",
     ]
-    return sid, cleanup
+    return wid, sid, cleanup
 
 
 def _cleanup(base_url: str, urls: list[str]) -> None:
@@ -117,21 +118,25 @@ def test_graph_session_liveness_pill_replaces_executor_missing_stub(
     unique_suffix: str,
     tmp_path,
 ) -> None:
-    sid, cleanup = _seed(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup = _seed(base_url, unique_suffix, tmp_path)
     try:
-        page.goto(
-            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded"
-        )
-        page.locator(".page-title").first.wait_for(state="visible", timeout=10_000)
+        # Re-pointed to the Studio graph panel. The old hardcoded
+        # "executor missing" stub + the References-panel "awaiting worker"
+        # liveness pill both lived in the retired SessionDetail. The Studio's
+        # panel-graph header derives its state from the reused StatusPill;
+        # a CREATED graph session reads "created" there. This pins the
+        # surviving invariant: the "executor missing" stub is gone
+        # everywhere, and the panel surfaces the real (created) status.
+        open_session_in_studio(page, console_url, wid, sid, kind="graph")
 
-        # The hardcoded stub must be gone everywhere on the page.
+        # The hardcoded stub must be gone everywhere in the Studio.
         expect(page.get_by_text("executor missing")).to_have_count(0)
 
-        # A CREATED graph session shows the derived "awaiting worker"
-        # liveness pill in the References panel (the header subtitle
-        # "awaiting worker claim" is plain text, not a `.pill`).
-        expect(
-            page.locator(".pill").filter(has_text="awaiting worker").first
-        ).to_be_visible()
+        # The graph panel header shows the derived StatusPill; a CREATED
+        # session reads "created" (StatusPill labels — shared.jsx).
+        header = page.locator('[data-testid="panel-graph-header"]')
+        expect(header.locator(".pill").filter(has_text="created").first).to_be_visible(
+            timeout=10_000,
+        )
     finally:
         _cleanup(base_url, cleanup)

--- a/tests/ui_e2e/test_session_lifecycle_journey.py
+++ b/tests/ui_e2e/test_session_lifecycle_journey.py
@@ -31,6 +31,8 @@ import time
 import httpx
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_studio
+
 
 # ---------------------------------------------------------------------------
 # Container-internal workspace provider path — host tmp_path is not visible
@@ -165,57 +167,44 @@ def test_u0103_sessions_full_lifecycle_journey(
     breadcrumb navigation.
     """
     ids = _seed_session_ladder(base_url, unique_suffix)
+    wid = ids["workspace"]
     sid = ids["session"]
     try:
-        # --- 1. Navigate to /sessions list ----------------------------------
-        page.goto(f"{console_url}#/sessions", wait_until="domcontentloaded")
-        expect(page.locator("h1.page-title")).to_have_text("Sessions", timeout=20_000)
-        # The seeded session id appears in the rows (mono-style cell).
-        row_locator = page.locator("tbody tr", has_text=sid)
-        expect(row_locator).to_be_visible(timeout=20_000)
+        # --- 1. Enter the Studio; the seeded session is a sidebar row -------
+        open_studio(page, console_url, wid)
+        row_locator = page.locator('[data-testid="session-row"]', has_text=sid)
+        expect(row_locator.first).to_be_visible(timeout=20_000)
 
-        # --- 2. Click row → /sessions/{id} ----------------------------------
+        # --- 2. Click the row → center tab + agent panel --------------------
         row_locator.first.click()
-        page.wait_for_url(f"**/console/#/sessions/{sid}", timeout=15_000)
-        # Wait for the detail page to actually render — page-title carries
-        # the session id (mono style, full string).
-        expect(page.locator("h1.page-title", has_text=sid)).to_be_visible(
-            timeout=20_000,
+        expect(page.locator('[data-testid="center-tab"]').first).to_be_visible(
+            timeout=15_000,
+        )
+        expect(page.locator('[data-testid="panel-agent"]')).to_be_visible(
+            timeout=15_000,
         )
 
-        # Sanity: status caption shows "awaiting worker claim" for CREATED.
-        # Don't assert too strictly — the worker pool may have moved it on.
-        # Just confirm Cancel button is enabled (not in terminal status).
-        cancel_btn = page.get_by_role("button", name="Cancel", exact=True)
+        # Sanity: the ctrl-cancel control is enabled (session non-terminal).
+        cancel_btn = page.locator('[data-testid="ctrl-cancel"]').first
         expect(cancel_btn).to_be_enabled(timeout=10_000)
 
-        # --- 3. Click Cancel → confirmation modal ---------------------------
+        # --- 3. Click ctrl-cancel (fires directly, no confirm modal) --------
         cancel_btn.click()
-        # Modal title from session-detail.jsx:432 is "Cancel session?".
-        modal = page.locator(".modal", has_text="Cancel session?")
-        expect(modal).to_be_visible(timeout=5_000)
-
-        # --- 4. Click "Cancel session" confirm button -----------------------
-        # Confirm button is inside the modal; scope to avoid matching the
-        # primary "Cancel" button outside the modal (which is now disabled).
-        modal.get_by_role("button", name="Cancel session", exact=True).click()
-
-        # --- 5. Assert toast appears ----------------------------------------
-        # Toast from session-detail.jsx:82 has title "Cancel signal sent".
+        # Toast from ST_SessionControls has title "Cancel signal sent".
         expect(page.get_by_text("Cancel signal sent")).to_be_visible(
             timeout=10_000,
         )
 
-        # --- 6. Watch status caption poll to a non-CREATED value ------------
-        # Cancellation flips parked_status / cancel_requested; the row will
-        # transition to cancelled or (depending on the worker pool race) to
-        # ended. Don't pin one specific status — pin "left CREATED" within
-        # the polling cadence (2 s poll, 30 s budget).
-        status_caption = page.locator(".page-sub .pill")
+        # --- 4. Panel-header status polls off CREATED -----------------------
+        # ST_SessionPanel polls /sessions/{id} every 2s while non-terminal;
+        # the header StatusPill catches up to cancelled/ended. Pin "left
+        # CREATED" (30s budget).
+        header = page.locator('[data-testid="panel-agent-header"]')
+        status_pill = header.locator(".pill").first
         deadline = time.time() + 30.0
         last_seen = None
         while time.time() < deadline:
-            txt = status_caption.text_content(timeout=2_000) or ""
+            txt = status_pill.text_content(timeout=2_000) or ""
             last_seen = txt.strip().lower()
             if last_seen and "created" not in last_seen:
                 break
@@ -225,17 +214,9 @@ def test_u0103_sessions_full_lifecycle_journey(
                 f"status pill never left CREATED within 30s; last seen: {last_seen!r}"
             )
 
-        # --- 7. Click "Sessions" breadcrumb → /sessions ---------------------
-        # session-detail.jsx:459 renders the breadcrumb anchor "Sessions".
-        page.locator(".crumb a", has_text="Sessions").click()
-        page.wait_for_url("**/console/#/sessions", timeout=10_000)
-        expect(page.locator("h1.page-title")).to_have_text(
-            "Sessions", timeout=10_000,
-        )
-
-        # --- 8. Row still listed in /sessions with non-CREATED status -------
-        row_after = page.locator("tbody tr", has_text=sid)
-        expect(row_after).to_be_visible(timeout=15_000)
+        # --- 5. The session is still listed in the Studio sidebar -----------
+        row_after = page.locator('[data-testid="session-row"]', has_text=sid)
+        expect(row_after.first).to_be_visible(timeout=15_000)
     finally:
         _cleanup(base_url, ids)
 
@@ -313,21 +294,22 @@ def test_u0104_workspace_sessions_tab_reflects_api_seeded_session(
 
         wid = ids["workspace"]
 
-        # --- 1. Navigate to /workspaces/{wid}?tab=sessions ------------------
-        page.goto(
-            f"{console_url}#/workspaces/{wid}?tab=sessions",
-            wait_until="domcontentloaded",
-        )
-        # Workspace detail header renders the workspace id in the page-title.
-        expect(page.locator("h1.page-title", has_text=wid)).to_be_visible(
-            timeout=20_000,
-        )
+        # --- 1. Enter the Studio for the workspace --------------------------
+        # Re-pointed: the workspace-detail Sessions tab is retired; sessions
+        # live in the Studio left-sidebar Sessions section, which polls
+        # /workspaces/{wid}/sessions every 3s (studio-sidebar.jsx).
+        open_studio(page, console_url, wid)
 
-        # --- 2. Sessions tab is selected; empty state visible ---------------
-        # SessionsTab renders div.empty with head "No sessions" before any
-        # session is seeded.
-        empty_state = page.locator(".empty", has_text="No sessions")
-        expect(empty_state).to_be_visible(timeout=15_000)
+        # --- 2. Sessions section shows the empty state ----------------------
+        # SessionsSection renders "No sessions yet." before any is seeded.
+        expect(page.locator('[data-testid="sessions-section"]')).to_be_visible(
+            timeout=15_000,
+        )
+        expect(
+            page.locator('[data-testid="sessions-section"]').get_by_text(
+                "No sessions yet", exact=False,
+            )
+        ).to_be_visible(timeout=15_000)
 
         # --- 3. Seed the session in the background --------------------------
         with httpx.Client(base_url=base_url, timeout=30.0) as c:
@@ -342,14 +324,16 @@ def test_u0104_workspace_sessions_tab_reflects_api_seeded_session(
             ids["session"] = r.json()["id"]
         sid = ids["session"]
 
-        # --- 4. Wait for the row to surface within the 5s poll --------------
-        row_locator = page.locator("tbody tr", has_text=sid)
-        expect(row_locator).to_be_visible(timeout=20_000)
+        # --- 4. Wait for the sidebar row to surface within the 3s poll ------
+        row_locator = page.locator('[data-testid="session-row"]', has_text=sid)
+        expect(row_locator.first).to_be_visible(timeout=20_000)
 
-        # --- 5. Click the row → /sessions/{id} ------------------------------
+        # --- 5. Click the row → center tab + agent panel --------------------
         row_locator.first.click()
-        page.wait_for_url(f"**/console/#/sessions/{sid}", timeout=15_000)
-        expect(page.locator("h1.page-title", has_text=sid)).to_be_visible(
+        expect(page.locator('[data-testid="center-tab"]').first).to_be_visible(
+            timeout=15_000,
+        )
+        expect(page.locator('[data-testid="panel-agent"]')).to_be_visible(
             timeout=15_000,
         )
     finally:

--- a/tests/ui_e2e/test_session_lifecycle_journey.py
+++ b/tests/ui_e2e/test_session_lifecycle_journey.py
@@ -31,7 +31,7 @@ import time
 import httpx
 from playwright.sync_api import expect
 
-from tests.ui_e2e._studio_helpers import open_studio
+from tests.ui_e2e._studio_helpers import open_studio, session_row
 
 
 # ---------------------------------------------------------------------------
@@ -171,8 +171,10 @@ def test_u0103_sessions_full_lifecycle_journey(
     sid = ids["session"]
     try:
         # --- 1. Enter the Studio; the seeded session is a sidebar row -------
+        # The row shows the session TITLE, not the raw sid — locate by the
+        # data-session-id stamp (studio-sidebar.jsx).
         open_studio(page, console_url, wid)
-        row_locator = page.locator('[data-testid="session-row"]', has_text=sid)
+        row_locator = session_row(page, sid)
         expect(row_locator.first).to_be_visible(timeout=20_000)
 
         # --- 2. Click the row → center tab + agent panel --------------------
@@ -215,7 +217,7 @@ def test_u0103_sessions_full_lifecycle_journey(
             )
 
         # --- 5. The session is still listed in the Studio sidebar -----------
-        row_after = page.locator('[data-testid="session-row"]', has_text=sid)
+        row_after = session_row(page, sid)
         expect(row_after.first).to_be_visible(timeout=15_000)
     finally:
         _cleanup(base_url, ids)
@@ -325,7 +327,8 @@ def test_u0104_workspace_sessions_tab_reflects_api_seeded_session(
         sid = ids["session"]
 
         # --- 4. Wait for the sidebar row to surface within the 3s poll ------
-        row_locator = page.locator('[data-testid="session-row"]', has_text=sid)
+        # Locate by data-session-id (the row shows the title, not the sid).
+        row_locator = session_row(page, sid)
         expect(row_locator.first).to_be_visible(timeout=20_000)
 
         # --- 5. Click the row → center tab + agent panel --------------------

--- a/tests/ui_e2e/test_session_panel_signals.py
+++ b/tests/ui_e2e/test_session_panel_signals.py
@@ -15,6 +15,8 @@ import time
 import httpx
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio
+
 
 # ---------------------------------------------------------------------------
 # Seed helpers (mirror tests/ui_e2e/test_navigation_and_signals.py)
@@ -99,21 +101,15 @@ def _cleanup(base_url: str, urls: list[str]) -> None:
 def test_u0052_ask_user_panel_hidden_on_terminal_session(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0052 — Cancel a session via the API → status flips to ENDED.
-    On the session detail page, the AskUserPanel's polling stops
-    (``pollMs: isTerminal ? 0 : 2000`` per
-    [`ui/components/session-detail.jsx`](../../ui/components/session-detail.jsx))
-    so even if a pending prompt existed in the backend's parked_state,
-    the panel must NEVER render on a terminal row.
+    """U0052 — Re-pointed to the Studio. A terminal (ENDED) session can
+    never be parked on ask_user, so the Studio's RIGHT sidebar Action
+    Required list surfaces NO action-item for it — the yielding-tools
+    quiet-state invariant carried over from the retired AskUserPanel.
 
-    We don't even need a real parked prompt — the panel's
-    ``if (!pending.data) return null;`` early-return guarantees
-    nothing renders when polling never fires. This test pins that
-    guarantee against a regression that would re-enable polling on
-    terminal rows (which would spam /ask_user/pending forever).
-
-    Priority area 1 — yielding-tools UI; defends a quiet-state
-    invariant that's easy to break.
+    Cancel the seeded session via the API (CREATED → ENDED), open it in
+    the Studio, wait past a poll cycle, and assert the action-required
+    list stays empty (no ``action-item``, no ask-controls). The old
+    ``ask-user-panel`` / "Input requested" copy is gone everywhere.
     """
     pid = f"llm-u52-{unique_suffix}"
     aid = f"ag-u52-{unique_suffix}"
@@ -137,26 +133,19 @@ def test_u0052_ask_user_panel_hidden_on_terminal_session(
             assert r.status_code == 200, r.text
             assert r.json()["status"] == "ended"
 
-        page.goto(
-            f"{console_url}#/sessions/{sid}",
-            wait_until="domcontentloaded",
-        )
-        # Wait for the page to render the session id in the title.
-        page.locator("h1.page-title").get_by_text(sid).first.wait_for(
-            state="visible", timeout=10_000,
-        )
-        # Wait an extra polling-cycle-worth of time to be sure the
-        # panel never appears in case polling was incorrectly active.
+        # Open the terminal session in the Studio (agent panel).
+        open_session_in_studio(page, console_url, wid, sid, kind="agent")
+        # Wait past a pending-poll cycle to be sure nothing shows up late.
         page.wait_for_timeout(2_500)
-        panel = page.locator("[data-testid='ask-user-panel']")
-        # Panel must NOT be present.
-        assert panel.count() == 0, (
-            "AskUserPanel rendered on a terminal session — polling "
-            "should be disabled per session-detail.jsx isTerminal gate"
+
+        # No action-item / ask-controls for a terminal session.
+        assert page.locator("[data-testid='action-item']").count() == 0, (
+            "Action Required surfaced an item for a terminal session"
         )
-        # The "Input requested" header text also must not appear
-        # anywhere on the page.
+        assert page.locator("[data-testid='action-ask-controls']").count() == 0
+        # The retired panel copy must not appear anywhere.
         assert page.get_by_text("Input requested").count() == 0
+        assert page.locator("[data-testid='ask-user-panel']").count() == 0
     finally:
         _cleanup(base_url, cleanup_urls)
 
@@ -176,8 +165,9 @@ def test_u0031_session_pause_resume_buttons_toggle_status(
     terminal). Then click Pause. Assert each click produces visible
     status text changes within polling cadence.
 
-    Priority area 2 — mutation feedback. Pins the
-    pause/resume signal flow at session-detail.jsx:51-77.
+    Priority area 2 — mutation feedback. Re-pointed to the Studio's
+    ``session-controls`` (``ctrl-resume``) in the center agent panel
+    (studio-center.jsx ``ST_SessionControls``).
 
     We tolerate the session reaching terminal (ended/failed) at any
     point — the LLM provider points at a closed port so the worker's
@@ -202,20 +192,12 @@ def test_u0031_session_pause_resume_buttons_toggle_status(
         f"/v1/llm_providers/{pid}",
     ]
     try:
-        page.goto(
-            f"{console_url}#/sessions/{sid}",
-            wait_until="domcontentloaded",
-        )
-        page.locator("h1.page-title").get_by_text(sid).first.wait_for(
-            state="visible", timeout=10_000,
-        )
-        # Page finished loading the session row when the Resume button
-        # appears (it's only rendered after `session.data` lands). Use
-        # that as the readiness signal rather than racing the loader.
-        resume_btn = page.get_by_role("button", name="Resume", exact=True).first
+        # Open the session in the Studio — the agent panel + controls mount.
+        open_session_in_studio(page, console_url, wid, sid, kind="agent")
+        resume_btn = page.locator("[data-testid='ctrl-resume']").first
         resume_btn.wait_for(state="visible", timeout=10_000)
 
-        # Now the body has the session details — assert initial CREATED.
+        # The panel header StatusPill reads "created" initially.
         body_initial = (page.locator("body").text_content() or "").lower()
         assert "created" in body_initial, "expected initial 'created' status"
 

--- a/tests/ui_e2e/test_session_state_and_history_journey.py
+++ b/tests/ui_e2e/test_session_state_and_history_journey.py
@@ -6,7 +6,11 @@ from __future__ import annotations
 import httpx
 from playwright.sync_api import expect
 
-from tests.ui_e2e._studio_helpers import open_session_in_studio, open_studio
+from tests.ui_e2e._studio_helpers import (
+    open_session_in_studio,
+    open_studio,
+    session_row,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -134,8 +138,9 @@ def test_cancelled_session_shows_cancelled_chip_in_list(
     _cancel_session(base_url, wid, sid)
 
     open_studio(page, console_url, wid)
-    # The cancelled session is listed as a sidebar row (matched by its id).
-    row = page.locator('[data-testid="session-row"]', has_text=sid).first
+    # The cancelled session is listed as a sidebar row (located by its
+    # data-session-id stamp — the row shows the title, not the raw sid).
+    row = session_row(page, sid).first
     expect(row).to_be_visible(timeout=20_000)
     # The row carries its status dot (terminal / gray tone for cancelled).
     expect(row.locator('[data-testid="session-status-dot"]')).to_be_visible(

--- a/tests/ui_e2e/test_session_state_and_history_journey.py
+++ b/tests/ui_e2e/test_session_state_and_history_journey.py
@@ -6,6 +6,8 @@ from __future__ import annotations
 import httpx
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio, open_studio
+
 
 # ---------------------------------------------------------------------------
 # Seed helpers — mirrored from test_graph_run_view_journey.py, adapted for
@@ -78,16 +80,30 @@ def test_cancelled_session_shows_outcome_banner(
     base_url, console_url, page, tmp_path,
 ) -> None:
     """Seed an agent session, cancel it via API (→ ENDED/cancelled), open
-    the detail page, and assert the outcome banner is visible."""
+    it in the Studio, and assert the terminal outcome is surfaced.
+
+    Re-pointed: the retired session-detail rendered a ``session-outcome``
+    panel. The Studio's reused ``SessionLiveStream`` (inside ``panel-agent``)
+    surfaces a terminal session as a "Session ended" notice, and the
+    ``panel-agent-header`` StatusPill reads the terminal status — that is
+    the closest real Studio surface for the "session's terminal outcome is
+    legible" intent.
+    """
     _seed_llm_provider(base_url, "sl-prov")
     _seed_agent(base_url, "sl-agent", "sl-prov")
     wid = _seed_workspace(base_url, "sl-wp", "sl-tpl", tmp_path)
     sid = _seed_agent_session(base_url, wid, "sl-agent")
     _cancel_session(base_url, wid, sid)
 
-    page.goto(f"{console_url}#/sessions/{sid}")
-    expect(page.locator('[data-testid="session-outcome"]')).to_be_visible(
+    open_session_in_studio(page, console_url, wid, sid, kind="agent")
+    # The reused live-stream shows the terminal "Session ended" notice.
+    expect(page.get_by_text("Session ended", exact=False).first).to_be_visible(
         timeout=20_000,
+    )
+    # And the panel header StatusPill reads a terminal status (ended).
+    header = page.locator('[data-testid="panel-agent-header"]')
+    expect(header.locator(".pill").filter(has_text="ended").first).to_be_visible(
+        timeout=10_000,
     )
 
 
@@ -99,12 +115,17 @@ def test_cancelled_session_shows_outcome_banner(
 def test_cancelled_session_shows_cancelled_chip_in_list(
     base_url, console_url, page, tmp_path,
 ) -> None:
-    """Seed + cancel an agent session, then open /sessions and assert that
-    the session row shows the "Cancelled" decoded-outcome chip.
+    """Seed + cancel an agent session, then open the workspace's Studio
+    and assert the cancelled session is listed in the sidebar with a
+    terminal status dot.
 
-    Note: describeSessionState classifies a cancelled session as
-    group="cancelled", NOT group="failed", so it does NOT appear under the
-    "Failed" filter.  We assert the chip label directly instead.
+    Re-pointed: the global ``#/sessions`` list (and its decoded "Cancelled"
+    outcome chip) is retired. Sessions now live in the per-workspace Studio
+    left-sidebar ``session-row`` list. That row surfaces terminal state via
+    a status DOT (``session-status-dot``, gray tone for ended/cancelled)
+    rather than a "Cancelled" text chip — there is no per-row outcome-label
+    text in the Studio sidebar — so this pins the closest real surface: the
+    cancelled row is present and carries its (terminal) status dot.
     """
     _seed_llm_provider(base_url, "sl-prov2")
     _seed_agent(base_url, "sl-agent2", "sl-prov2")
@@ -112,10 +133,11 @@ def test_cancelled_session_shows_cancelled_chip_in_list(
     sid = _seed_agent_session(base_url, wid, "sl-agent2")
     _cancel_session(base_url, wid, sid)
 
-    page.goto(f"{console_url}#/sessions")
-    expect(page.get_by_text(sid[:8], exact=False).first).to_be_visible(
-        timeout=20_000,
-    )
-    expect(page.get_by_text("Cancelled", exact=False).first).to_be_visible(
-        timeout=20_000,
+    open_studio(page, console_url, wid)
+    # The cancelled session is listed as a sidebar row (matched by its id).
+    row = page.locator('[data-testid="session-row"]', has_text=sid).first
+    expect(row).to_be_visible(timeout=20_000)
+    # The row carries its status dot (terminal / gray tone for cancelled).
+    expect(row.locator('[data-testid="session-status-dot"]')).to_be_visible(
+        timeout=10_000,
     )

--- a/tests/ui_e2e/test_signals_files_workers.py
+++ b/tests/ui_e2e/test_signals_files_workers.py
@@ -16,6 +16,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_session_in_studio
+
 
 # ---------------------------------------------------------------------------
 # Seed helpers
@@ -107,15 +109,16 @@ def _cleanup(base_url: str, urls: list[str]) -> None:
 def test_u0068_steer_queue_renders_submitted_instruction(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0068 — On the session detail page, type a steer instruction
-    in the textarea, click "Queue steer". Assert:
+    """U0068 — Re-pointed to the Studio's steer control. Open the session
+    in the Studio (agent panel), click ``ctrl-steer`` to reveal the
+    ``steer-popover``, type an instruction into its textarea, click Queue.
+    Assert the "Steer queued" success toast appears and the popover
+    closes (studio-center.jsx ``ST_SessionControls`` steerMut onSuccess).
 
-    * "Steer queued" success toast appears
-    * "Queued this session (1)" panel header appears
-    * The instruction text is visible in the queued panel
-
-    Defends the optimistic-queue update + toast in
-    primer's session-detail.jsx onSteer handler.
+    (The retired session-detail rendered a "Queued this session (N)" panel
+    that echoed each submitted instruction; the Studio's steer is a
+    fire-and-forget popover with no queued-echo panel, so that assertion
+    is dropped — the toast + popover-close is the surviving contract.)
     """
     pid = f"llm-st-{unique_suffix}"
     aid = f"ag-st-{unique_suffix}"
@@ -133,42 +136,26 @@ def test_u0068_steer_queue_renders_submitted_instruction(
         f"/v1/agents/{aid}",
         f"/v1/llm_providers/{pid}",
     ]
-    instruction = f"please check the build status — {unique_suffix}"
+    instruction = f"please check the build status - {unique_suffix}"
     try:
-        page.goto(
-            f"{console_url}#/sessions/{sid}", wait_until="domcontentloaded",
-        )
-        # Resilience: gate on .nav-item to absorb CDN slow-cache.
-        page.locator(".nav-item").first.wait_for(
-            state="visible", timeout=20_000,
-        )
-        # Wait for the Queue steer button (signals area mounted).
-        queue_btn = page.get_by_role(
-            "button", name="Queue steer", exact=False,
-        ).first
-        queue_btn.wait_for(state="visible", timeout=10_000)
+        open_session_in_studio(page, console_url, wid, sid, kind="agent")
 
-        # Find the steer textarea via placeholder.
-        textarea = page.get_by_placeholder(
-            "Drop a hint or new directive for the next turn…",
-            exact=False,
-        )
-        textarea.wait_for(state="visible", timeout=5_000)
-        textarea.fill(instruction)
-        queue_btn.click()
+        # Click ctrl-steer → the steer popover opens with its textarea.
+        steer_btn = page.locator("[data-testid='ctrl-steer']").first
+        steer_btn.wait_for(state="visible", timeout=10_000)
+        steer_btn.click()
 
-        # Success toast.
+        popover = page.locator("[data-testid='steer-popover']")
+        expect(popover).to_be_visible(timeout=5_000)
+        popover.locator("textarea").fill(instruction)
+        # The Queue button submits (POST .../steer).
+        popover.get_by_role("button", name="Queue", exact=True).click()
+
+        # Success toast, and the popover closes on success.
         expect(
             page.get_by_text("Steer queued", exact=False).first
         ).to_be_visible(timeout=5_000)
-
-        # Queued this session (1) header + the instruction text.
-        expect(
-            page.get_by_text("Queued this session (1)", exact=False).first
-        ).to_be_visible(timeout=5_000)
-        expect(
-            page.get_by_text(instruction, exact=False).first
-        ).to_be_visible()
+        expect(popover).to_have_count(0, timeout=5_000)
     finally:
         _cleanup(base_url, cleanup_urls)
 

--- a/tests/ui_e2e/test_studio.py
+++ b/tests/ui_e2e/test_studio.py
@@ -252,10 +252,15 @@ def test_studio_shell_sidebar_center_and_palette(
         page.keyboard.press("Escape")
 
         # --- 6. No console errors across the whole flow ----------------
+        # The Studio renders IN-SHELL, so the app Topbar's pre-existing
+        # GET /v1/internal_collections/config probe (404 when the feature
+        # is inactive — the e2e default) is now visible here. It is an
+        # app-shell fetch, not a Studio bug, so it rides the allowlist.
         from tests.ui_e2e.conftest import assert_no_console_errors
+        from tests.ui_e2e._studio_helpers import STUDIO_CONSOLE_IGNORES
         assert_no_console_errors(
             console_messages,
-            ignore_patterns=[r"net::ERR_ABORTED", r"favicon"],
+            ignore_patterns=STUDIO_CONSOLE_IGNORES,
         )
 
     finally:
@@ -300,10 +305,15 @@ def test_studio_session_redirect_lands_with_tab_open(
             timeout=15_000,
         )
 
+        # The B6 redirect lands in-shell, so the app Topbar's pre-existing
+        # GET /v1/internal_collections/config 404 (feature inactive) is now
+        # visible here. Allowlist it — it is an app-shell fetch, not a
+        # Studio/redirect bug.
         from tests.ui_e2e.conftest import assert_no_console_errors
+        from tests.ui_e2e._studio_helpers import STUDIO_CONSOLE_IGNORES
         assert_no_console_errors(
             console_messages,
-            ignore_patterns=[r"net::ERR_ABORTED", r"favicon"],
+            ignore_patterns=STUDIO_CONSOLE_IGNORES,
         )
 
     finally:

--- a/tests/ui_e2e/test_studio.py
+++ b/tests/ui_e2e/test_studio.py
@@ -40,6 +40,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import session_row
+
 
 from tests._support.smk import smk  # noqa: E402
 
@@ -210,11 +212,14 @@ def test_studio_shell_sidebar_center_and_palette(
             )
 
         # --- 2. Left sidebar lists the seeded session ------------------
-        session_row = page.locator('[data-testid="session-row"]').first
-        expect(session_row).to_be_visible(timeout=20_000)
+        # Locate the SEEDED row by its data-session-id (the visible row text
+        # is the session title, not the raw sid), so the click targets the
+        # right row deterministically.
+        seeded_row = session_row(page, ids["session"]).first
+        expect(seeded_row).to_be_visible(timeout=20_000)
 
         # --- 3. Click session row → center tab + agent panel ----------
-        session_row.click()
+        seeded_row.click()
         expect(page.locator('[data-testid="center-tab"]').first).to_be_visible(
             timeout=15_000,
         )

--- a/tests/ui_e2e/test_workspace_destroy_graph_provider.py
+++ b/tests/ui_e2e/test_workspace_destroy_graph_provider.py
@@ -21,6 +21,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_studio, open_workspace_settings
+
 
 # ---------------------------------------------------------------------------
 # Seed helpers
@@ -105,11 +107,18 @@ def _cleanup(base_url: str, urls: list[str]) -> None:
 def test_u0077_workspace_detail_tabs_all_reachable(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0077 — Each of the 5 workspace detail tabs (Files / Sessions
-    / Log / Config / Destroy) is clickable and renders a labelled
-    panel without console errors.
+    """U0077 — Re-pointed to the Studio. The old WorkspaceDetail's five
+    tabs split across the Studio: Files + Sessions became left-sidebar
+    sections, and Log / Config / Destroy moved into the Settings modal's
+    left-rail nav (studio-settings.jsx). This asserts every one of those
+    surfaces is reachable:
 
-    Pins the tab routing in workspaces.jsx:WorkspaceDetail TABS array.
+    * left sidebar ``sessions-section`` + ``files-section`` render,
+    * the Settings modal's ``workspace-settings-nav:{channels,config,log,
+      destroy}`` items are each clickable and render their panel.
+
+    (Channels was not a WorkspaceDetail *tab* here but is one of the four
+    settings-nav items, so we walk all four for completeness.)
     """
     wp_id = f"wp-77-{unique_suffix}"
     tpl_id = f"tpl-77-{unique_suffix}"
@@ -120,20 +129,22 @@ def test_u0077_workspace_detail_tabs_all_reachable(
         f"/v1/workspace_providers/{wp_id}",
     ]
     try:
-        page.goto(
-            f"{console_url}#/workspaces/{wid}",
-            wait_until="domcontentloaded",
-        )
-        # Resilience gate.
-        page.locator(".nav-item").first.wait_for(
-            state="visible", timeout=20_000,
-        )
-        # Each tab is a button with the label visible in topbar.
-        for label in ("Files", "Sessions", "Log", "Config", "Destroy"):
-            btn = page.get_by_role("button", name=label, exact=True).first
-            btn.wait_for(state="visible", timeout=5_000)
-            btn.click()
-            # Brief settle so the tab panel renders.
+        open_studio(page, console_url, wid)
+        # Files + Sessions are left-sidebar sections in the Studio.
+        expect(page.locator("[data-testid='sessions-section']")).to_be_visible(timeout=15_000)
+        expect(page.locator("[data-testid='files-section']")).to_be_visible(timeout=15_000)
+
+        # Log / Config / Destroy (+ Channels) live in the Settings modal.
+        gear = page.locator("[data-testid='studio-settings-btn']")
+        gear.wait_for(state="visible", timeout=10_000)
+        gear.click()
+        modal = page.locator("[data-testid='workspace-settings']")
+        expect(modal).to_be_visible(timeout=10_000)
+        for section in ("channels", "config", "log", "destroy"):
+            nav = page.locator(f"[data-testid='workspace-settings-nav:{section}']")
+            nav.wait_for(state="visible", timeout=5_000)
+            nav.click()
+            # Brief settle so the reused panel renders.
             page.wait_for_timeout(300)
     finally:
         _cleanup(base_url, cleanup_urls)
@@ -181,22 +192,18 @@ def test_u0078_workspace_destroy_modal_cancel_does_not_delete(
             ),
         )
 
-        page.goto(
-            f"{console_url}#/workspaces/{wid}?tab=destroy",
-            wait_until="domcontentloaded",
-        )
-        page.locator(".nav-item").first.wait_for(
-            state="visible", timeout=20_000,
-        )
+        # Open the Studio → Settings modal → Destroy section. The reused
+        # WS_DestroyTab renders the same "Destroy workspace" button + confirm.
+        open_workspace_settings(page, console_url, wid, "destroy")
 
-        # Click Destroy workspace → modal opens.
+        # Click Destroy workspace → confirm modal opens.
         destroy_btn = page.get_by_role(
             "button", name="Destroy workspace", exact=True,
         ).first
         destroy_btn.wait_for(state="visible", timeout=10_000)
         destroy_btn.click()
 
-        # Modal title contains the workspace id.
+        # Confirm modal title contains the workspace id.
         page.get_by_text(f"Destroy {wid}?", exact=False).first.wait_for(
             state="visible", timeout=5_000,
         )
@@ -204,10 +211,10 @@ def test_u0078_workspace_destroy_modal_cancel_does_not_delete(
         # ESC dismiss.
         page.keyboard.press("Escape")
         page.wait_for_timeout(500)
-        # Modal title gone.
+        # Confirm modal title gone.
         assert page.get_by_text(
             f"Destroy {wid}?", exact=False,
-        ).count() == 0, "Destroy modal didn't dismiss on ESC"
+        ).count() == 0, "Destroy confirm modal didn't dismiss on ESC"
 
         # No DELETE was fired.
         assert delete_calls["count"] == 0, (

--- a/tests/ui_e2e/test_workspace_file_download_journey.py
+++ b/tests/ui_e2e/test_workspace_file_download_journey.py
@@ -39,6 +39,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_studio
+
 
 from tests._support.smk import smk  # noqa: E402
 pytestmark = smk("SMK-UI-06", status="partial")
@@ -109,8 +111,8 @@ def test_u0106_workspace_file_inspect_and_download_journey(
     console_url: str,
     unique_suffix: str,
 ) -> None:
-    """U0106 — Multi-page operator journey to inspect + download a
-    workspace file via the UI.
+    """U0106 — Re-pointed to the Studio's file panel: inspect a workspace
+    file's content via the UI.
 
     Steps:
 
@@ -119,18 +121,23 @@ def test_u0106_workspace_file_inspect_and_download_journey(
          Skip-soft on 5xx (U0072-class: container can't reach
          host bind-mount path).
       3. Navigate /workspaces list — assert seeded row visible.
-      4. Click row → /workspaces/{wid} (Files tab is default).
-      5. Wait for the file tree to render the seeded file.
-      6. Click the file → editor pane shows the content.
-      7. Click the Download button — Playwright captures the
-         browser download — assert the payload matches the
-         seeded content byte-for-byte.
-      8. Click the "Workspaces" breadcrumb → back to /workspaces
-         list, row still visible.
+      4. Click row → /workspaces/{wid} (the Studio).
+      5. Wait for the Studio sidebar ``file-row`` for the seeded file.
+      6. Click it → the center ``panel-file`` opens with the file's
+         breadcrumb + the text preview showing the seeded content.
+      7. Also verify the download endpoint delivers the exact bytes
+         (an API probe on the same /files/download URL the panel uses).
 
-    Pins workspaces.jsx:663-669 anchor-style Download button +
-    workspaces.jsx:701-705 file content rendering through the
-    <pre>+CodeHighlight path for text files.
+    NOTE (re-point): the Studio only renders a ``file-download`` control for
+    NON-editable files (binary / >1MB); a small ``.txt`` is editable, so its
+    panel exposes preview + Save rather than a Download anchor. The old
+    browser-download-button click therefore has no Studio equivalent for a
+    text file — the download PAYLOAD is instead verified via the same
+    ``/files/download`` endpoint the panel's download href targets, keeping
+    the "content is downloadable + matches" half of the contract.
+
+    Pins the Studio file panel (studio-center.jsx ``FilePanel`` /
+    ``ST_FilePreview``) render path for text files.
     """
     file_name = f"u0106-{unique_suffix}.txt"
     ids, content = _seed_workspace_with_file(base_url, unique_suffix)
@@ -159,65 +166,43 @@ def test_u0106_workspace_file_inspect_and_download_journey(
         ws_row = page.locator("tbody tr", has_text=wid)
         expect(ws_row).to_be_visible(timeout=20_000)
 
-        # ----- 2. Click row → /workspaces/{wid} ---------------------
+        # ----- 2. Click row → the Studio for that workspace ---------
         ws_row.first.click()
         page.wait_for_url(f"**/console/#/workspaces/{wid}**", timeout=15_000)
-        expect(page.locator("h1.page-title", has_text=wid)).to_be_visible(
-            timeout=15_000,
-        )
+        open_studio(page, console_url, wid)
 
-        # Files tab is the default; the file tree must surface the
-        # seeded file within the SessionsTab's poll cadence (~5 s).
-        file_row = page.get_by_text(file_name, exact=False).first
+        # The Files section defaults open; the seeded file surfaces as a
+        # sidebar file-row within its lazy tree fetch.
+        file_row = page.locator(
+            '[data-testid="file-row"]', has_text=file_name,
+        ).first
         expect(file_row).to_be_visible(timeout=20_000)
 
-        # ----- 3. Click file → content pane renders -----------------
+        # ----- 3. Click file-row → panel-file preview shows content -
         file_row.click()
-        # The CodeHighlight wraps the content in nested <span>s line
-        # by line; check that a stable substring of our content
-        # appears somewhere in the page after the click.
-        # Pick a distinctive marker rather than the full content.
+        panel = page.locator('[data-testid="panel-file"]')
+        expect(panel).to_be_visible(timeout=15_000)
+        expect(
+            page.locator('[data-testid="file-breadcrumb"]')
+        ).to_contain_text(file_name, timeout=10_000)
+        # The text preview shows a distinctive marker from the content.
         marker = f"suffix={unique_suffix}"
-        expect(page.get_by_text(marker, exact=False).first).to_be_visible(
+        expect(panel.get_by_text(marker, exact=False).first).to_be_visible(
             timeout=15_000,
         )
 
-        # ----- 4. Click Download — capture the browser download ----
-        download_link = page.locator("a[download]").filter(
-            has=page.get_by_role("button", name="Download")
-        ).first
-        expect(download_link).to_be_visible(timeout=10_000)
-
-        with page.expect_download(timeout=15_000) as download_info:
-            download_link.click()
-        download = download_info.value
-        # The downloaded file's content must match exactly what was seeded.
-        downloaded_bytes = download.path().read_bytes()
-        assert downloaded_bytes.decode("utf-8") == content, (
-            f"download payload mismatch:\n"
-            f"expected={content!r}\n"
-            f"got={downloaded_bytes!r}"
-        )
-
-        # ----- 5. Click "Workspaces" breadcrumb → back to list -----
-        # WorkspaceHeader renders a breadcrumb anchor that navigates
-        # back. The breadcrumb selector matches the .crumb pattern
-        # used in session-detail.jsx; workspaces.jsx renders a similar
-        # link with text "Workspaces".
-        # Fall back to direct nav if no breadcrumb is present —
-        # the assertion target is the list state, not the
-        # navigation mechanism.
-        crumb = page.locator(".crumb a", has_text="Workspaces").first
-        if crumb.count() > 0:
-            crumb.click()
-        else:
-            page.goto(
-                f"{console_url}#/workspaces", wait_until="domcontentloaded",
+        # ----- 4. Download endpoint delivers the exact bytes --------
+        # (The panel's download href targets this same URL for
+        # non-editable files; a text file uses Save + preview instead,
+        # so we verify the payload via the endpoint directly.)
+        with httpx.Client(base_url=base_url, timeout=30.0) as c:
+            dl = c.get(
+                f"/v1/workspaces/{wid}/files/download?path={file_name}"
             )
-        page.wait_for_url("**/console/#/workspaces", timeout=10_000)
-        expect(page.locator("tbody tr", has_text=wid)).to_be_visible(
-            timeout=15_000,
-        )
+            assert dl.status_code == 200, dl.text
+            assert dl.text == content, (
+                f"download payload mismatch:\nexpected={content!r}\ngot={dl.text!r}"
+            )
     finally:
         for url in cleanup_urls:
             try:

--- a/tests/ui_e2e/test_workspace_reply_binding.py
+++ b/tests/ui_e2e/test_workspace_reply_binding.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import httpx
 
 from tests._support.smk import smk
+from tests.ui_e2e._studio_helpers import open_workspace_settings
 
 pytestmark = smk("SMK-UI-RB-01")
 
@@ -71,24 +72,26 @@ def test_workspace_channels_tab_shows_reply_binding_label(
     console_url: str,
     unique_suffix: str,
 ) -> None:
-    """Navigate to a seeded workspace's Channels tab and assert the
-    panel exposes a "Reply binding" label (not "Channel association")."""
+    """Open the Studio Settings modal's Channels section and assert the
+    reused panel exposes a "Reply binding" label (not "Channel
+    association").
+
+    Re-pointed to the Studio: the old ``?tab=channels`` workspace-detail
+    tab moved into the Settings modal (studio-settings.jsx →
+    ``workspace-settings-nav:channels``), which renders the SAME
+    WS_ChannelsTab, so the label/absence assertions are unchanged.
+    """
     ids = _seed_workspace(base_url, unique_suffix)
     wid = ids["workspace"]
     try:
-        page.goto(
-            f"{console_url}#/workspaces/{wid}?tab=channels",
-            wait_until="domcontentloaded",
-        )
-        page.wait_for_url(f"**/console/#/workspaces/{wid}**", timeout=15_000)
+        modal = open_workspace_settings(page, console_url, wid, "channels")
 
-        # The panel copy now frames the outbound surface as a "reply
-        # binding"; the old "Channel association" wording must be gone.
-        panel = page.locator("body")
-        panel.get_by_text("Reply binding", exact=False).first.wait_for(
+        # The reused Channels panel copy frames the outbound surface as a
+        # "reply binding"; the old "Channel association" wording must be gone.
+        modal.get_by_text("Reply binding", exact=False).first.wait_for(
             state="visible", timeout=10_000,
         )
-        body_text = panel.inner_text()
+        body_text = modal.inner_text()
         assert "Reply binding" in body_text, body_text
         assert "Channel association" not in body_text, body_text
     finally:

--- a/tests/ui_e2e/test_workspace_session_graph_signals.py
+++ b/tests/ui_e2e/test_workspace_session_graph_signals.py
@@ -15,6 +15,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e._studio_helpers import open_workspace_settings
+
 
 # ---------------------------------------------------------------------------
 # Seed helpers
@@ -102,12 +104,16 @@ def _cleanup(base_url: str, urls: list[str]) -> None:
 def test_u0079_workspace_destroy_confirm_navigates_back_to_list(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0079 — Click Destroy workspace → modal opens → click
+    """U0079 — Re-pointed to the Studio Settings modal. Open Studio →
+    Settings → Destroy section → click "Destroy workspace" → confirm
     "Destroy permanently" → API DELETE fires → "Workspace destroyed"
-    toast (kind=warning per workspaces.jsx:867) → page navigates
-    back to /workspaces → row absent from list.
+    toast → the workspace row is gone (API GET 404s).
 
-    Positive-path mirror of U0078 (which exercised ESC dismiss).
+    Positive-path mirror of U0078 (ESC dismiss). The reused
+    WS_DestroyTab keeps its label/role assertions; after success it
+    leaves the (now-destroyed) workspace's Studio, so we assert the
+    server-side deletion (the authoritative signal) rather than pin a
+    specific post-destroy route.
     """
     wp_id = f"wp-79-{unique_suffix}"
     tpl_id = f"tpl-79-{unique_suffix}"
@@ -119,15 +125,9 @@ def test_u0079_workspace_destroy_confirm_navigates_back_to_list(
         f"/v1/workspace_providers/{wp_id}",
     ]
     try:
-        page.goto(
-            f"{console_url}#/workspaces/{wid}?tab=destroy",
-            wait_until="domcontentloaded",
-        )
-        page.locator(".nav-item").first.wait_for(
-            state="visible", timeout=20_000,
-        )
+        open_workspace_settings(page, console_url, wid, "destroy")
 
-        # Click Destroy workspace → modal.
+        # Click Destroy workspace → confirm modal.
         destroy_btn = page.get_by_role(
             "button", name="Destroy workspace", exact=True,
         ).first
@@ -146,22 +146,19 @@ def test_u0079_workspace_destroy_confirm_navigates_back_to_list(
             page.get_by_text("Workspace destroyed", exact=False).first
         ).to_be_visible(timeout=10_000)
 
-        # Page navigated back to /workspaces.
-        page.wait_for_url("**/console/**", timeout=5_000)
-        # URL hash now contains /workspaces (not /workspaces/<id>).
-        # Wait briefly for navigation.
-        deadline = time.monotonic() + 5.0
+        # Workspace row deleted server-side (the authoritative signal).
+        deadline = time.monotonic() + 8.0
+        gone = False
         while time.monotonic() < deadline:
-            if page.url.endswith("#/workspaces") or "/workspaces" in page.url:
+            with httpx.Client(base_url=base_url, timeout=30.0) as c:
+                r = c.get(f"/v1/workspaces/{wid}")
+            if r.status_code == 404:
+                gone = True
                 break
-            page.wait_for_timeout(200)
-        # Workspace row absent from the list (API DELETE removed it).
-        with httpx.Client(base_url=base_url, timeout=30.0) as c:
-            r = c.get(f"/v1/workspaces/{wid}")
-            # DELETE is idempotent — second GET should 404.
-            assert r.status_code == 404, (
-                f"workspace row still exists after destroy: {r.status_code}"
-            )
+            page.wait_for_timeout(300)
+        assert gone, (
+            f"workspace row still exists after destroy: last status {r.status_code}"
+        )
     finally:
         _cleanup(base_url, cleanup_urls)
 
@@ -171,83 +168,13 @@ def test_u0079_workspace_destroy_confirm_navigates_back_to_list(
 # ===========================================================================
 
 
-def test_u0081_sessions_list_status_chip_filter_narrows_table(
-    page, base_url, console_url, unique_suffix, tmp_path,
-) -> None:
-    """U0081 — Seed 3 sessions: two CREATED + one ENDED (via API
-    cancel). Click the "ended" status chip; only the ENDED session
-    row remains in the table.
-
-    Pins the status-chip filter in sessions-list.jsx:toggleStatus.
-    """
-    pid = f"llm-81-{unique_suffix}"
-    aid = f"ag-81-{unique_suffix}"
-    wp_id = f"wp-81-{unique_suffix}"
-    tpl_id = f"tpl-81-{unique_suffix}"
-    _seed_llm_provider(base_url, pid)
-    _seed_agent(base_url, aid, pid)
-    wid = _seed_workspace(base_url, wp_id, tpl_id, tmp_path)
-    sid_created_1 = _seed_session(base_url, wid, aid)
-    sid_created_2 = _seed_session(base_url, wid, aid)
-    sid_ended = _seed_session(base_url, wid, aid)
-    _cancel_session(base_url, wid, sid_ended)
-    cleanup_urls = [
-        f"/v1/workspaces/{wid}/sessions/{sid_created_1}/cancel",
-        f"/v1/workspaces/{wid}/sessions/{sid_created_2}/cancel",
-        f"/v1/workspaces/{wid}",
-        f"/v1/workspace_templates/{tpl_id}",
-        f"/v1/workspace_providers/{wp_id}",
-        f"/v1/agents/{aid}",
-        f"/v1/llm_providers/{pid}",
-    ]
-    try:
-        page.goto(
-            f"{console_url}#/sessions",
-            wait_until="domcontentloaded",
-        )
-        page.locator(".nav-item").first.wait_for(
-            state="visible", timeout=20_000,
-        )
-
-        # Wait for our 3 session rows to land in the list (sessions
-        # list fetches once on mount, possibly polls).
-        # Filter the body by the session ids to find them; wait until
-        # at least one of ours is visible.
-        for sid in (sid_created_1, sid_created_2, sid_ended):
-            page.get_by_text(sid, exact=False).first.wait_for(
-                state="visible", timeout=10_000,
-            )
-
-        # Click the "ended" status chip. The chip is a span with
-        # title="ended" inside .chip-group.
-        ended_chip = page.locator(
-            ".chip-group [title='ended']",
-        ).first
-        ended_chip.wait_for(state="visible", timeout=5_000)
-        ended_chip.click()
-
-        # After filter: ENDED row remains, the two CREATED rows
-        # disappear. Wait for the CREATED rows to be gone.
-        deadline = time.monotonic() + 8.0
-        filtered_ok = False
-        while time.monotonic() < deadline:
-            page.wait_for_timeout(400)
-            ended_visible = page.get_by_text(
-                sid_ended, exact=False,
-            ).count() >= 1
-            created_visible = (
-                page.get_by_text(sid_created_1, exact=False).count() >= 1
-                or page.get_by_text(sid_created_2, exact=False).count() >= 1
-            )
-            if ended_visible and not created_visible:
-                filtered_ok = True
-                break
-        assert filtered_ok, (
-            "status chip filter didn't narrow table: "
-            f"ended_visible={ended_visible}, created_visible={created_visible}"
-        )
-    finally:
-        _cleanup(base_url, cleanup_urls)
+# U0081 REMOVED (no Studio equivalent) — this pinned the GLOBAL
+# ``#/sessions`` list's status-chip filter (sessions-list.jsx toggleStatus)
+# narrowing the cross-workspace table to just the "ended" rows. The Studio
+# retired that global list AND the status-chip filter UI; the per-workspace
+# Studio sidebar ``session-row`` list has no status-chip filter (it only
+# sorts + tags rows). Per the re-point guidance, a global status-chip filter
+# with no Studio equivalent is removed with this documented note.
 
 
 # ===========================================================================

--- a/ui/app.jsx
+++ b/ui/app.jsx
@@ -308,7 +308,38 @@ function App() {
   };
   const removeToast = (id) => setToasts((arr) => arr.filter((x) => x.id !== id));
 
+  // Open the Studio for the last-opened workspace. The Studio persists
+  // localStorage["studio:lastWid"] whenever it mounts (see the effect in the
+  // workspace-detail render path); read it back here. Falls back to the first
+  // workspace from the already-polled topbar:workspaces resource, and finally
+  // to a one-shot GET /v1/workspaces if that cache is still cold. When nothing
+  // resolves we land on the workspaces list so the nav item never dead-ends.
+  const openStudio = () => {
+    let wid = null;
+    try { wid = window.localStorage.getItem("studio:lastWid") || null; } catch { wid = null; }
+    if (!wid) {
+      const items = realWorkspaces.data && realWorkspaces.data.items;
+      if (Array.isArray(items) && items.length) wid = items[0].id;
+    }
+    if (wid) {
+      window.location.hash = "#/workspaces/" + encodeURIComponent(wid);
+      return;
+    }
+    window.primerApi
+      .apiFetch("GET", "/workspaces?limit=1")
+      .then((r) => {
+        const first = r && Array.isArray(r.items) && r.items[0];
+        if (first && first.id) {
+          window.location.hash = "#/workspaces/" + encodeURIComponent(first.id);
+        } else {
+          window.location.hash = "#/workspaces";
+        }
+      })
+      .catch(() => { window.location.hash = "#/workspaces"; });
+  };
+
   const navigate = (target, extra) => {
+    if (target === "studio") { openStudio(); return; }
     // Designer's API: navigate(page, extra?). Map to URL paths.
     const ROUTES = {
       dashboard: "/",
@@ -796,11 +827,13 @@ function App() {
       />
     );
   } else if (page === "workspace-detail" && currentWorkspaceId) {
-    // /workspaces/:wid is the Studio (PR-B). Studio renders its own full
-    // header + 3-column shell, so we return it directly below — bypassing
-    // the standard page chrome (sidebar/topbar/page-header) the other
-    // pages share. See the early-return guard after the page switch.
-    return <Studio wid={currentWorkspaceId} pushToast={pushToast} />;
+    // /workspaces/:wid is the Studio (PR-B). It now renders as ordinary PAGE
+    // CONTENT inside the shared shell (app Topbar + Sidebar stay mounted) —
+    // no header takeover. The Studio supplies its own slim sub-header (the
+    // workspace selector + ⌘K palette + terminal toggle). pageHeader is left
+    // null so the standard .page-header bar collapses out of the way.
+    pageHeader = null;
+    pageBody = <Studio wid={currentWorkspaceId} pushToast={pushToast} />;
   } else if (page === "workspace-providers") {
     pageHeader = (
       <>
@@ -1042,12 +1075,12 @@ function App() {
   }
 
   return (
-    <div className={`app ${sidebarCollapsed ? "sidebar-collapsed" : ""}`}>
+    <div className={`app ${sidebarCollapsed ? "sidebar-collapsed" : ""} ${page === "workspace-detail" ? "studio-page" : ""}`}>
       <Topbar workerStats={workerStats} onNavigate={navigate} onOpenPalette={() => setPaletteOpen(true)} onOpenDrawer={() => setDrawerOpen(true)} />
       {(() => {
         const sidebarPage = (
-          page === "session-detail" ? "sessions"
-          : page === "workspace-detail" ? "workspaces"
+          page === "session-detail" ? "studio"
+          : page === "workspace-detail" ? "studio"
           : page === "workspace-provider-detail" ? "workspace-providers"
           : page === "workspace-template-detail" ? "workspace-templates"
           : page === "agent-detail" ? "agents"

--- a/ui/components/chrome.jsx
+++ b/ui/components/chrome.jsx
@@ -5,12 +5,12 @@ const NAV = [
     group: null,
     items: [
       { id: "dashboard", label: "Dashboard", icon: "home" },
+      { id: "studio", label: "Studio", icon: "panel-left" },
     ],
   },
   {
     group: "Compute",
     items: [
-      { id: "sessions", label: "Sessions", icon: "zap", countKey: "sessions" },
       { id: "agents", label: "Agents", icon: "agent" },
       { id: "graphs", label: "Graphs", icon: "graph" },
       { id: "chats", label: "Chats", icon: "send", countKey: "chats" },

--- a/ui/components/studio-settings.jsx
+++ b/ui/components/studio-settings.jsx
@@ -1,0 +1,165 @@
+/* global React, Icon, Btn, Banner */
+// Studio → Workspace Settings overlay.
+//
+// The Studio (studio.jsx) replaced the old WorkspaceDetail page at
+// /workspaces/:wid, absorbing only its files / sessions / activity tabs. The
+// remaining WorkspaceDetail tabs — channels (reply-binding), config, git-log,
+// and destroy — became unreachable. This overlay restores them by RE-USING the
+// very same panel components WorkspaceDetail rendered (surfaced on window.* from
+// workspaces.jsx): WS_ChannelsTab · WS_ConfigTab · WS_LogTab · WS_DestroyTab.
+// Nothing about those panels is reimplemented here; we only build the resource
+// objects they expect and lay them out behind a left rail of sections.
+//
+// No-build scope rules (see studio.jsx): top-level declarations use `var`;
+// helpers are prefixed SS_; every component is exported via `window.X = X`.
+
+// The section rail. `id` keys the active section; `label` is the visible rail
+// text; `icon` mirrors the icon WorkspaceDetail's tab strip used for the tab.
+var SS_SECTIONS = [
+  { id: "channels", label: "Channels", icon: "bell" },
+  { id: "config", label: "Config", icon: "settings" },
+  { id: "log", label: "Git log", icon: "git-commit" },
+  { id: "destroy", label: "Destroy", icon: "trash", danger: true },
+];
+
+// ---------------------------------------------------------------------------
+// WorkspaceSettings — modal surface with a left rail + a reused detail panel.
+//
+// Props: { wid, onClose, pushToast }. Builds the `ws` (workspace-detail) and
+// `sessionsForBadge` (workspace-sessions) resources the reused panels consume,
+// keyed identically to WorkspaceDetail so both share the useResource cache.
+// ---------------------------------------------------------------------------
+
+function WorkspaceSettings({ wid, onClose, pushToast }) {
+  var { useResource, apiFetch } = window.primerApi;
+  var [section, setSection] = React.useState("channels");
+
+  // Same cache keys + fetchers WorkspaceDetail uses, so the reused panels see
+  // identical data and their invalidations line up with the rest of the app.
+  var ws = useResource(
+    "workspace-detail:" + wid,
+    function (signal) { return apiFetch("GET", "/workspaces/" + encodeURIComponent(wid), null, { signal }); },
+    { deps: [wid] }
+  );
+  var sessionsForBadge = useResource(
+    "workspace-sessions:" + wid,
+    function (signal) { return apiFetch("GET", "/workspaces/" + encodeURIComponent(wid) + "/sessions?limit=200", null, { signal }); },
+    { pollMs: 5000, deps: [wid] }
+  );
+
+  // Resolve the reused panel components from window.* at render time so this
+  // file is load-order-independent from workspaces.jsx (which exports them).
+  var ChannelsTab = window.WS_ChannelsTab;
+  var ConfigTab = window.WS_ConfigTab;
+  var LogTab = window.WS_LogTab;
+  var DestroyTab = window.WS_DestroyTab;
+
+  function renderPanel() {
+    if (section === "channels") {
+      return ChannelsTab
+        ? <ChannelsTab wid={wid} ws={ws} pushToast={pushToast} />
+        : <SS_Missing name="channels" />;
+    }
+    if (section === "config") {
+      return ConfigTab ? <ConfigTab wid={wid} ws={ws} /> : <SS_Missing name="config" />;
+    }
+    if (section === "log") {
+      return LogTab ? <LogTab wid={wid} /> : <SS_Missing name="log" />;
+    }
+    if (section === "destroy") {
+      return DestroyTab
+        ? <DestroyTab wid={wid} pushToast={pushToast} sessionsForBadge={sessionsForBadge} />
+        : <SS_Missing name="destroy" />;
+    }
+    return null;
+  }
+
+  return (
+    <div className="modal-overlay" data-testid="workspace-settings" onClick={onClose}>
+      <div
+        className="modal"
+        style={{ width: "min(920px, 94vw)", maxWidth: "94vw" }}
+        role="dialog"
+        aria-modal="true"
+        aria-label="Workspace settings"
+        onClick={function (e) { e.stopPropagation(); }}
+      >
+        <div className="modal-h">
+          <span className="title">
+            Workspace settings <span className="mono muted text-sm">· {wid}</span>
+          </span>
+          <button className="close" onClick={onClose} aria-label="Close"><Icon name="x" size={14} /></button>
+        </div>
+        <div
+          className="modal-b"
+          style={{ padding: 0, display: "flex", minHeight: 420, maxHeight: "72vh", overflow: "hidden" }}
+        >
+          {/* Left rail of sections. */}
+          <div
+            className="st-settings-rail"
+            style={{
+              flex: "0 0 200px",
+              borderRight: "1px solid var(--border)",
+              padding: "10px 8px",
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+              overflow: "auto",
+            }}
+          >
+            {SS_SECTIONS.map(function (sec) {
+              var active = section === sec.id;
+              return (
+                <button
+                  key={sec.id}
+                  type="button"
+                  data-testid={"workspace-settings-nav:" + sec.id}
+                  onClick={function () { setSection(sec.id); }}
+                  style={{
+                    display: "flex",
+                    alignItems: "center",
+                    gap: 8,
+                    textAlign: "left",
+                    padding: "8px 10px",
+                    borderRadius: 6,
+                    border: "1px solid " + (active ? "var(--border)" : "transparent"),
+                    background: active ? "var(--bg-hover)" : "transparent",
+                    color: sec.danger ? "var(--red)" : active ? "var(--text)" : "var(--text-2)",
+                    fontSize: 12.5,
+                    fontWeight: active ? 600 : 400,
+                    cursor: "pointer",
+                  }}
+                >
+                  <Icon name={sec.icon} size={13} style={{ color: sec.danger ? "var(--red)" : undefined }} />
+                  {sec.label}
+                </button>
+              );
+            })}
+          </div>
+
+          {/* Section body — the reused WorkspaceDetail panel for `section`. */}
+          <div style={{ flex: 1, minWidth: 0, overflow: "auto", background: "var(--bg)" }}>
+            {renderPanel()}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// Fallback shown only if workspaces.jsx failed to export a panel (defensive —
+// should never render in a healthy bundle).
+function SS_Missing({ name }) {
+  return (
+    <div style={{ padding: 16 }}>
+      <Banner
+        kind="error"
+        title={"Panel unavailable"}
+        detail={"The reused \"" + name + "\" panel is not registered (window.WS_* export missing)."}
+      />
+    </div>
+  );
+}
+
+// No-build export.
+window.WorkspaceSettings = WorkspaceSettings;

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -471,6 +471,7 @@ function SessionsSection({ wid, studio }) {
                 key={session.id}
                 className="st-session-row"
                 data-testid="session-row"
+                data-session-id={session.id}
                 onClick={function() { openSession(session); }}
                 style={{
                   display: "flex",

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -120,8 +120,10 @@ function ST_sessionSort(sessions) {
     var aParked = a.parked_status === "parked" || a.parked_status === "resumable" ? -1 : 0;
     var bParked = b.parked_status === "parked" || b.parked_status === "resumable" ? -1 : 0;
     if (aParked !== bParked) return aParked - bParked;
-    var aId = a.id || "";
-    var bId = b.id || "";
+    // The list endpoint returns SessionInfo, which carries `session_id`
+    // (not `id`). Fall back to `id` for the create-response / detail shapes.
+    var aId = a.session_id || a.id || "";
+    var bId = b.session_id || b.id || "";
     return aId < bId ? -1 : aId > bId ? 1 : 0;
   });
 }
@@ -375,14 +377,17 @@ function SessionsSection({ wid, studio }) {
   var [showNewForm, setShowNewForm] = React.useState(false);
 
   function openSession(session) {
+    // The list endpoint returns SessionInfo (`session_id`); the create
+    // response / detail fetch use the fuller shape (`id`). Resolve either.
+    var sid = session.session_id || session.id;
     var isGraph = (session.binding && session.binding.kind === "graph") ||
                   session.binding_kind === "graph";
-    var title = session.name || session.id;
+    var title = session.name || sid;
     var glyph = isGraph ? "◈" : "◆";
     studio.openTab({
-      id: "session:" + session.id,
+      id: "session:" + sid,
       kind: "session",
-      ref: session.id,
+      ref: sid,
       title: title,
       glyph: glyph,
     });
@@ -460,18 +465,22 @@ function SessionsSection({ wid, studio }) {
           )}
           {sessions.map(function(session) {
             var st = ST_sessionStatus(session);
+            // SessionInfo (list endpoint) carries `session_id`, not `id`;
+            // the create/detail shapes carry `id`. Resolve either so the
+            // row key, tab id, title, and data-session-id are the real id.
+            var sid = session.session_id || session.id;
             var isGraph = (session.binding && session.binding.kind === "graph") ||
                           session.binding_kind === "graph";
-            var tabId = "session:" + session.id;
+            var tabId = "session:" + sid;
             var isActive = s.activeTabId === tabId;
-            var title = session.name || session.id;
+            var title = session.name || sid;
 
             return (
               <div
-                key={session.id}
+                key={sid}
                 className="st-session-row"
                 data-testid="session-row"
-                data-session-id={session.id}
+                data-session-id={sid}
                 onClick={function() { openSession(session); }}
                 style={{
                   display: "flex",

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -378,9 +378,12 @@ function useStudioState(wid) {
 // collapse to a single document there.
 // ---------------------------------------------------------------------------
 
-function StudioHeader({ wid, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, onToggleLeftPanel, onToggleRightPanel }) {
+function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, onToggleLeftPanel, onToggleRightPanel }) {
   var { useResource, apiFetch } = window.primerApi;
   var [menuOpen, setMenuOpen] = React.useState(false);
+  // Workspace Settings overlay — restores the orphaned WorkspaceDetail tabs
+  // (channels / config / git-log / destroy) via the reused panel components.
+  var [settingsOpen, setSettingsOpen] = React.useState(false);
 
   // Workspace list for the selector dropdown. Reuse the same cache key the
   // app already polls so we ride on its data instead of a second roundtrip.
@@ -452,7 +455,28 @@ function StudioHeader({ wid, onTogglePalette, onSelectWorkspace, terminalOpen, o
         )}
       </div>
 
+      {/* Workspace settings (gear) — opens the channels / config / git-log /
+          destroy panels reused from WorkspaceDetail. Sits next to the
+          workspace selector so it reads as "settings for THIS workspace". */}
+      <button
+        className="st-hbtn touch-target"
+        data-testid="studio-settings-btn"
+        title="Workspace settings"
+        aria-label="Open workspace settings"
+        onClick={function () { setSettingsOpen(true); }}
+      >
+        <Icon name="settings" size={15} />
+      </button>
+
       <div style={{ flex: 1 }} />
+
+      {settingsOpen && window.WorkspaceSettings && (
+        <window.WorkspaceSettings
+          wid={wid}
+          pushToast={pushToast}
+          onClose={function () { setSettingsOpen(false); }}
+        />
+      )}
 
       {/* ⌘K command palette (run · jump · search within the workspace). The
           wide trigger is hidden on phones (see .st-palette-trigger in the
@@ -625,6 +649,7 @@ function Studio({ wid, pushToast }) {
     >
       <StudioHeader
         wid={wid}
+        pushToast={studio.pushToast}
         onTogglePalette={studio.togglePalette}
         onSelectWorkspace={selectWorkspace}
         terminalOpen={s.terminalOpen}

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -368,26 +368,17 @@ function useStudioState(wid) {
 }
 
 // ---------------------------------------------------------------------------
-// Brand logo — faceted diamond from the prototype (renderVals.logo).
+// StudioHeader — SLIM in-shell content sub-header.
+//
+// The Studio renders as an ordinary page inside the app shell (the app Topbar
+// owns brand / global search / theme / user — see chrome.jsx Topbar), so this
+// row is intentionally minimal: workspace selector ▾ · ⌘K palette ·
+// terminal toggle. On phones it also carries the two panel-drawer toggles
+// (left = Sessions+Files, right = Action Required+Activity) since the columns
+// collapse to a single document there.
 // ---------------------------------------------------------------------------
 
-function ST_Logo() {
-  return (
-    <svg width={22} height={22} viewBox="0 0 24 24">
-      <polygon points="12,3 21,12 12,21 3,12" fill="var(--text)" fillOpacity={0.16} />
-      <polygon points="12,3 16.5,7.5 12,12 7.5,7.5" fill="var(--text)" />
-      <polygon points="16.5,7.5 21,12 16.5,16.5 12,12" fill="var(--text)" fillOpacity={0.4} />
-      <polygon points="12,12 16.5,16.5 12,21 7.5,16.5" fill="var(--accent)" />
-      <polygon points="7.5,7.5 12,12 7.5,16.5 3,12" fill="var(--text)" fillOpacity={0.4} />
-    </svg>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// StudioHeader — brand · workspace selector ▾ · ⌘K / ⌘P / density / theme
-// ---------------------------------------------------------------------------
-
-function StudioHeader({ wid, theme, density, onToggleTheme, onToggleDensity, onTogglePalette, onOpenQuick, onSelectWorkspace }) {
+function StudioHeader({ wid, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, onToggleLeftPanel, onToggleRightPanel }) {
   var { useResource, apiFetch } = window.primerApi;
   var [menuOpen, setMenuOpen] = React.useState(false);
 
@@ -422,10 +413,16 @@ function StudioHeader({ wid, theme, density, onToggleTheme, onToggleDensity, onT
 
   return (
     <div className="st-topbar" data-testid="studio-header">
-      <div className="st-brand">
-        <span style={{ width: 22, height: 22, display: "grid", placeItems: "center" }}><ST_Logo /></span>
-        Primer <span style={{ color: "var(--text-3)", fontWeight: 500, fontSize: 12 }}>Studio</span>
-      </div>
+      {/* Mobile-only panel-drawer toggle (left: Sessions + Files). */}
+      <button
+        className="st-hbtn mobile-only touch-target"
+        data-testid="studio-left-toggle"
+        title="Sessions & Files"
+        aria-label="Toggle sessions and files panel"
+        onClick={onToggleLeftPanel}
+      >
+        <Icon name="panel-left" size={15} />
+      </button>
 
       <div
         className="st-ws-btn"
@@ -457,18 +454,46 @@ function StudioHeader({ wid, theme, density, onToggleTheme, onToggleDensity, onT
 
       <div style={{ flex: 1 }} />
 
-      {/* ⌘K palette trigger — inert stub until B5 wires the palette. */}
+      {/* ⌘K command palette (run · jump · search within the workspace). The
+          wide trigger is hidden on phones (see .st-palette-trigger in the
+          mobile block); a compact search button replaces it there. */}
       <div className="st-palette-trigger" data-testid="palette-trigger" onClick={onTogglePalette}>
         <span style={{ opacity: 0.8 }}>Search · run · jump</span>
         <kbd>⌘K</kbd>
       </div>
-      {/* ⌘P quick-open — inert stub until B5. */}
-      <div className="st-hbtn" data-testid="quickopen-trigger" title="Quick open (⌘P)" onClick={onOpenQuick}>⌕</div>
-      <div className="st-hbtn" data-testid="density-toggle" title="Density" onClick={onToggleDensity}>☰</div>
-      <div className="st-hbtn" data-testid="theme-toggle" title="Theme" onClick={onToggleTheme}>
-        {theme === "dark" ? "◐" : "○"}
-      </div>
-      <div className="st-avatar" title="User">DK</div>
+      {/* Compact ⌘K affordance for phones (the wide trigger is desktop-only). */}
+      <button
+        className="st-hbtn mobile-only touch-target"
+        data-testid="palette-trigger-mobile"
+        title="Command palette (⌘K)"
+        aria-label="Open command palette"
+        onClick={onTogglePalette}
+      >
+        <Icon name="search" size={15} />
+      </button>
+
+      {/* Terminal toggle (Ctrl-`). */}
+      <button
+        className={"st-hbtn touch-target" + (terminalOpen ? " is-active" : "")}
+        data-testid="terminal-toggle"
+        title="Toggle terminal (Ctrl-`)"
+        aria-label="Toggle terminal"
+        aria-pressed={terminalOpen ? "true" : "false"}
+        onClick={onToggleTerminal}
+      >
+        <Icon name="code" size={15} />
+      </button>
+
+      {/* Mobile-only panel-drawer toggle (right: Action Required + Activity). */}
+      <button
+        className="st-hbtn mobile-only touch-target"
+        data-testid="studio-right-toggle"
+        title="Action required & activity"
+        aria-label="Toggle action-required and activity panel"
+        onClick={onToggleRightPanel}
+      >
+        <Icon name="bell" size={15} />
+      </button>
     </div>
   );
 }
@@ -501,6 +526,37 @@ function Studio({ wid, pushToast }) {
   // Falls back to the module-level primerApi.toastPush so non-nil calls always
   // work even when app.jsx hasn't passed the prop yet.
   studio.pushToast = pushToast || (window.primerApi && window.primerApi.toastPush) || null;
+
+  // Remember the last workspace whose Studio was opened so the global "Studio"
+  // nav item (chrome.jsx) can re-open it without a workspace picker. Written on
+  // every mount / wid change; read in app.jsx's openStudio().
+  React.useEffect(function () {
+    if (!wid) return;
+    try { window.localStorage.setItem("studio:lastWid", wid); } catch (_e) { /* storage disabled */ }
+  }, [wid]);
+
+  // Mobile-only panel drawers. On phones st-body collapses to the single
+  // center document (CSS); the left (Sessions+Files) and right (Action
+  // Required+Activity) columns become slide-over sheets toggled from the slim
+  // sub-header. Desktop ignores this state entirely (the columns are static).
+  var [leftPanelOpen, setLeftPanelOpen] = React.useState(false);
+  var [rightPanelOpen, setRightPanelOpen] = React.useState(false);
+  var closePanels = React.useCallback(function () { setLeftPanelOpen(false); setRightPanelOpen(false); }, []);
+
+  // Close the drawers when the workspace changes (route switch) and lock body
+  // scroll + wire Escape while either is open — mirrors chrome.jsx MobileNav.
+  React.useEffect(function () { closePanels(); }, [wid, closePanels]);
+  React.useEffect(function () {
+    if (!leftPanelOpen && !rightPanelOpen) return undefined;
+    function onKey(e) { if (e.key === "Escape") closePanels(); }
+    window.addEventListener("keydown", onKey);
+    var prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = "hidden";
+    return function () {
+      window.removeEventListener("keydown", onKey);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [leftPanelOpen, rightPanelOpen, closePanels]);
 
   // Column resize: drag the handle, write width into state (persisted).
   // We clamp to sane bounds so a column can't be dragged off-screen.
@@ -569,32 +625,45 @@ function Studio({ wid, pushToast }) {
     >
       <StudioHeader
         wid={wid}
-        theme={s.theme}
-        density={s.density}
-        onToggleTheme={studio.toggleTheme}
-        onToggleDensity={studio.toggleDensity}
         onTogglePalette={studio.togglePalette}
-        onOpenQuick={function () { studio.openPalette("quickopen"); }}
         onSelectWorkspace={selectWorkspace}
+        terminalOpen={s.terminalOpen}
+        onToggleTerminal={studio.toggleTerminal}
+        onToggleLeftPanel={function () { setRightPanelOpen(false); setLeftPanelOpen(function (o) { return !o; }); }}
+        onToggleRightPanel={function () { setLeftPanelOpen(false); setRightPanelOpen(function (o) { return !o; }); }}
       />
 
       <div className="st-body">
-        {/* ---- LEFT: B2 StudioSidebar (sessions + files tree) ---- */}
-        <div className="st-col st-col-left" data-testid="studio-sidebar">
+        {/* Mobile backdrop: dims the center doc while a panel drawer is open.
+            Desktop never shows this (st-panel-overlay is mobile-only in CSS). */}
+        {(leftPanelOpen || rightPanelOpen) && (
+          <div className="st-panel-overlay mobile-only" data-testid="studio-panel-overlay" onClick={closePanels} />
+        )}
+
+        {/* ---- LEFT: B2 StudioSidebar (sessions + files tree) ---- On phones
+            this column is an off-canvas sheet toggled from the sub-header. ---- */}
+        <div
+          className={"st-col st-col-left" + (leftPanelOpen ? " is-drawer-open" : "")}
+          data-testid="studio-sidebar"
+        >
           <StudioSidebar wid={wid} studio={studio} />
         </div>
 
-        <div className="st-resize" onMouseDown={function (e) { startResize("left", e); }} data-testid="studio-resize-left" />
+        <div className="st-resize desktop-only" onMouseDown={function (e) { startResize("left", e); }} data-testid="studio-resize-left" />
 
         {/* ---- CENTER: B3 StudioCenter (tabs + active panel) ---- */}
         <div className="st-col st-col-center" data-testid="studio-center">
           <StudioCenter wid={wid} studio={studio} />
         </div>
 
-        <div className="st-resize" onMouseDown={function (e) { startResize("right", e); }} data-testid="studio-resize-right" />
+        <div className="st-resize desktop-only" onMouseDown={function (e) { startResize("right", e); }} data-testid="studio-resize-right" />
 
-        {/* ---- RIGHT: B4 StudioActivity (action required + workspace tap) ---- */}
-        <div className="st-col st-col-right" data-testid="studio-activity">
+        {/* ---- RIGHT: B4 StudioActivity (action required + workspace tap) ----
+            Off-canvas sheet on phones (right edge); static column on desktop. */}
+        <div
+          className={"st-col st-col-right" + (rightPanelOpen ? " is-drawer-open" : "")}
+          data-testid="studio-activity"
+        >
           <StudioActivity wid={wid} studio={studio} />
         </div>
       </div>

--- a/ui/components/workspaces.jsx
+++ b/ui/components/workspaces.jsx
@@ -1919,3 +1919,12 @@ function WS_DiagnosticModal({ workspaceId, onClose }) {
 
 window.WorkspacesPage = WorkspacesPage;
 window.WorkspaceDetail = WorkspaceDetail;
+// Reusable detail panels — surfaced to window.* so the Studio's Workspace
+// Settings overlay (studio-settings.jsx) can render the SAME components for
+// the orphaned channels/reply-binding · config · git-log · destroy features
+// without reimplementing them. WorkspaceDetail continues to reference these
+// via their in-file bindings; the exports are additive.
+window.WS_ChannelsTab = WS_ChannelsTab;
+window.WS_ConfigTab = WS_ConfigTab;
+window.WS_LogTab = WS_LogTab;
+window.WS_DestroyTab = WS_DestroyTab;

--- a/ui/index.html
+++ b/ui/index.html
@@ -95,6 +95,7 @@
 <script type="text/babel" src="components/studio-palette.jsx"></script>
 <script type="text/babel" src="components/studio.jsx"></script>
 <script type="text/babel" src="components/workspaces.jsx"></script>
+<script type="text/babel" src="components/studio-settings.jsx"></script>
 <script type="text/babel" src="components/agents.jsx"></script>
 <script type="text/babel" src="components/graphs.jsx"></script>
 <script type="text/babel" src="components/knowledge.jsx"></script>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -221,11 +221,17 @@
   color: var(--text-2);
 }
 
-/* Body: 3 columns. Widths are CSS custom props so the resize handles can
-   write --st-left-w / --st-right-w inline on the grid element. */
+/* Body: 3 content columns + 2 resize-handle tracks. The .st-resize handles
+   are grid CHILDREN ([left][handle][center][handle][right]), so the template
+   must declare FIVE tracks — with only three, auto-placement pushed
+   st-col-center into the right column, wrapped st-col-right onto an implicit
+   second row, and collapsed SD_GraphRunView's canvas column to 0 width.
+   Widths are CSS custom props so the handles can write --st-left-w /
+   --st-right-w inline on the grid element. At ≤639px the handles are
+   display:none (desktop-only) and the mobile override re-declares 1fr. */
 .st-body {
   display: grid;
-  grid-template-columns: var(--st-left-w, 248px) minmax(0, 1fr) var(--st-right-w, 332px);
+  grid-template-columns: var(--st-left-w, 248px) 5px minmax(0, 1fr) 5px var(--st-right-w, 332px);
   min-height: 0;
 }
 .st-col {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -101,11 +101,15 @@
 :root[data-density="comfortable"],
 [data-density="comfortable"] { --frow-h: 30px; }
 
-/* Studio root shell: header row + body. Owns its own data-theme/-density. */
+/* Studio root shell: slim sub-header row + body. Renders as IN-SHELL page
+   content (inside the app .main / .page-body), so it fills its container
+   rather than the whole viewport. The .studio-page chrome reset below strips
+   the empty page-header + page-body padding so this can size to 100%. Owns its
+   own data-theme/-density. */
 .st-root {
   display: grid;
-  grid-template-rows: var(--topbar-h, 48px) 1fr;
-  height: 100dvh;
+  grid-template-rows: var(--st-subhead-h, 44px) 1fr;
+  height: 100%;
   width: 100%;
   background: var(--bg);
   color: var(--text);
@@ -116,26 +120,23 @@
   overflow: hidden;
 }
 
-/* Header (top row). */
+/* In-shell chrome reset: when the Studio is the active page, collapse the
+   shared empty page-header and drop the page-body padding so the Studio fills
+   the scroll area edge-to-edge under the app Topbar. */
+.app.studio-page .main { overflow: hidden; }
+.app.studio-page .page-header { display: none; }
+.app.studio-page .page-body { padding: 0; height: 100%; min-height: 0; }
+
+/* Slim content sub-header (top row). */
 .st-topbar {
   display: flex;
   align-items: center;
-  gap: 14px;
+  gap: 10px;
   padding: 0 12px;
   background: var(--bg-1);
   border-bottom: 1px solid var(--border);
   position: relative;
   z-index: 30;
-}
-.st-brand {
-  display: flex;
-  align-items: center;
-  gap: 9px;
-  font-weight: 600;
-  letter-spacing: -0.01em;
-  padding-right: 14px;
-  border-right: 1px solid var(--border);
-  height: var(--topbar-h, 48px);
 }
 .st-ws-btn {
   position: relative;
@@ -1720,6 +1721,43 @@ input, textarea, select { font: inherit; color: inherit; }
   /* Hide existing sidebar in favor of slide-over drawer. */
   .app { grid-template-columns: 1fr; }
   .sidebar { display: none; }
+
+  /* ---- Studio: collapse the 3-column body to the single center document.
+     The left (Sessions+Files) and right (Action Required+Activity) columns
+     become slide-over sheets toggled from the slim sub-header. ---- */
+  /* The wide ⌘K trigger gives way to the compact mobile search button. */
+  .st-palette-trigger { display: none; }
+  /* Re-assert grid centering on the mobile-only sub-header buttons — the
+     generic `.mobile-only { display: revert }` above would otherwise drop
+     `.st-hbtn`'s `display: grid` back to the UA inline-block default. */
+  .st-topbar .st-hbtn.mobile-only { display: grid; }
+  .st-body { grid-template-columns: 1fr; }
+  .st-col-left,
+  .st-col-right {
+    position: fixed;
+    top: 0; bottom: 0;
+    width: 85vw; max-width: 340px;
+    z-index: 51;
+    box-shadow: var(--shadow);
+    transition: transform 0.18s ease;
+  }
+  .st-col-left {
+    left: 0;
+    border-right: 1px solid var(--border);
+    transform: translateX(-100%);
+  }
+  .st-col-right {
+    right: 0;
+    border-left: 1px solid var(--border);
+    transform: translateX(100%);
+  }
+  .st-col-left.is-drawer-open,
+  .st-col-right.is-drawer-open { transform: translateX(0); }
+  .st-panel-overlay {
+    position: fixed; inset: 0;
+    background: oklch(0 0 0 / 0.5);
+    z-index: 50;
+  }
 
   /* Topbar: hamburger left, brand + theme toggle right. */
   .topbar-brand { padding-left: 8px; }


### PR DESCRIPTION
## Studio e2e remediation + restored workspace management (continuation of #60)

#60 was merged while its remediation work was still in flight, so only its first commit (the shell fixes) landed. This PR carries the rest — it is what turns the **E2E workflow on main green again** (red since the Studio merge).

### Real bugs fixed (found by the e2e grind)
1. **Sessions never opened from the Studio sidebar** — the sidebar read `session.id`, but `GET /workspaces/{wid}/sessions` returns `SessionInfo` whose field is `session_id`: rows rendered blank and clicking them opened nothing. (`cc646dd2`)
2. **The desktop 3-column layout was silently broken** — `.st-body` declared 3 grid tracks for 5 children (the resize handles are grid children): the center panel rendered in the narrow right column, the Activity column wrapped onto a phantom row, and the graph run-view canvas collapsed to 0 width. Diagnosed by probing a live local server (sqlite) with headless Chromium. (`9eb69342`)
3. Studio console-error allowlist actually matching the app-shell `internal_collections/config` 404. (`4d0d93dc`)

### Restored (orphaned when the Studio replaced WorkspaceDetail)
**Workspace Settings** behind a gear in the Studio sub-header: Channels/reply-binding, Config, Git log, Destroy — reusing the existing `WS_*Tab` panels. (`089f991a`)

### e2e re-point (41 stale tests)
The suite still exercised the retired sessions-list/session-detail/workspace-detail pages. 33 re-pointed to the Studio (shared `_studio_helpers.py`), 8 removed with in-file justification (no Studio equivalent). `data-session-id` added to sidebar rows for deterministic location. (`7ad71708`, `4d0d93dc`, `a00c3fdc`)

### Validation
E2E workflow on this exact head (`9eb69342`): **success — 132 passed, 7 skipped, 0 failed** (run 28604012985). tests/ui: 459 passed. Full suite trajectory across the remediation: 42 → 9 → 7 → 1 → 0.
