### PR TITLE
feat(ui): shared table pagination across the console list pages (#19)

### DIFF
--- a/tests/ui/test_pagination.py
+++ b/tests/ui/test_pagination.py
@@ -1,0 +1,157 @@
+"""Structural checks for the shared list pagination primitive (bug #19).
+
+The backend list endpoints already paginate (OffsetPageResponse,
+``?limit=&offset=``); the console previously fetched a hard ``limit=200``
+and dumped everything. This suite pins the shared ``usePagedList`` hook +
+``Pager`` component: that they exist, are registered in the bundle in the
+right order, expose the required testids, and are actually wired into a
+few representative list pages.
+
+Static-source + bundle-build checks only (matching the rest of the ui/
+suite — no React render).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+PAGER = UI / "components" / "shared" / "pager.jsx"
+INDEX = UI / "index.html"
+
+
+def _pager_src() -> str:
+    return PAGER.read_text(encoding="utf-8")
+
+
+# ---- The primitive exists + is defined ---------------------------------
+
+
+def test_pager_file_exists() -> None:
+    assert PAGER.exists()
+
+
+def test_hook_and_component_defined() -> None:
+    src = _pager_src()
+    assert "function usePagedList" in src
+    assert "function Pager" in src
+
+
+def test_exported_to_window() -> None:
+    src = _pager_src()
+    # Both the bare globals and the primerApi namespace, so call sites can
+    # destructure from window.primerApi like the rest of the app.
+    assert "window.usePagedList" in src
+    assert "window.Pager" in src
+    assert "ns.usePagedList" in src
+    assert "ns.Pager" in src
+
+
+# ---- Required testids --------------------------------------------------
+
+
+def test_required_testids_present() -> None:
+    src = _pager_src()
+    for tid in ("pager", "pager-range", "pager-prev", "pager-next"):
+        assert f'data-testid="{tid}"' in src, f"missing testid {tid}"
+
+
+# ---- Uses the real OffsetPageResponse fields ---------------------------
+
+
+def test_relies_on_offsetpage_fields() -> None:
+    src = _pager_src()
+    # limit/offset query params + items/total response fields.
+    assert "limit=" in src and "offset=" in src
+    assert ".items" in src
+    assert ".total" in src
+
+
+def test_infers_has_next_without_total() -> None:
+    # total may be null -> a full page implies there may be more.
+    src = _pager_src()
+    assert "items.length >= pageSize" in src
+
+
+def test_default_page_size_is_50() -> None:
+    assert "DEFAULT_PAGE_SIZE = 50" in _pager_src()
+
+
+def test_uses_distinct_css_class_not_pager() -> None:
+    # Named .list-pager so it never collides with the older hand-rolled
+    # `.tbl-foot .pager` markup still present on a few pages.
+    assert "list-pager" in _pager_src()
+
+
+# ---- Registered in the bundle, in the right order ----------------------
+
+
+def _bundle_order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            start = line.index('src="') + len('src="')
+            end = line.index('"', start)
+            out.append(line[start:end])
+    return out
+
+
+def test_registered_in_index() -> None:
+    assert "components/shared/pager.jsx" in _bundle_order()
+
+
+def test_loads_after_shared_before_pages() -> None:
+    order = _bundle_order()
+    pager_at = order.index("components/shared/pager.jsx")
+    # After shared.jsx (needs Btn / Icon).
+    assert pager_at > order.index("components/shared.jsx")
+    # Before the page components that consume it.
+    for page in (
+        "components/agents.jsx",
+        "components/providers.jsx",
+        "components/chats.jsx",
+    ):
+        assert order.index(page) > pager_at, f"{page} loads before pager.jsx"
+
+
+# ---- Representative pages actually use the primitive -------------------
+
+REPRESENTATIVE = [
+    "agents.jsx",
+    "graphs.jsx",
+    "chats.jsx",
+    "providers.jsx",
+    "channels.jsx",
+    "triggers.jsx",
+    "harnesses.jsx",
+    "semantic-search.jsx",
+    "knowledge.jsx",
+    "workspaces.jsx",
+]
+
+
+def test_representative_pages_use_hook_and_component() -> None:
+    for name in REPRESENTATIVE:
+        src = (UI / "components" / name).read_text(encoding="utf-8")
+        assert "usePagedList" in src, f"{name} does not use usePagedList"
+        assert "Pager" in src, f"{name} does not render Pager"
+
+
+def test_workspace_subpages_use_hook() -> None:
+    for name in ("templates.jsx", "providers.jsx"):
+        src = (UI / "components" / "workspaces" / name).read_text(encoding="utf-8")
+        assert "usePagedList" in src, f"workspaces/{name} missing usePagedList"
+
+
+# ---- The whole bundle still transpiles with the new primitive ----------
+
+
+def test_bundle_transpiles_with_pager() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/shared/pager.jsx === */" in text
+    assert "usePagedList" in text

--- a/tests/ui_e2e/test_docs_embed_spike.py
+++ b/tests/ui_e2e/test_docs_embed_spike.py
@@ -57,8 +57,12 @@ def test_real_agents_page_renders_in_iframe_under_fixture_stub(
     frame = page.frame_locator("iframe#host")
 
     # --- ASSERTION 1: the fixture agent text is present. ---
+    # 30s (was 15s): this waits for the FULL app bundle to load + React to
+    # mount + the stubbed fetch to resolve inside the embed iframe, which can
+    # exceed 15s under full-suite CI load. The pager fix (stub now keyed to
+    # limit=50) makes the row render; this just gives the render headroom.
     id_cell = frame.locator("td.mono", has_text=re.compile(r"^weekly-digest$"))
-    id_cell.first.wait_for(state="visible", timeout=15_000)
+    id_cell.first.wait_for(state="visible", timeout=30_000)
     assert id_cell.count() >= 1, "expected an id cell with text 'weekly-digest'"
 
     # --- ASSERTION 2: it is the REAL component markup, not a mock. ---

--- a/ui/components/agents.jsx
+++ b/ui/components/agents.jsx
@@ -46,7 +46,7 @@ function _agToastErr(pushToast, fallbackTitle) {
 // ============================================================================
 
 function AgentsPage({ onOpen, pushToast }) {
-  const { useResource, useRouter, useViewport, apiFetch } = window.primerApi;
+  const { useResource, useRouter, useViewport, apiFetch, usePagedList, Pager } = window.primerApi;
   const { navigate } = useRouter();
   const { isMobile } = useViewport();
 
@@ -54,18 +54,21 @@ function AgentsPage({ onOpen, pushToast }) {
   const [textFilter, setTextFilter] = React.useState("");
   const filterFocused = React.useRef(false);
 
-  const list = useResource(
-    "agents:list",
-    (signal) => apiFetch("GET", "/agents?limit=200", null, { signal }),
-    { pollMs: null }
-  );
+  // Server-side offset pagination (bug #19). The text filter is applied
+  // client-side over the current page, so typing snaps back to page 0.
+  const list = usePagedList({
+    key: "agents:list",
+    path: "/agents",
+    pageSize: 50,
+    resetKey: textFilter,
+  });
   const providers = useResource(
     "agents:llm-providers",
     (signal) => apiFetch("GET", "/llm_providers?limit=200", null, { signal }),
     { pollMs: null }
   );
 
-  const items = list.data?.items ?? [];
+  const items = list.items;
   const filtered = React.useMemo(() => {
     if (!textFilter) return items;
     const q = textFilter.toLowerCase();
@@ -265,6 +268,8 @@ function AgentsPage({ onOpen, pushToast }) {
         </table>
       </div>
       )}
+
+      <Pager pager={list} label="agents" />
 
       {isMobile && (
         <Fab icon="plus" label="New agent" onClick={() => setCreateOpen(true)} />

--- a/ui/components/channels.jsx
+++ b/ui/components/channels.jsx
@@ -65,24 +65,28 @@ function ProviderBadge({ kind }) {
 // ============== Providers list ==============
 
 function ChannelProvidersPage({ onOpen, pushToast }) {
-  const { apiFetch, useResource, useViewport } = window.primerApi;
+  const { apiFetch, useResource, useViewport, usePagedList, Pager } = window.primerApi;
   const { isMobile } = useViewport();
   const [showNew, setShowNew] = React.useState(false);
   const [filter, setFilter] = React.useState("");
   const [platform, setPlatform] = React.useState("");
 
-  const providers = useResource(
-    CH_LIST_PROVIDERS,
-    (signal) => apiFetch("GET", "/channel_providers?limit=200", null, { signal }),
-    {},
-  );
+  // Providers are the paginated table (bug #19); text + platform filters
+  // narrow the current page and reset to page 0. The channels fetch is only a
+  // per-provider count lookup, so it stays a bounded full fetch.
+  const providers = usePagedList({
+    key: CH_LIST_PROVIDERS,
+    path: "/channel_providers",
+    pageSize: 50,
+    resetKey: filter + "|" + platform,
+  });
   const channels = useResource(
     CH_LIST_CHANNELS,
     (signal) => apiFetch("GET", "/channels?limit=200", null, { signal }),
     {},
   );
 
-  const items = providers.data?.items ?? [];
+  const items = providers.items;
   const channelItems = channels.data?.items ?? [];
   const filtered = items.filter((p) => {
     if (platform && p.provider !== platform) return false;
@@ -168,6 +172,8 @@ function ChannelProvidersPage({ onOpen, pushToast }) {
         </table>
       </div>
       )}
+
+      <Pager pager={providers} label="providers" />
 
       {isMobile && (
         <Fab icon="plus" label="New channel provider" onClick={() => setShowNew(true)} />
@@ -583,26 +589,30 @@ function ChannelProviderDetail({ providerId, pushToast }) {
 // ============== Channels list ==============
 
 function ChannelsPage({ onNavigate, pushToast }) {
-  const { apiFetch, useResource, useMutation, useViewport } = window.primerApi;
+  const { apiFetch, useResource, useMutation, useViewport, usePagedList, Pager } = window.primerApi;
   const { isMobile } = useViewport();
   const [showNew, setShowNew] = React.useState(false);
   const [editing, setEditing] = React.useState(null);
   const [filter, setFilter] = React.useState("");
   const [providerFilter, setProviderFilter] = React.useState("");
 
+  // Providers back the dropdown + row badges — a small, bounded lookup, so it
+  // stays a full fetch. Only the channels table is offset-paginated (bug #19);
+  // the text + provider filters narrow the current page and reset to page 0.
   const providers = useResource(
     CH_LIST_PROVIDERS,
     (signal) => apiFetch("GET", "/channel_providers?limit=200", null, { signal }),
     {},
   );
-  const channels = useResource(
-    CH_LIST_CHANNELS,
-    (signal) => apiFetch("GET", "/channels?limit=200", null, { signal }),
-    {},
-  );
+  const channels = usePagedList({
+    key: CH_LIST_CHANNELS,
+    path: "/channels",
+    pageSize: 50,
+    resetKey: filter + "|" + providerFilter,
+  });
 
   const providerItems = providers.data?.items ?? [];
-  const channelItems = channels.data?.items ?? [];
+  const channelItems = channels.items;
   const filtered = channelItems.filter((c) => {
     if (providerFilter && c.provider_id !== providerFilter) return false;
     if (!filter) return true;
@@ -750,6 +760,8 @@ function ChannelsPage({ onNavigate, pushToast }) {
         </table>
       </div>
       )}
+
+      <Pager pager={channels} label="channels" />
 
       {isMobile && providerItems.length > 0 && (
         <Fab icon="plus" label="New channel" onClick={() => setShowNew(true)} />

--- a/ui/components/chats.jsx
+++ b/ui/components/chats.jsx
@@ -9,8 +9,6 @@
 // Top-level consts are CT_-prefixed so babel-standalone's flat eval
 // scope doesn't collide with sibling components (precedent: Task 3).
 
-const CT_PAGE_SIZE = 12;
-
 // Map a chat_messages row kind → simple bubble role for layout.
 function CT_roleForKind(kind) {
   if (kind === "user_message") return "user";
@@ -35,20 +33,25 @@ function CT_textOf(m) {
 // ============================================================================
 
 function ChatsPage({ onOpen, pushToast }) {
-  const { useResource, useMutation, useRouter, apiFetch } = window.primerApi;
+  const { useMutation, useRouter, apiFetch, usePagedList, Pager } = window.primerApi;
   const { navigate } = useRouter();
   const [showNew, setShowNew] = React.useState(false);
   const [textQuery, setTextQuery] = React.useState("");
   const [agentFilter, setAgentFilter] = React.useState("");
-  const [page, setPage] = React.useState(1);
   const [pendingDelete, setPendingDelete] = React.useState(null);
   const filterFocused = React.useRef(false);
 
-  const list = useResource(
-    "chats:list",
-    (signal) => apiFetch("GET", "/chats?limit=200", null, { signal }),
-    { pollMs: 5000, pauseWhile: () => filterFocused.current }
-  );
+  // Server-side offset pagination (bug #19) — replaces the old hard
+  // limit=200 fetch + client-side page slicing. The text + agent filters
+  // narrow the current page client-side, so changing either resets to page 0.
+  const list = usePagedList({
+    key: "chats:list",
+    path: "/chats",
+    pageSize: 50,
+    pollMs: 5000,
+    pauseWhile: () => filterFocused.current,
+    resetKey: textQuery + "|" + agentFilter,
+  });
 
   const remove = useMutation(
     (cid) => apiFetch("DELETE", `/chats/${encodeURIComponent(cid)}?force=true`),
@@ -75,7 +78,7 @@ function ChatsPage({ onOpen, pushToast }) {
     },
   );
 
-  const items = list.data?.items ?? [];
+  const items = list.items;
 
   const agents = React.useMemo(() => {
     const set = new Set();
@@ -96,10 +99,6 @@ function ChatsPage({ onOpen, pushToast }) {
     if (agentFilter) arr = arr.filter((c) => c.agent_id === agentFilter);
     return arr;
   }, [items, textQuery, agentFilter]);
-
-  const total = filtered.length;
-  const totalPages = Math.max(1, Math.ceil(total / CT_PAGE_SIZE));
-  const pageItems = filtered.slice((page - 1) * CT_PAGE_SIZE, page * CT_PAGE_SIZE);
 
   const openRow = (cid) => {
     if (typeof onOpen === "function") onOpen(cid);
@@ -133,7 +132,7 @@ function ChatsPage({ onOpen, pushToast }) {
             className="input"
             placeholder="Filter chats…"
             value={textQuery}
-            onChange={(e) => { setTextQuery(e.target.value); setPage(1); }}
+            onChange={(e) => setTextQuery(e.target.value)}
             onFocus={() => { filterFocused.current = true; }}
             onBlur={() => { filterFocused.current = false; }}
           />
@@ -142,7 +141,7 @@ function ChatsPage({ onOpen, pushToast }) {
         <select
           className="select"
           value={agentFilter}
-          onChange={(e) => { setAgentFilter(e.target.value); setPage(1); }}
+          onChange={(e) => setAgentFilter(e.target.value)}
         >
           <option value="">all agents</option>
           {agents.map((a) => <option key={a} value={a}>{a}</option>)}
@@ -194,7 +193,7 @@ function ChatsPage({ onOpen, pushToast }) {
               </tr>
             </thead>
             <tbody>
-              {pageItems.length === 0 ? (
+              {filtered.length === 0 ? (
                 <tr><td colSpan={6} className="muted text-sm" style={{ padding: 20, textAlign: "center" }}>
                   No chats match the current filter{textQuery ? ` "${textQuery}"` : ""}.
                   {" · "}<a
@@ -202,7 +201,7 @@ function ChatsPage({ onOpen, pushToast }) {
                     style={{ cursor: "pointer", color: "var(--accent)" }}
                   >Clear filters</a>
                 </td></tr>
-              ) : pageItems.map((c) => {
+              ) : filtered.map((c) => {
                 const createdSec = ageSec(c.created_at);
                 const status = c.status || "active";
                 return (
@@ -257,20 +256,10 @@ function ChatsPage({ onOpen, pushToast }) {
               })}
             </tbody>
           </table>
-          <div className="tbl-foot">
-            <span className="tabular">
-              Showing <strong style={{ color: "var(--text)" }}>{total === 0 ? 0 : (page - 1) * CT_PAGE_SIZE + 1}</strong>–
-              <strong style={{ color: "var(--text)" }}>{Math.min(page * CT_PAGE_SIZE, total)}</strong> of{" "}
-              <strong style={{ color: "var(--text)" }}>{total}</strong>
-            </span>
-            <div className="pager">
-              <button disabled={page === 1} onClick={() => setPage(page - 1)}><Icon name="chevron-left" size={12} /></button>
-              <span className="muted text-sm tabular" style={{ padding: "0 8px" }}>Page {page} of {totalPages}</span>
-              <button disabled={page === totalPages} onClick={() => setPage(page + 1)}><Icon name="chevron-right" size={12} /></button>
-            </div>
-          </div>
         </div>
       )}
+
+      <Pager pager={list} label="chats" />
 
       {showNew && (
         <CT_NewChatModal onClose={() => setShowNew(false)} pushToast={pushToast} />

--- a/ui/components/docs/embed-preview.jsx
+++ b/ui/components/docs/embed-preview.jsx
@@ -154,12 +154,59 @@
       return { isMobile: false, width: 1366, height: 768 };
     }
 
+    // usePagedList(...) — the paginated list pages (agents, graphs, chats…)
+    // now fetch through this instead of useResource. In a read-only docs
+    // preview there is one fixture page, so fetch page 0 via the stubbed
+    // apiFetch and report a single, non-navigable page. Mirrors the real
+    // hook's return surface so the page component + <Pager> render.
+    function usePagedList(opts) {
+      const path = (opts && opts.path) || "";
+      const pageSize = (opts && opts.pageSize) || 50;
+      const res = useResource(
+        "docs-stub:" + path,
+        () =>
+          apiFetch(
+            "GET",
+            path + (path.indexOf("?") >= 0 ? "&" : "?") +
+              "limit=" + pageSize + "&offset=0",
+          ),
+      );
+      const data = res.data || {};
+      const items = data.items || [];
+      return {
+        items: items,
+        total: data.total != null ? data.total : items.length,
+        data: res.data,
+        loading: res.loading,
+        error: null,
+        refetch: () => {},
+        offset: 0,
+        pageSize: pageSize,
+        page: 0,
+        hasNext: false,
+        hasPrev: false,
+        rangeStart: items.length ? 1 : 0,
+        rangeEnd: items.length,
+        next: () => {},
+        prev: () => {},
+        reset: () => {},
+        setOffset: () => {},
+      };
+    }
+
+    // Pager(...) — inert in a docs preview (one fixture page, no navigation).
+    function Pager() {
+      return null;
+    }
+
     return {
       apiFetch,
       useResource,
       useMutation,
       useRouter,
       useViewport,
+      usePagedList,
+      Pager,
       // Marker so debuggers / tests can confirm the stub (not the live api)
       // is in force inside an embed iframe.
       __isDocsStub: true,

--- a/ui/components/graphs.jsx
+++ b/ui/components/graphs.jsx
@@ -227,16 +227,19 @@ function GR_NewGraphModal({ onClose, onCreate, pushToast }) {
 // ============================================================================
 
 function GraphsPage({ onOpen, pushToast }) {
-  const { apiFetch, useResource, useViewport } = window.primerApi;
+  const { useViewport, usePagedList, Pager } = window.primerApi;
+  const apiFetch = window.primerApi.apiFetch;
   const { isMobile } = useViewport();
-  const list = useResource(
-    "graphs:list",
-    (s) => apiFetch("GET", "/graphs?limit=200", null, { signal: s }),
-    {},
-  );
-
   const [textFilter, setTextFilter] = React.useState("");
-  const items = list.data?.items ?? [];
+  // Server-side offset pagination (bug #19); filter narrows the current page.
+  const list = usePagedList({
+    key: "graphs:list",
+    path: "/graphs",
+    pageSize: 50,
+    resetKey: textFilter,
+  });
+
+  const items = list.items;
   const filtered = items.filter((g) =>
     !textFilter
       || g.id.toLowerCase().includes(textFilter.toLowerCase())
@@ -401,6 +404,8 @@ function GraphsPage({ onOpen, pushToast }) {
         </table>
       </div>
       )}
+
+      <Pager pager={list} label="graphs" />
 
       {isMobile && (
         <Fab icon="plus" label="New graph" onClick={() => setCreateOpen(true)} />

--- a/ui/components/harnesses.jsx
+++ b/ui/components/harnesses.jsx
@@ -96,7 +96,7 @@ function HR_OutdatedChips({ harness }) {
 // ============================================================================
 
 function HarnessList() {
-  const { useResource, useRouter, useViewport, apiFetch } = window.primerApi;
+  const { useRouter, useViewport, apiFetch, usePagedList, Pager } = window.primerApi;
   const { navigate } = useRouter();
   const { isMobile } = useViewport();
   const [registerOpen, setRegisterOpen] = React.useState(false);
@@ -104,31 +104,20 @@ function HarnessList() {
   // Direction filter: "all" | "inbound" | "outbound". Server supports
   // ?direction=<x> from Phase 6; we pass it through when non-"all".
   const [directionFilter, setDirectionFilter] = React.useState("all");
-  // Client-side pagination over the fetched list (same approach as the
-  // agent toolset pager). The list endpoint is capped at 200 rows.
-  const [page, setPage] = React.useState(1);
   const HR_PAGE_SIZE = 20;
 
-  const listUrl = directionFilter === "all"
-    ? "/harnesses?limit=200"
-    : "/harnesses?limit=200&direction=" + encodeURIComponent(directionFilter);
+  // Server-side offset pagination (bug #19), replacing the client-side slice
+  // over a hard limit=200 fetch. The direction pill filter is a server-side
+  // query param; changing it resets to the first page via resetKey.
+  const list = usePagedList({
+    key: "harnesses:list",
+    path: "/harnesses",
+    pageSize: HR_PAGE_SIZE,
+    params: { direction: directionFilter === "all" ? undefined : directionFilter },
+    resetKey: directionFilter,
+  });
 
-  const list = useResource(
-    "harnesses:list:" + directionFilter,
-    (signal) => apiFetch("GET", listUrl, null, { signal }),
-    { pollMs: null, deps: [directionFilter] }
-  );
-
-  const items = list.data?.items ?? [];
-
-  // Snap back to page 1 whenever the filter changes the result set.
-  React.useEffect(() => { setPage(1); }, [directionFilter]);
-
-  const totalPages = Math.max(1, Math.ceil(items.length / HR_PAGE_SIZE));
-  const safePage = Math.min(page, totalPages);
-  const pageStart = (safePage - 1) * HR_PAGE_SIZE;
-  const pageEnd = Math.min(pageStart + HR_PAGE_SIZE, items.length);
-  const pageItems = items.slice(pageStart, pageEnd);
+  const items = list.items;
 
   const onCreated = (harness) => {
     setRegisterOpen(false);
@@ -232,7 +221,7 @@ function HarnessList() {
               </tr>
             </thead>
             <tbody>
-              {pageItems.map((h) => {
+              {items.map((h) => {
                 const isOutbound = h.direction === "outbound";
                 const trackedCount = isOutbound ? (h.tracked_entities?.length || 0) : 0;
                 const driftDirty = isOutbound && (h.status === "OUTDATED" || h.status === "outdated");
@@ -323,18 +312,10 @@ function HarnessList() {
               })}
             </tbody>
           </table>
-          {totalPages > 1 && (
-            <div className="tbl-foot">
-              <span className="tabular">Showing <strong style={{ color: "var(--text)" }}>{pageStart + 1}</strong>–<strong style={{ color: "var(--text)" }}>{pageEnd}</strong> of <strong style={{ color: "var(--text)" }}>{items.length}</strong></span>
-              <div className="pager">
-                <button disabled={safePage <= 1} onClick={() => setPage(safePage - 1)}><Icon name="chevron-left" size={12} /></button>
-                <span className="muted text-sm tabular" style={{ padding: "0 8px" }}>Page {safePage} of {totalPages}</span>
-                <button disabled={safePage >= totalPages} onClick={() => setPage(safePage + 1)}><Icon name="chevron-right" size={12} /></button>
-              </div>
-            </div>
-          )}
         </div>
       )}
+
+      <Pager pager={list} label="harnesses" />
 
       {isMobile && (
         <Fab icon="plus" label="New harness" onClick={() => setRegisterOpen(true)} />

--- a/ui/components/knowledge.jsx
+++ b/ui/components/knowledge.jsx
@@ -31,15 +31,10 @@ function _knToastErr(pushToast, fallbackTitle) {
 // ============================================================================
 
 function CollectionsPage({ pushToast, onOpen, onNavigate }) {
-  const { useResource, useRouter, useViewport, apiFetch } = window.primerApi;
+  const { useResource, useRouter, useViewport, apiFetch, usePagedList, Pager } = window.primerApi;
   const { navigate } = useRouter();
   const { isMobile } = useViewport();
 
-  const list = useResource(
-    "collections:list",
-    (signal) => apiFetch("GET", "/collections?limit=200", null, { signal }),
-    { pollMs: null },
-  );
   const embedProviders = useResource(
     "collections:embedding-providers",
     (signal) => apiFetch("GET", "/embedding_providers?limit=200", null, { signal }),
@@ -60,7 +55,16 @@ function CollectionsPage({ pushToast, onOpen, onNavigate }) {
   const [createOpen, setCreateOpen] = React.useState(false);
   const [textFilter, setTextFilter] = React.useState("");
 
-  const items = list.data?.items ?? [];
+  // Server-side offset pagination (bug #19); the text filter narrows the
+  // current page and resets to page 0 via resetKey.
+  const list = usePagedList({
+    key: "collections:list",
+    path: "/collections",
+    pageSize: 50,
+    resetKey: textFilter,
+  });
+
+  const items = list.items;
   const filtered = items.filter(
     (c) => !textFilter || (c.id || "").toLowerCase().includes(textFilter.toLowerCase()),
   );
@@ -170,6 +174,8 @@ function CollectionsPage({ pushToast, onOpen, onNavigate }) {
         )}
       </div>
       )}
+
+      <Pager pager={list} label="collections" />
 
       {isMobile && (
         <Fab icon="plus" label="New collection" onClick={() => setCreateOpen(true)} />
@@ -395,35 +401,29 @@ function KN_CollectionListModal({ collection, pushToast, onClose }) {
 // System collections: paginated chunk enumeration from /indexed_documents,
 // which still returns the {items, total, offset, limit} OffsetPage shape.
 function KN_SystemCollectionListView({ collection, pushToast, onClose, titleBar }) {
-  const { useResource, apiFetch } = window.primerApi;
+  const { usePagedList } = window.primerApi;
   const PAGE_SIZE = 25;
-  const [offset, setOffset] = React.useState(0);
-  const indexed = useResource(
-    `collection-list:${collection.id}:indexed_documents:${offset}`,
-    (signal) => apiFetch(
-      "GET",
-      `/collections/${encodeURIComponent(collection.id)}/indexed_documents?limit=${PAGE_SIZE}&offset=${offset}`,
-      null,
-      { signal },
-    ),
-    { pollMs: null, deps: [collection.id, offset] },
-  );
-  const items = (indexed.data?.items || []).map((r) => ({
+  // Shared offset pager (bug #19) drives this documents modal too — same
+  // /indexed_documents?limit=&offset= endpoint, now via the reusable hook
+  // instead of a bespoke offset/hasNext computation.
+  const indexed = usePagedList({
+    key: `collection-list:${collection.id}:indexed_documents`,
+    path: `/collections/${encodeURIComponent(collection.id)}/indexed_documents`,
+    pageSize: PAGE_SIZE,
+  });
+  const offset = indexed.offset;
+  const items = (indexed.items || []).map((r) => ({
     document_id: r.document_id,
     chunk_id: r.chunk_id,
     text: r.text,
     meta: r.meta,
     score: null,
   }));
-  const total = indexed.data?.total ?? null;
-  const showingFrom = total != null && total > 0 ? offset + 1 : 0;
-  const showingTo = total != null
-    ? Math.min(offset + PAGE_SIZE, total)
-    : offset + items.length;
-  const hasPrev = offset > 0;
-  const hasNext = total != null
-    ? (offset + PAGE_SIZE) < total
-    : items.length >= PAGE_SIZE;
+  const total = indexed.total;
+  const showingFrom = indexed.rangeStart;
+  const showingTo = indexed.rangeEnd;
+  const hasPrev = indexed.hasPrev;
+  const hasNext = indexed.hasNext;
 
   return (
     <Modal
@@ -441,10 +441,10 @@ function KN_SystemCollectionListView({ collection, pushToast, onClose, titleBar 
           <div style={{ marginLeft: "auto", display: "flex", gap: 6 }}>
             <Btn size="sm" kind="ghost" icon="chevron-left"
               disabled={!hasPrev || indexed.loading}
-              onClick={() => setOffset((o) => Math.max(0, o - PAGE_SIZE))}>Prev</Btn>
+              onClick={indexed.prev}>Prev</Btn>
             <Btn size="sm" kind="ghost"
               disabled={!hasNext || indexed.loading}
-              onClick={() => setOffset((o) => o + PAGE_SIZE)}>Next <Icon name="chevron-right" size={12} /></Btn>
+              onClick={indexed.next}>Next <Icon name="chevron-right" size={12} /></Btn>
             <Btn kind="ghost" onClick={onClose}>Close</Btn>
           </div>
         </div>

--- a/ui/components/providers.jsx
+++ b/ui/components/providers.jsx
@@ -259,18 +259,20 @@ function ProvidersPage({ kind: kindProp, pushToast }) {
 // ============================================================================
 
 function ProvidersList({ kindProp, pushToast }) {
-  const { apiFetch, useResource, useViewport } = window.primerApi;
+  const { useViewport, usePagedList, Pager } = window.primerApi;
   const k = KINDS[kindProp];
   const { isMobile } = useViewport();
-  const list = useResource(
-    `providers:${k.plural}`,
-    (s) => apiFetch("GET", "/" + k.plural + "?limit=200", null, { signal: s }),
-    {},
-  );
   const [createOpen, setCreateOpen] = React.useState(false);
   const [textFilter, setTextFilter] = React.useState("");
+  // Server-side offset pagination (bug #19); filter narrows the current page.
+  const list = usePagedList({
+    key: `providers:${k.plural}`,
+    path: "/" + k.plural,
+    pageSize: 50,
+    resetKey: textFilter,
+  });
 
-  const items = list.data?.items ?? [];
+  const items = list.items;
   const filtered = items.filter((p) => !textFilter || (p.id || "").toLowerCase().includes(textFilter.toLowerCase()));
 
   const navigateDetail = (id) => { window.location.hash = "#/providers/" + k.segment + "/" + encodeURIComponent(id); };
@@ -372,6 +374,8 @@ function ProvidersList({ kindProp, pushToast }) {
         </table>
       </div>
       )}
+
+      <Pager pager={list} label="providers" />
 
       {isMobile && (
         <Fab icon="plus" label="New provider" onClick={() => setCreateOpen(true)} />

--- a/ui/components/semantic-search.jsx
+++ b/ui/components/semantic-search.jsx
@@ -43,7 +43,7 @@ function _sspAgeSec(iso) {
 // ----------------------------------------------------------------------
 
 function SSPListPage({ onOpen, pushToast }) {
-  const { useResource, useRouter, useViewport, apiFetch } = window.primerApi;
+  const { useRouter, useViewport, usePagedList, Pager } = window.primerApi;
   const { navigate } = useRouter();
   const { isMobile } = useViewport();
 
@@ -52,13 +52,18 @@ function SSPListPage({ onOpen, pushToast }) {
   const [backendFilter, setBackendFilter] = React.useState("");
   const filterFocused = React.useRef(false);
 
-  const list = useResource(
-    SSP_CACHE_LIST,
-    (signal) => apiFetch("GET", "/ssp?limit=200", null, { signal }),
-    { pollMs: 5000, pauseWhile: () => filterFocused.current }
-  );
+  // Server-side offset pagination (bug #19); text + backend filters narrow
+  // the current page and reset to page 0 via resetKey.
+  const list = usePagedList({
+    key: SSP_CACHE_LIST,
+    path: "/ssp",
+    pageSize: 50,
+    pollMs: 5000,
+    pauseWhile: () => filterFocused.current,
+    resetKey: textQuery + "|" + backendFilter,
+  });
 
-  const items = Array.isArray(list.data?.items) ? list.data.items : [];
+  const items = list.items;
 
   const filtered = React.useMemo(() => {
     let arr = items;
@@ -215,6 +220,7 @@ function SSPListPage({ onOpen, pushToast }) {
             </table>
           </div>
         )}
+        <Pager pager={list} label="providers" />
       </div>
       {modal}
     </>

--- a/ui/components/shared/pager.jsx
+++ b/ui/components/shared/pager.jsx
@@ -1,0 +1,192 @@
+/* global React, Icon, Btn */
+
+// Shared, reusable pagination primitive for the console's list/table views.
+//
+// The backend list endpoints already paginate: they accept `?limit=&offset=`
+// and return an OffsetPageResponse — `{ kind:"offset", offset, length,
+// total (nullable), items:[...] }`. Historically the UI fetched a hard
+// `limit=200` and dumped everything with no controls; this module replaces
+// that with a real offset pager.
+//
+// Two exports (both on window for the no-build shared global scope):
+//   usePagedList({ key, path, pageSize, pollMs, params, resetKey }) -> state
+//   <Pager pager={...} label="agents" />                            -> control
+//
+// `total` may be null (backends that can't count cheaply). When it is, we
+// infer "has next" from a full page: a page that came back full (length ===
+// pageSize) MIGHT have more behind it, so Next stays enabled; a short page
+// is definitively the last one.
+
+(function () {
+  const { useState, useEffect, useMemo, useCallback } = window.React;
+
+  const DEFAULT_PAGE_SIZE = 50;
+
+  function _appendQuery(path, limit, offset, params) {
+    const parts = ["limit=" + limit, "offset=" + offset];
+    if (params && typeof params === "object") {
+      for (const k of Object.keys(params)) {
+        const v = params[k];
+        if (v === null || v === undefined || v === "") continue;
+        parts.push(encodeURIComponent(k) + "=" + encodeURIComponent(v));
+      }
+    }
+    return path + (path.indexOf("?") >= 0 ? "&" : "?") + parts.join("&");
+  }
+
+  // usePagedList — owns limit/offset for a single server-paginated list and
+  // wraps window.primerApi.useResource so callers keep the same polling,
+  // dedupe and stale-while-error behaviour they already rely on.
+  //
+  // opts:
+  //   key       cache key base (required, e.g. "agents:list")
+  //   path      list path base (required, e.g. "/agents"); extra query allowed
+  //   pageSize  rows per page (default 50, server caps at 200)
+  //   pollMs    optional poll cadence forwarded to useResource
+  //   params    optional extra query params object ({} filters/scopes)
+  //   resetKey  when this changes, offset snaps back to page 0 (filters/chips)
+  //
+  // Returns: { items, total, data, loading, error, refetch, offset, pageSize,
+  //            page, hasNext, hasPrev, rangeStart, rangeEnd, next, prev,
+  //            reset, setOffset }.
+  function usePagedList(opts) {
+    const api = window.primerApi || {};
+    const useResource = api.useResource;
+    const apiFetch = api.apiFetch;
+    const pageSize = opts.pageSize || DEFAULT_PAGE_SIZE;
+    const params = opts.params || null;
+    const paramsKey = params ? JSON.stringify(params) : "";
+    const resetKey =
+      opts.resetKey && typeof opts.resetKey === "object"
+        ? JSON.stringify(opts.resetKey)
+        : opts.resetKey;
+
+    const [offset, setOffset] = useState(0);
+
+    // Reset to the first page whenever the caller's filter/search/chip
+    // selection changes. Skipped on first mount (offset already 0).
+    useEffect(() => {
+      setOffset(0);
+    }, [resetKey, pageSize, paramsKey]);
+
+    const url = useMemo(
+      () => _appendQuery(opts.path, pageSize, offset, params),
+      [opts.path, pageSize, offset, paramsKey] // eslint-disable-line
+    );
+
+    const res = useResource(
+      opts.key,
+      (signal) => apiFetch("GET", url, null, { signal }),
+      {
+        pollMs: opts.pollMs != null ? opts.pollMs : null,
+        pauseWhile: opts.pauseWhile,
+        deps: [offset, pageSize, paramsKey],
+      }
+    );
+
+    const data = res.data;
+    const items = data && Array.isArray(data.items) ? data.items : [];
+    const total =
+      data && typeof data.total === "number" ? data.total : null;
+
+    const hasPrev = offset > 0;
+    // total known → we're at the end once offset+returned reaches total.
+    // total unknown → a full page implies there may be more behind it.
+    const hasNext =
+      total != null
+        ? offset + items.length < total
+        : items.length >= pageSize;
+
+    const page = Math.floor(offset / pageSize);
+    const rangeStart = items.length === 0 ? 0 : offset + 1;
+    const rangeEnd = offset + items.length;
+
+    const next = useCallback(() => {
+      setOffset((o) => o + pageSize);
+    }, [pageSize]);
+    const prev = useCallback(() => {
+      setOffset((o) => Math.max(0, o - pageSize));
+    }, [pageSize]);
+    const reset = useCallback(() => setOffset(0), []);
+
+    return {
+      items,
+      total,
+      data,
+      loading: res.loading,
+      error: res.error,
+      refetch: res.refetch,
+      offset,
+      pageSize,
+      page,
+      hasNext,
+      hasPrev,
+      rangeStart,
+      rangeEnd,
+      next,
+      prev,
+      reset,
+      setOffset,
+    };
+  }
+
+  // Pager — Prev / range / Next control. Pass the object returned by
+  // usePagedList as `pager`. Renders nothing when there is no data and no
+  // navigation is possible, so single-request/empty pages stay clean.
+  //
+  // testids: pager (root), pager-range, pager-prev, pager-next.
+  function Pager(props) {
+    const p = props.pager;
+    const label = props.label || "";
+    const className = props.className || "";
+    if (!p) return null;
+
+    const count = p.items ? p.items.length : 0;
+    // Nothing to show and nowhere to go — don't render an empty control.
+    if (count === 0 && !p.hasPrev && !p.hasNext) return null;
+
+    const rangeText =
+      p.total != null
+        ? p.rangeStart + "–" + p.rangeEnd + " of " + p.total
+        : count === 0
+          ? "0"
+          : p.rangeStart + "–" + p.rangeEnd;
+
+    return (
+      <div className={"list-pager " + className} data-testid="pager">
+        <span className="pager-range muted text-sm" data-testid="pager-range">
+          {rangeText}
+          {label ? " " + label : ""}
+        </span>
+        <div className="pager-controls">
+          <Btn
+            size="sm"
+            kind="ghost"
+            icon="chevron-left"
+            disabled={!p.hasPrev || (p.loading && count === 0)}
+            onClick={p.prev}
+            data-testid="pager-prev"
+          >
+            Prev
+          </Btn>
+          <Btn
+            size="sm"
+            kind="ghost"
+            iconRight="chevron-right"
+            disabled={!p.hasNext || (p.loading && count === 0)}
+            onClick={p.next}
+            data-testid="pager-next"
+          >
+            Next
+          </Btn>
+        </div>
+      </div>
+    );
+  }
+
+  window.usePagedList = usePagedList;
+  window.Pager = Pager;
+  const ns = (window.primerApi = window.primerApi || {});
+  ns.usePagedList = usePagedList;
+  ns.Pager = Pager;
+})();

--- a/ui/components/triggers.jsx
+++ b/ui/components/triggers.jsx
@@ -169,34 +169,21 @@ function TR_TriggersPage({ triggerId }) {
 const TR_PAGE_SIZE = 25;
 
 function TR_TriggerList() {
-  const { useResource, useRouter, apiFetch } = window.primerApi;
+  const { useRouter, usePagedList, Pager } = window.primerApi;
   const { navigate } = useRouter();
   const [createOpen, setCreateOpen] = React.useState(false);
-  const [page, setPage] = React.useState(0);
 
-  const list = useResource(
-    "triggers:list",
-    (signal) => apiFetch("GET", "/triggers", null, { signal }),
-    { pollMs: 5000 },
-  );
+  // Server-side offset pagination (bug #19). Replaces the client-side slice
+  // over a default-limit /triggers fetch, which silently capped the visible
+  // list at the server's default page size.
+  const list = usePagedList({
+    key: "triggers:list",
+    path: "/triggers",
+    pageSize: TR_PAGE_SIZE,
+    pollMs: 5000,
+  });
 
-  const items = list.data?.items ?? [];
-
-  // Client-side windowing - the list endpoint returns the full set, so we
-  // slice locally and expose Prev/Next controls for visual parity with the
-  // other paginated console list pages.
-  const total = items.length;
-  const pages = Math.max(1, Math.ceil(total / TR_PAGE_SIZE));
-  const safePage = Math.min(page, pages - 1);
-  const start = safePage * TR_PAGE_SIZE;
-  const rows = items.slice(start, start + TR_PAGE_SIZE);
-  const from = total === 0 ? 0 : start + 1;
-  const to = start + rows.length;
-
-  // Clamp back into range if the set shrinks (delete) under us.
-  React.useEffect(() => {
-    if (page > pages - 1) setPage(pages - 1);
-  }, [page, pages]);
+  const items = list.items;
 
   const onCreated = (trigger) => {
     setCreateOpen(false);
@@ -258,7 +245,7 @@ function TR_TriggerList() {
               </tr>
             </thead>
             <tbody>
-              {rows.map((t) => (
+              {items.map((t) => (
                 <TR_TriggerRow
                   key={t.id}
                   trigger={t}
@@ -268,16 +255,10 @@ function TR_TriggerList() {
               ))}
             </tbody>
           </table>
-          <div className="tbl-foot">
-            <span className="tabular">Showing <strong style={{ color: "var(--text)" }}>{from}</strong>–<strong style={{ color: "var(--text)" }}>{to}</strong> of <strong style={{ color: "var(--text)" }}>{total}</strong></span>
-            <div className="pager">
-              <button disabled={safePage === 0} onClick={() => setPage(safePage - 1)}><Icon name="chevron-left" size={12} /></button>
-              <span className="muted text-sm tabular" style={{ padding: "0 8px" }}>Page {safePage + 1} of {pages}</span>
-              <button disabled={safePage + 1 >= pages} onClick={() => setPage(safePage + 1)}><Icon name="chevron-right" size={12} /></button>
-            </div>
-          </div>
         </div>
       )}
+
+      <Pager pager={list} label="triggers" />
 
       {createOpen && (
         <TR_CreateTriggerDialog

--- a/ui/components/workspaces.jsx
+++ b/ui/components/workspaces.jsx
@@ -53,7 +53,7 @@ function _wsToastErr(pushToast, fallbackTitle) {
 // ============================================================================
 
 function WorkspacesPage({ onOpen, pushToast }) {
-  const { useResource, useRouter, useViewport, apiFetch } = window.primerApi;
+  const { useRouter, useViewport, usePagedList, Pager } = window.primerApi;
   const { navigate } = useRouter();
   const { isMobile } = useViewport();
 
@@ -64,13 +64,18 @@ function WorkspacesPage({ onOpen, pushToast }) {
   const [providerFilter, setProviderFilter] = React.useState("");
   const filterFocused = React.useRef(false);
 
-  const list = useResource(
-    "workspaces:list",
-    (signal) => apiFetch("GET", "/workspaces?limit=200", null, { signal }),
-    { pollMs: 5000, pauseWhile: () => filterFocused.current }
-  );
+  // Server-side offset pagination (bug #19); the text/template/provider
+  // filters narrow the current page and reset to page 0 via resetKey.
+  const list = usePagedList({
+    key: "workspaces:list",
+    path: "/workspaces",
+    pageSize: 50,
+    pollMs: 5000,
+    pauseWhile: () => filterFocused.current,
+    resetKey: textQuery + "|" + templateFilter + "|" + providerFilter,
+  });
 
-  const items = list.data?.items ?? [];
+  const items = list.items;
 
   const filtered = React.useMemo(() => {
     let arr = items;
@@ -234,6 +239,8 @@ function WorkspacesPage({ onOpen, pushToast }) {
           </table>
         </div>
       )}
+
+      <Pager pager={list} label="workspaces" />
 
       {isMobile && (
         <Fab icon="plus" label="New workspace" onClick={() => setCreateOpen(true)} />

--- a/ui/components/workspaces/providers.jsx
+++ b/ui/components/workspaces/providers.jsx
@@ -42,17 +42,19 @@ function _wpSummary(p) {
 }
 
 function WorkspaceProvidersPage({ pushToast }) {
-  const { useResource, useRouter, useViewport, apiFetch } = window.primerApi;
+  const { useRouter, useViewport, usePagedList, Pager } = window.primerApi;
   const { navigate } = useRouter();
   const { isMobile } = useViewport();
   const [createOpen, setCreateOpen] = React.useState(false);
 
-  const list = useResource(
-    WP_LIST_KEY,
-    (signal) => apiFetch("GET", "/workspace_providers?limit=200", null, { signal }),
-    { pollMs: 5000 }
-  );
-  const items = Array.isArray(list.data?.items) ? list.data.items : [];
+  // Server-side offset pagination (bug #19).
+  const list = usePagedList({
+    key: WP_LIST_KEY,
+    path: "/workspace_providers",
+    pageSize: 50,
+    pollMs: 5000,
+  });
+  const items = list.items;
 
   const modal = createOpen ? (
     <WorkspaceProviderCreateModal
@@ -130,6 +132,7 @@ function WorkspaceProvidersPage({ pushToast }) {
             </table>
           </div>
         )}
+        <Pager pager={list} label="providers" />
         {isMobile && (
           <Fab icon="plus" label="New provider" onClick={() => setCreateOpen(true)} />
         )}

--- a/ui/components/workspaces/templates.jsx
+++ b/ui/components/workspaces/templates.jsx
@@ -51,17 +51,19 @@ function _wtToastErr(pushToast, fallback) {
 }
 
 function WorkspaceTemplatesPage({ pushToast }) {
-  const { useResource, useRouter, useViewport, apiFetch } = window.primerApi;
+  const { useRouter, useViewport, usePagedList, Pager } = window.primerApi;
   const { navigate } = useRouter();
   const { isMobile } = useViewport();
   const [createOpen, setCreateOpen] = React.useState(false);
 
-  const list = useResource(
-    WT_LIST_KEY,
-    (signal) => apiFetch("GET", "/workspace_templates?limit=200", null, { signal }),
-    { pollMs: 5000 }
-  );
-  const items = Array.isArray(list.data?.items) ? list.data.items : [];
+  // Server-side offset pagination (bug #19).
+  const list = usePagedList({
+    key: WT_LIST_KEY,
+    path: "/workspace_templates",
+    pageSize: 50,
+    pollMs: 5000,
+  });
+  const items = list.items;
 
   const modal = createOpen ? (
     <WorkspaceTemplateCreateModal
@@ -143,6 +145,7 @@ function WorkspaceTemplatesPage({ pushToast }) {
             </table>
           </div>
         )}
+        <Pager pager={list} label="templates" />
         {isMobile && (
           <Fab icon="plus" label="New template" onClick={() => setCreateOpen(true)} />
         )}

--- a/ui/docs-embed-spike.html
+++ b/ui/docs-embed-spike.html
@@ -35,7 +35,7 @@
 // /v1/user_docs/_fixtures/<name>.json). This is the committed fixture
 // primer/user_docs/_fixtures/agents-page.json, verbatim.
 const AGENTS_FIXTURE = {
-  "GET /agents?limit=200&offset=0": {
+  "GET /agents?limit=50&offset=0": {
     "kind": "offset", "offset": 0, "length": 1, "total": 1,
     "items": [{
       "id": "weekly-digest",

--- a/ui/index.html
+++ b/ui/index.html
@@ -77,6 +77,7 @@
 
 <!-- Shared components first (Icon/Btn/Modal etc.) + mock data + unused helper -->
 <script type="text/babel" src="components/shared.jsx"></script>
+<script type="text/babel" src="components/shared/pager.jsx"></script>
 <script type="text/babel" src="components/session-state.jsx"></script>
 <script type="text/babel" src="components/shared/token-meter.jsx"></script>
 <script type="text/babel" src="components/shared/card-list.jsx"></script>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -986,6 +986,25 @@ input, textarea, select { font: inherit; color: inherit; }
   align-items: center;
   margin-bottom: 14px;
 }
+
+/* Shared pagination control (components/shared/pager.jsx). Sits below a
+   table/list; keeps the range readout left and the Prev/Next buttons right.
+   Named `.list-pager` (not `.pager`) so it never collides with the older
+   hand-rolled `.tbl-foot .pager` markup still present on a few pages. */
+.list-pager {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+.list-pager .pager-range { flex: 0 0 auto; }
+.list-pager .pager-controls {
+  margin-left: auto;
+  display: flex;
+  gap: 6px;
+  flex: 0 0 auto;
+}
 .filter-bar .input-icon { flex: 0 0 auto; }
 .filter-bar .input-icon .input { width: 160px; min-width: 0; }
 .filter-bar .select { padding: 4px 22px 4px 8px; font-size: 12px; max-width: 120px; }


### PR DESCRIPTION
## Table pagination across the console (#19 + FE-review §2/N-list)

Field-test bug #19: "The agents page is not paginated, ideally every table view should be paginated." The backend list endpoints already paginate (`OffsetPageResponse`, `limit`/`offset`); the UI just fetched a hard `limit=200` and dumped everything. This adds a shared pagination primitive and applies it across the standalone list pages.

**Shared primitive** — `ui/components/shared/pager.jsx`: `usePagedList({path, pageSize})` managing `limit`/`offset` (detects "has next" from a full page when `total` is absent, resets to page 0 on filter/search change) + a `<Pager>` control (Prev/Next, "1–N of M" range). testids `pager`, `pager-prev`, `pager-next`, `pager-range`.

**Applied to** (grouped commits): agents, graphs (list), chats, providers (compute) · triggers, harnesses, channels (comms) · knowledge, semantic-search, workspaces + workspace providers/templates. Pages whose lists are already bounded/not offset-paginated were left as-is.

Tests: `tests/ui/test_pagination.py` (primitive exists + registered, testids, representative pages wired); full `tests/ui` 513 green; ruff clean.
