### PR TITLE
fix(runtime): stabilise flaky PTY workdir test (split module identity → EINTERNAL)

### DIFF
--- a/runtime/primer_runtime/pty_op.py
+++ b/runtime/primer_runtime/pty_op.py
@@ -256,11 +256,24 @@ async def _run_pty(
         return
     except Exception as exc:  # noqa: BLE001 — protocol boundary: the client
         # is waiting on this op; an uncaught exception here would leave it
-        # hanging with no frame at all. Map anything unexpected to EINTERNAL.
-        log.exception("pty_open validation failed unexpectedly (req_id=%d)", req_id)
+        # hanging with no frame at all.
+        #
+        # An OpError raised inside primer_runtime.ops may NOT be the same class
+        # as the OpError imported at the top of this module when the package is
+        # loaded via BOTH the installed dist AND the `runtime` pythonpath entry
+        # (two module objects → split class identity; happens under
+        # pytest-xdist in CI). In that case `except OpError` above misses it and
+        # we land here. Duck-type it so a path-escape still reports its real
+        # code (EACCES) rather than being masked as EINTERNAL. ErrorCode is a
+        # StrEnum, so the foreign copy's .code still serialises to "EACCES".
+        if type(exc).__name__ == "OpError" and hasattr(exc, "code") and hasattr(exc, "message"):
+            code, message = exc.code, exc.message
+        else:
+            log.exception("pty_open validation failed unexpectedly (req_id=%d)", req_id)
+            code, message = ErrorCode.EINTERNAL, f"pty_open: {exc}"
         await send(serialize(Response(
             req_id=req_id, ok=False,
-            error={"code": ErrorCode.EINTERNAL, "message": f"pty_open: {exc}"},
+            error={"code": code, "message": message},
         )))
         return
 

--- a/tests/runtime/test_pty_op.py
+++ b/tests/runtime/test_pty_op.py
@@ -154,6 +154,55 @@ async def test_pty_bad_workdir_emits_error(tmp_path: Path) -> None:
 
 
 @pytest.mark.asyncio
+async def test_pty_bad_workdir_reports_real_code_on_split_module_identity(
+    tmp_path: Path, monkeypatch
+) -> None:
+    """A split-identity OpError must still report EACCES, not EINTERNAL.
+
+    On CI primer_runtime is importable via BOTH the installed dist and the
+    ``runtime`` pythonpath entry, so the OpError raised in
+    ``primer_runtime.ops`` can be a DIFFERENT class object than the OpError
+    imported in ``pty_op`` — ``except OpError`` misses it and the catch-all
+    runs. Simulate that with a foreign class whose ``__name__`` is "OpError"
+    but which is NOT ``pty_op.OpError``; the emitted frame must carry the
+    real code (duck-typed), not the masked EINTERNAL.
+    """
+    import primer_runtime.pty_op as pty_op_mod
+
+    class _ForeignOpError(Exception):
+        def __init__(self, code: str, message: str) -> None:
+            super().__init__(message)
+            self.code = code
+            self.message = message
+
+    _ForeignOpError.__name__ = "OpError"  # mimic the split-identity class name
+    _ForeignOpError.__qualname__ = "OpError"
+    assert _ForeignOpError is not pty_op_mod.OpError  # genuinely foreign
+
+    def _raise_foreign(raw_path: str, workspace_root: str):
+        raise _ForeignOpError("EACCES", f"Path escapes workspace root: {raw_path!r}")
+
+    monkeypatch.setattr(pty_op_mod, "_resolve_safe", _raise_foreign)
+
+    registry = PtyRegistry()
+    frames: list[str] = []
+
+    async def send(frame: str) -> None:
+        frames.append(frame)
+
+    task = start_pty(
+        req_id=17,
+        args={"cmd": ["/bin/sh"], "workdir": "../../etc"},
+        workspace_root=str(tmp_path),
+        send=send,
+        registry=registry,
+    )
+    await task
+    err = next(e for e in _events(frames) if "ok" in e and e["ok"] is False)
+    assert err["error"]["code"] == "EACCES"  # NOT "EINTERNAL"
+
+
+@pytest.mark.asyncio
 async def test_pty_cancel_all_terminates(tmp_path: Path) -> None:
     registry = PtyRegistry()
     frames: list[str] = []


### PR DESCRIPTION
## Fix flaky `test_pty_bad_workdir_emits_error` on CI (split module identity)

The PTY workdir-escape test intermittently fails on CI with `assert 'EINTERNAL' == 'EACCES'` (green on #67's run, red on #68's).

**Root cause:** CI installs `primer_runtime` **non-editable** (`uv pip install --no-deps ./runtime`) *and* adds `runtime` to the pytest `pythonpath`. So `primer_runtime.ops` can exist as **two distinct module objects**; under pytest-xdist a worker may raise an `OpError` whose class identity differs from the `OpError` imported in `pty_op.py`. The `except OpError` clause then misses it, and the `except Exception` catch-all (added in #67) masked the real `EACCES` as `EINTERNAL`.

**Fix:** in the catch-all, duck-type the `OpError` (`type(exc).__name__ == "OpError"` + `.code`/`.message`) and report its real code. `ErrorCode` is a `StrEnum`, so even the foreign copy's `.code` serialises to `"EACCES"`. Genuinely unexpected errors still map to `EINTERNAL`. Adds a regression that monkeypatches `_resolve_safe` to raise a foreign `OpError`-named class and asserts `EACCES`.

This was shipped to main by #67 — fixing it here stabilises every PR's `test` check. (Follow-up worth considering: install `runtime` editable in CI to collapse the double-load at the source.)
