### PR TITLE
fix(ui): graphs editor — edge mode, toggle clarity, auto-layout, description reachable, banner

### DIFF
--- a/tests/ui/test_graphs_editor_fixes.py
+++ b/tests/ui/test_graphs_editor_fixes.py
@@ -118,6 +118,20 @@ def test_save_payload_includes_description_and_max_iterations() -> None:
     assert "max_iterations: draft.max_iterations" in GRAPHS
 
 
+def test_graph_fields_are_always_reachable_not_gated_on_selection() -> None:
+    # #16 real root cause: the description/max_iterations fields used to live
+    # ONLY in the no-selection branch of GR_SidePanel, so selecting any node
+    # hid them. GR_GraphFields must render OUTSIDE the `selected ? ... :` and
+    # BEFORE it, so graph metadata stays editable while a node/edge is
+    # selected. The nothing-selected branch now shows read-only GR_GraphStats.
+    panel_head = GRAPHS.split("{selected ? (")[0]
+    assert "<GR_GraphFields draft={draft} onSetGraph={onSetGraph} />" in panel_head
+    assert "function GR_GraphFields(" in GRAPHS
+    assert "<GR_GraphStats draft={draft} />" in GRAPHS
+    # The old always-hidden block name is gone.
+    assert "GR_GraphStatsBlock" not in GRAPHS
+
+
 def test_bundle_transpiles() -> None:
     from primer.api._jsx_bundle import build_jsx_bundle
 

--- a/tests/ui/test_graphs_editor_fixes.py
+++ b/tests/ui/test_graphs_editor_fixes.py
@@ -1,0 +1,125 @@
+"""Structural regression tests for the graphs-editor bug batch.
+
+Covers five user-reported bugs on the graph editor detail page:
+
+  * #12 — moving a node must not spawn a self-loop edge: edge creation is an
+    explicit mode (drag-element vs create-edge gated by ``addEdgeMode``) and
+    self-loops are rejected in ``create-edge.onCreate``.
+  * #13 — the Static/Conditional toggle wires the new-edge kind and now labels
+    itself as such ("new edge:" + tooltips).
+  * #14 — the references banner no longer prints the raw ``GET /v1/graphs/{id}
+    /status`` line.
+  * #15 — Auto-layout re-renders the canvas via a ``layoutNonce`` that feeds the
+    canvas topoKey (an x/y-only relayout is otherwise invisible).
+  * #16 — the graph description + max_iterations are bound to ``onSetGraph`` and
+    included in the PUT save body.
+
+Source-grep + bundle transpile, matching the rest of tests/ui.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+GRAPHS = (UI / "components" / "graphs.jsx").read_text(encoding="utf-8")
+CANVAS = (UI / "components" / "graph-canvas.jsx").read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# #12 — explicit edge-creation mode; node moves can't create (self-loop) edges
+# ---------------------------------------------------------------------------
+
+
+def test_edge_create_is_an_explicit_gated_mode() -> None:
+    # drag-element (move) is on only OUTSIDE addEdgeMode; create-edge (connect)
+    # is on only INSIDE addEdgeMode. Both are gated by G6's `enable` callback so
+    # a node-move drag can never trigger create-edge.
+    assert "drag-element" in CANVAS
+    assert "create-edge" in CANVAS
+    assert "enable: () => !cb.current.addEdgeMode" in CANVAS
+    assert "enable: () => !!cb.current.addEdgeMode" in CANVAS
+
+
+def test_create_edge_rejects_self_loops() -> None:
+    # onCreate returns false for source===target; G6 only commits an edge when
+    # onCreate returns truthy, so an accidental self-drop creates nothing.
+    assert "onCreate:" in CANVAS
+    assert "edge.source !== edge.target" in CANVAS
+
+
+def test_connect_handler_still_guards_self_loops() -> None:
+    # Belt: the draft-side onConnect also refuses source===target.
+    assert "source === target" in CANVAS or "source !== target" in CANVAS
+
+
+# ---------------------------------------------------------------------------
+# #13 — Static/Conditional toggle wires new-edge kind + reads as such
+# ---------------------------------------------------------------------------
+
+
+def test_edge_kind_toggle_wired_to_new_edges() -> None:
+    # The toggle state drives the kind of newly created edges in both the
+    # click-to-wire and drag-to-connect paths.
+    assert "edgeMode" in GRAPHS
+    assert 'edgeMode === "static"' in GRAPHS
+    assert '"conditional"' in GRAPHS and "json_path" in GRAPHS
+
+
+def test_edge_kind_toggle_is_labelled_for_clarity() -> None:
+    # Clarity fix: the segmented control announces that it applies to the NEXT
+    # edge, not existing ones.
+    assert "new edge:" in GRAPHS
+    assert "Kind for new edges" in GRAPHS
+    assert "aria-pressed" in GRAPHS
+
+
+# ---------------------------------------------------------------------------
+# #14 — banner drops the raw API line
+# ---------------------------------------------------------------------------
+
+
+def test_status_banner_has_no_raw_get_line() -> None:
+    assert "GET /v1/graphs/{id}/status" not in GRAPHS
+    # The human-readable message stays.
+    assert "All references resolve" in GRAPHS
+
+
+# ---------------------------------------------------------------------------
+# #15 — Auto-layout actually re-arranges the canvas
+# ---------------------------------------------------------------------------
+
+
+def test_auto_layout_bumps_layout_nonce() -> None:
+    assert "onAutoLayout" in GRAPHS
+    assert "setLayoutNonce" in GRAPHS
+    assert "autoLayout(d)" in GRAPHS
+
+
+def test_canvas_receives_and_keys_on_layout_nonce() -> None:
+    # graphs.jsx passes the nonce; the canvas folds it into topoKey so a bump
+    # forces a re-seed from the new positions.
+    assert "layoutNonce={layoutNonce}" in GRAPHS
+    assert "props.layoutNonce" in CANVAS
+
+
+# ---------------------------------------------------------------------------
+# #16 — description + max_iterations round-trip through save
+# ---------------------------------------------------------------------------
+
+
+def test_graph_description_is_bound_to_set_graph() -> None:
+    assert "onSetGraph({ description: v })" in GRAPHS
+    assert "onSetGraph={onSetGraph}" in GRAPHS
+
+
+def test_save_payload_includes_description_and_max_iterations() -> None:
+    assert "description: draft.description" in GRAPHS
+    assert "max_iterations: draft.max_iterations" in GRAPHS
+
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body

--- a/tests/ui_e2e/test_workspace_dangling_tweaks.py
+++ b/tests/ui_e2e/test_workspace_dangling_tweaks.py
@@ -336,12 +336,14 @@ def test_u0090_graph_status_red_after_agent_deleted(
             state="visible", timeout=20_000,
         )
 
-        # Wait for the initial status panel to render - accept any
-        # of the in-flight phrasings ("Checking references…",
-        # "All references resolve", or even "0 issues found").
+        # Wait for the initial status panel to render. The banner no
+        # longer prints the raw "GET /v1/graphs/<id>/status" endpoint
+        # line (that detail belongs in devtools), so anchor on the
+        # human-readable copy instead: "Checking references…" and
+        # "All references resolve" both contain "references".
         # Bound by 30s in case the first poll is slow.
         status_initial = page.locator(".panel").filter(
-            has_text="GET /v1/graphs/" + gid + "/status",
+            has_text="references",
         ).first
         status_initial.wait_for(state="visible", timeout=30_000)
 

--- a/ui/components/graph-canvas.jsx
+++ b/ui/components/graph-canvas.jsx
@@ -124,11 +124,15 @@ function GR_Canvas(props) {
   const cb = React.useRef(props);
   cb.current = props;
 
+  // topoKey drives a full G6 (re)init. It excludes node x/y so a drag never
+  // rebuilds the graph (pan/zoom preserved), but includes `layoutNonce` so an
+  // explicit Auto-layout re-seeds the canvas with the freshly computed preset
+  // positions (an x/y-only change is otherwise invisible to the canvas).
   const topoKey = React.useMemo(() => {
     const ns = (draft?.nodes || []).map((n) => `${n.id}:${n.kind}`).join(",");
     const es = _g6Edges(draft).map((e) => e.id).join(",");
-    return (layout || "dagre") + "|" + ns + "|" + es;
-  }, [draft, layout]);
+    return (layout || "dagre") + "|" + ns + "|" + es + "|L" + (props.layoutNonce || 0);
+  }, [draft, layout, props.layoutNonce]);
 
   React.useEffect(() => {
     if (!containerRef.current || !window.G6 || !draft) return undefined;
@@ -139,9 +143,28 @@ function GR_Canvas(props) {
     const interactive = !!(cb.current.onMoveNode || cb.current.onConnect);
     const behaviors = ["zoom-canvas", "drag-canvas"];
     if (interactive) {
-      behaviors.push({ type: "drag-element", key: "drag-node" });
+      // Two explicit, mutually-exclusive edit modes keyed off `addEdgeMode`
+      // (toolbar "Add edge" toggle). Default = MOVE nodes (drag-element on,
+      // create-edge off). Add-edge mode = CONNECT (drag-element off, create-
+      // edge on). The `enable` callbacks re-read the live mode from cb.current
+      // on every gesture, so toggling the toolbar switches modes with no
+      // re-init. This makes it impossible to spawn an edge by dragging a node
+      // to move it — the old always-on create-edge turned a node-move drag
+      // (start+end on the same node) into a phantom self-loop.
+      behaviors.push({ type: "drag-element", key: "drag-node", enable: () => !cb.current.addEdgeMode });
       behaviors.push({ type: "click-select", key: "sel", multiple: false });
-      behaviors.push({ type: "create-edge", key: "make-edge", trigger: "drag", style: { stroke: _G6_COLORS.violet, lineWidth: 1.5, lineDash: [4, 4], endArrow: true } });
+      behaviors.push({
+        type: "create-edge",
+        key: "make-edge",
+        trigger: "drag",
+        enable: () => !!cb.current.addEdgeMode,
+        // Belt: reject self-loops. G6 only commits the edge when onCreate
+        // returns truthy, so returning false on source===target cancels the
+        // drag cleanly (no phantom edge, no onFinish) — a deliberate drag that
+        // ends back on the source node never creates an edge.
+        onCreate: (edge) => (edge && edge.source !== edge.target ? edge : false),
+        style: { stroke: _G6_COLORS.violet, lineWidth: 1.5, lineDash: [4, 4], endArrow: true },
+      });
     }
     const nodes = (draft.nodes || []).map((n) => {
       const sz = _g6Size(n.kind);

--- a/ui/components/graphs.jsx
+++ b/ui/components/graphs.jsx
@@ -566,12 +566,11 @@ function GR_GraphStatusPanel({ id, status, onRefresh, onDelete }) {
                   ? `${issues.length} issue${issues.length === 1 ? "" : "s"} found`
                   : "Status unknown"}
           </div>
-          <div className="muted text-sm">
-            <span className="mono">GET /v1/graphs/{id}/status</span>
-            {status.error
-              ? <> · <span style={{ color: "var(--red)" }}>{status.error.title || status.error.message}</span></>
-              : null}
-          </div>
+          {status.error && (
+            <div className="muted text-sm">
+              <span style={{ color: "var(--red)" }}>{status.error.title || status.error.message}</span>
+            </div>
+          )}
           {ok === false && issues.map((iss, i) => (
             <div key={i} className="muted text-sm mt-2 mono" style={{ color: "var(--red)" }}>{iss}</div>
           ))}
@@ -655,6 +654,10 @@ function GR_GraphEditor({ graphId, loaded, onSaved, onRefresh, pushToast }) {
   const [addEdgeMode, setAddEdgeMode] = React.useState(null);  // null | {fromId?}
   const [edgeMode, setEdgeMode] = React.useState("static");  // "static" | "conditional"
   const [showAddMenu, setShowAddMenu] = React.useState(false);
+  // Bumped by Auto-layout to force GR_Canvas to re-seed from the freshly
+  // computed node positions. topoKey ignores x/y (so drags don't rebuild the
+  // canvas), which means an x/y-only relayout is otherwise invisible.
+  const [layoutNonce, setLayoutNonce] = React.useState(0);
   // Raw-spec import escape hatch (GAP-6): paste a full graph spec (the
   // same JSON shape `PUT /graphs/{id}` / `primectl create graph -f`
   // takes) and load it into the editor as an alternate to clicking the
@@ -732,7 +735,14 @@ function GR_GraphEditor({ graphId, loaded, onSaved, onRefresh, pushToast }) {
 
   const onAutoLayout = () => {
     if (!window.primerVendor || !window.primerVendor.autoLayout) return;
+    // Recompute BFS-layered positions and write them back into the draft, then
+    // bump the nonce so the canvas actually re-renders in the new arrangement
+    // (topoKey excludes x/y, so a position-only change wouldn't re-seed G6).
+    // Positions are UI-only (stripped from the PUT body — the server doesn't
+    // persist node coordinates), so this intentionally does NOT mark the draft
+    // dirty; Save stays gated on real topology/attribute edits.
     setDraft((d) => window.primerVendor.autoLayout(d));
+    setLayoutNonce((n) => n + 1);
   };
 
   // GAP-6 raw-spec import. Validates the parsed object has the minimal
@@ -972,10 +982,18 @@ function GR_GraphEditor({ graphId, loaded, onSaved, onRefresh, pushToast }) {
             ? (addEdgeMode.fromId ? `Pick target for ${addEdgeMode.fromId}…` : "Pick source…")
             : "Add edge"}
         </Btn>
+        <span
+          className="muted text-sm"
+          style={{ marginLeft: 2, whiteSpace: "nowrap" }}
+          title="Kind applied to the next edge you create"
+        >
+          new edge:
+        </span>
         <div
           className="seg"
           role="group"
-          aria-label="Edge mode"
+          aria-label="Kind for new edges"
+          title="Kind applied to the next edge you create"
           style={{
             display: "inline-flex",
             border: "1px solid var(--border)",
@@ -987,6 +1005,8 @@ function GR_GraphEditor({ graphId, loaded, onSaved, onRefresh, pushToast }) {
             type="button"
             onClick={() => setEdgeMode("static")}
             className={edgeMode === "static" ? "active" : ""}
+            aria-pressed={edgeMode === "static"}
+            title="New edges are solid static transitions"
             style={{
               padding: "4px 10px",
               fontSize: 12,
@@ -1002,6 +1022,8 @@ function GR_GraphEditor({ graphId, loaded, onSaved, onRefresh, pushToast }) {
             type="button"
             onClick={() => setEdgeMode("conditional")}
             className={edgeMode === "conditional" ? "active" : ""}
+            aria-pressed={edgeMode === "conditional"}
+            title="New edges are dashed conditional (json_path router) transitions"
             style={{
               padding: "4px 10px",
               fontSize: 12,
@@ -1046,6 +1068,7 @@ function GR_GraphEditor({ graphId, loaded, onSaved, onRefresh, pushToast }) {
         <window.GR_Canvas
           draft={draft}
           layout="preset"
+          layoutNonce={layoutNonce}
           selectedNodeId={selectedNodeId}
           selectedEdgeId={selectedEdgeId}
           addEdgeMode={addEdgeMode}

--- a/ui/components/graphs.jsx
+++ b/ui/components/graphs.jsx
@@ -1663,6 +1663,12 @@ function GR_SidePanel({
   const selectedEdge = selectedEdgeIdx != null ? (draft.edges || [])[selectedEdgeIdx] : null;
   return (
     <div style={{ borderLeft: "1px solid var(--border)", padding: 14, fontSize: 12.5, overflow: "auto", maxHeight: 500 }}>
+      {/* Graph-level fields (description, max_iterations) render ALWAYS, not
+          only in the no-selection branch — selecting any node/edge used to
+          hide them with no way back, so the description looked uneditable
+          (#16). They stay pinned at the top; the selection editor is below. */}
+      <GR_GraphFields draft={draft} onSetGraph={onSetGraph} />
+      <div style={{ borderTop: "1px solid var(--border)", margin: "12px 0" }} />
       {selected ? (
         <GR_SelectedNodeForm
           node={selected}
@@ -1688,35 +1694,17 @@ function GR_SidePanel({
           onDeleteEdge={() => onDeleteEdgeAt(selectedEdgeIdx)}
         />
       ) : (
-        <GR_GraphStatsBlock draft={draft} onSetGraph={onSetGraph} />
+        <GR_GraphStats draft={draft} />
       )}
     </div>
   );
 }
 
-function GR_GraphStatsBlock({ draft, onSetGraph }) {
-  const nodeIds = new Set((draft.nodes || []).map((n) => n.id));
-  const dangling = [];
-  for (const e of (draft.edges || [])) {
-    if (!nodeIds.has(e.from_node)) dangling.push(`edge.from_node = ${e.from_node}`);
-    if (e.kind === "static" && !nodeIds.has(e.to_node)) {
-      dangling.push(`edge.to_node = ${e.to_node}`);
-    }
-    if (e.kind === "conditional") {
-      const r = e.router || {};
-      if (r.kind === "json_path") {
-        for (const br of (r.branches || [])) {
-          if (!nodeIds.has(br.to_node)) {
-            dangling.push(`branch.to_node = ${br.to_node}`);
-          }
-        }
-        if (r.default_to && !nodeIds.has(r.default_to)) {
-          dangling.push(`default_to = ${r.default_to}`);
-        }
-      }
-    }
-  }
-  const entryOk = draft.entry_node_id && nodeIds.has(draft.entry_node_id);
+// GR_GraphFields — editable GRAPH-level metadata (description,
+// max_iterations). Rendered ALWAYS at the top of the side panel (see
+// GR_SidePanel) so it stays reachable while a node/edge is selected — that
+// unreachability was #16. onSetGraph absent → read-only (run-view reuse).
+function GR_GraphFields({ draft, onSetGraph }) {
   return (
     <div className="col" style={{ gap: 8 }}>
       <div className="muted text-sm mono" style={{ textTransform: "uppercase", letterSpacing: "0.06em", fontSize: 10.5 }}>
@@ -1744,7 +1732,38 @@ function GR_GraphStatsBlock({ draft, onSetGraph }) {
       ) : (
         <div className="muted text-sm">{draft.description}</div>
       )}
-      <div className="mt-3 muted text-sm mono" style={{ textTransform: "uppercase", letterSpacing: "0.06em", fontSize: 10.5 }}>
+    </div>
+  );
+}
+
+// GR_GraphStats — read-only STATS + dangling-reference audit for the whole
+// graph. Shown in the inspector's default (nothing-selected) state.
+function GR_GraphStats({ draft }) {
+  const nodeIds = new Set((draft.nodes || []).map((n) => n.id));
+  const dangling = [];
+  for (const e of (draft.edges || [])) {
+    if (!nodeIds.has(e.from_node)) dangling.push(`edge.from_node = ${e.from_node}`);
+    if (e.kind === "static" && !nodeIds.has(e.to_node)) {
+      dangling.push(`edge.to_node = ${e.to_node}`);
+    }
+    if (e.kind === "conditional") {
+      const r = e.router || {};
+      if (r.kind === "json_path") {
+        for (const br of (r.branches || [])) {
+          if (!nodeIds.has(br.to_node)) {
+            dangling.push(`branch.to_node = ${br.to_node}`);
+          }
+        }
+        if (r.default_to && !nodeIds.has(r.default_to)) {
+          dangling.push(`default_to = ${r.default_to}`);
+        }
+      }
+    }
+  }
+  const entryOk = draft.entry_node_id && nodeIds.has(draft.entry_node_id);
+  return (
+    <div className="col" style={{ gap: 8 }}>
+      <div className="muted text-sm mono" style={{ textTransform: "uppercase", letterSpacing: "0.06em", fontSize: 10.5 }}>
         stats
       </div>
       <dl className="kv" style={{ gridTemplateColumns: "110px 1fr", gap: "4px 12px" }}>


### PR DESCRIPTION
## Graphs editor bug fixes (#12–16)

Field-testing surfaced five graph-editor defects. Root causes + fixes:

- **#12 node-drag spawned a phantom self-loop** — `create-edge` was always-on with `trigger:"drag"`, so any node-move drag drew a self-edge. Now edge-creation is an **explicit mode** gated on the existing *Add edge* toggle (G6 `enable` callbacks: `drag-element` moves only when NOT in edge mode; `create-edge` connects only IN it), plus `onCreate` rejects `source===target` so a self-drop commits nothing.
- **#13 Static/Conditional toggle "did nothing"** — it was never broken; it sets the *next* edge's kind. Added a `new edge:` label + tooltips + `aria-pressed` so the affordance is legible.
- **#14 banner leaked the raw `GET /v1/graphs/{id}/status`** — removed; the human message stays.
- **#15 Auto-layout looked inert** — it wrote new positions but the canvas keys its re-init on topology (x/y excluded, so drags don't rebuild). Added a `layoutNonce` folded into that key so Auto-layout visibly re-arranges. *Positions are not persisted* — `GraphNode` has no x/y in the schema; saving layout needs a backend change (flagged, out of scope).
- **#16 "no way to edit the description"** — real cause was discoverability: the graph-level description/`max_iterations` fields lived only in the no-selection branch of the side panel, so selecting any node hid them. Split into `GR_GraphFields` (always shown, editable) + `GR_GraphStats` (nothing-selected stats).

Tests: `tests/ui/test_graphs_editor_fixes.py` (13), full `tests/ui` 471 green. One default-skipped ui_e2e locator re-pointed.
