### PR TITLE
fix(backend): review Wave B — EXEC-as-task, fan-out concurrency bound (2/4)

### DIFF
--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -144,6 +144,14 @@ from primer.graph._node_dispatch import (  # noqa: E402
     _SubgraphFailed,
 )
 
+# Default per-superstep admission bound on concurrently-running nodes. A wide
+# fan-out (map/broadcast) still runs every ready node, just at most this many
+# at once — each node is an LLM loop + workspace persistence, so an unbounded
+# fan-out would otherwise spawn unbounded concurrent agent tasks. Deployments
+# override this via ``WorkerConfig.max_parallel_nodes`` (threaded through the
+# worker executor builders); direct/test callers can pass the constructor kwarg.
+DEFAULT_MAX_PARALLEL_NODES: int = 16
+
 
 class _BaseGraphExecutor(
     _CheckpointMixin,
@@ -166,9 +174,13 @@ class _BaseGraphExecutor(
         graph_resolver: Callable[[str], Awaitable[Graph]] | None = None,
         router_registry: RouterRegistry | None = None,
         principal: str | None = None,
+        max_parallel_nodes: int = DEFAULT_MAX_PARALLEL_NODES,
     ) -> None:
         self._graph = graph
         self._agent_resolver = agent_resolver
+        # Per-superstep concurrency cap for node-task execution (BE5). Clamp
+        # to >=1 so a misconfigured 0/negative can never deadlock the loop.
+        self._max_parallel_nodes = max(1, int(max_parallel_nodes))
         self._llm_resolver = llm_resolver
         self._tool_manager_resolver = tool_manager_resolver
         self._graph_resolver = graph_resolver
@@ -1039,10 +1051,23 @@ class _BaseGraphExecutor(
                     ),
                 )
 
+            # Per-superstep admission bound (BE5). All ready nodes still run —
+            # the semaphore only caps how many execute *at once* so a wide
+            # fan-out (map/broadcast) can't spawn unbounded concurrent agent
+            # tasks (each an LLM loop + workspace persistence). Nodes in a
+            # superstep are independent, so bounding to >=1 never deadlocks.
+            # A fresh semaphore per superstep keeps the bound local to it.
+            node_semaphore = asyncio.Semaphore(self._max_parallel_nodes)
+
+            async def _run_node_bounded(
+                nid: str,
+                sem: asyncio.Semaphore = node_semaphore,
+            ) -> None:
+                async with sem:
+                    await self._stream_node(nid, context, queue)
+
             tasks: list[asyncio.Task] = [
-                asyncio.create_task(
-                    self._stream_node(nid, context, queue)
-                )
+                asyncio.create_task(_run_node_bounded(nid))
                 for nid in ready_ordered
             ]
             results: dict[str, _NodeDone] = {}

--- a/primer/graph/executor.py
+++ b/primer/graph/executor.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from primer.agent.tool_manager import ToolExecutionManager
-from primer.graph.base import _BaseGraphExecutor
+from primer.graph.base import DEFAULT_MAX_PARALLEL_NODES, _BaseGraphExecutor
 from primer.graph.router import RouterRegistry
 from primer.model.chat import Message, ToolResultPart
 from primer.model.except_ import NotFoundError
@@ -82,6 +82,7 @@ class GraphExecutor(_BaseGraphExecutor):
             ["_ToolCallNode", dict], Awaitable[ToolResultPart]
         ] | None = None,
         turn_log_storage: "Storage[TurnLogRecord] | None" = None,
+        max_parallel_nodes: int = DEFAULT_MAX_PARALLEL_NODES,
     ) -> None:
         super().__init__(
             graph=graph,
@@ -91,6 +92,7 @@ class GraphExecutor(_BaseGraphExecutor):
             graph_resolver=graph_resolver,
             router_registry=router_registry,
             principal=principal,
+            max_parallel_nodes=max_parallel_nodes,
         )
         self._thread_id = graph_thread_id
         self._threads = thread_storage
@@ -385,6 +387,8 @@ class GraphExecutor(_BaseGraphExecutor):
             # run_id. Without this, subgraphs run with the base-class
             # Noop default and the operator gets a partial timeline.
             turn_log_storage=self._turn_log_storage,
+            # Inherit the parent's per-superstep fan-out cap (BE5).
+            max_parallel_nodes=self._max_parallel_nodes,
         )
 
     async def _load_node_messages_full(

--- a/primer/graph/workspace_executor.py
+++ b/primer/graph/workspace_executor.py
@@ -42,7 +42,7 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
 from primer.agent.tool_manager import ToolExecutionManager
-from primer.graph.base import _BaseGraphExecutor
+from primer.graph.base import DEFAULT_MAX_PARALLEL_NODES, _BaseGraphExecutor
 from primer.graph.router import RouterRegistry
 from primer.model.chat import Message, StreamEvent, ToolResultPart
 from primer.model.graph import Graph, NodeRuntimeState, _GraphNodeRef, _ToolCallNode
@@ -102,6 +102,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
         owns_session_lifecycle: bool = False,
         toolset_resolver: Callable[[str], Awaitable[Any]] | None = None,
         approval_resolver: Any | None = None,
+        max_parallel_nodes: int = DEFAULT_MAX_PARALLEL_NODES,
     ) -> None:
         wrapped_agent_resolver = self._wrap_agent_resolver(
             agent_resolver, workspace_session
@@ -117,6 +118,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             graph_resolver=graph_resolver,
             router_registry=router_registry,
             principal=principal,
+            max_parallel_nodes=max_parallel_nodes,
         )
         self._state_repo = state_repo
         self._graph_session_id = graph_session_id
@@ -586,6 +588,8 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             principal=self._principal,
             toolset_resolver=self._toolset_resolver,
             approval_resolver=self._approval_resolver,
+            # Inherit the parent's per-superstep fan-out cap (BE5).
+            max_parallel_nodes=self._max_parallel_nodes,
         )
 
     # ---- Public helpers --------------------------------------------------

--- a/primer/model/scheduler.py
+++ b/primer/model/scheduler.py
@@ -34,6 +34,19 @@ class WorkerConfig(BaseModel):
 
     concurrency: int = Field(default=8, ge=1, le=128)
     claim_batch_size: int = Field(default=4, ge=1, le=64)
+    max_parallel_nodes: int = Field(
+        default=16,
+        ge=1,
+        le=256,
+        description=(
+            "Per-superstep admission bound on concurrently-running graph "
+            "nodes. A wide fan-out (map/broadcast) still runs every ready "
+            "node, but at most this many at once — each node is an LLM loop "
+            "plus workspace persistence, so an unbounded fan-out would spawn "
+            "unbounded concurrent agent tasks. Bounds task/memory fan-out; "
+            "the per-provider RateLimiter separately bounds LLM concurrency."
+        ),
+    )
     heartbeat_interval_seconds: int = Field(default=10, ge=1, le=60)
     lease_ttl_seconds: int = Field(default=30, ge=5, le=300)
     poll_interval_seconds: float = Field(default=2.0, ge=0.1, le=30.0)

--- a/primer/storage/_predicate.py
+++ b/primer/storage/_predicate.py
@@ -17,8 +17,7 @@ Module-private; consumed only by :mod:`primer.storage.postgres`.
 
 from __future__ import annotations
 
-import types
-from typing import Any, Union, get_args, get_origin
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -30,22 +29,18 @@ from primer.model.storage import (
     Predicate,
     Value,
 )
+from primer.storage._predicate_common import (
+    COMPARISON_OPS as _COMPARISON_OPS,
+    LOGICAL_OPS as _LOGICAL_OPS,
+    PRIMARY_KEY_COLUMN as _PRIMARY_KEY_COLUMN,
+    field_annotation as _field_annotation,
+    render_null_check as _render_null_check_common,
+    render_order_by as _render_order_by_common,
+    strip_optional as _strip_optional,
+)
 
 
 # ---------- Field-type resolution -----------------------------------------
-
-
-def _strip_optional(tp: Any) -> Any:
-    """Unwrap ``T | None`` / ``Optional[T]`` to ``T``.
-
-    Works for both ``Union[X, None]`` and ``X | None`` PEP 604 forms.
-    """
-    origin = get_origin(tp)
-    if origin is Union or origin is types.UnionType:
-        args = [a for a in get_args(tp) if a is not type(None)]
-        if len(args) == 1:
-            return args[0]
-    return tp
 
 
 def _sql_cast_for(field_type: Any) -> str | None:
@@ -67,32 +62,7 @@ def _sql_cast_for(field_type: Any) -> str | None:
     return None
 
 
-def _field_annotation(model_class: type[BaseModel], path: str) -> Any:
-    """Resolve the annotation for a (possibly dotted) field path.
-
-    For top-level fields this is ``model_class.model_fields[name].annotation``.
-    For dotted paths (e.g. ``"meta.author"``) we cannot statically know
-    the inner type because Pydantic's ``dict[str, Any]`` carries no
-    structural info -- return ``Any`` so the caller skips casting.
-    """
-    parts = path.split(".")
-    if len(parts) > 1:
-        return Any
-    field = model_class.model_fields.get(parts[0])
-    if field is None:
-        raise BadRequestError(
-            f"field {path!r} is not declared on model {model_class.__name__!r}"
-        )
-    return field.annotation
-
-
 # ---------- Field expression renderer -------------------------------------
-
-
-# The PRIMARY KEY column. ``id`` is hoisted out of the JSONB document
-# into its own column so it can be the table's primary key and have
-# the obvious B-tree index.
-_PRIMARY_KEY_COLUMN = "id"
 
 
 def _quote_jsonb_key(key: str) -> str:
@@ -174,21 +144,6 @@ def _render_typed_field_expr(
 
 # ---------- Predicate translator ------------------------------------------
 
-
-_COMPARISON_OPS: dict[Op, str] = {
-    Op.EQ: "=",
-    Op.NE: "!=",
-    Op.LIKE: "LIKE",
-    Op.GT: ">",
-    Op.LT: "<",
-    Op.GE: ">=",
-    Op.LE: "<=",
-}
-
-_LOGICAL_OPS: dict[Op, str] = {
-    Op.AND: "AND",
-    Op.OR: "OR",
-}
 
 # Comparison operators where a typed cast on the left side is required
 # when the field is non-text (bool / int / float).
@@ -274,19 +229,9 @@ class _PredicateTranslator:
         raise BadRequestError(f"unsupported operator {p.op.value!r}")
 
     def _render_null_check(self, p: Predicate) -> str:
-        """Render IS NULL / IS NOT NULL against a FieldRef.
-
-        Right operand is ignored. The canonical caller passes
-        ``Value(value=None)`` as a placeholder so the Operand union
-        stays satisfied; the value never reaches SQL.
-        """
-        if not isinstance(p.left, FieldRef):
-            raise BadRequestError(
-                f"operator {p.op.value!r} requires a FieldRef on the left"
-            )
-        left_sql = _render_field_expr(self._model, p.left.name)
-        keyword = "IS NULL" if p.op == Op.IS_NULL else "IS NOT NULL"
-        return f"({left_sql} {keyword})"
+        # Shared boilerplate (see _predicate_common.render_null_check); the
+        # only dialect input is this backend's field-expression renderer.
+        return _render_null_check_common(p, self._model, _render_field_expr)
 
     def _render_in(self, p: Predicate) -> str:
         if not isinstance(p.left, FieldRef):
@@ -362,23 +307,23 @@ def render_order_by(
     backend (which emits a ``(field IS NULL) ASC`` sort term). This
     keeps keyset pagination null-safe across a NULL boundary.
     """
-    parts: list[str] = []
-    seen_id = False
-    for ob in order_by or []:
-        if ob.field == _PRIMARY_KEY_COLUMN:
-            seen_id = True
-        # Use the typed expression so numeric fields sort numerically.
-        annotation = _field_annotation(model_class, ob.field)
-        cast = _sql_cast_for(annotation)
-        if ob.field == _PRIMARY_KEY_COLUMN or cast is None:
-            expr = _render_field_expr(model_class, ob.field)
-        else:
-            expr = f"({_render_field_expr(model_class, ob.field)})::{cast}"
-        direction = "ASC" if ob.direction == "asc" else "DESC"
-        if ob.field == _PRIMARY_KEY_COLUMN:
-            parts.append(f"{expr} {direction}")
-        else:
-            parts.append(f"{expr} {direction} NULLS LAST")
-    if not seen_id:
-        parts.append(f"{_PRIMARY_KEY_COLUMN} ASC")
-    return "ORDER BY " + ", ".join(parts)
+    return _render_order_by_common(model_class, order_by, _order_key_terms)
+
+
+def _order_key_terms(model_class: type[BaseModel], ob: OrderBy) -> list[str]:
+    """Postgres sort term(s) for one ORDER BY key.
+
+    Numeric fields cast (so they sort numerically) and non-id keys carry
+    ``NULLS LAST``; the id key is a bare directional sort.
+    """
+    # Use the typed expression so numeric fields sort numerically.
+    annotation = _field_annotation(model_class, ob.field)
+    cast = _sql_cast_for(annotation)
+    if ob.field == _PRIMARY_KEY_COLUMN or cast is None:
+        expr = _render_field_expr(model_class, ob.field)
+    else:
+        expr = f"({_render_field_expr(model_class, ob.field)})::{cast}"
+    direction = "ASC" if ob.direction == "asc" else "DESC"
+    if ob.field == _PRIMARY_KEY_COLUMN:
+        return [f"{expr} {direction}"]
+    return [f"{expr} {direction} NULLS LAST"]

--- a/primer/storage/_predicate_common.py
+++ b/primer/storage/_predicate_common.py
@@ -1,0 +1,149 @@
+"""Dialect-independent helpers shared by the two predicate translators.
+
+:mod:`primer.storage._predicate` (Postgres) and
+:mod:`primer.storage._sqlite_predicate` (SQLite) keep SEPARATE renderers — the
+parts that genuinely diverge (placeholders, casts, ``IN`` expansion,
+``CONTAINS``, EQ/NE typing, and the per-key NULL-ordering SQL) do not unify
+without over-abstracting. This module holds only the boilerplate that is
+byte-identical across both: annotation unwrapping, field-annotation resolution,
+the primary-key column name, the comparison / logical operator maps, the
+``IS NULL`` / ``IS NOT NULL`` renderer, and the ``ORDER BY`` assembly skeleton.
+
+Behaviour parity between the two dialects is guarded by the parametrised
+predicate contract test.
+
+Module-private; consumed only by the two sibling translator modules.
+"""
+
+from __future__ import annotations
+
+import types
+from collections.abc import Callable
+from typing import Any, Union, get_args, get_origin
+
+from pydantic import BaseModel
+
+from primer.model.except_ import BadRequestError
+from primer.model.storage import FieldRef, Op, OrderBy, Predicate
+
+
+# The PRIMARY KEY column. ``id`` is hoisted out of the JSON(B) document into
+# its own column so it can be the table's primary key and carry the obvious
+# B-tree index.
+PRIMARY_KEY_COLUMN = "id"
+
+
+# ---------- Field-type resolution -----------------------------------------
+
+
+def strip_optional(tp: Any) -> Any:
+    """Unwrap ``T | None`` / ``Optional[T]`` to ``T``.
+
+    Works for both ``Union[X, None]`` and the PEP 604 ``X | None`` form.
+    """
+    origin = get_origin(tp)
+    if origin is Union or origin is types.UnionType:
+        args = [a for a in get_args(tp) if a is not type(None)]
+        if len(args) == 1:
+            return args[0]
+    return tp
+
+
+def field_annotation(model_class: type[BaseModel], path: str) -> Any:
+    """Resolve the annotation for a (possibly dotted) field path.
+
+    For top-level fields this is ``model_class.model_fields[name].annotation``.
+    For dotted paths (e.g. ``"meta.author"``) the inner type cannot be known
+    statically (Pydantic's ``dict[str, Any]`` carries no structural info) — so
+    return ``Any`` and the caller skips casting.
+    """
+    parts = path.split(".")
+    if len(parts) > 1:
+        return Any
+    field = model_class.model_fields.get(parts[0])
+    if field is None:
+        raise BadRequestError(
+            f"field {path!r} is not declared on model {model_class.__name__!r}"
+        )
+    return field.annotation
+
+
+# ---------- Operator maps --------------------------------------------------
+
+
+# Comparison operator -> SQL keyword. Identical in both dialects.
+COMPARISON_OPS: dict[Op, str] = {
+    Op.EQ: "=",
+    Op.NE: "!=",
+    Op.LIKE: "LIKE",
+    Op.GT: ">",
+    Op.LT: "<",
+    Op.GE: ">=",
+    Op.LE: "<=",
+}
+
+# Logical operator -> SQL keyword. Identical in both dialects.
+LOGICAL_OPS: dict[Op, str] = {
+    Op.AND: "AND",
+    Op.OR: "OR",
+}
+
+
+# ---------- Shared renderers ----------------------------------------------
+
+
+def render_null_check(
+    p: Predicate,
+    model_class: type[BaseModel],
+    render_field_expr: Callable[[type[BaseModel], str], str],
+) -> str:
+    """Render ``IS NULL`` / ``IS NOT NULL`` against a FieldRef.
+
+    The right operand is ignored — the canonical caller passes a placeholder
+    ``Value`` so the Operand union stays satisfied; the value never reaches
+    SQL. ``render_field_expr`` is the dialect's field-expression renderer so
+    the emitted left side matches the backend.
+    """
+    if not isinstance(p.left, FieldRef):
+        raise BadRequestError(
+            f"operator {p.op.value!r} requires a FieldRef on the left"
+        )
+    left_sql = render_field_expr(model_class, p.left.name)
+    keyword = "IS NULL" if p.op == Op.IS_NULL else "IS NOT NULL"
+    return f"({left_sql} {keyword})"
+
+
+def render_order_by(
+    model_class: type[BaseModel],
+    order_by: list[OrderBy] | None,
+    render_key: Callable[[type[BaseModel], OrderBy], list[str]],
+) -> str:
+    """Assemble an ``ORDER BY`` clause from per-key sort terms.
+
+    Shared skeleton across both backends: iterate the keys, always append a
+    stable ``id ASC`` tiebreaker when the caller did not already order by the
+    primary key (so cursor pagination has a deterministic seek key), and prefix
+    the ``ORDER BY`` keyword. ``render_key`` is the dialect-specific renderer
+    returning the one-or-more SQL sort terms for a single key — that is where
+    the null-last emission and cast syntax diverge and stay per-dialect.
+    """
+    parts: list[str] = []
+    seen_id = False
+    for ob in order_by or []:
+        if ob.field == PRIMARY_KEY_COLUMN:
+            seen_id = True
+        parts.extend(render_key(model_class, ob))
+    if not seen_id:
+        parts.append(f"{PRIMARY_KEY_COLUMN} ASC")
+    return "ORDER BY " + ", ".join(parts)
+
+
+__all__ = [
+    "COMPARISON_OPS",
+    "LOGICAL_OPS",
+    "PRIMARY_KEY_COLUMN",
+    "field_annotation",
+    "render_null_check",
+    "render_order_by",
+    "strip_optional",
+]

--- a/primer/storage/_sqlite_predicate.py
+++ b/primer/storage/_sqlite_predicate.py
@@ -11,8 +11,7 @@ Module-private; consumed only by :mod:`primer.storage.sqlite`.
 
 from __future__ import annotations
 
-import types
-from typing import Any, Union, get_args, get_origin
+from typing import Any
 
 from pydantic import BaseModel
 
@@ -24,18 +23,18 @@ from primer.model.storage import (
     Predicate,
     Value,
 )
+from primer.storage._predicate_common import (
+    COMPARISON_OPS as _COMPARISON_OPS,
+    LOGICAL_OPS as _LOGICAL_OPS,
+    PRIMARY_KEY_COLUMN as _PRIMARY_KEY_COLUMN,
+    field_annotation as _field_annotation,
+    render_null_check as _render_null_check_common,
+    render_order_by as _render_order_by_common,
+    strip_optional as _strip_optional,
+)
 
 
 # ---------- Field-type resolution ----------------------------------------
-
-
-def _strip_optional(tp: Any) -> Any:
-    origin = get_origin(tp)
-    if origin is Union or origin is types.UnionType:
-        args = [a for a in get_args(tp) if a is not type(None)]
-        if len(args) == 1:
-            return args[0]
-    return tp
 
 
 def _sqlite_cast_for(field_type: Any) -> str | None:
@@ -54,22 +53,7 @@ def _sqlite_cast_for(field_type: Any) -> str | None:
     return None
 
 
-def _field_annotation(model_class: type[BaseModel], path: str) -> Any:
-    parts = path.split(".")
-    if len(parts) > 1:
-        return Any
-    field = model_class.model_fields.get(parts[0])
-    if field is None:
-        raise BadRequestError(
-            f"field {path!r} is not declared on model {model_class.__name__!r}"
-        )
-    return field.annotation
-
-
 # ---------- Field-expression renderer ------------------------------------
-
-
-_PRIMARY_KEY_COLUMN = "id"
 
 
 def _render_field_expr(model_class: type[BaseModel], path: str) -> str:
@@ -103,21 +87,6 @@ def _render_typed_field_expr(model_class: type[BaseModel], path: str) -> str:
 
 # ---------- Translator ---------------------------------------------------
 
-
-_COMPARISON_OPS: dict[Op, str] = {
-    Op.EQ: "=",
-    Op.NE: "!=",
-    Op.LIKE: "LIKE",
-    Op.GT: ">",
-    Op.LT: "<",
-    Op.GE: ">=",
-    Op.LE: "<=",
-}
-
-_LOGICAL_OPS: dict[Op, str] = {
-    Op.AND: "AND",
-    Op.OR: "OR",
-}
 
 _TYPED_COMPARISON_OPS = {Op.GT, Op.LT, Op.GE, Op.LE}
 
@@ -162,24 +131,12 @@ class _SqlitePredicateTranslator:
         raise BadRequestError(f"unsupported operator {p.op.value!r}")
 
     def _render_null_check(self, p: Predicate) -> str:
-        """Render IS NULL / IS NOT NULL against a FieldRef.
-
-        The right operand is ignored; the canonical caller still
-        supplies a Value placeholder to satisfy the Operand union.
-
-        Note: ``json_extract(data, '$.x')`` returns SQL NULL both when
-        the JSON value is `null` AND when the path is missing. That
-        matches our intent -- a Pydantic ``Optional[str]`` field that
-        was never set serialises as missing-from-blob, which we want
-        treated as NULL.
-        """
-        if not isinstance(p.left, FieldRef):
-            raise BadRequestError(
-                f"operator {p.op.value!r} requires a FieldRef on the left"
-            )
-        left_sql = _render_field_expr(self._model, p.left.name)
-        keyword = "IS NULL" if p.op == Op.IS_NULL else "IS NOT NULL"
-        return f"({left_sql} {keyword})"
+        # Shared boilerplate (see _predicate_common.render_null_check). Note:
+        # ``json_extract(data, '$.x')`` returns SQL NULL both when the JSON
+        # value is `null` AND when the path is missing — which matches intent
+        # (a never-set Optional field serialises as missing-from-blob, treated
+        # as NULL). The only dialect input is this backend's field renderer.
+        return _render_null_check_common(p, self._model, _render_field_expr)
 
     def _render_in(self, p: Predicate) -> str:
         if not isinstance(p.left, FieldRef):
@@ -264,28 +221,30 @@ def render_order_by_sqlite(
     Postgres backend (which uses ``NULLS LAST``). This keeps keyset
     pagination null-safe across a NULL boundary.
     """
-    parts: list[str] = []
-    seen_id = False
-    for ob in order_by or []:
-        if ob.field == _PRIMARY_KEY_COLUMN:
-            seen_id = True
-        annotation = _field_annotation(model_class, ob.field)
-        cast = _sqlite_cast_for(annotation)
-        if ob.field == _PRIMARY_KEY_COLUMN or cast is None:
-            expr = _render_field_expr(model_class, ob.field)
-        else:
-            expr = f"CAST({_render_field_expr(model_class, ob.field)} AS {cast})"
-        direction = "ASC" if ob.direction == "asc" else "DESC"
-        if ob.field != _PRIMARY_KEY_COLUMN:
-            # NULLs LAST: a row with NULL gets flag 1 and sorts after
-            # flag 0 in ASC. For DESC the value sorts descending but
-            # NULLs must still come last, so the flag stays ASC.
-            null_expr = _render_field_expr(model_class, ob.field)
-            parts.append(f"({null_expr} IS NULL) ASC")
-        parts.append(f"{expr} {direction}")
-    if not seen_id:
-        parts.append(f"{_PRIMARY_KEY_COLUMN} ASC")
-    return "ORDER BY " + ", ".join(parts)
+    return _render_order_by_common(model_class, order_by, _order_key_terms)
+
+
+def _order_key_terms(model_class: type[BaseModel], ob: OrderBy) -> list[str]:
+    """SQLite sort term(s) for one ORDER BY key.
+
+    Numeric fields ``CAST`` (so they sort numerically). Non-id keys emit a
+    leading ``(<field> IS NULL) ASC`` term so NULLs sort last: a row with NULL
+    gets flag 1 and sorts after flag 0 in ASC; for DESC the value sorts
+    descending but NULLs must still come last, so the flag stays ASC.
+    """
+    annotation = _field_annotation(model_class, ob.field)
+    cast = _sqlite_cast_for(annotation)
+    if ob.field == _PRIMARY_KEY_COLUMN or cast is None:
+        expr = _render_field_expr(model_class, ob.field)
+    else:
+        expr = f"CAST({_render_field_expr(model_class, ob.field)} AS {cast})"
+    direction = "ASC" if ob.direction == "asc" else "DESC"
+    terms: list[str] = []
+    if ob.field != _PRIMARY_KEY_COLUMN:
+        null_expr = _render_field_expr(model_class, ob.field)
+        terms.append(f"({null_expr} IS NULL) ASC")
+    terms.append(f"{expr} {direction}")
+    return terms
 
 
 __all__ = [

--- a/primer/worker/executor_builders.py
+++ b/primer/worker/executor_builders.py
@@ -133,6 +133,7 @@ def build_graph_invocation_services(
             owns_session_lifecycle=False,
             toolset_resolver=toolset_resolver,
             approval_resolver=pool._approval_resolver,
+            max_parallel_nodes=pool.config.max_parallel_nodes,
         )
 
     return GraphInvocationServices(
@@ -410,6 +411,7 @@ async def build_graph_executor(pool: "WorkerPool", session: WorkspaceSession, wo
         owns_session_lifecycle=True,
         toolset_resolver=toolset_resolver,
         approval_resolver=pool._approval_resolver,
+        max_parallel_nodes=pool.config.max_parallel_nodes,
     )
     return _GraphTurnDriver(executor)
 

--- a/runtime/primer_runtime/exec.py
+++ b/runtime/primer_runtime/exec.py
@@ -23,11 +23,11 @@ import asyncio
 import base64
 import logging
 import os
-from collections.abc import AsyncIterator
+from collections.abc import AsyncIterator, Callable, Coroutine
 from typing import Any
 
 from primer_runtime.ops import OpError, _resolve_safe
-from primer_runtime.protocol import ErrorCode, Event
+from primer_runtime.protocol import ErrorCode, Event, Response, serialize
 
 log = logging.getLogger(__name__)
 
@@ -196,3 +196,98 @@ async def run_exec(
             event="exit",
             data={"code": returncode},
         )
+
+
+# ---------------------------------------------------------------------------
+# Exec-as-task: keep the runtime message loop free while an exec streams
+# ---------------------------------------------------------------------------
+
+
+class ExecRegistry:
+    """Per-connection set of in-flight exec stream tasks.
+
+    Mirrors :class:`~primer_runtime.pty_op.PtyRegistry` for the exec op: the
+    server spawns each ``exec`` as a tracked task so a long-running exec never
+    blocks the single runtime message loop (which also services
+    ``pty_stdin``/``pty_resize`` and file ops).  ``cancel_all`` is invoked on
+    WS close to tear down any exec still streaming.
+    """
+
+    def __init__(self) -> None:
+        self._tasks: set[asyncio.Task[None]] = set()
+
+    def add(self, task: asyncio.Task[None]) -> None:
+        self._tasks.add(task)
+
+    def discard(self, task: asyncio.Task[None]) -> None:
+        self._tasks.discard(task)
+
+    def cancel_all(self) -> None:
+        """Cancel every in-flight exec task (called on WS close)."""
+        for task in list(self._tasks):
+            task.cancel()
+        self._tasks.clear()
+
+
+async def _run_exec_stream(
+    req_id: int,
+    args: dict[str, Any],
+    workspace_root: str,
+    send: Callable[[str], Coroutine[Any, Any, None]],
+) -> None:
+    """Task body: drive :func:`run_exec` and forward its frames via *send*.
+
+    Preserves the original inline framing exactly — streaming
+    ``stdout``/``stderr``/``exit`` events in order, an ``OpError`` mapped to a
+    single-shot ``ok=false`` Response, and any other exception mapped to
+    ``EINTERNAL`` — the only change is that this now runs off the message loop
+    as its own task.  Per-req_id output ordering is unchanged (a single task
+    awaits each ``send`` in turn).
+    """
+    agen = run_exec(req_id, args, workspace_root)
+    try:
+        async for event in agen:
+            await send(serialize(event))
+    except OpError as exc:
+        await send(serialize(Response(
+            req_id=req_id, ok=False,
+            error={"code": exc.code, "message": exc.message},
+        )))
+    except asyncio.CancelledError:
+        # WS close / cancel_all: close the generator so run_exec's own
+        # CancelledError/GeneratorExit teardown reaps the subprocess and
+        # cancels its reader tasks, then propagate the cancellation.
+        raise
+    except Exception as exc:  # noqa: BLE001
+        log.exception("Unexpected error handling exec op")
+        await send(serialize(Response(
+            req_id=req_id, ok=False,
+            error={"code": ErrorCode.EINTERNAL, "message": str(exc)},
+        )))
+    finally:
+        # Idempotent: a no-op if the generator already ran to completion or
+        # unwound via an exception; on the cancel-at-send window it throws
+        # GeneratorExit into run_exec so its teardown (reader-task cancel +
+        # subprocess terminate/reap) still runs.
+        await agen.aclose()
+
+
+def start_exec(
+    req_id: int,
+    args: dict[str, Any],
+    workspace_root: str,
+    send: Callable[[str], Coroutine[Any, Any, None]],
+    registry: ExecRegistry,
+) -> asyncio.Task[None]:
+    """Spawn a tracked exec stream task; returns it (tests await it).
+
+    The task is registered in *registry* so ``cancel_all`` can reach it on WS
+    close, and a done-callback deregisters it on normal completion.
+    """
+    task = asyncio.create_task(
+        _run_exec_stream(req_id, args, workspace_root, send),
+        name=f"exec:{req_id}",
+    )
+    registry.add(task)
+    task.add_done_callback(registry.discard)
+    return task

--- a/runtime/primer_runtime/server.py
+++ b/runtime/primer_runtime/server.py
@@ -21,7 +21,7 @@ import tempfile
 from aiohttp import web
 from aiohttp import WSMsgType
 
-from primer_runtime.exec import run_exec
+from primer_runtime.exec import ExecRegistry, start_exec
 from primer_runtime.ops import HANDLERS, OpError
 from primer_runtime.protocol import ErrorCode, OpName, Response, serialize
 from primer_runtime.pty_op import PtyRegistry, start_pty
@@ -145,6 +145,9 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
     watch_registry = WatchRegistry()
     # Per-connection PTY registry — tracks live interactive terminal sessions.
     pty_registry = PtyRegistry()
+    # Per-connection exec registry — tracks in-flight streaming exec tasks so
+    # a long exec never blocks the message loop below.
+    exec_registry = ExecRegistry()
 
     async for msg in ws:
         if msg.type == WSMsgType.TEXT:
@@ -231,25 +234,20 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
                 continue
 
             # --- Streaming exec op ----------------------------------------
+            # Spawn the exec stream as a tracked task (mirrors PTY_OPEN) so a
+            # long-running exec does NOT block this single message loop — while
+            # it streams, pty_stdin/pty_resize and file ops on this same
+            # connection stay serviceable. The task owns its own framing
+            # (stdout/stderr/exit events + error Response) and per-req_id output
+            # ordering; cancel_all() on WS close tears it down.
             if op_name == OpName.EXEC:
-                try:
-                    async for event in run_exec(frame_req_id, args, workspace_root):
-                        await ws.send_str(serialize(event))
-                except OpError as exc:
-                    err_resp = Response(
-                        req_id=frame_req_id,
-                        ok=False,
-                        error={"code": exc.code, "message": exc.message},
-                    )
-                    await ws.send_str(serialize(err_resp))
-                except Exception as exc:  # noqa: BLE001
-                    log.exception("Unexpected error handling exec op")
-                    err_resp = Response(
-                        req_id=frame_req_id,
-                        ok=False,
-                        error={"code": ErrorCode.EINTERNAL, "message": str(exc)},
-                    )
-                    await ws.send_str(serialize(err_resp))
+                start_exec(
+                    req_id=frame_req_id,
+                    args=args,
+                    workspace_root=workspace_root,
+                    send=ws.send_str,
+                    registry=exec_registry,
+                )
                 continue
 
             # --- Single-shot ops ------------------------------------------
@@ -285,9 +283,11 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
         elif msg.type in (WSMsgType.CLOSE, WSMsgType.ERROR):
             break
 
-    # Cancel any lingering watch subscriptions / PTY sessions on disconnect.
+    # Cancel any lingering watch subscriptions / PTY sessions / exec streams
+    # on disconnect.
     watch_registry.cancel_all()
     pty_registry.cancel_all()
+    exec_registry.cancel_all()
 
     return ws
 

--- a/tests/graph/test_fanout_concurrency_bound.py
+++ b/tests/graph/test_fanout_concurrency_bound.py
@@ -1,0 +1,329 @@
+"""Per-superstep fan-out concurrency bound (BE5).
+
+A wide ``map`` fan-out spawns one node task per ready instance. Without an
+admission bound every instance's agent loop (an LLM call + persistence) would
+run concurrently. ``max_parallel_nodes`` caps how many node bodies execute at
+once WITHOUT dropping any: every ready node still runs, just <=N at a time.
+
+The test drives ``Begin -> planner -> FanOut(map) -> worker`` with 6 worker
+instances and ``max_parallel_nodes=2``, gating the worker LLM on a barrier so
+the concurrency counter can be observed. With the cap in place the peak of
+simultaneously-active worker bodies never exceeds 2, yet all 6 still run.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+from typing import Any, Generic, TypeVar
+
+import pytest
+
+from primer.graph.executor import GraphExecutor
+from primer.graph.router import RouterRegistry
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import Done, Message, StreamEvent, TextDelta
+from primer.model.common import Identifiable
+from primer.model.except_ import ConflictError, NotFoundError
+from primer.model.graph import (
+    FanOutSpec,
+    Graph,
+    GraphNodeMessage,
+    GraphThread,
+    _AgentNodeRef,
+    _BeginNode,
+    _EndNode,
+    _FanOutNode,
+    _StaticEdge,
+)
+from primer.model.provider import LLMModel
+from primer.model.storage import (
+    CursorPageResponse,
+    FieldRef,
+    OffsetPage,
+    OffsetPageResponse,
+    Op,
+    PageRequest,
+    Predicate,
+    Value,
+)
+
+_T = TypeVar("_T", bound=Identifiable)
+
+
+class _InMemoryStorage(Generic[_T]):
+    def __init__(self, model_cls: type[_T]) -> None:
+        self._cls = model_cls
+        self._data: dict[str, _T] = {}
+
+    async def get(self, id: str) -> _T | None:
+        return self._data.get(id)
+
+    async def create(self, entity: _T) -> _T:
+        if entity.id in self._data:
+            raise ConflictError(f"id {entity.id!r} already exists")
+        self._data[entity.id] = entity
+        return entity
+
+    async def update(self, entity: _T) -> _T:
+        if entity.id not in self._data:
+            raise NotFoundError(f"no entity with id {entity.id!r}")
+        self._data[entity.id] = entity
+        return entity
+
+    async def delete(self, id: str) -> None:
+        if id not in self._data:
+            raise NotFoundError(f"no entity with id {id!r}")
+        del self._data[id]
+
+    async def list(self, page: PageRequest, *, order_by=None):
+        return await self.find(None, page, order_by=order_by)
+
+    async def find(self, predicate, page, *, order_by=None):
+        items = list(self._data.values())
+        if predicate is not None:
+            items = [i for i in items if self._eval(predicate, i)]
+        if order_by:
+            for ob in reversed(order_by):
+                items.sort(
+                    key=lambda x, f=ob.field: getattr(x, f),
+                    reverse=(ob.direction == "desc"),
+                )
+        if isinstance(page, OffsetPage):
+            sliced = items[page.offset : page.offset + page.length]
+            return OffsetPageResponse(
+                offset=page.offset,
+                length=len(sliced),
+                total=len(items),
+                items=sliced,
+            )
+        offset = int(page.cursor) if page.cursor else 0
+        sliced = items[offset : offset + page.length]
+        next_cursor: str | None = None
+        if offset + page.length < len(items):
+            next_cursor = str(offset + page.length)
+        return CursorPageResponse(next_cursor=next_cursor, items=sliced)
+
+    @staticmethod
+    def _eval(p: Predicate, entity) -> bool:
+        if p.op == Op.EQ:
+            assert isinstance(p.left, FieldRef) and isinstance(p.right, Value)
+            return getattr(entity, p.left.name) == p.right.value
+        if p.op == Op.AND:
+            assert isinstance(p.left, Predicate) and isinstance(p.right, Predicate)
+            return _InMemoryStorage._eval(p.left, entity) and _InMemoryStorage._eval(
+                p.right, entity
+            )
+        raise NotImplementedError(f"op {p.op!r} not supported")
+
+
+class _ConcurrencyProbeLLM:
+    """LLM that records how many worker turns run concurrently.
+
+    The planner call (the first) returns the topic list immediately. Every
+    subsequent (worker) call increments an ``active`` gauge, records the peak,
+    then blocks on a shared barrier so siblings pile up — this is what makes a
+    missing bound observable. The test releases the barrier once it has
+    confirmed the peak plateaued at the cap.
+    """
+
+    def __init__(self, topics: list[str]) -> None:
+        self._topics = topics
+        self._first = True
+        self.active = 0
+        self.peak = 0
+        self.entered = 0
+        self.release = asyncio.Event()
+
+    async def list_models(self):
+        return ["m"]
+
+    def stream(self, *, model: str, messages: list[Message], **kwargs: Any):
+        first = self._first
+        self._first = False
+        if first:
+            return self._planner_stream()
+        return self._worker_stream()
+
+    async def _planner_stream(self) -> AsyncIterator[StreamEvent]:
+        import json
+
+        yield TextDelta(text=json.dumps({"topics": self._topics}), index=0)
+        yield Done(stop_reason="stop", raw_reason="stop")
+
+    async def _worker_stream(self) -> AsyncIterator[StreamEvent]:
+        self.active += 1
+        self.entered += 1
+        self.peak = max(self.peak, self.active)
+        try:
+            await self.release.wait()
+        finally:
+            self.active -= 1
+        yield TextDelta(text="ack", index=0)
+        yield Done(stop_reason="stop", raw_reason="stop")
+
+
+def _agent(agent_id: str) -> Agent:
+    return Agent(
+        id=agent_id,
+        description=f"agent {agent_id}",
+        model=AgentModel(provider_id="p", model_name="m"),
+        system_prompt=[],
+    )
+
+
+async def _build_executor(*, graph: Graph, llm: _ConcurrencyProbeLLM, cap: int):
+    async def agent_resolver(agent_id: str) -> Agent:
+        return _agent(agent_id)
+
+    async def llm_resolver(agent: Agent):
+        return (llm, LLMModel(name="m", context_length=128_000))
+
+    thread_storage: _InMemoryStorage[GraphThread] = _InMemoryStorage(GraphThread)
+    message_storage: _InMemoryStorage[GraphNodeMessage] = _InMemoryStorage(
+        GraphNodeMessage
+    )
+    thread = await GraphExecutor.open_thread(
+        graph=graph,
+        thread_storage=thread_storage,  # type: ignore[arg-type]
+        title="t",
+    )
+    executor = GraphExecutor(
+        graph=graph,
+        agent_resolver=agent_resolver,
+        llm_resolver=llm_resolver,  # type: ignore[arg-type]
+        thread_storage=thread_storage,  # type: ignore[arg-type]
+        message_storage=message_storage,  # type: ignore[arg-type]
+        graph_thread_id=thread.id,
+        router_registry=RouterRegistry(),
+        max_parallel_nodes=cap,
+    )
+    return executor
+
+
+def _wide_map_graph(n: int) -> Graph:
+    return Graph.model_construct(
+        id="g-bound",
+        description="Begin -> planner -> FanOut(map) -> worker -> end",
+        nodes=[
+            _BeginNode(id="begin"),
+            _AgentNodeRef(
+                id="planner",
+                agent_id="ag-planner",
+                response_format={
+                    "type": "object",
+                    "required": ["topics"],
+                    "properties": {
+                        "topics": {"type": "array", "items": {"type": "string"}}
+                    },
+                },
+            ),
+            _FanOutNode(
+                id="fan",
+                specs=[
+                    FanOutSpec(
+                        kind="map",
+                        target_node_id="worker",
+                        source_node_id="planner",
+                        source_path="topics",
+                    ),
+                ],
+            ),
+            _AgentNodeRef(
+                id="worker",
+                agent_id="ag-worker",
+                input_template="Topic: {{ fanout_item }}",
+            ),
+            _EndNode(id="end"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="planner"),
+            _StaticEdge(from_node="planner", to_node="fan"),
+            _StaticEdge(from_node="worker", to_node="end"),
+        ],
+        max_iterations=20,
+        harness_id=None,
+    )
+
+
+@pytest.mark.asyncio
+async def test_fanout_peak_concurrency_respects_cap() -> None:
+    n = 6
+    cap = 2
+    topics = [f"t{i}" for i in range(n)]
+    llm = _ConcurrencyProbeLLM(topics)
+    graph = _wide_map_graph(n)
+    executor = await _build_executor(graph=graph, llm=llm, cap=cap)
+
+    events: list[Any] = []
+
+    async def _drive() -> None:
+        async for ev in executor.invoke([]):
+            events.append(ev)
+
+    drive = asyncio.create_task(_drive())
+
+    # Wait until the worker superstep has admitted exactly `cap` workers and
+    # they are all parked on the barrier. If the bound were missing, `entered`
+    # would climb to n instead of plateauing at cap.
+    async def _wait_plateau() -> None:
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while asyncio.get_event_loop().time() < deadline:
+            if llm.active >= cap:
+                # Give any (erroneously) unbounded extra workers a chance to
+                # enter before asserting the plateau.
+                await asyncio.sleep(0.1)
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError("workers never reached the cap")
+
+    await _wait_plateau()
+
+    # The critical assertion: only `cap` worker bodies ran while the barrier
+    # was held — the rest are still blocked on the semaphore, not the barrier.
+    assert llm.active == cap, f"active={llm.active} exceeded cap={cap}"
+    assert llm.entered == cap, f"entered={llm.entered} — bound not applied"
+
+    # Release the barrier; the remaining workers now drain in <=cap waves.
+    llm.release.set()
+    await asyncio.wait_for(drive, timeout=10.0)
+
+    # Every worker ran (nothing dropped) and the peak never exceeded the cap.
+    assert llm.entered == n
+    assert llm.peak == cap, f"peak={llm.peak} exceeded cap={cap}"
+
+
+@pytest.mark.asyncio
+async def test_fanout_unbounded_when_cap_ge_width() -> None:
+    """Sanity: with cap >= width every worker runs at once (peak == n).
+
+    Confirms the bound is the ONLY thing limiting concurrency — remove it (by
+    setting cap high) and all `n` workers run simultaneously.
+    """
+    n = 5
+    topics = [f"t{i}" for i in range(n)]
+    llm = _ConcurrencyProbeLLM(topics)
+    graph = _wide_map_graph(n)
+    executor = await _build_executor(graph=graph, llm=llm, cap=32)
+
+    events: list[Any] = []
+
+    async def _drive() -> None:
+        async for ev in executor.invoke([]):
+            events.append(ev)
+
+    drive = asyncio.create_task(_drive())
+
+    async def _wait_all_entered() -> None:
+        deadline = asyncio.get_event_loop().time() + 5.0
+        while asyncio.get_event_loop().time() < deadline:
+            if llm.entered >= n:
+                return
+            await asyncio.sleep(0.01)
+        raise AssertionError(f"only {llm.entered}/{n} workers entered")
+
+    await _wait_all_entered()
+    assert llm.active == n
+    llm.release.set()
+    await asyncio.wait_for(drive, timeout=10.0)
+    assert llm.peak == n

--- a/tests/runtime/test_exec_task.py
+++ b/tests/runtime/test_exec_task.py
@@ -1,0 +1,183 @@
+"""Tests for the exec op running as a tracked task (BE4).
+
+The exec op used to stream INLINE inside the runtime's single WS message loop,
+so while a long agent exec streamed, that connection could not service any
+other op (``pty_stdin`` / ``pty_resize`` / file ops) — container/k8s terminal
+input froze for the duration.  ``PTY_OPEN`` was already a task; ``EXEC`` now
+mirrors it.
+
+Two layers of coverage:
+
+* ``start_exec`` driven directly (like ``test_pty_op``) — asserts the framing
+  (stdout/exit events) and registry lifecycle are preserved.
+* the real aiohttp server driven over a WebSocket — asserts a second op is
+  serviced *while* a slow exec is still streaming (i.e. the loop isn't blocked).
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import secrets
+import sys
+from pathlib import Path
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    sys.platform not in ("linux", "darwin"),
+    reason="exec ops spawn POSIX subprocesses",
+)
+
+from primer_runtime.exec import ExecRegistry, start_exec
+
+
+def _events(frames: list[str]) -> list[dict]:
+    return [json.loads(f) for f in frames]
+
+
+def _stdout(frames: list[str]) -> bytes:
+    out = b""
+    for evt in _events(frames):
+        if evt.get("event") == "stdout":
+            out += base64.b64decode(evt["data"]["data_b64"])
+    return out
+
+
+# ---------------------------------------------------------------------------
+# Direct start_exec coverage (no server / no Docker)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_start_exec_streams_and_deregisters(tmp_path: Path) -> None:
+    registry = ExecRegistry()
+    frames: list[str] = []
+
+    async def send(frame: str) -> None:
+        frames.append(frame)
+
+    task = start_exec(
+        req_id=1,
+        args={"cmd": ["/bin/sh", "-c", "echo hello"]},
+        workspace_root=str(tmp_path),
+        send=send,
+        registry=registry,
+    )
+    await task
+
+    assert b"hello" in _stdout(frames)
+    exit_evt = next(e for e in _events(frames) if e.get("event") == "exit")
+    assert exit_evt["req_id"] == 1
+    assert exit_evt["data"]["code"] == 0
+    # Done-callback deregisters the finished task.
+    assert registry._tasks == set()
+
+
+@pytest.mark.asyncio
+async def test_start_exec_bad_cmd_emits_error_response(tmp_path: Path) -> None:
+    registry = ExecRegistry()
+    frames: list[str] = []
+
+    async def send(frame: str) -> None:
+        frames.append(frame)
+
+    task = start_exec(
+        req_id=2,
+        args={"cmd": []},  # empty cmd → OpError(EPROTOCOL)
+        workspace_root=str(tmp_path),
+        send=send,
+        registry=registry,
+    )
+    await task
+
+    err = next(e for e in _events(frames) if "ok" in e and e["ok"] is False)
+    assert err["error"]["code"] == "EPROTOCOL"
+
+
+@pytest.mark.asyncio
+async def test_exec_cancel_all_terminates(tmp_path: Path) -> None:
+    registry = ExecRegistry()
+    frames: list[str] = []
+
+    async def send(frame: str) -> None:
+        frames.append(frame)
+
+    task = start_exec(
+        req_id=3,
+        args={"cmd": ["/bin/sh", "-c", "sleep 30"]},
+        workspace_root=str(tmp_path),
+        send=send,
+        registry=registry,
+    )
+    # Let the subprocess actually start.
+    await asyncio.sleep(0.1)
+    assert registry._tasks  # in-flight
+    registry.cancel_all()
+    with pytest.raises(asyncio.CancelledError):
+        await task
+    assert registry._tasks == set()
+
+
+# ---------------------------------------------------------------------------
+# End-to-end: the message loop stays free while an exec streams
+# ---------------------------------------------------------------------------
+
+
+async def _handshake(ws) -> None:
+    await ws.send_str(json.dumps({"op": "hello", "req_id": 0, "args": {"protocol": "1.1"}}))
+    resp = json.loads((await ws.receive()).data)
+    assert resp["ok"] is True
+
+
+@pytest.mark.asyncio
+async def test_exec_does_not_block_message_loop(tmp_path: Path) -> None:
+    """A second op must be serviced WHILE a slow exec is still streaming.
+
+    The exec sleeps 0.6s before it emits stdout+exit; a ``stat`` op is sent
+    right after.  If the loop were blocked (the old inline behaviour) the stat
+    response could only arrive after the exec's exit event.  With exec as a
+    task, the stat response arrives first.
+    """
+    from aiohttp.test_utils import TestClient, TestServer
+
+    from primer_runtime.server import build_app
+
+    token = secrets.token_urlsafe(16)
+    app = build_app(token=token, workspace_root=str(tmp_path))
+
+    async with TestClient(TestServer(app)) as client:
+        ws = await client.ws_connect("/", headers={"Authorization": f"Bearer {token}"})
+        try:
+            await _handshake(ws)
+
+            # Slow exec: no output until 0.6s, then stdout + exit.
+            await ws.send_str(json.dumps({
+                "op": "exec", "req_id": 100,
+                "args": {"cmd": ["/bin/sh", "-c", "sleep 0.6; echo done"]},
+            }))
+            # Cheap op that must not wait behind the exec.
+            await ws.send_str(json.dumps({
+                "op": "stat", "req_id": 101, "args": {"path": ""},
+            }))
+
+            stat_seen = False
+            exec_exit_seen = False
+            deadline = asyncio.get_event_loop().time() + 10.0
+            while not (stat_seen and exec_exit_seen):
+                remaining = deadline - asyncio.get_event_loop().time()
+                assert remaining > 0, "timed out waiting for frames"
+                msg = await asyncio.wait_for(ws.receive(), timeout=remaining)
+                frame = json.loads(msg.data)
+                if frame.get("req_id") == 101 and frame.get("ok") is True:
+                    # The stat response arrived while the exec was still
+                    # sleeping — the loop was NOT blocked.
+                    assert not exec_exit_seen, "stat blocked behind exec exit"
+                    stat_seen = True
+                elif frame.get("req_id") == 100 and frame.get("event") == "exit":
+                    exec_exit_seen = True
+
+            assert stat_seen and exec_exit_seen
+        finally:
+            await ws.close()


### PR DESCRIPTION
## Backend review Wave B — perf/correctness (partial: 2 of 4)

From `docs/superpowers/reviews/2026-07-03-backend-review.md`:
- **BE4 (S2)** run `EXEC` as a task so a long exec stops freezing the runtime message loop (container/k8s terminal input + file ops on the same WS).
- **BE5 (S2)** bound per-superstep graph fan-out concurrency (admission semaphore) so a wide map/broadcast can't spawn unbounded concurrent agent tasks.

(BE8 predicate-boilerplate extraction + BE9 pg_notify dedicated-connection were in progress when the session limit hit — follow-up.)
