### PR TITLE
feat(providers): total-generation timeout to abort runaway streamed generations

### DIFF
--- a/primer/llm/_timeout.py
+++ b/primer/llm/_timeout.py
@@ -1,13 +1,16 @@
-"""Per-event inactivity timeout for LLM streaming calls.
+"""Streaming timeouts for LLM adapter calls.
 
-Shared by every LLM adapter so the stall-detection logic is written once
-and tested once. The helper wraps any async iterable and adds a per-item
-deadline: if no event arrives within ``timeout_seconds`` the underlying
-``__anext__`` call is cancelled and ``asyncio.TimeoutError`` is raised,
-propagating to the adapter's caller.
+Shared by every LLM adapter so the deadline logic is written once and
+tested once. :func:`_iter_with_timeout` wraps any async iterable and adds
+two independent deadlines: a per-item STALL window (``timeout_seconds`` --
+no event within the window raises ``asyncio.TimeoutError``) and a TOTAL
+generation budget (``total_timeout_seconds`` -- the whole iteration
+exceeding it raises :class:`GenerationBudgetExceeded`, catching runaway
+generations whose steady token trickle never trips the stall window).
+:func:`_open_with_connect_timeout` bounds opening the stream itself.
 
-When ``timeout_seconds`` is ``None`` the iterable is passed through
-unchanged with no overhead.
+When every deadline is ``None`` the iterable is passed through unchanged
+with no overhead.
 """
 
 from __future__ import annotations
@@ -17,6 +20,19 @@ from collections.abc import AsyncIterator, Awaitable, Callable
 from typing import Any, TypeVar
 
 _T = TypeVar("_T")
+
+
+class GenerationBudgetExceeded(TimeoutError):
+    """A streamed generation exceeded its total wall-clock budget.
+
+    Subclasses :class:`TimeoutError` so every adapter's existing
+    ``except TimeoutError`` stall handler catches it unchanged; adapters
+    that want a precise error message ``isinstance``-check for this class
+    first. Raised by :func:`_iter_with_timeout` when
+    ``total_timeout_seconds`` elapses while the stream is still emitting
+    events -- the runaway-generation case the per-event stall timeout
+    cannot detect (events keep arriving, so the stall window never trips).
+    """
 
 
 async def _open_with_connect_timeout(
@@ -57,18 +73,24 @@ async def _open_with_connect_timeout(
 async def _iter_with_timeout(
     aiter: Any,
     timeout_seconds: float | None,
+    total_timeout_seconds: float | None = None,
 ) -> AsyncIterator[Any]:
-    """Yield items from ``aiter`` with a per-item inactivity timeout.
+    """Yield items from ``aiter`` with per-item and total-budget deadlines.
 
     Parameters
     ----------
     aiter:
         Any async iterable (an SDK streaming response, for example).
     timeout_seconds:
-        Maximum seconds to wait for the NEXT item. If no item arrives
-        within this window ``asyncio.TimeoutError`` is raised. Pass
-        ``None`` to disable the timeout entirely (items are awaited
-        without a deadline).
+        Maximum seconds to wait for the NEXT item (stall detection). If no
+        item arrives within this window ``asyncio.TimeoutError`` is raised.
+        Pass ``None`` to disable stall detection.
+    total_timeout_seconds:
+        Wall-clock ceiling for the WHOLE iteration, measured from the first
+        wait. When it elapses :class:`GenerationBudgetExceeded` is raised --
+        even if items are still arriving. This is the runaway-generation
+        backstop; stall detection alone never fires while tokens trickle.
+        Pass ``None`` (the default) to disable.
 
     Yields
     ------
@@ -77,20 +99,45 @@ async def _iter_with_timeout(
 
     Raises
     ------
+    GenerationBudgetExceeded
+        When ``total_timeout_seconds`` is not ``None`` and the iteration has
+        run longer than that budget.
     asyncio.TimeoutError
-        When ``timeout_seconds`` is not ``None`` and no item arrives
-        within the configured window.
+        When ``timeout_seconds`` is not ``None`` and no item arrives within
+        the configured window.
     """
-    if timeout_seconds is None:
+    if timeout_seconds is None and total_timeout_seconds is None:
         async for item in aiter:
             yield item
         return
 
+    loop = asyncio.get_running_loop()
+    deadline = (
+        loop.time() + total_timeout_seconds
+        if total_timeout_seconds is not None
+        else None
+    )
     it = aiter.__aiter__()
     while True:
+        wait = timeout_seconds
+        if deadline is not None:
+            remaining = deadline - loop.time()
+            if remaining <= 0:
+                raise GenerationBudgetExceeded(
+                    f"generation exceeded its total budget of "
+                    f"{total_timeout_seconds} s"
+                )
+            wait = remaining if wait is None else min(wait, remaining)
         try:
-            async with asyncio.timeout(timeout_seconds):
+            async with asyncio.timeout(wait):
                 item = await it.__anext__()
         except StopAsyncIteration:
             return
+        except TimeoutError:
+            if deadline is not None and loop.time() >= deadline:
+                raise GenerationBudgetExceeded(
+                    f"generation exceeded its total budget of "
+                    f"{total_timeout_seconds} s"
+                ) from None
+            raise
         yield item

--- a/primer/llm/anthropic.py
+++ b/primer/llm/anthropic.py
@@ -23,7 +23,7 @@ from pydantic import BaseModel as PydanticBaseModel
 
 from primer.common.anthropic_errors import classify_anthropic_exception
 from primer.int.llm import LLM
-from primer.llm._timeout import _iter_with_timeout, _open_with_connect_timeout
+from primer.llm._timeout import GenerationBudgetExceeded, _iter_with_timeout, _open_with_connect_timeout
 from primer.llm._tokenizer.anthropic import count_tokens_anthropic
 from primer.model.chat import (
     AudioPart,
@@ -575,6 +575,7 @@ class AnthropicLLM(LLM):
         self._rate_limit_key = f"llm:{provider.id}"
         self._max_concurrency = provider.limits.max_concurrency
         self._request_timeout_seconds = provider.limits.request_timeout_seconds
+        self._total_timeout_seconds = provider.limits.total_timeout_seconds
         self._connect_timeout_seconds = provider.limits.connect_timeout_seconds
         self._trace_llm_io = trace_llm_io
 
@@ -735,7 +736,9 @@ class AnthropicLLM(LLM):
                     state = _StreamState()
                     try:
                         async for raw in _iter_with_timeout(
-                            sdk_stream, self._request_timeout_seconds
+                            sdk_stream,
+                            self._request_timeout_seconds,
+                            self._total_timeout_seconds,
                         ):
                             for event in _translate_event(raw, state, model_name=model):
                                 if isinstance(event, Usage):
@@ -744,6 +747,22 @@ class AnthropicLLM(LLM):
                                 yield event
                     except TimeoutError as exc:
                         from primer.model.except_ import ProviderTimeoutError
+                        if isinstance(exc, GenerationBudgetExceeded):
+                            total_val = self._total_timeout_seconds
+                            logger.error(
+                                "Anthropic generation exceeded its total budget (%.1f s)",
+                                total_val,
+                                extra={
+                                    "provider_id": self._provider.id,
+                                    "model": model,
+                                },
+                            )
+                            raise ProviderTimeoutError(
+                                f"Anthropic generation exceeded its total budget of "
+                                f"{total_val} s (provider_id={self._provider.id!r}, "
+                                f"model={model!r})",
+                                code="generation_timeout",
+                            ) from exc
                         timeout_val = self._request_timeout_seconds
                         logger.error(
                             "Anthropic stream timed out (no event in %.1f s)",

--- a/primer/llm/gemini.py
+++ b/primer/llm/gemini.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel
 
 from primer.common.google_errors import classify_google_exception
 from primer.int.llm import LLM
-from primer.llm._timeout import _iter_with_timeout, _open_with_connect_timeout
+from primer.llm._timeout import GenerationBudgetExceeded, _iter_with_timeout, _open_with_connect_timeout
 from primer.llm._tokenizer.gemini import count_tokens_gemini
 from primer.model.except_ import (
     ConfigError,
@@ -835,6 +835,7 @@ class GeminiLLM(LLM):
         self._rate_limit_key = f"llm:{provider.id}"
         self._max_concurrency = provider.limits.max_concurrency
         self._request_timeout_seconds = provider.limits.request_timeout_seconds
+        self._total_timeout_seconds = provider.limits.total_timeout_seconds
         self._connect_timeout_seconds = provider.limits.connect_timeout_seconds
         self._trace_llm_io = trace_llm_io
 
@@ -988,7 +989,9 @@ class GeminiLLM(LLM):
                     state = _StreamState()
                     try:
                         async for chunk in _iter_with_timeout(
-                            sdk_stream, self._request_timeout_seconds
+                            sdk_stream,
+                            self._request_timeout_seconds,
+                            self._total_timeout_seconds,
                         ):
                             for ev in _translate_chunk(chunk, state, model_name=model):
                                 if isinstance(ev, Usage):
@@ -997,6 +1000,22 @@ class GeminiLLM(LLM):
                                 yield ev
                     except TimeoutError as exc:
                         from primer.model.except_ import ProviderTimeoutError
+                        if isinstance(exc, GenerationBudgetExceeded):
+                            total_val = self._total_timeout_seconds
+                            logger.error(
+                                "Gemini generation exceeded its total budget (%.1f s)",
+                                total_val,
+                                extra={
+                                    "provider_id": self._provider.id,
+                                    "model": model,
+                                },
+                            )
+                            raise ProviderTimeoutError(
+                                f"Gemini generation exceeded its total budget of "
+                                f"{total_val} s (provider_id={self._provider.id!r}, "
+                                f"model={model!r})",
+                                code="generation_timeout",
+                            ) from exc
                         timeout_val = self._request_timeout_seconds
                         logger.error(
                             "Gemini stream timed out (no event in %.1f s)",

--- a/primer/llm/ollama.py
+++ b/primer/llm/ollama.py
@@ -25,7 +25,7 @@ import ollama
 from pydantic import BaseModel as PydanticBaseModel
 
 from primer.int.llm import LLM
-from primer.llm._timeout import _iter_with_timeout, _open_with_connect_timeout
+from primer.llm._timeout import GenerationBudgetExceeded, _iter_with_timeout, _open_with_connect_timeout
 from primer.llm._tokenizer.hf import count_tokens_hf
 from primer.model.chat import (
     AudioPart,
@@ -428,6 +428,7 @@ class OllamaLLM(LLM):
         self._rate_limit_key = f"llm:{provider.id}"
         self._max_concurrency = provider.limits.max_concurrency
         self._request_timeout_seconds = provider.limits.request_timeout_seconds
+        self._total_timeout_seconds = provider.limits.total_timeout_seconds
         self._connect_timeout_seconds = provider.limits.connect_timeout_seconds
         self._trace_llm_io = trace_llm_io
 
@@ -578,7 +579,9 @@ class OllamaLLM(LLM):
                     state = _StreamState()
                     try:
                         async for chunk in _iter_with_timeout(
-                            sdk_stream, self._request_timeout_seconds
+                            sdk_stream,
+                            self._request_timeout_seconds,
+                            self._total_timeout_seconds,
                         ):
                             for ev in _translate_chunk(chunk, state, model_name=model):
                                 if isinstance(ev, Usage):
@@ -587,6 +590,22 @@ class OllamaLLM(LLM):
                                 yield ev
                     except TimeoutError as exc:
                         from primer.model.except_ import ProviderTimeoutError
+                        if isinstance(exc, GenerationBudgetExceeded):
+                            total_val = self._total_timeout_seconds
+                            logger.error(
+                                "Ollama generation exceeded its total budget (%.1f s)",
+                                total_val,
+                                extra={
+                                    "provider_id": self._provider.id,
+                                    "model": model,
+                                },
+                            )
+                            raise ProviderTimeoutError(
+                                f"Ollama generation exceeded its total budget of "
+                                f"{total_val} s (provider_id={self._provider.id!r}, "
+                                f"model={model!r})",
+                                code="generation_timeout",
+                            ) from exc
                         timeout_val = self._request_timeout_seconds
                         logger.error(
                             "Ollama stream timed out (no event in %.1f s)",

--- a/primer/llm/openchat.py
+++ b/primer/llm/openchat.py
@@ -27,7 +27,7 @@ from pydantic import BaseModel
 from primer.common.openai_errors import classify_openai_exception
 from primer.int.coordinator import RateLimiter
 from primer.int.llm import LLM
-from primer.llm._timeout import _iter_with_timeout
+from primer.llm._timeout import GenerationBudgetExceeded, _iter_with_timeout
 from primer.llm._openai_compat import (
     _build_sampling_params,
     _build_usage,
@@ -125,6 +125,7 @@ class OpenChatLLM(LLM):
         self._rate_limit_key = f"llm:{provider.id}"
         self._max_concurrency = provider.limits.max_concurrency
         self._request_timeout_seconds = provider.limits.request_timeout_seconds
+        self._total_timeout_seconds = provider.limits.total_timeout_seconds
         self._trace_llm_io = trace_llm_io
 
         logger.info(
@@ -262,12 +263,30 @@ class OpenChatLLM(LLM):
                 state = _StreamState()
                 try:
                     async for raw in _iter_with_timeout(
-                        sdk_stream, self._request_timeout_seconds
+                        sdk_stream,
+                        self._request_timeout_seconds,
+                        self._total_timeout_seconds,
                     ):
                         for event in _translate_chunk(raw, state):
                             yield event
                 except TimeoutError as exc:
                     from primer.model.except_ import ProviderTimeoutError
+                    if isinstance(exc, GenerationBudgetExceeded):
+                        total_val = self._total_timeout_seconds
+                        logger.error(
+                            "OpenChat generation exceeded its total budget (%.1f s)",
+                            total_val,
+                            extra={
+                                "provider_id": self._provider.id,
+                                "model": model,
+                            },
+                        )
+                        raise ProviderTimeoutError(
+                            f"OpenChat generation exceeded its total budget of "
+                            f"{total_val} s (provider_id={self._provider.id!r}, "
+                            f"model={model!r})",
+                            code="generation_timeout",
+                        ) from exc
                     timeout_val = self._request_timeout_seconds
                     logger.error(
                         "OpenChat stream timed out (no event in %.1f s)",

--- a/primer/llm/openresponses.py
+++ b/primer/llm/openresponses.py
@@ -28,7 +28,7 @@ from pydantic import BaseModel
 from primer.common.openai_errors import classify_openai_exception
 from primer.int.llm import LLM
 from primer.llm._openai_common import build_sampling_params as _build_sampling_params_impl
-from primer.llm._timeout import _iter_with_timeout
+from primer.llm._timeout import GenerationBudgetExceeded, _iter_with_timeout
 from primer.model.except_ import (
     ConfigError,
     ModelNotFoundError,
@@ -828,6 +828,7 @@ class OpenResponsesLLM(LLM):
         self._rate_limit_key = f"llm:{provider.id}"
         self._max_concurrency = provider.limits.max_concurrency
         self._request_timeout_seconds = provider.limits.request_timeout_seconds
+        self._total_timeout_seconds = provider.limits.total_timeout_seconds
         self._connect_timeout_seconds = provider.limits.connect_timeout_seconds
         self._trace_llm_io = trace_llm_io
 
@@ -1005,7 +1006,9 @@ class OpenResponsesLLM(LLM):
                     state = _StreamState()
                     try:
                         async for raw in _iter_with_timeout(
-                            sdk_stream, self._request_timeout_seconds
+                            sdk_stream,
+                            self._request_timeout_seconds,
+                            self._total_timeout_seconds,
                         ):
                             for event in _translate_event(raw, state):
                                 if isinstance(event, Usage):
@@ -1014,6 +1017,22 @@ class OpenResponsesLLM(LLM):
                                 yield event
                     except TimeoutError as exc:
                         from primer.model.except_ import ProviderTimeoutError
+                        if isinstance(exc, GenerationBudgetExceeded):
+                            total_val = self._total_timeout_seconds
+                            logger.error(
+                                "OpenResponses generation exceeded its total budget (%.1f s)",
+                                total_val,
+                                extra={
+                                    "provider_id": self._provider.id,
+                                    "model": model,
+                                },
+                            )
+                            raise ProviderTimeoutError(
+                                f"OpenResponses generation exceeded its total budget of "
+                                f"{total_val} s (provider_id={self._provider.id!r}, "
+                                f"model={model!r})",
+                                code="generation_timeout",
+                            ) from exc
                         timeout_val = self._request_timeout_seconds
                         logger.error(
                             "OpenResponses stream timed out (no event in %.1f s)",

--- a/primer/llm/openrouter.py
+++ b/primer/llm/openrouter.py
@@ -38,7 +38,7 @@ from pydantic import BaseModel
 from primer.common.openai_errors import classify_openai_exception
 from primer.int.coordinator import RateLimiter
 from primer.int.llm import LLM
-from primer.llm._timeout import _iter_with_timeout
+from primer.llm._timeout import GenerationBudgetExceeded, _iter_with_timeout
 from primer.llm._openai_compat import (
     _build_sampling_params,
     _extract_extended_kwargs,
@@ -115,6 +115,7 @@ class OpenRouterLLM(LLM):
         self._rate_limit_key = f"llm:{provider.id}"
         self._max_concurrency = provider.limits.max_concurrency
         self._request_timeout_seconds = provider.limits.request_timeout_seconds
+        self._total_timeout_seconds = provider.limits.total_timeout_seconds
         self._trace_llm_io = trace_llm_io
 
         logger.info(
@@ -254,12 +255,30 @@ class OpenRouterLLM(LLM):
                 state = _StreamState()
                 try:
                     async for raw in _iter_with_timeout(
-                        sdk_stream, self._request_timeout_seconds
+                        sdk_stream,
+                        self._request_timeout_seconds,
+                        self._total_timeout_seconds,
                     ):
                         for event in _translate_chunk(raw, state):
                             yield event
                 except TimeoutError as exc:
                     from primer.model.except_ import ProviderTimeoutError
+                    if isinstance(exc, GenerationBudgetExceeded):
+                        total_val = self._total_timeout_seconds
+                        logger.error(
+                            "OpenRouter generation exceeded its total budget (%.1f s)",
+                            total_val,
+                            extra={
+                                "provider_id": self._provider.id,
+                                "model": model,
+                            },
+                        )
+                        raise ProviderTimeoutError(
+                            f"OpenRouter generation exceeded its total budget of "
+                            f"{total_val} s (provider_id={self._provider.id!r}, "
+                            f"model={model!r})",
+                            code="generation_timeout",
+                        ) from exc
                     timeout_val = self._request_timeout_seconds
                     logger.error(
                         "OpenRouter stream timed out (no event in %.1f s)",

--- a/primer/model/providers/_shared.py
+++ b/primer/model/providers/_shared.py
@@ -82,3 +82,21 @@ class Limits(BaseModel):
             "network request; not applicable to local (in-process) backends."
         ),
     )
+    total_timeout_seconds: float | None = Field(
+        default=None,
+        ge=0.0,
+        description=(
+            "Wall-clock ceiling in seconds for ONE full streamed generation, "
+            "measured from the first wait after the stream opens. ``None`` "
+            "(the default) means no ceiling. This is the RUNAWAY-GENERATION "
+            "backstop: a model that keeps emitting tokens forever (e.g. a "
+            "small local model free-running on a structured-output request) "
+            "never trips the per-event stall timeout because events keep "
+            "arriving -- this cap aborts such a generation cleanly, failing "
+            "the turn and releasing the concurrency slot. Set it comfortably "
+            "above your slowest legitimate generation. The three timeouts "
+            "compose: ``connect_timeout_seconds`` bounds opening the stream "
+            "(incl. cold model load), ``request_timeout_seconds`` bounds each "
+            "gap between events, and this bounds the whole generation."
+        ),
+    )

--- a/tests/llm/test_llm_timeout.py
+++ b/tests/llm/test_llm_timeout.py
@@ -17,7 +17,7 @@ from unittest.mock import AsyncMock, MagicMock
 import pytest
 from pydantic import HttpUrl, SecretStr, ValidationError
 
-from primer.llm._timeout import _iter_with_timeout
+from primer.llm._timeout import GenerationBudgetExceeded, _iter_with_timeout
 from primer.model.except_ import ProviderTimeoutError
 from primer.model.provider import (
     AnthropicConfig,
@@ -173,6 +173,121 @@ class TestIterWithTimeout:
             await it.__anext__()  # should raise TimeoutError after ~50 ms
 
         with pytest.raises(asyncio.TimeoutError):
+            await asyncio.wait_for(_run(), timeout=3.0)
+
+
+# ---------------------------------------------------------------------------
+# total_timeout_seconds: Limits field + runaway-generation budget
+# ---------------------------------------------------------------------------
+
+
+async def _runaway_agen():
+    """Yield tokens forever with no stall -- the runaway-generation case."""
+    n = 0
+    while True:
+        yield n
+        n += 1
+        await asyncio.sleep(0)
+
+
+class TestTotalTimeoutField:
+    def test_default_is_none(self) -> None:
+        lim = Limits(max_concurrency=1)
+        assert lim.total_timeout_seconds is None
+
+    def test_explicit_value(self) -> None:
+        lim = Limits(max_concurrency=1, total_timeout_seconds=900.0)
+        assert lim.total_timeout_seconds == 900.0
+
+    def test_negative_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            Limits(max_concurrency=1, total_timeout_seconds=-1.0)
+
+    def test_round_trip(self) -> None:
+        lim = Limits(max_concurrency=1, total_timeout_seconds=42.0)
+        restored = Limits.model_validate(lim.model_dump())
+        assert restored.total_timeout_seconds == 42.0
+
+    def test_independent_of_other_timeouts(self) -> None:
+        lim = Limits(
+            max_concurrency=1,
+            request_timeout_seconds=60.0,
+            connect_timeout_seconds=10.0,
+            total_timeout_seconds=900.0,
+        )
+        assert lim.request_timeout_seconds == 60.0
+        assert lim.connect_timeout_seconds == 10.0
+        assert lim.total_timeout_seconds == 900.0
+
+
+class TestTotalGenerationBudget:
+    @pytest.mark.asyncio
+    async def test_runaway_aborted_by_budget(self) -> None:
+        """A stream that keeps emitting never trips the stall window but IS
+        aborted by the total budget, raising GenerationBudgetExceeded."""
+        async def _run():
+            count = 0
+            async for _ in _iter_with_timeout(
+                _runaway_agen(), 10.0, total_timeout_seconds=0.1
+            ):
+                count += 1
+            return count
+
+        with pytest.raises(GenerationBudgetExceeded):
+            await asyncio.wait_for(_run(), timeout=3.0)
+
+    @pytest.mark.asyncio
+    async def test_budget_exceeded_is_a_timeout_error(self) -> None:
+        """Adapters' existing ``except TimeoutError`` handlers must catch it."""
+        assert issubclass(GenerationBudgetExceeded, TimeoutError)
+
+    @pytest.mark.asyncio
+    async def test_no_budget_means_unbounded(self) -> None:
+        """total=None keeps prior behaviour: fast finite streams complete."""
+        result = []
+        async for item in _iter_with_timeout(
+            _fast_agen(1, 2, 3), 10.0, total_timeout_seconds=None
+        ):
+            result.append(item)
+        assert result == [1, 2, 3]
+
+    @pytest.mark.asyncio
+    async def test_completes_within_budget(self) -> None:
+        """A finite stream that ends inside the budget is untouched."""
+        result = []
+        async for item in _iter_with_timeout(
+            _fast_agen("a", "b"), None, total_timeout_seconds=10.0
+        ):
+            result.append(item)
+        assert result == ["a", "b"]
+
+    @pytest.mark.asyncio
+    async def test_stall_still_fires_with_budget_set(self) -> None:
+        """The stall window keeps working when a (larger) budget is set, and
+        a stall raises plain TimeoutError, not GenerationBudgetExceeded."""
+        async def _run():
+            it = _iter_with_timeout(
+                _stalling_agen(), 0.05, total_timeout_seconds=30.0
+            )
+            await it.__anext__()  # "first" -- instant
+            await it.__anext__()  # stalls; stall window should fire
+
+        with pytest.raises(asyncio.TimeoutError) as excinfo:
+            await asyncio.wait_for(_run(), timeout=3.0)
+        assert not isinstance(excinfo.value, GenerationBudgetExceeded)
+
+    @pytest.mark.asyncio
+    async def test_budget_wins_when_smaller_than_stall_window(self) -> None:
+        """With budget < stall window, a stalling stream fails with the
+        budget error (the remaining budget caps the wait)."""
+        async def _run():
+            it = _iter_with_timeout(
+                _stalling_agen(), 30.0, total_timeout_seconds=0.1
+            )
+            await it.__anext__()  # "first" -- instant
+            await it.__anext__()  # stalls; budget expires first
+
+        with pytest.raises(GenerationBudgetExceeded):
             await asyncio.wait_for(_run(), timeout=3.0)
 
 

--- a/ui/components/providers.jsx
+++ b/ui/components/providers.jsx
@@ -633,6 +633,12 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
       ? String(existing.limits.connect_timeout_seconds)
       : ""
   );
+  const [totalTimeoutSeconds, setTotalTimeoutSeconds] = React.useState(
+    existing?.limits?.total_timeout_seconds !== undefined &&
+      existing?.limits?.total_timeout_seconds !== null
+      ? String(existing.limits.total_timeout_seconds)
+      : ""
+  );
   const [fieldErrors, setFieldErrors] = React.useState({});
 
   // Whenever the provider type changes, re-seed config defaults + wipe the
@@ -792,6 +798,9 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
           : {}),
         ...(connectTimeoutSeconds !== "" && connectTimeoutSeconds !== null
           ? { connect_timeout_seconds: Number(connectTimeoutSeconds) }
+          : {}),
+        ...(totalTimeoutSeconds !== "" && totalTimeoutSeconds !== null
+          ? { total_timeout_seconds: Number(totalTimeoutSeconds) }
           : {}),
       },
     };
@@ -1006,6 +1015,33 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
         {fieldErrors["body.limits.connect_timeout_seconds"] && (
           <div className="field-help" style={{ color: "var(--red)" }}>
             {fieldErrors["body.limits.connect_timeout_seconds"]}
+          </div>
+        )}
+      </div>
+      <div className="field">
+        <label className="field-label">
+          Total generation timeout <span className="hint">seconds; blank = unbounded</span>
+        </label>
+        <input
+          className="input"
+          type="number"
+          min="0"
+          step="1"
+          value={totalTimeoutSeconds}
+          onChange={(e) => setTotalTimeoutSeconds(e.target.value)}
+          style={{ width: 120 }}
+          placeholder="unbounded"
+        />
+        <div className="field-help">
+          Wall-clock ceiling for one full streamed generation. Catches RUNAWAY
+          generations: a model that keeps emitting tokens forever never trips
+          the inactivity timeout above, because events keep arriving. Blank
+          (the default) means unbounded. Set it comfortably above your slowest
+          legitimate generation (e.g. 900 for slow local models).
+        </div>
+        {fieldErrors["body.limits.total_timeout_seconds"] && (
+          <div className="field-help" style={{ color: "var(--red)" }}>
+            {fieldErrors["body.limits.total_timeout_seconds"]}
           </div>
         )}
       </div>


### PR DESCRIPTION
## Problem
Small local models can free-run on a structured-output request and emit tokens forever. Neither existing timeout catches this:
- the **per-event stall timeout** never fires — events keep arriving;
- backends like LM Studio **ignore `max_output_tokens`** (verified empirically);
- with no wall-clock ceiling the turn hangs indefinitely.

Observed repeatedly while dogfooding graph pipelines on LM Studio: a gemma-12b node stuck generating for 30–60+ minutes, wedging the whole graph run (single-slot backend), three separate recurrences on different nodes.

## Fix
`Limits.total_timeout_seconds` (default `None` = unbounded, `ge=0`) — the third timeout completing the trio:

| timeout | bounds |
|---|---|
| `connect_timeout_seconds` | opening the stream (incl. cold model load) |
| `request_timeout_seconds` | each gap between events (stall) |
| `total_timeout_seconds` (new) | the whole generation (runaway) |

- `_iter_with_timeout` gains a total budget: per-wait deadline = `min(stall, remaining_budget)`; on budget exhaustion raises `GenerationBudgetExceeded` — a `TimeoutError` subclass, so every adapter's existing `except TimeoutError` handler catches it unchanged.
- All **six** LLM adapters (openresponses, ollama, anthropic, gemini, openchat, openrouter) read the limit and report a precise `ProviderTimeoutError(code="generation_timeout")`, distinct from the stall message (`stream_timeout`) — runaway vs stall are opposite failure modes and the log should say which.
- Console provider form gets a "Total generation timeout" field alongside the other two.

## Tests
- `Limits` field: default/explicit/negative-rejected/round-trip/independence.
- Helper: runaway stream aborted by budget; `None` = unbounded; finite stream within budget untouched; stall still raises plain `TimeoutError` (not the subclass) when budget is larger; budget wins when smaller than the stall window; subclass relationship asserted.
- `tests/llm/` 618 passed; `tests/test_provider.py tests/model/ tests/embedder/` pass except 2 pre-existing `test_workspace_session_model` xdist-ordering flakes that fail identically without this diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)