### PR TITLE
feat(workers): dead-worker cleanup, worker detail view, honest controls (#17, #18)

### DIFF
--- a/primer/api/routers/workers.py
+++ b/primer/api/routers/workers.py
@@ -1,13 +1,17 @@
-"""Worker observability + drain endpoint.
+"""Worker observability + lifecycle endpoints.
 
 Operators read ``GET /v1/workers`` to see which scheduler-registered
 workers are alive (and their last heartbeat). ``POST /v1/workers/{id}/drain``
 marks one as draining so other workers take over its sessions at the
-next turn boundary.
+next turn boundary. Once a worker has been reaped to ``dead`` (it stopped
+heart-beating) its row lingers in the registry forever, so
+``DELETE /v1/workers/{id}`` removes a single dead worker and
+``POST /v1/workers/purge_dead`` clears every dead worker in one call.
 
 The actual lifecycle (registration, heartbeats, turn execution) is
-owned by ``WorkerPool``; this router just exposes the read/drain
-surface backed by ``Scheduler.list_workers`` / ``drain_worker``.
+owned by ``WorkerPool``; this router just exposes the read/drain/remove
+surface backed by ``Scheduler.list_workers`` / ``drain_worker`` /
+``deregister_worker``.
 """
 
 from __future__ import annotations
@@ -16,6 +20,7 @@ from fastapi import APIRouter, Depends, Path
 
 from primer.api.deps import get_scheduler, require_auth
 from primer.api.errors import common_responses
+from primer.model.except_ import ConflictError, NotFoundError
 
 
 router = APIRouter(tags=["workers"])
@@ -47,6 +52,57 @@ async def drain_worker(
     scheduler=Depends(get_scheduler),
 ) -> None:
     await scheduler.drain_worker(worker_id)
+
+
+@router.post(
+    "/workers/purge_dead",
+    summary="Remove every dead worker from the registry",
+    responses=common_responses(401, 500),
+    dependencies=[Depends(require_auth)],
+)
+async def purge_dead_workers(scheduler=Depends(get_scheduler)) -> dict:
+    """Bulk-remove all workers currently in the ``dead`` state.
+
+    Dead workers are rows the scheduler reaped after they stopped
+    heart-beating; they never come back on their own, so this frees the
+    registry of accumulated tombstones. Returns the number removed.
+    Active/draining workers are never touched.
+    """
+    workers = await scheduler.list_workers()
+    dead_ids = [w.id for w in workers if w.status == "dead"]
+    for worker_id in dead_ids:
+        await scheduler.deregister_worker(worker_id)
+    return {"removed": len(dead_ids)}
+
+
+@router.delete(
+    "/workers/{worker_id}",
+    status_code=204,
+    summary="Remove a single dead worker from the registry",
+    responses=common_responses(401, 404, 409, 500),
+    # Mutating endpoint: requires auth (see drain_worker note).
+    dependencies=[Depends(require_auth)],
+)
+async def delete_worker(
+    worker_id: str = Path(...),
+    scheduler=Depends(get_scheduler),
+) -> None:
+    """Deregister one worker — but only if it is ``dead``.
+
+    Refuses (409) to remove an ``active`` or ``draining`` worker: those
+    are still (or soon to be) doing work and their rows are managed by
+    the heartbeat/drain lifecycle. Unknown ids are 404.
+    """
+    workers = await scheduler.list_workers()
+    match = next((w for w in workers if w.id == worker_id), None)
+    if match is None:
+        raise NotFoundError(f"Worker {worker_id!r} does not exist")
+    if match.status != "dead":
+        raise ConflictError(
+            f"Worker {worker_id!r} is {match.status!r}, not dead; only dead "
+            "workers can be removed. Drain it and let it be reaped first."
+        )
+    await scheduler.deregister_worker(worker_id)
 
 
 __all__ = ["router"]

--- a/primer/scheduler/in_memory.py
+++ b/primer/scheduler/in_memory.py
@@ -93,6 +93,15 @@ class InMemoryScheduler(Scheduler):
     def session_snapshot_for_test(self, sid: str) -> _SessionState:
         return self._sessions[sid]
 
+    def mark_worker_dead_for_test(self, worker_id: str) -> None:
+        """Flip a registered worker to ``dead``.
+
+        Production marks workers dead via the reaper sweep once they stop
+        heart-beating; this single-process impl has no timer, so tests use
+        this seam to exercise dead-worker cleanup paths."""
+        w = self._workers[worker_id]
+        w.info = w.info.model_copy(update={"status": "dead"})
+
     def watch_cancel(self, worker_id: str) -> AsyncIterator[str]:
         """Test-only parallel of watch_ready, scoped to cancel events."""
 

--- a/tests/api/test_workers.py
+++ b/tests/api/test_workers.py
@@ -72,3 +72,102 @@ async def test_list_workers_stays_public(raw_client):
     resp = await raw_client.get("/v1/workers")
     assert resp.status_code == 200
     assert resp.json() == {"items": []}
+
+
+# ---- DELETE /workers/{id} + POST /workers/purge_dead --------------------
+
+
+async def test_delete_dead_worker_removes_it(client, app):
+    """A dead worker can be removed; the registry row disappears."""
+    await app.state.scheduler.register_worker(
+        worker_id="w1", host="h", pid=1, capacity=4,
+    )
+    app.state.scheduler.mark_worker_dead_for_test("w1")
+    resp = await client.delete("/v1/workers/w1")
+    assert resp.status_code == 204
+    workers = await app.state.scheduler.list_workers()
+    assert workers == []
+
+
+async def test_delete_active_worker_is_rejected(client, app):
+    """Deleting a live (active) worker is a 409 — never remove one that
+    is still doing work. The row must survive."""
+    await app.state.scheduler.register_worker(
+        worker_id="w1", host="h", pid=1, capacity=4,
+    )
+    resp = await client.delete("/v1/workers/w1")
+    assert resp.status_code == 409
+    workers = await app.state.scheduler.list_workers()
+    assert len(workers) == 1 and workers[0].status == "active"
+
+
+async def test_delete_draining_worker_is_rejected(client, app):
+    """Draining workers are still finishing in-flight leases, so they
+    are protected from removal too (409)."""
+    await app.state.scheduler.register_worker(
+        worker_id="w1", host="h", pid=1, capacity=4,
+    )
+    await app.state.scheduler.drain_worker("w1")
+    resp = await client.delete("/v1/workers/w1")
+    assert resp.status_code == 409
+    workers = await app.state.scheduler.list_workers()
+    assert len(workers) == 1 and workers[0].status == "draining"
+
+
+async def test_delete_unknown_worker_is_404(client):
+    resp = await client.delete("/v1/workers/no-such-worker")
+    assert resp.status_code == 404
+
+
+async def test_delete_worker_requires_auth(raw_client, app):
+    """DELETE is a mutation: an unauthenticated caller is rejected 401
+    and the (dead) worker row must survive."""
+    await app.state.scheduler.register_worker(
+        worker_id="w1", host="h", pid=1, capacity=4,
+    )
+    app.state.scheduler.mark_worker_dead_for_test("w1")
+    resp = await raw_client.delete("/v1/workers/w1")
+    assert resp.status_code == 401
+    workers = await app.state.scheduler.list_workers()
+    assert len(workers) == 1
+
+
+async def test_purge_dead_removes_only_dead_and_returns_count(client, app):
+    """purge_dead deletes every dead worker, leaves active/draining
+    alone, and reports how many it removed."""
+    await app.state.scheduler.register_worker(
+        worker_id="alive", host="h", pid=1, capacity=4,
+    )
+    await app.state.scheduler.register_worker(
+        worker_id="drainy", host="h", pid=2, capacity=4,
+    )
+    await app.state.scheduler.drain_worker("drainy")
+    for wid in ("d1", "d2", "d3"):
+        await app.state.scheduler.register_worker(
+            worker_id=wid, host="h", pid=9, capacity=4,
+        )
+        app.state.scheduler.mark_worker_dead_for_test(wid)
+
+    resp = await client.post("/v1/workers/purge_dead")
+    assert resp.status_code == 200
+    assert resp.json() == {"removed": 3}
+
+    remaining = {w.id for w in await app.state.scheduler.list_workers()}
+    assert remaining == {"alive", "drainy"}
+
+
+async def test_purge_dead_empty_returns_zero(client):
+    resp = await client.post("/v1/workers/purge_dead")
+    assert resp.status_code == 200
+    assert resp.json() == {"removed": 0}
+
+
+async def test_purge_dead_requires_auth(raw_client, app):
+    await app.state.scheduler.register_worker(
+        worker_id="w1", host="h", pid=1, capacity=4,
+    )
+    app.state.scheduler.mark_worker_dead_for_test("w1")
+    resp = await raw_client.post("/v1/workers/purge_dead")
+    assert resp.status_code == 401
+    workers = await app.state.scheduler.list_workers()
+    assert len(workers) == 1

--- a/tests/ui/test_workers_controls.py
+++ b/tests/ui/test_workers_controls.py
@@ -1,0 +1,122 @@
+"""Regression: workers.jsx must wire its filter/status controls, expose
+dead-worker cleanup affordances, and drop the fake/inert controls the
+FE review flagged (bug #17).
+
+Static-source + bundle-build checks only (matching the rest of the
+ui/ suite — no React render).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SRC = UI / "components" / "workers.jsx"
+APP = UI / "app.jsx"
+
+
+def _src() -> str:
+    return SRC.read_text(encoding="utf-8")
+
+
+# ---- Filter input is wired (was inert: no value/onChange) ---------------
+
+
+def test_filter_input_is_stateful() -> None:
+    src = _src()
+    assert "setFilterText" in src, "filter input must drive state"
+    assert 'data-testid="workers-filter"' in src
+    assert "onChange={(e) => setFilterText" in src
+    assert "value={filterText}" in src
+
+
+# ---- Status chips are wired (were plain <span>s, no handler) ------------
+
+
+def test_status_chips_are_wired() -> None:
+    src = _src()
+    assert "setStatusFilter" in src, "chips must set the status filter"
+    assert 'data-testid={`workers-chip-${c}`}' in src
+    # The active chip is derived from state, not hardcoded to "all".
+    assert 'statusFilter === c ? " active" : ""' in src
+    assert 'className="chip active"' not in src, (
+        "the 'all' chip must not be hardcoded active"
+    )
+
+
+def test_client_side_filtering_applied() -> None:
+    src = _src()
+    # The table iterates the filtered list, not the raw worker list.
+    assert "filtered.map" in src
+    assert "w.status !== statusFilter" in src
+    assert "(w.id || \"\").toLowerCase().includes(q)" in src
+
+
+# ---- Fake "Scheduler: alive · last claim 2s ago" tile removed ----------
+
+
+def test_fake_scheduler_tile_removed() -> None:
+    src = _src()
+    assert "last claim 2s ago" not in src, (
+        "the hardcoded fake scheduler telemetry tile must be gone"
+    )
+
+
+# ---- Fake per-row "· N sessions" annotation removed --------------------
+
+
+def test_fake_sessions_annotation_removed() -> None:
+    src = _src()
+    # The always-empty `sessions` prop and its per-row derivation are gone.
+    assert "onWorker" not in src
+    assert "s.worker_id === w.id" not in src
+    assert "session{onWorker" not in src
+
+
+def test_app_no_longer_passes_fake_sessions_prop() -> None:
+    app = APP.read_text(encoding="utf-8")
+    assert "<WorkersPage pushToast={pushToast} />" in app
+    assert "<WorkersPage sessions=" not in app
+
+
+# ---- Dead-worker cleanup affordances (bug #17) -------------------------
+
+
+def test_per_row_delete_button_on_dead_rows() -> None:
+    src = _src()
+    assert 'data-testid="worker-delete"' in src
+    # Deletes via the new DELETE /workers/{id} endpoint.
+    assert '"DELETE"' in src
+    assert "/workers/${encodeURIComponent(id)}`" in src
+    # Only dead rows get the remove button.
+    assert 'w.status === "dead" ? (' in src
+
+
+def test_bulk_clear_dead_button() -> None:
+    src = _src()
+    assert 'data-testid="workers-clear-dead"' in src
+    assert "/workers/purge_dead" in src
+    # Shown only when there are dead workers.
+    assert "totals.dead > 0 &&" in src
+
+
+def test_bulk_clear_dead_confirms_via_modal() -> None:
+    src = _src()
+    # The bulk button opens a Modal confirm rather than firing inline.
+    assert "setClearDeadOpen(true)" in src
+    assert "clearDeadOpen && (" in src
+    assert "confirmClearDead" in src
+    assert "purgeMut.mutate()" in src
+
+
+# ---- Bundle still transpiles with the rewritten workers.jsx ------------
+
+
+def test_bundle_transpiles_with_workers() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/workers.jsx === */" in text

--- a/tests/ui/test_workers_detail.py
+++ b/tests/ui/test_workers_detail.py
@@ -1,0 +1,69 @@
+"""Regression: workers.jsx must open a worker detail view on row click
+(bug #18), showing the full membership record over data that already
+exists — no invented time-series.
+
+Static-source + bundle-build checks only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SRC = UI / "components" / "workers.jsx"
+
+
+def _src() -> str:
+    return SRC.read_text(encoding="utf-8")
+
+
+def test_detail_opens_on_row_click() -> None:
+    src = _src()
+    # The row is clickable and reports its selection to open the drawer.
+    assert 'data-testid="worker-row"' in src
+    assert "onClick={() => onSelect(w)}" in src
+    assert "setDetailId(worker.id)" in src
+
+
+def test_detail_panel_has_testid() -> None:
+    assert 'data-testid="worker-detail"' in _src()
+
+
+def test_detail_reflects_live_record_not_stale_snapshot() -> None:
+    src = _src()
+    # Detail is derived from the polled list by id, so it stays fresh.
+    assert "workers.find((w) => w.id === detailId)" in src
+
+
+def test_detail_shows_full_record() -> None:
+    src = _src()
+    assert "function WorkerDetail(" in src
+    # id / host / pid / status / capacity / heartbeat / started all present.
+    for label in ("Host / PID", "Status", "Capacity", "Last heartbeat", "Started"):
+        assert label in src, f"detail missing {label!r} field"
+    # Heartbeat + started shown as relative *and* absolute.
+    assert "fmtDate(new Date(w.last_heartbeat))" in src
+    assert "relativeTime(startedSecondsAgo)" in src
+
+
+def test_action_cell_stops_row_click_propagation() -> None:
+    src = _src()
+    # Drain/Remove buttons must not also open the detail drawer.
+    assert "onClick={(e) => e.stopPropagation()}" in src
+
+
+def test_no_invented_history_chart() -> None:
+    src = _src()
+    # v1 detail is over existing data only — no fabricated time-series.
+    assert "Sparkline" not in src
+    assert "per-worker counters or heartbeat history" in src.lower()
+
+
+def test_bundle_transpiles_with_workers_detail() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "function WorkerDetail(" in text

--- a/ui/app.jsx
+++ b/ui/app.jsx
@@ -918,7 +918,7 @@ function App() {
       </>
     );
     pageBody = (
-      <WorkersPage sessions={sessions} pushToast={pushToast} />
+      <WorkersPage pushToast={pushToast} />
     );
   } else if (page === "dashboard") {
     pageHeader = (

--- a/ui/components/workers.jsx
+++ b/ui/components/workers.jsx
@@ -5,6 +5,10 @@ function WorkersPage({ pushToast }) {
   const { isMobile } = useViewport();
   const [drainTarget, setDrainTarget] = React.useState(null);
   const [clearDeadOpen, setClearDeadOpen] = React.useState(false);
+  // Row-click detail: track the id (not the record) so the drawer
+  // reflects the 2s poll + 1s heartbeat tick live instead of a stale
+  // snapshot; it closes itself if the worker disappears.
+  const [detailId, setDetailId] = React.useState(null);
   const [filterText, setFilterText] = React.useState("");
   // Status chip: "all" | "active" | "draining" | "dead".
   const [statusFilter, setStatusFilter] = React.useState("all");
@@ -127,6 +131,8 @@ function WorkersPage({ pushToast }) {
       (w.host || "").toLowerCase().includes(q)
     );
   });
+
+  const detail = detailId ? workers.find((w) => w.id === detailId) || null : null;
 
   const chips = ["all", "active", "draining", "dead"];
   const chipCount = (c) =>
@@ -255,6 +261,8 @@ function WorkersPage({ pushToast }) {
               <WorkerRow
                 key={w.id}
                 w={w}
+                onSelect={(worker) => setDetailId(worker.id)}
+                selected={w.id === detailId}
                 onDrain={onDrain}
                 onDelete={onDelete}
                 draining={drainMut.loading}
@@ -323,11 +331,86 @@ function WorkersPage({ pushToast }) {
           </ul>
         </Modal>
       )}
+
+      {detail && (
+        <Modal
+          title={`Worker ${detail.id}`}
+          width={520}
+          onClose={() => setDetailId(null)}
+          footer={
+            <>
+              {detail.status === "active" && (
+                <Btn kind="ghost" icon="alert" onClick={() => { setDetailId(null); onDrain(detail); }}>Drain</Btn>
+              )}
+              {detail.status === "dead" && (
+                <Btn kind="danger" icon="trash" onClick={() => { setDetailId(null); onDelete(detail); }}>Remove</Btn>
+              )}
+              <Btn kind="ghost" onClick={() => setDetailId(null)}>Close</Btn>
+            </>
+          }
+        >
+          <WorkerDetail w={detail} />
+        </Modal>
+      )}
     </div>
   );
 }
 
-function WorkerRow({ w, onDrain, onDelete, draining, deleting }) {
+function WorkerDetail({ w }) {
+  const capacity = w.capacity || 0;
+  const inFlight = w.in_flight || 0;
+  const heartbeatAge = w.heartbeat ?? 0;
+  const heartbeatBad = heartbeatAge > 30;
+  const hbAbs = w.last_heartbeat ? fmtDate(new Date(w.last_heartbeat)) : "—";
+  const startedSecondsAgo = w.started_at
+    ? Math.max(0, (Date.now() - new Date(w.started_at).getTime()) / 1000)
+    : null;
+  const startedAbs = w.started_at ? fmtDate(new Date(w.started_at)) : "—";
+  return (
+    <div data-testid="worker-detail" className="col" style={{ gap: 10 }}>
+      <DetailRow label="ID"><span className="mono">{w.id}</span></DetailRow>
+      <DetailRow label="Host / PID">
+        <span className="mono">{w.host}</span>
+        <span className="mono muted"> · pid {w.pid}</span>
+      </DetailRow>
+      <DetailRow label="Status">
+        {w.status === "active" && <span className="pill pill-ended"><span className="dot"></span>active</span>}
+        {w.status === "draining" && <span className="pill pill-paused"><span className="dot"></span>draining</span>}
+        {w.status === "dead" && <span className="pill pill-failed"><span className="dot"></span>dead</span>}
+      </DetailRow>
+      <DetailRow label="Capacity">
+        <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
+          <div style={{ width: 140 }}><CapacityBar inFlight={inFlight} capacity={capacity} /></div>
+          <span className="mono muted text-sm">{inFlight} / {capacity} slots in use</span>
+        </div>
+      </DetailRow>
+      <DetailRow label="Last heartbeat">
+        <span className="mono" style={{ color: heartbeatBad ? "var(--red)" : undefined }}>{heartbeatAge.toFixed(1)}s ago</span>
+        <span className="mono muted text-sm"> · {hbAbs}</span>
+      </DetailRow>
+      <DetailRow label="Started">
+        <span className="mono">{startedSecondsAgo != null ? relativeTime(startedSecondsAgo) : "—"}</span>
+        <span className="mono muted text-sm"> · {startedAbs}</span>
+      </DetailRow>
+      <div className="muted text-sm" style={{ marginTop: 2 }}>
+        The scheduler records only these membership fields per worker — no
+        per-worker counters or heartbeat history are stored, so there is no
+        time-series to chart here.
+      </div>
+    </div>
+  );
+}
+
+function DetailRow({ label, children }) {
+  return (
+    <div style={{ display: "flex", gap: 12, alignItems: "baseline" }}>
+      <div className="muted text-sm mono" style={{ width: 120, flex: "0 0 120px", textTransform: "uppercase", letterSpacing: "0.05em", fontSize: 10.5 }}>{label}</div>
+      <div style={{ flex: 1, minWidth: 0 }}>{children}</div>
+    </div>
+  );
+}
+
+function WorkerRow({ w, onSelect, selected, onDrain, onDelete, draining, deleting }) {
   const heartbeatAge = w.heartbeat ?? 0;
   const heartbeatBad = heartbeatAge > 30;
   const capacity = w.capacity || 0;
@@ -339,7 +422,21 @@ function WorkerRow({ w, onDrain, onDelete, draining, deleting }) {
     : null;
 
   return (
-    <tr>
+    <tr
+      className={selected ? "selected" : undefined}
+      style={{ cursor: "pointer" }}
+      data-testid="worker-row"
+      role="button"
+      tabIndex={0}
+      aria-label={`Worker ${w.id} details`}
+      onClick={() => onSelect(w)}
+      onKeyDown={(e) => {
+        if (e.key === "Enter" || e.key === " ") {
+          e.preventDefault();
+          onSelect(w);
+        }
+      }}
+    >
       <td className="mono" style={{ fontWeight: 500 }}>{w.id}</td>
       <td>
         <div className="mono">{w.host}</div>
@@ -367,7 +464,7 @@ function WorkerRow({ w, onDrain, onDelete, draining, deleting }) {
         </span>
       </td>
       <td className="mono muted">{startedAtSecondsAgo != null ? relativeTime(startedAtSecondsAgo) : "—"}</td>
-      <td style={{ textAlign: "right", paddingRight: 12 }}>
+      <td style={{ textAlign: "right", paddingRight: 12 }} onClick={(e) => e.stopPropagation()}>
         {w.status === "dead" ? (
           <Btn
             size="sm"

--- a/ui/components/workers.jsx
+++ b/ui/components/workers.jsx
@@ -1,9 +1,13 @@
 /* global React, Icon, Btn, Modal, relativeTime, fmtDate */
 
-function WorkersPage({ sessions, pushToast }) {
+function WorkersPage({ pushToast }) {
   const { useResource, useMutation, useViewport, apiFetch } = window.primerApi;
   const { isMobile } = useViewport();
   const [drainTarget, setDrainTarget] = React.useState(null);
+  const [clearDeadOpen, setClearDeadOpen] = React.useState(false);
+  const [filterText, setFilterText] = React.useState("");
+  // Status chip: "all" | "active" | "draining" | "dead".
+  const [statusFilter, setStatusFilter] = React.useState("all");
   const [, tick] = React.useState(0);
   // Tick heartbeats live
   React.useEffect(() => {
@@ -54,22 +58,90 @@ function WorkersPage({ sessions, pushToast }) {
     }
   );
 
+  // Remove a single DEAD worker row (409 from the API for a non-dead
+  // worker — the button only renders on dead rows, so that's a guard-rail).
+  const deleteTargetRef = React.useRef(null);
+  const deleteMut = useMutation(
+    (id) => {
+      deleteTargetRef.current = id;
+      return apiFetch("DELETE", `/workers/${encodeURIComponent(id)}`);
+    },
+    {
+      invalidates: ["workers:list"],
+      onSuccess: () =>
+        pushToast({
+          kind: "success",
+          title: `Removed ${deleteTargetRef.current || "worker"}`.trim(),
+          detail: "The dead worker was cleared from the registry.",
+        }),
+      onError: (err) =>
+        pushToast({
+          kind: "error",
+          title: err.title || "Remove failed",
+          detail: err.detail,
+          requestId: err.requestId,
+        }),
+    }
+  );
+
+  // Bulk-clear every DEAD worker in one call.
+  const purgeMut = useMutation(
+    () => apiFetch("POST", "/workers/purge_dead"),
+    {
+      invalidates: ["workers:list"],
+      onSuccess: (data) =>
+        pushToast({
+          kind: "success",
+          title: `Cleared ${data?.removed ?? 0} dead worker${data?.removed === 1 ? "" : "s"}`,
+          detail: "Dead workers were removed from the registry.",
+        }),
+      onError: (err) =>
+        pushToast({
+          kind: "error",
+          title: err.title || "Clear dead failed",
+          detail: err.detail,
+          requestId: err.requestId,
+        }),
+    }
+  );
+
   const totals = workers.reduce(
     (acc, w) => {
       acc.cap += w.capacity || 0;
       acc.flight += w.in_flight || 0;
       if (w.status === "active") acc.active += 1;
       if (w.status === "draining") acc.draining += 1;
+      if (w.status === "dead") acc.dead += 1;
       return acc;
     },
-    { cap: 0, flight: 0, active: 0, draining: 0 }
+    { cap: 0, flight: 0, active: 0, draining: 0, dead: 0 }
   );
+
+  // Client-side filter: status chip + free-text over id / host.
+  const q = filterText.trim().toLowerCase();
+  const filtered = workers.filter((w) => {
+    if (statusFilter !== "all" && w.status !== statusFilter) return false;
+    if (!q) return true;
+    return (
+      (w.id || "").toLowerCase().includes(q) ||
+      (w.host || "").toLowerCase().includes(q)
+    );
+  });
+
+  const chips = ["all", "active", "draining", "dead"];
+  const chipCount = (c) =>
+    c === "all" ? workers.length : workers.filter((w) => w.status === c).length;
 
   const onDrain = (w) => setDrainTarget(w);
   const confirmDrain = () => {
     const w = drainTarget;
     setDrainTarget(null);
     if (w) drainMut.mutate(w.id);
+  };
+  const onDelete = (w) => deleteMut.mutate(w.id);
+  const confirmClearDead = () => {
+    setClearDeadOpen(false);
+    purgeMut.mutate();
   };
 
   return (
@@ -80,7 +152,7 @@ function WorkersPage({ sessions, pushToast }) {
           label="Total"
           value={workers.length}
           sub="registered workers"
-          title="Every worker process the pool knows about, including ones currently draining."
+          title="Every worker process the pool knows about, including ones currently draining or dead."
         />
         <SummaryStat
           label="Active"
@@ -105,26 +177,61 @@ function WorkersPage({ sessions, pushToast }) {
           }
         />
         <SummaryStat
-          label="Scheduler"
-          value="alive"
-          sub="last claim 2s ago"
-          accent="green"
-          title="The claim engine is polling and ready to hand work to workers."
+          label="Dead"
+          value={totals.dead}
+          sub={totals.dead > 0 ? "clear to tidy the registry" : "none — registry clean"}
+          accent={totals.dead > 0 ? "red" : "green"}
+          title="Workers reaped after they stopped heart-beating. Their rows linger until removed — use the per-row remove button or Clear dead."
         />
       </div>
 
       <div className="filter-bar">
         <div className="input-icon">
           <Icon name="search" size={13} className="icon" />
-          <input className="input" placeholder="Filter workers…" />
+          <input
+            className="input"
+            placeholder="Filter workers…"
+            aria-label="Filter workers by id or host"
+            data-testid="workers-filter"
+            value={filterText}
+            onChange={(e) => setFilterText(e.target.value)}
+          />
         </div>
         <div className="sep-v" />
-        <div className="chip-group">
-          <span className="chip active">all</span>
-          <span className="chip">active</span>
-          <span className="chip">draining</span>
-          <span className="chip">dead</span>
+        <div className="chip-group" role="tablist" aria-label="Filter by status">
+          {chips.map((c) => (
+            <span
+              key={c}
+              className={`chip${statusFilter === c ? " active" : ""}`}
+              role="tab"
+              tabIndex={0}
+              aria-selected={statusFilter === c}
+              data-testid={`workers-chip-${c}`}
+              onClick={() => setStatusFilter(c)}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  setStatusFilter(c);
+                }
+              }}
+            >
+              {c}
+              <span className="mono muted" style={{ fontSize: 10 }}>{chipCount(c)}</span>
+            </span>
+          ))}
         </div>
+        {totals.dead > 0 && (
+          <Btn
+            size="sm"
+            kind="ghost"
+            icon="trash"
+            data-testid="workers-clear-dead"
+            disabled={purgeMut.loading}
+            onClick={() => setClearDeadOpen(true)}
+          >
+            {purgeMut.loading ? "Clearing…" : `Clear dead (${totals.dead})`}
+          </Btn>
+        )}
         <span className="muted text-sm tabular" style={{ marginLeft: "auto" }}>
           <span className="mono" style={{ color: "var(--green)" }}>● live</span> · /v1/workers every 2s
         </span>
@@ -140,23 +247,36 @@ function WorkersPage({ sessions, pushToast }) {
               <th style={{ width: 180 }}>Capacity</th>
               <th style={{ width: 130 }}>Last heartbeat</th>
               <th>Started</th>
-              <th style={{ width: 70, textAlign: "right" }}></th>
+              <th style={{ width: 90, textAlign: "right" }}></th>
             </tr>
           </thead>
           <tbody>
-            {workers.map((w) => (
+            {filtered.map((w) => (
               <WorkerRow
                 key={w.id}
                 w={w}
-                sessions={sessions || []}
                 onDrain={onDrain}
+                onDelete={onDelete}
                 draining={drainMut.loading}
+                deleting={deleteMut.loading}
               />
             ))}
           </tbody>
         </table>
+        {filtered.length === 0 && (
+          <div className="empty" style={{ padding: "18px 14px" }} data-testid="workers-empty">
+            {workers.length === 0
+              ? "No workers registered."
+              : "No workers match the current filter."}
+          </div>
+        )}
         <div className="tbl-foot">
-          <span className="tabular">{workers.length} workers · polling every 2s</span>
+          <span className="tabular">
+            {filtered.length === workers.length
+              ? `${workers.length} worker${workers.length === 1 ? "" : "s"}`
+              : `${filtered.length} of ${workers.length} workers`}
+            {" · polling every 2s"}
+          </span>
         </div>
       </div>
 
@@ -181,14 +301,33 @@ function WorkersPage({ sessions, pushToast }) {
           </ul>
         </Modal>
       )}
+
+      {clearDeadOpen && (
+        <Modal
+          title={`Clear ${totals.dead} dead worker${totals.dead === 1 ? "" : "s"}?`}
+          danger
+          onClose={() => setClearDeadOpen(false)}
+          footer={
+            <>
+              <Btn kind="ghost" onClick={() => setClearDeadOpen(false)}>Cancel</Btn>
+              <Btn kind="danger" icon="trash" data-testid="workers-clear-dead-confirm" onClick={confirmClearDead}>Clear dead</Btn>
+            </>
+          }
+        >
+          Removing every worker currently in the <strong>dead</strong> state from
+          the registry.
+          <ul>
+            <li>Dead workers stopped heart-beating and were reaped — they never come back on their own.</li>
+            <li>Active and draining workers are left untouched.</li>
+            <li>This only tidies the registry; it does not stop any running process.</li>
+          </ul>
+        </Modal>
+      )}
     </div>
   );
 }
 
-function WorkerRow({ w, sessions, onDrain, draining }) {
-  const onWorker = sessions.filter(
-    (s) => s.worker_id === w.id && (s.status === "running" || s.status === "paused")
-  );
+function WorkerRow({ w, onDrain, onDelete, draining, deleting }) {
   const heartbeatAge = w.heartbeat ?? 0;
   const heartbeatBad = heartbeatAge > 30;
   const capacity = w.capacity || 0;
@@ -215,7 +354,6 @@ function WorkerRow({ w, sessions, onDrain, draining }) {
         <CapacityBar inFlight={inFlight} capacity={capacity} />
         <div className="mono muted text-sm" style={{ marginTop: 2 }}>
           {inFlight} / {capacity}
-          {onWorker.length > 0 && <> · <span style={{ color: "var(--blue)" }}>{onWorker.length} session{onWorker.length === 1 ? "" : "s"}</span></>}
         </div>
       </td>
       <td className={heartbeatBad ? "mono" : "mono muted"} style={{ color: heartbeatBad ? "var(--red)" : undefined }}>
@@ -230,15 +368,28 @@ function WorkerRow({ w, sessions, onDrain, draining }) {
       </td>
       <td className="mono muted">{startedAtSecondsAgo != null ? relativeTime(startedAtSecondsAgo) : "—"}</td>
       <td style={{ textAlign: "right", paddingRight: 12 }}>
-        <Btn
-          size="sm"
-          kind="ghost"
-          icon="alert"
-          disabled={w.status !== "active" || draining}
-          onClick={() => onDrain(w)}
-        >
-          {draining ? "Draining…" : "Drain"}
-        </Btn>
+        {w.status === "dead" ? (
+          <Btn
+            size="sm"
+            kind="ghost"
+            icon="trash"
+            data-testid="worker-delete"
+            disabled={deleting}
+            onClick={() => onDelete(w)}
+          >
+            {deleting ? "Removing…" : "Remove"}
+          </Btn>
+        ) : (
+          <Btn
+            size="sm"
+            kind="ghost"
+            icon="alert"
+            disabled={w.status !== "active" || draining}
+            onClick={() => onDrain(w)}
+          >
+            {draining ? "Draining…" : "Drain"}
+          </Btn>
+        )}
       </td>
     </tr>
   );


### PR DESCRIPTION
## Workers / Operations page — cleanup, detail view, honest controls (#17, #18)

Field-testing found the Workers page kept days-dead rows with no way to clear them, and shipped several inert/fake controls.

**#17 — dead-worker cleanup + real controls**
- New backend: `POST /v1/workers/purge_dead` → `{"removed": N}` (only `dead` workers); `DELETE /v1/workers/{id}` → 204, **409** if the worker is active/draining (never delete a live worker), 404 if unknown. Both auth-gated; implemented via the existing `Scheduler.deregister_worker`.
- UI: per-row **Remove** on dead rows (`worker-delete`) + a **Clear dead (N)** bulk button (`workers-clear-dead`, `Modal`-confirmed).
- **Wired** the previously-inert "Filter workers…" input (`workers-filter`, id/host substring) and the all/active/draining/dead status chips (`workers-chip-*`, with counts).
- **Removed** the hardcoded "Scheduler: alive · last claim 2s ago" tile (the API exposes no scheduler state — no fake telemetry; replaced with a real **Dead** count tile) and the always-empty "· N sessions" per-row annotation (+ dropped its dead `sessions` prop from `app.jsx`).

**#18 — worker detail view**
- Row click (`worker-row`) opens a `Modal` (`worker-detail`) with the full record: id, host/pid, status, capacity + in-flight, heartbeat freshness (relative + absolute), started. Tracked by id so the 2 s poll keeps it live; closes if the worker vanishes. No new endpoint — every field is already in the list row.

**Known data gap (out of scope):** `WorkerInfo` has no per-worker `in_flight` or history, so the in-flight figure renders 0/N and there are no time-series charts — flagged for a future backend change, not invented here.

Tests: `tests/api/test_workers.py` +9 (delete-dead, reject-live-409, 404, auth, purge count/empty) = 14; new `tests/ui/test_workers_{controls,detail}.py`; full `tests/ui` 488 green.
