### PR TITLE
fix(backend): review Wave A — matrix guards, chat-drain O(suffix), PTY queue bound, os.write (4/5)

### DIFF
--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -367,6 +367,9 @@ def _make_lifespan(config: AppConfig):
 
         # --- Scheduler + worker pool wiring (Task 23) ----------------
         scheduler = None
+        # Set when the wired scheduler/runtime-mode combination is unsafe
+        # (surfaced on /v1/health as SchedulerHealth.degraded). None = healthy.
+        app.state.scheduler_degraded_reason = None
         if scheduler_config is not None:
             from primer.scheduler.factory import SchedulerFactory
 
@@ -380,17 +383,30 @@ def _make_lifespan(config: AppConfig):
             # Loud warning: in-memory scheduler is single-process; running it
             # alongside any worker pool (whether colocated 'api+worker' or
             # separate 'worker' processes) means cross-process state is not
-            # synchronised — sessions can be double-claimed. Production should
-            # use the Postgres scheduler. See spec §9.1.
+            # synchronised — a lease armed in one process is invisible to
+            # another, and parked rows flipped to 'resumable' in shared storage
+            # are never re-claimed. Sessions can be double-claimed or silently
+            # stranded. Production should use the Postgres scheduler. See spec
+            # §9.1. We both log loudly AND surface the condition on /v1/health
+            # (SchedulerHealth.degraded) so a misconfigured deployment is
+            # observable, not just buried in boot logs. There is no
+            # strict/fail-fast config knob today, so this stays a degraded
+            # signal rather than a hard ConfigError; add one here if a strict
+            # mode is introduced.
             if (
                 scheduler_config.provider == SchedulerProviderType.IN_MEMORY
                 and config.runtime_mode != RuntimeMode.API
             ):
-                logger.warning(
-                    "in-memory scheduler with runtime_mode=%s is not safe for "
-                    "multi-worker deployment; switch to Postgres for production",
-                    config.runtime_mode.value,
+                degraded_reason = (
+                    "in-memory scheduler with runtime_mode="
+                    f"{config.runtime_mode.value} is not safe for multi-process "
+                    "or external-worker deployment: each process has its own "
+                    "claim engine, so leases and resumable parks are not shared "
+                    "across processes. Switch to the Postgres scheduler for any "
+                    "topology beyond a single process."
                 )
+                logger.warning("scheduler degraded: %s", degraded_reason)
+                app.state.scheduler_degraded_reason = degraded_reason
         app.state.scheduler = scheduler
 
         # --- Event bus + yield background tasks (M2/M3) -------------

--- a/primer/api/routers/health.py
+++ b/primer/api/routers/health.py
@@ -31,6 +31,22 @@ class SchedulerHealth(BaseModel):
         ...,
         description="True when the API process has a live Scheduler instance.",
     )
+    degraded: bool = Field(
+        default=False,
+        description=(
+            "True when the wired scheduler/runtime-mode combination is "
+            "unsafe for the deployment topology (e.g. an in-memory "
+            "scheduler in a multi-process or external-worker mode, where "
+            "leases and resumable parks are not shared across processes)."
+        ),
+    )
+    degraded_reason: str | None = Field(
+        default=None,
+        description=(
+            "Human-readable explanation of the degraded condition, or null "
+            "when the scheduler configuration is healthy."
+        ),
+    )
     metrics: dict[str, Any] = Field(
         default_factory=dict,
         description=(
@@ -91,6 +107,9 @@ class HealthStatus(BaseModel):
 async def health(request: Request) -> HealthStatus:
     scheduler = getattr(request.app.state, "scheduler", None)
     worker_pool = getattr(request.app.state, "worker_pool", None)
+    degraded_reason = getattr(
+        request.app.state, "scheduler_degraded_reason", None
+    )
 
     sched_metrics: dict[str, Any] = {}
     if scheduler is not None:
@@ -116,6 +135,8 @@ async def health(request: Request) -> HealthStatus:
         version=APP_VERSION,
         scheduler=SchedulerHealth(
             alive=scheduler is not None,
+            degraded=degraded_reason is not None,
+            degraded_reason=degraded_reason,
             metrics=sched_metrics,
         ),
         worker_pool=WorkerPoolHealth(

--- a/primer/chat/dispatch.py
+++ b/primer/chat/dispatch.py
@@ -553,15 +553,27 @@ async def _read_messages_from_cursor(
 ) -> list[ChatMessage]:
     """Read every ChatMessage with ``seq >= cursor`` in ascending seq order.
 
-    Pages internally (window of 200) so memory stays bounded. Filtering
-    by ``seq >= cursor`` is applied in-process to keep the storage query
-    backend-agnostic; the cursor still bounds how far back the page walk
-    can start mattering, and skipped pages are cheap reads. When the
-    cursor is 0 this returns every row, identical to the old full scan.
+    The ``seq >= cursor`` bound is pushed into the storage predicate (an
+    ``Op.GE`` clause AND-ed with the ``chat_id`` match) so the scan is
+    O(suffix): only rows at or after the drain cursor are ever read from
+    storage. Previously this paged from ``offset=0`` over the entire chat
+    history and discarded ``seq < cursor`` rows in Python, costing O(N)
+    reads on every drain regardless of how much was already processed.
+
+    Pages internally (window of 200) so memory stays bounded. When the
+    cursor is 0 the ``seq >= 0`` clause matches every row (``seq`` starts
+    at 1), identical to the old full scan.
     """
     pred = Predicate(
-        left=FieldRef(name="chat_id"), op=Op.EQ,
-        right=Value(value=chat_id),
+        left=Predicate(
+            left=FieldRef(name="chat_id"), op=Op.EQ,
+            right=Value(value=chat_id),
+        ),
+        op=Op.AND,
+        right=Predicate(
+            left=FieldRef(name="seq"), op=Op.GE,
+            right=Value(value=cursor),
+        ),
     )
     out: list[ChatMessage] = []
     offset = 0
@@ -571,9 +583,7 @@ async def _read_messages_from_cursor(
             pred, OffsetPage(offset=offset, length=PAGE),
             order_by=[OrderBy(field="seq", direction="asc")],
         )
-        for row in page.items:
-            if row.seq >= cursor:
-                out.append(row)
+        out.extend(page.items)
         if len(page.items) < PAGE:
             break
         offset += PAGE

--- a/primer/scheduler/factory.py
+++ b/primer/scheduler/factory.py
@@ -47,6 +47,23 @@ class SchedulerFactory:
                     "Postgres scheduler requires a StorageProvider to "
                     "share its connection pool"
                 )
+            # The Postgres scheduler reaches into ``storage_provider.pool``
+            # (an asyncpg pool) throughout ``initialize()`` and every claim
+            # query. Only ``PostgresStorageProvider`` exposes that pool; a
+            # SQLite (or any non-Postgres) provider would AttributeError deep
+            # inside ``initialize()``. Reject the misconfiguration here at the
+            # single wiring choke point with a clear message instead.
+            from primer.storage.postgres import PostgresStorageProvider
+
+            if not isinstance(storage_provider, PostgresStorageProvider):
+                raise ConfigError(
+                    "Postgres scheduler requires a Postgres storage provider "
+                    "(it shares the asyncpg connection pool), but the "
+                    f"configured storage provider is "
+                    f"{type(storage_provider).__name__}. Either switch the "
+                    "storage backend to Postgres or use the in-memory "
+                    "scheduler."
+                )
             from primer.scheduler.postgres import PostgresScheduler
 
             return PostgresScheduler(

--- a/primer/tap/router.py
+++ b/primer/tap/router.py
@@ -31,6 +31,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from collections import OrderedDict
 from collections.abc import AsyncIterator
 from dataclasses import dataclass
 from typing import TYPE_CHECKING
@@ -96,6 +97,10 @@ class WorkspaceTapRouter:
     (cached) and fanned to every subscriber for that workspace.
     """
 
+    #: Max entries in the sid->wid LRU cache before least-recently-used
+    #: eviction. Bounds memory in a long-lived process; sid/wid are tiny.
+    _WID_CACHE_MAX = 8192
+
     def __init__(
         self,
         event_bus: "EventBus",
@@ -105,8 +110,10 @@ class WorkspaceTapRouter:
         self._sessions = session_storage
         # workspace_id -> set of subscriber queues
         self._subs: dict[str, set[asyncio.Queue[WorkspaceTick]]] = {}
-        # sid -> wid resolution cache (refresh-on-miss from storage)
-        self._wid_by_sid: dict[str, str] = {}
+        # sid -> wid resolution cache (refresh-on-miss from storage). Bounded
+        # LRU: one entry per session id ever ticked would otherwise leak in a
+        # long-lived process. sid/wid are tiny strings, so the cap is generous.
+        self._wid_by_sid: OrderedDict[str, str] = OrderedDict()
         self._sub = None
         self._task: asyncio.Task[None] | None = None
 
@@ -203,6 +210,7 @@ class WorkspaceTapRouter:
         """
         cached = self._wid_by_sid.get(sid)
         if cached is not None:
+            self._wid_by_sid.move_to_end(sid)  # LRU: mark recently used
             return cached
         session = await self._sessions.get(sid)
         if session is None:
@@ -213,6 +221,9 @@ class WorkspaceTapRouter:
             return None
         wid = session.workspace_id
         self._wid_by_sid[sid] = wid
+        self._wid_by_sid.move_to_end(sid)
+        while len(self._wid_by_sid) > self._WID_CACHE_MAX:
+            self._wid_by_sid.popitem(last=False)  # evict least-recently-used
         return wid
 
     def _publish(self, workspace_id: str, tick: WorkspaceTick) -> None:

--- a/primer/workspace/local/pty_host.py
+++ b/primer/workspace/local/pty_host.py
@@ -207,13 +207,28 @@ class LocalPtySession:
             yield chunk
 
     async def write(self, data: bytes) -> None:
-        """Write *data* (browser stdin) to the pty master."""
+        """Write *data* (browser stdin) to the pty master.
+
+        ``os.write`` can accept fewer bytes than supplied when the pty input
+        buffer is full (a large paste), so loop over the remainder — the old
+        single call silently lost the tail. ``BlockingIOError`` (only on a
+        non-blocking fd) means "buffer full, retry"; ``OSError`` means the pty
+        is gone (child exited) so we drop the write.
+        """
         if self._master_fd is None or self._finalized:
             return
-        try:
-            os.write(self._master_fd, data)
-        except OSError:
-            pass
+        mv = memoryview(data)
+        while mv:
+            try:
+                written = os.write(self._master_fd, mv)
+            except BlockingIOError:
+                await asyncio.sleep(0)
+                continue
+            except OSError:
+                return
+            if written <= 0:
+                return
+            mv = mv[written:]
 
     async def resize(self, cols: int, rows: int) -> None:
         """Change the terminal window size."""

--- a/primer/workspace/local/pty_host.py
+++ b/primer/workspace/local/pty_host.py
@@ -36,6 +36,41 @@ logger = logging.getLogger(__name__)
 
 _READ_CHUNK = 65536
 
+# High-water mark for the master-fd -> WebSocket output queue. Each chunk is
+# up to ``_READ_CHUNK`` (64 KiB), so this caps buffered terminal output at
+# ~16 MiB. A runaway child (``yes``, a chatty build) paired with a slow or
+# blocked WebSocket consumer would otherwise grow the queue without bound.
+# When the cap is hit we drop the OLDEST buffered chunk (see
+# ``_enqueue_output``) — losing the stalest terminal output is the acceptable
+# degradation. Mirrors ``primer_runtime.pty_op``.
+_OUTPUT_QUEUE_MAX_CHUNKS = 256
+
+
+def _enqueue_output(queue: "asyncio.Queue[bytes]", data: bytes) -> bool:
+    """Put *data* on the bounded output *queue*, dropping the OLDEST buffered
+    chunk when the queue is already at its high-water mark.
+
+    Returns ``True`` iff a chunk was dropped. Drop-oldest keeps memory bounded
+    when a slow/blocked WebSocket consumer can't keep up with a runaway child.
+    The empty EOF sentinel is never starved out: a slot is always freed before
+    the re-put, so the terminating ``b""`` always lands.
+    """
+    try:
+        queue.put_nowait(data)
+        return False
+    except asyncio.QueueFull:
+        dropped = False
+        try:
+            queue.get_nowait()
+            dropped = True
+        except asyncio.QueueEmpty:
+            pass
+        try:
+            queue.put_nowait(data)
+        except asyncio.QueueFull:
+            pass
+        return dropped
+
 
 def _default_shell() -> list[str]:
     """Return the argv for a login shell: ``$SHELL`` → bash → sh, ``-l``."""
@@ -95,7 +130,10 @@ class LocalPtySession:
 
         self._master_fd: int | None = None
         self._proc: asyncio.subprocess.Process | None = None
-        self._queue: asyncio.Queue[bytes] = asyncio.Queue()
+        self._queue: asyncio.Queue[bytes] = asyncio.Queue(
+            maxsize=_OUTPUT_QUEUE_MAX_CHUNKS
+        )
+        self._dropped_chunks = 0
         self._exit_code: int | None = None
         self._started = False
         self._finalized = False
@@ -146,8 +184,15 @@ class LocalPtySession:
                 data = os.read(master_fd, _READ_CHUNK)
             except OSError:
                 data = b""  # EIO on Linux after the child exits == EOF
-            self._queue.put_nowait(data)
+            if _enqueue_output(self._queue, data):
+                self._dropped_chunks += 1
             if not data:
+                if self._dropped_chunks:
+                    logger.warning(
+                        "local pty dropped %d output chunk(s): consumer "
+                        "could not keep up (queue capped at %d chunks)",
+                        self._dropped_chunks, _OUTPUT_QUEUE_MAX_CHUNKS,
+                    )
                 loop.remove_reader(master_fd)
 
         loop.add_reader(master_fd, _on_readable)

--- a/runtime/primer_runtime/pty_op.py
+++ b/runtime/primer_runtime/pty_op.py
@@ -147,15 +147,28 @@ class PtySession:
         self._closed = False
 
     def write_stdin(self, data: bytes) -> None:
-        """Write *data* to the master fd (child stdin)."""
+        """Write *data* to the master fd (child stdin).
+
+        ``os.write`` can accept fewer bytes than supplied when the pty input
+        buffer is full (a large paste), so loop over the remainder — the old
+        single call silently lost the tail. ``BlockingIOError`` (only on a
+        non-blocking fd) means "buffer full, retry"; ``OSError`` means the pty
+        is gone (child exited between frames) so we drop the write and let the
+        reader task emit ``exit`` and self-deregister.
+        """
         if self._closed:
             return
-        try:
-            os.write(self.master_fd, data)
-        except OSError:
-            # The pty is gone (child exited between frames) — drop the write;
-            # the reader task will emit ``exit`` and self-deregister.
-            pass
+        mv = memoryview(data)
+        while mv:
+            try:
+                written = os.write(self.master_fd, mv)
+            except BlockingIOError:
+                continue
+            except OSError:
+                return
+            if written <= 0:
+                return
+            mv = mv[written:]
 
     def resize(self, cols: int, rows: int) -> None:
         """Change the terminal window size."""

--- a/runtime/primer_runtime/pty_op.py
+++ b/runtime/primer_runtime/pty_op.py
@@ -65,6 +65,41 @@ log = logging.getLogger(__name__)
 
 _READ_CHUNK = 65536
 
+# High-water mark for the master-fd -> WebSocket output queue. Each chunk is
+# up to ``_READ_CHUNK`` (64 KiB), so this caps buffered terminal output at
+# ~16 MiB. A runaway child (``yes``, a chatty build) paired with a slow or
+# blocked WebSocket consumer would otherwise grow the queue without bound.
+# When the cap is hit we drop the OLDEST buffered chunk (see
+# ``_enqueue_output``) — losing the stalest terminal output is the acceptable
+# degradation.
+_OUTPUT_QUEUE_MAX_CHUNKS = 256
+
+
+def _enqueue_output(queue: "asyncio.Queue[bytes]", data: bytes) -> bool:
+    """Put *data* on the bounded output *queue*, dropping the OLDEST buffered
+    chunk when the queue is already at its high-water mark.
+
+    Returns ``True`` iff a chunk was dropped. Drop-oldest keeps memory bounded
+    when a slow/blocked WebSocket consumer can't keep up with a runaway child.
+    The empty EOF sentinel is never starved out: a slot is always freed before
+    the re-put, so the terminating ``b""`` always lands.
+    """
+    try:
+        queue.put_nowait(data)
+        return False
+    except asyncio.QueueFull:
+        dropped = False
+        try:
+            queue.get_nowait()
+            dropped = True
+        except asyncio.QueueEmpty:
+            pass
+        try:
+            queue.put_nowait(data)
+        except asyncio.QueueFull:
+            pass
+        return dropped
+
 
 def _default_shell() -> list[str]:
     """Return the argv for a login shell: ``$SHELL`` → bash → sh, ``-l``."""
@@ -324,15 +359,26 @@ async def _run_pty(
     registry.add(session)
 
     loop = asyncio.get_running_loop()
-    queue: asyncio.Queue[bytes] = asyncio.Queue()
+    queue: asyncio.Queue[bytes] = asyncio.Queue(
+        maxsize=_OUTPUT_QUEUE_MAX_CHUNKS
+    )
+    dropped_chunks = 0
 
     def _on_readable() -> None:
+        nonlocal dropped_chunks
         try:
             data = os.read(master_fd, _READ_CHUNK)
         except OSError:
             data = b""  # EIO on Linux after the child exits == EOF
-        queue.put_nowait(data)
+        if _enqueue_output(queue, data):
+            dropped_chunks += 1
         if not data:
+            if dropped_chunks:
+                log.warning(
+                    "pty req_id=%d dropped %d output chunk(s): consumer "
+                    "could not keep up (queue capped at %d chunks)",
+                    req_id, dropped_chunks, _OUTPUT_QUEUE_MAX_CHUNKS,
+                )
             loop.remove_reader(master_fd)
 
     # Announce readiness, then start draining the master fd.

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -34,6 +34,31 @@ async def test_health_surfaces_scheduler_alive(client, app) -> None:
 
 
 @pytest.mark.asyncio
+async def test_health_scheduler_not_degraded_by_default(client) -> None:
+    """A healthy single-process wiring reports degraded=False."""
+    response = await client.get("/v1/health")
+    body = response.json()
+    assert body["scheduler"]["degraded"] is False
+    assert body["scheduler"]["degraded_reason"] is None
+
+
+@pytest.mark.asyncio
+async def test_health_surfaces_scheduler_degraded(app, client) -> None:
+    """When the wiring flags an unsafe scheduler/runtime-mode combo (e.g.
+    in-memory scheduler + external/multi-process worker), /v1/health surfaces
+    it via scheduler.degraded + scheduler.degraded_reason."""
+    reason = "in-memory scheduler with runtime_mode=worker is not safe"
+    app.state.scheduler_degraded_reason = reason
+    try:
+        response = await client.get("/v1/health")
+        body = response.json()
+        assert body["scheduler"]["degraded"] is True
+        assert body["scheduler"]["degraded_reason"] == reason
+    finally:
+        app.state.scheduler_degraded_reason = None
+
+
+@pytest.mark.asyncio
 async def test_health_surfaces_worker_pool_in_flight_capacity(client) -> None:
     """/v1/health includes worker_pool.in_flight + worker_pool.capacity.
 

--- a/tests/api/test_runtime_modes.py
+++ b/tests/api/test_runtime_modes.py
@@ -221,11 +221,14 @@ async def test_in_memory_scheduler_with_worker_mode_emits_warning(
         ),
     )
     app = create_app(cfg)
-    with caplog.at_level(logging.WARNING, logger="primer.api.app"):
+    # Capture at the root (the warning is emitted by the primer.api._app_lifespan
+    # logger, not primer.api.app) so the degraded-scheduler record is visible.
+    with caplog.at_level(logging.WARNING):
         async with app.router.lifespan_context(app):
             pass
     assert any(
-        "in-memory scheduler" in r.message and "multi-worker" in r.message
+        "in-memory scheduler" in r.message
+        and ("multi-process" in r.message or "external-worker" in r.message)
         for r in caplog.records
     )
 

--- a/tests/chat/test_dispatch_cursor_equivalence.py
+++ b/tests/chat/test_dispatch_cursor_equivalence.py
@@ -16,8 +16,10 @@ from primer.chat.dispatch import (
     ChatDispatchDeps,
     _find_next_user_message,
     _find_resume_reply,
+    _read_messages_from_cursor,
 )
 from primer.model.chats import Chat, ChatMessage
+from primer.model.storage import FieldRef, Op, Predicate
 
 
 def _deps(sp) -> ChatDispatchDeps:
@@ -140,6 +142,67 @@ async def test_multi_turn_index_equivalence(fake_storage_provider):
     await sp.get_storage(Chat).update(chat)
     picked_cursor = await _find_next_user_message(_deps(sp), "c4")
     assert picked_cursor is not None and picked_cursor.seq == 5
+
+
+# --- _read_messages_from_cursor push-down -----------------------------------
+
+
+def _find_ge_seq_clause(node, cursor: int) -> bool:
+    """True if the predicate tree contains a ``seq >= cursor`` GE clause."""
+    if not isinstance(node, Predicate):
+        return False
+    if (
+        node.op == Op.GE
+        and isinstance(node.left, FieldRef)
+        and node.left.name == "seq"
+        and getattr(node.right, "value", None) == cursor
+    ):
+        return True
+    return _find_ge_seq_clause(node.left, cursor) or _find_ge_seq_clause(
+        node.right, cursor
+    )
+
+
+@pytest.mark.asyncio
+async def test_read_from_cursor_reads_only_suffix(fake_storage_provider):
+    """``_read_messages_from_cursor`` pushes ``seq >= cursor`` into the storage
+    predicate, so storage only ever returns the suffix at/after the cursor --
+    not the full O(N) history it used to page through and filter in Python.
+    """
+    sp = fake_storage_provider
+    await _seed_chat(sp, "cbig", cursor=0)
+    for seq in range(1, 601):  # 600-message history
+        await _add(sp, "cbig", seq, "assistant_token", {"delta": "x"})
+    await _set_last_seq(sp, "cbig", 600)
+
+    msgs = sp.get_storage(ChatMessage)
+
+    captured_predicates: list = []
+    returned_seqs: list[int] = []
+    real_find = msgs.find
+
+    async def spy_find(predicate, page, *, order_by=None):
+        captured_predicates.append(predicate)
+        result = await real_find(predicate, page, order_by=order_by)
+        returned_seqs.extend(r.seq for r in result.items)
+        return result
+
+    msgs.find = spy_find  # type: ignore[assignment]
+
+    cursor = 550
+    rows = await _read_messages_from_cursor(msgs, "cbig", cursor)
+
+    # Behaviour: exactly the suffix in ascending order.
+    assert [r.seq for r in rows] == list(range(cursor, 601))
+
+    # Push-down: every find() carried the seq>=cursor GE clause, and storage
+    # therefore never handed back a single row below the cursor (the O(N)
+    # prefix is never read).
+    assert captured_predicates
+    assert all(_find_ge_seq_clause(p, cursor) for p in captured_predicates)
+    assert returned_seqs, "expected suffix rows to be read"
+    assert all(s >= cursor for s in returned_seqs)
+    assert len(returned_seqs) == 601 - cursor  # 51 rows read, not 600
 
 
 # --- _find_resume_reply -----------------------------------------------------

--- a/tests/runtime/test_pty_op.py
+++ b/tests/runtime/test_pty_op.py
@@ -253,6 +253,56 @@ async def test_output_queue_eof_sentinel_survives_full_queue() -> None:
     assert items[-1] == b""  # EOF landed at the tail
 
 
+def test_write_stdin_loops_over_short_writes(monkeypatch) -> None:
+    """A large stdin write is fully delivered even when os.write accepts only
+    a few bytes per call (BE7: loop over the remainder)."""
+    import os as _os
+
+    from primer_runtime.pty_op import PtySession
+
+    _SENTINEL_FD = 0x7FED_CAFE  # not a real fd; os.write is intercepted for it
+    real_write = _os.write
+    delivered = bytearray()
+    calls = 0
+
+    def fake_write(fd, buf):
+        nonlocal calls
+        if fd != _SENTINEL_FD:
+            return real_write(fd, buf)
+        calls += 1
+        chunk = bytes(buf[:4])  # accept at most 4 bytes per call
+        delivered.extend(chunk)
+        return len(chunk)
+
+    monkeypatch.setattr(_os, "write", fake_write)
+
+    session = PtySession(req_id=1, master_fd=_SENTINEL_FD, proc=None)  # type: ignore[arg-type]
+    payload = b"a-large-paste-exceeding-one-write-buffer" * 3
+    session.write_stdin(payload)
+
+    assert bytes(delivered) == payload
+    assert calls > 1  # actually looped, not a single write
+
+
+def test_write_stdin_drops_on_dead_pty(monkeypatch) -> None:
+    """OSError from os.write (dead pty) is swallowed, not raised."""
+    import os as _os
+
+    from primer_runtime.pty_op import PtySession
+
+    _SENTINEL_FD = 0x7FED_BEEF
+    real_write = _os.write
+
+    def fake_write(fd, buf):
+        if fd != _SENTINEL_FD:
+            return real_write(fd, buf)
+        raise OSError("pty gone")
+
+    monkeypatch.setattr(_os, "write", fake_write)
+    session = PtySession(req_id=2, master_fd=_SENTINEL_FD, proc=None)  # type: ignore[arg-type]
+    session.write_stdin(b"data")  # must not raise
+
+
 @pytest.mark.asyncio
 async def test_pty_cancel_all_terminates(tmp_path: Path) -> None:
     registry = PtyRegistry()

--- a/tests/runtime/test_pty_op.py
+++ b/tests/runtime/test_pty_op.py
@@ -203,6 +203,57 @@ async def test_pty_bad_workdir_reports_real_code_on_split_module_identity(
 
 
 @pytest.mark.asyncio
+async def test_output_queue_bounded_drop_oldest() -> None:
+    """The output queue never exceeds its cap under a flood; the OLDEST chunks
+    are dropped and the NEWEST are retained (bounded memory, fresh tail)."""
+    from primer_runtime.pty_op import (
+        _OUTPUT_QUEUE_MAX_CHUNKS,
+        _enqueue_output,
+    )
+
+    queue: asyncio.Queue[bytes] = asyncio.Queue(
+        maxsize=_OUTPUT_QUEUE_MAX_CHUNKS
+    )
+    total = _OUTPUT_QUEUE_MAX_CHUNKS * 4  # flood: 4x the cap
+    dropped = 0
+    for i in range(total):
+        if _enqueue_output(queue, i.to_bytes(4, "big")):
+            dropped += 1
+
+    # Never exceeded the cap...
+    assert queue.qsize() == _OUTPUT_QUEUE_MAX_CHUNKS
+    # ...and the overflow was reported as drops.
+    assert dropped == total - _OUTPUT_QUEUE_MAX_CHUNKS
+    # The retained chunks are the NEWEST suffix, in order.
+    drained = [queue.get_nowait() for _ in range(queue.qsize())]
+    expected = [
+        i.to_bytes(4, "big")
+        for i in range(total - _OUTPUT_QUEUE_MAX_CHUNKS, total)
+    ]
+    assert drained == expected
+
+
+@pytest.mark.asyncio
+async def test_output_queue_eof_sentinel_survives_full_queue() -> None:
+    """A full queue must still admit the empty EOF sentinel (else the drain
+    loop would hang), evicting one oldest chunk to make room."""
+    from primer_runtime.pty_op import (
+        _OUTPUT_QUEUE_MAX_CHUNKS,
+        _enqueue_output,
+    )
+
+    queue: asyncio.Queue[bytes] = asyncio.Queue(
+        maxsize=_OUTPUT_QUEUE_MAX_CHUNKS
+    )
+    for i in range(_OUTPUT_QUEUE_MAX_CHUNKS):
+        _enqueue_output(queue, i.to_bytes(4, "big"))
+    assert queue.full()
+    assert _enqueue_output(queue, b"") is True  # dropped one to fit the EOF
+    items = [queue.get_nowait() for _ in range(queue.qsize())]
+    assert items[-1] == b""  # EOF landed at the tail
+
+
+@pytest.mark.asyncio
 async def test_pty_cancel_all_terminates(tmp_path: Path) -> None:
     registry = PtyRegistry()
     frames: list[str] = []

--- a/tests/scheduler/test_factory.py
+++ b/tests/scheduler/test_factory.py
@@ -34,6 +34,29 @@ def test_factory_postgres_requires_storage_provider():
         SchedulerFactory.create(cfg, storage_provider=None)
 
 
+def test_factory_postgres_rejects_non_postgres_storage(tmp_path):
+    """Postgres scheduler + non-Postgres storage is a clean ConfigError.
+
+    The Postgres scheduler reaches into ``storage_provider.pool`` (asyncpg),
+    which SQLite storage does not expose. Guarding at the factory choke point
+    turns a deep AttributeError inside ``initialize()`` into a clear message.
+    """
+    from primer.model.scheduler import PostgresSchedulerConfig
+    from primer.storage.sqlite import SqliteConfig, SqliteStorageProvider
+
+    sqlite_provider = SqliteStorageProvider(
+        SqliteConfig(path=tmp_path / "s.sqlite")
+    )
+    cfg = SchedulerProviderConfig(
+        provider=SchedulerProviderType.POSTGRES,
+        config=PostgresSchedulerConfig(),
+    )
+    with pytest.raises(ConfigError) as exc:
+        SchedulerFactory.create(cfg, storage_provider=sqlite_provider)
+    # The message must name the offending storage provider type.
+    assert "SqliteStorageProvider" in str(exc.value)
+
+
 def test_factory_rejects_unknown():
     """Defensive: future provider type with no impl branch should raise."""
 

--- a/tests/tap/test_router.py
+++ b/tests/tap/test_router.py
@@ -189,3 +189,29 @@ async def test_aclose_is_idempotent_and_stops_consume_loop(
     # Second aclose must be a no-op (idempotent), like the bus + sub.
     await router.aclose()
     await bus.aclose()
+
+
+async def test_wid_cache_is_bounded_lru(fake_storage_provider) -> None:
+    """BE6: the sid->wid resolution cache evicts least-recently-used entries
+    instead of growing without bound in a long-lived process."""
+    bus = InMemoryEventBus()
+    router = WorkspaceTapRouter(
+        bus, fake_storage_provider.get_storage(WorkspaceSession)
+    )
+    router._WID_CACHE_MAX = 3  # shrink the cap for the test
+
+    for i in range(5):
+        await _seed(fake_storage_provider, _session(f"s{i}", "W"))
+        assert await router._resolve_wid(f"s{i}") == "W"
+
+    # Never exceeds the cap; the 3 most-recent survive, the 2 oldest evicted.
+    assert len(router._wid_by_sid) <= 3
+    assert set(router._wid_by_sid) == {"s2", "s3", "s4"}
+
+    # A cache HIT on s3 makes it most-recent, so s2 becomes least-recently-used;
+    # the next insert (s5) then evicts s2, not s3. Cache order is now
+    # [s2, s4, s3] -> insert s5 -> evict s2 -> {s3, s4, s5}.
+    assert await router._resolve_wid("s3") == "W"
+    await _seed(fake_storage_provider, _session("s5", "W"))
+    assert await router._resolve_wid("s5") == "W"
+    assert set(router._wid_by_sid) == {"s3", "s4", "s5"}

--- a/tests/workspace/test_pty_host.py
+++ b/tests/workspace/test_pty_host.py
@@ -1,12 +1,15 @@
-"""Unit tests for the local-workspace PTY host (BE3 bounded output queue).
+"""Unit tests for the local-workspace PTY host (BE3 bounded output queue,
+BE7 write remainder loop).
 
-These exercise the pure helpers directly — no real pseudo-terminal is
-spawned — so they run on every platform.
+These exercise the pure helpers / methods directly — no real pseudo-terminal
+is spawned — so they run on every platform.
 """
 
 from __future__ import annotations
 
 import asyncio
+
+import pytest
 
 from primer.workspace.local.pty_host import (
     _OUTPUT_QUEUE_MAX_CHUNKS,
@@ -48,3 +51,57 @@ def test_output_queue_eof_sentinel_survives_full_queue() -> None:
     assert _enqueue_output(queue, b"") is True
     items = [queue.get_nowait() for _ in range(queue.qsize())]
     assert items[-1] == b""
+
+
+@pytest.mark.asyncio
+async def test_write_loops_over_short_writes(tmp_path, monkeypatch) -> None:
+    """A large stdin write is fully delivered even when os.write accepts only
+    a few bytes per call (BE7: loop over the remainder)."""
+    import os as _os
+
+    from primer.workspace.local.pty_host import LocalPtySession
+
+    _SENTINEL_FD = 0x7FED_1234
+    real_write = _os.write
+    delivered = bytearray()
+    calls = 0
+
+    def fake_write(fd, buf):
+        nonlocal calls
+        if fd != _SENTINEL_FD:
+            return real_write(fd, buf)
+        calls += 1
+        chunk = bytes(buf[:4])
+        delivered.extend(chunk)
+        return len(chunk)
+
+    monkeypatch.setattr(_os, "write", fake_write)
+
+    session = LocalPtySession(root=tmp_path)
+    session._master_fd = _SENTINEL_FD  # bypass a real pty
+    payload = b"a-large-paste-exceeding-one-write-buffer" * 3
+    await session.write(payload)
+
+    assert bytes(delivered) == payload
+    assert calls > 1
+
+
+@pytest.mark.asyncio
+async def test_write_drops_on_dead_pty(tmp_path, monkeypatch) -> None:
+    """OSError from os.write (dead pty) is swallowed, not raised."""
+    import os as _os
+
+    from primer.workspace.local.pty_host import LocalPtySession
+
+    _SENTINEL_FD = 0x7FED_5678
+    real_write = _os.write
+
+    def fake_write(fd, buf):
+        if fd != _SENTINEL_FD:
+            return real_write(fd, buf)
+        raise OSError("pty gone")
+
+    monkeypatch.setattr(_os, "write", fake_write)
+    session = LocalPtySession(root=tmp_path)
+    session._master_fd = _SENTINEL_FD
+    await session.write(b"data")  # must not raise

--- a/tests/workspace/test_pty_host.py
+++ b/tests/workspace/test_pty_host.py
@@ -1,0 +1,50 @@
+"""Unit tests for the local-workspace PTY host (BE3 bounded output queue).
+
+These exercise the pure helpers directly — no real pseudo-terminal is
+spawned — so they run on every platform.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+from primer.workspace.local.pty_host import (
+    _OUTPUT_QUEUE_MAX_CHUNKS,
+    _enqueue_output,
+)
+
+
+def test_output_queue_bounded_drop_oldest() -> None:
+    """The output queue never exceeds its cap under a flood; the OLDEST chunks
+    are dropped and the NEWEST are retained (bounded memory, fresh tail)."""
+    queue: asyncio.Queue[bytes] = asyncio.Queue(
+        maxsize=_OUTPUT_QUEUE_MAX_CHUNKS
+    )
+    total = _OUTPUT_QUEUE_MAX_CHUNKS * 4
+    dropped = 0
+    for i in range(total):
+        if _enqueue_output(queue, i.to_bytes(4, "big")):
+            dropped += 1
+
+    assert queue.qsize() == _OUTPUT_QUEUE_MAX_CHUNKS
+    assert dropped == total - _OUTPUT_QUEUE_MAX_CHUNKS
+    drained = [queue.get_nowait() for _ in range(queue.qsize())]
+    expected = [
+        i.to_bytes(4, "big")
+        for i in range(total - _OUTPUT_QUEUE_MAX_CHUNKS, total)
+    ]
+    assert drained == expected
+
+
+def test_output_queue_eof_sentinel_survives_full_queue() -> None:
+    """A full queue must still admit the empty EOF sentinel so ``output()``
+    can terminate instead of hanging."""
+    queue: asyncio.Queue[bytes] = asyncio.Queue(
+        maxsize=_OUTPUT_QUEUE_MAX_CHUNKS
+    )
+    for i in range(_OUTPUT_QUEUE_MAX_CHUNKS):
+        _enqueue_output(queue, i.to_bytes(4, "big"))
+    assert queue.full()
+    assert _enqueue_output(queue, b"") is True
+    items = [queue.get_nowait() for _ in range(queue.qsize())]
+    assert items[-1] == b""


### PR DESCRIPTION
## Backend review Wave A — correctness & perf (partial: 4 of 5)

From `docs/superpowers/reviews/2026-07-03-backend-review.md`:
- **BE1 (S1/S2)** guard the two broken operational-mode-matrix cells at wiring time (ConfigError for postgres-scheduler + non-pg storage; surface in-memory-scheduler + multi-process worker).
- **BE2 (S2, highest-value)** push `seq>=cursor` into the chat-drain predicate → O(N)→O(suffix) reads (also stabilises the flaky FIFO test).
- **BE3 (S2)** bound the PTY output queues (drop-oldest high-water mark), both impls.
- **BE7 (S3)** loop `os.write` over the remainder in both PTY writers (large-paste tail loss).

(BE6 tap-router `_wid_by_sid` eviction was in progress when the session limit hit — follow-up.)
