### PR TITLE
feat(studio): UX batch — sessions, single-tap streaming, activity, graph zoom + dark-mode canvas (#1-7,9-11,20-22)

### DIFF
--- a/primer/api/routers/sessions.py
+++ b/primer/api/routers/sessions.py
@@ -647,12 +647,21 @@ async def _read_workspace_turn_log(
     limit: int,
     offset: int,
     since_seq: int | None,
+    tail: bool = False,
 ) -> dict:
     """JSONL-parse the file at ``relative_path`` inside ``workspace``.
 
     Missing file is treated as an empty log (a fresh session that's
     written nothing yet). Bogus lines are skipped silently — the turn
     log is observability data, not a contract.
+
+    ``tail`` flips the window to the *end* of the log: the console loads a
+    session transcript newest-page-first (most-recent ``limit`` rows) and pages
+    older rows on demand, instead of pulling the whole file at once (#3/#7).
+    With ``tail`` the ``offset`` counts rows from the tail — ``offset=0`` is the
+    most-recent ``limit`` rows, ``offset=limit`` the next-older page — so
+    paging is anchored to the end of the log, not a shifting start. Rows are
+    always returned in ascending ``seq`` order.
     """
     try:
         raw = await workspace.read_file(relative_path)
@@ -671,7 +680,12 @@ async def _read_workspace_turn_log(
             continue
         items.append(obj)
     total = len(items)
-    window = items[offset:offset + limit]
+    if tail:
+        end = max(0, total - offset)
+        start = max(0, end - limit)
+        window = items[start:end]
+    else:
+        window = items[offset:offset + limit]
     return {
         "items": window,
         "total": total,
@@ -690,6 +704,15 @@ async def get_session_messages(
     limit: int = Query(default=200, ge=1, le=1000),
     offset: int = Query(default=0, ge=0),
     after_seq: int | None = Query(default=None, ge=0),
+    tail: bool = Query(
+        default=False,
+        description=(
+            "Return the most-recent `limit` rows (newest page) instead of the "
+            "oldest. With `tail`, `offset` counts rows from the end, so the "
+            "console can load a long transcript's tail immediately and page "
+            "older rows lazily rather than fetching the whole log at once."
+        ),
+    ),
     sessions=Depends(get_session_storage),
     workspace_registry=Depends(get_workspace_registry),
 ) -> dict:
@@ -714,6 +737,7 @@ async def get_session_messages(
         limit=limit,
         offset=offset,
         since_seq=after_seq,
+        tail=tail,
     )
 
 

--- a/primer/api/routers/sessions.py
+++ b/primer/api/routers/sessions.py
@@ -58,6 +58,15 @@ class SessionCreateBody(BaseModel):
     """
 
     binding: SessionBinding
+    name: str | None = Field(
+        default=None,
+        description=(
+            "Optional user-supplied friendly name for the session. Persisted "
+            "onto both the scheduler row and the on-disk SessionInfo "
+            "(session.json) so the console shows it instead of the opaque "
+            "session id. Null / empty defaults to the id."
+        ),
+    )
     initial_instructions: str | None = None
     parent_session_id: str | None = None
     auto_start: bool = False
@@ -130,6 +139,7 @@ async def create_session(
         auto_start=body.auto_start,
         metadata=body.metadata,
         parent_session_id=body.parent_session_id,
+        name=body.name,
         deps=deps,
     )
 

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -193,6 +193,19 @@ class SteerBody(BaseModel):
     )
 
 
+class SessionRenameBody(BaseModel):
+    """Body of ``PATCH /v1/workspaces/{id}/sessions/{sid}``."""
+
+    name: str | None = Field(
+        default=None,
+        description=(
+            "New friendly name for the session. Pass null or an empty / "
+            "whitespace-only string to clear it and fall back to the id in "
+            "the console."
+        ),
+    )
+
+
 # ===========================================================================
 # Provider router (CRUD minus update)
 # ===========================================================================
@@ -757,6 +770,61 @@ async def get_session(
         "info": info.model_dump(mode="json"),
         "status": status.value if hasattr(status, "value") else str(status),
     }
+
+
+@sessions_router.patch(
+    "/workspaces/{workspace_id}/sessions/{session_id}",
+    summary="Rename a session (set its friendly display name)",
+    responses=common_responses(404, 422, 500),
+)
+async def rename_session(
+    body: SessionRenameBody = Body(...),
+    workspace_id: str = Path(..., description="Workspace id"),
+    session_id: str = Path(..., description="Session id"),
+    registry: WorkspaceRegistry = Depends(get_workspace_registry),
+    session_storage=Depends(get_session_storage),
+) -> dict:
+    """Set (or clear) a session's friendly name.
+
+    Rewrites the ``name`` on the on-disk :class:`SessionInfo`
+    (``session.json``) via :meth:`AgentSession.set_name` — the authoritative
+    display source for the workspace sessions list — and best-effort mirrors
+    it onto the scheduler-visible :class:`WorkspaceSession` row so the
+    top-level ``GET /sessions/{id}`` read agrees. An empty / null name clears
+    the label (the console falls back to the id). Returns the updated
+    :class:`SessionInfo`.
+    """
+    ws = await registry.get_workspace(workspace_id)
+    session = await ws.get_session(session_id)
+    if session is None:
+        raise NotFoundError(
+            f"Session {session_id!r} does not exist on workspace "
+            f"{workspace_id!r}"
+        )
+    info = await session.set_name(body.name)
+
+    # Best-effort: mirror the new name onto the scheduler row so reads that
+    # go through WorkspaceSession storage (the top-level GET /sessions/{id}
+    # and the Studio center panel) reflect the rename too. A missing row
+    # (e.g. an on-disk-only session) must not fail the rename. session_storage
+    # is the Storage[WorkspaceSession] (see get_session_storage).
+    try:
+        row = await session_storage.get(session_id)
+        if row is not None and row.workspace_id == workspace_id:
+            row.name = info.name
+            await session_storage.update(row)
+    except Exception as exc:  # noqa: BLE001 — advisory mirror, never fatal
+        logger.warning(
+            "rename_session: failed to mirror name onto scheduler row",
+            extra={
+                "session_id": session_id,
+                "workspace_id": workspace_id,
+                "exception": type(exc).__name__,
+                "error": str(exc),
+            },
+        )
+
+    return info.model_dump(mode="json")
 
 
 @sessions_router.post(

--- a/primer/int/workspace.py
+++ b/primer/int/workspace.py
@@ -160,6 +160,7 @@ class Workspace(ABC):
         id: str | None = None,
         instructions: str | None = None,
         parent_session_id: str | None = None,
+        name: str | None = None,
     ) -> "AgentSession":
         """Begin a new session of ``agent_binding.agent_id`` on this workspace.
 
@@ -180,6 +181,10 @@ class Workspace(ABC):
         another session (the agent runtime's spawn meta-tool); used
         for history attribution. No state is automatically propagated
         from parent to child.
+
+        ``name`` is an optional user-supplied friendly label persisted
+        onto ``session.json``; ``None`` (the default) leaves the console
+        falling back to the id.
 
         Returns a fresh :class:`AgentSession` in status
         :attr:`SessionStatus.RUNNING`.

--- a/primer/model/workspace.py
+++ b/primer/model/workspace.py
@@ -206,6 +206,7 @@ Op = Literal[
     "memory_write",
     "todo_update",
     "status_change",
+    "rename",
 ]
 """Allowed values of the ``op`` trailer on state-repo commits."""
 

--- a/primer/model/workspace_session.py
+++ b/primer/model/workspace_session.py
@@ -196,6 +196,15 @@ class SessionInfo(BaseModel):
     session_id: str = Field(..., min_length=1)
     agent_id: str = Field(..., min_length=1)
     workspace_id: str = Field(..., min_length=1)
+    name: str | None = Field(
+        default=None,
+        description=(
+            "Optional user-supplied friendly name for the session. When set, "
+            "the console shows it instead of the opaque ``sess-<hex>`` id. "
+            "Backward-compatible: session.json files written before this "
+            "field existed simply default to ``None``."
+        ),
+    )
     status: SessionStatus = Field(
         ...,
         description="Current lifecycle state of the session.",
@@ -344,6 +353,14 @@ class WorkspaceSession(Identifiable):
     workspace_id: str = Field(..., min_length=1)
     binding: SessionBinding
     status: SessionStatus
+    name: str | None = Field(
+        default=None,
+        description=(
+            "Optional user-supplied friendly name, mirrored onto the on-disk "
+            "SessionInfo (``session.json``). ``None`` falls back to the id in "
+            "the console. Backward-compatible default for existing rows."
+        ),
+    )
     parent_session_id: str | None = Field(default=None)
     initial_instructions: str | None = Field(default=None)
     metadata: dict[str, Any] = Field(default_factory=dict)

--- a/primer/workspace/local/workspace.py
+++ b/primer/workspace/local/workspace.py
@@ -196,6 +196,7 @@ class LocalWorkspace(Workspace):
         id: str | None = None,
         instructions: str | None = None,
         parent_session_id: str | None = None,
+        name: str | None = None,
     ) -> AgentSession:
         async with self._lock:
             if id is not None and id in self._sessions:
@@ -212,6 +213,7 @@ class LocalWorkspace(Workspace):
                 workspace_tools=self._tools,
                 instructions=instructions,
                 parent_session_id=parent_session_id,
+                name=name,
             )
             self._sessions[session_id] = session
             return session

--- a/primer/workspace/sandbox/workspace.py
+++ b/primer/workspace/sandbox/workspace.py
@@ -189,6 +189,7 @@ class SandboxWorkspace(Workspace):
         id: str | None = None,
         instructions: str | None = None,
         parent_session_id: str | None = None,
+        name: str | None = None,
     ) -> AgentSession:
         async with self._lock:
             if id is not None and id in self._sessions:
@@ -205,6 +206,7 @@ class SandboxWorkspace(Workspace):
                 workspace_tools=self._tools,
                 instructions=instructions,
                 parent_session_id=parent_session_id,
+                name=name,
             )
             self._sessions[session_id] = session
             return session

--- a/primer/workspace/session.py
+++ b/primer/workspace/session.py
@@ -220,7 +220,11 @@ class AgentSession:
             session_id=session_id,
             agent_id=agent_binding.agent_id,
             workspace_id=workspace_id,
-            name=name,
+            # Normalize blank/whitespace to None so the on-disk SessionInfo
+            # matches the scheduler-row normalization in create_session and
+            # set_name — otherwise "   " renders as a blank sidebar label
+            # (the UI falls back to the id only on a falsy name).
+            name=(name or "").strip() or None,
             status=SessionStatus.RUNNING,
             started_at=now,
             last_activity_at=now,

--- a/primer/workspace/session.py
+++ b/primer/workspace/session.py
@@ -203,6 +203,7 @@ class AgentSession:
         workspace_tools: "list[WorkspaceTool] | tuple[WorkspaceTool, ...]" = (),
         instructions: str | None = None,
         parent_session_id: str | None = None,
+        name: str | None = None,
     ) -> "AgentSession":
         """Allocate a fresh slot and return a live session handle.
 
@@ -219,6 +220,7 @@ class AgentSession:
             session_id=session_id,
             agent_id=agent_binding.agent_id,
             workspace_id=workspace_id,
+            name=name,
             status=SessionStatus.RUNNING,
             started_at=now,
             last_activity_at=now,
@@ -418,6 +420,31 @@ class AgentSession:
             )
             self._info = updated_info
             return instruction
+
+    async def set_name(self, name: str | None) -> SessionInfo:
+        """Set (or clear) the session's friendly display name.
+
+        Rewrites ``session.json`` with the new ``name`` in a single
+        ``rename`` commit. An empty / whitespace-only value clears the
+        name (the console then falls back to the id). Allowed in any
+        status -- the name is pure display metadata and does not affect
+        the lifecycle. Returns the updated :class:`SessionInfo`.
+        """
+        normalised = (name or "").strip() or None
+        async with self._lock:
+            now = datetime.now(timezone.utc)
+            updated_info = self._info.model_copy(
+                update={"name": normalised, "last_activity_at": now},
+            )
+            sid_short = self.session_id[-12:]
+            await self._state.commit(
+                self.session_id,
+                summary=f"rename[{sid_short}]: {normalised or '(cleared)'}",
+                op="rename",
+                files={"session.json": updated_info.model_dump_json(indent=2)},
+            )
+            self._info = updated_info
+            return updated_info
 
     async def request_pause(self, *, reason: str | None = None) -> None:
         """Set the pause flag the runtime checks before each turn.

--- a/primer/workspace/session_factory.py
+++ b/primer/workspace/session_factory.py
@@ -96,6 +96,7 @@ async def start_workspace_session(
     metadata: dict | None,
     parent_session_id: str | None,
     deps: SessionFactoryDeps,
+    name: str | None = None,
 ) -> WorkspaceSession:
     """Full create flow shared by the REST route and the workspaces tool:
     validate workspace + binding (+ graph_input vs Begin.input_schema),
@@ -203,6 +204,7 @@ async def start_workspace_session(
             id=sid,
             instructions=initial_instructions,
             parent_session_id=parent_session_id,
+            name=name,
         )
     elif isinstance(binding, GraphSessionBinding):
         # Synthetic AgentBinding for the graph-holder slot. The
@@ -224,6 +226,7 @@ async def start_workspace_session(
             id=sid,
             instructions=initial_instructions,
             parent_session_id=parent_session_id,
+            name=name,
         )
 
     # Persist the row + (optionally) auto-start + always register a
@@ -238,6 +241,7 @@ async def start_workspace_session(
         metadata=metadata,
         parent_session_id=parent_session_id,
         session_id=sid,
+        name=name,
         deps=SessionFactoryDeps(
             storage_provider=deps.storage_provider,
             claim_engine=deps.claim_engine,
@@ -258,6 +262,7 @@ async def create_session(
     deps: SessionFactoryDeps,
     parent_session_id: str | None = None,
     session_id: str | None = None,
+    name: str | None = None,
 ) -> WorkspaceSession:
     """Persist a :class:`WorkspaceSession` row + optionally auto-start.
 
@@ -314,6 +319,7 @@ async def create_session(
         workspace_id=workspace_id,
         binding=binding,
         status=SessionStatus.CREATED,
+        name=(name.strip() or None) if isinstance(name, str) else name,
         parent_session_id=parent_session_id,
         initial_instructions=initial_instructions,
         metadata=md,

--- a/primer/workspace/state_helpers.py
+++ b/primer/workspace/state_helpers.py
@@ -43,6 +43,7 @@ VALID_OPS: frozenset[str] = frozenset(
         "memory_write",
         "todo_update",
         "status_change",
+        "rename",
     ]
 )
 

--- a/tests/api/test_session_messages_tail.py
+++ b/tests/api/test_session_messages_tail.py
@@ -1,0 +1,93 @@
+"""`_read_workspace_turn_log` tail-paging (#3/#7).
+
+The session-messages endpoint gained a ``tail`` flag so the console can load a
+long transcript newest-page-first (most-recent ``limit`` rows) and page older
+rows lazily, instead of pulling the whole ``messages.jsonl`` at once. These
+unit-test the reader's windowing directly against a fake workspace IO handle —
+no app fixtures needed.
+"""
+
+from __future__ import annotations
+
+import json
+
+from primer.api.routers.sessions import _read_workspace_turn_log
+
+
+class _FakeWorkspace:
+    """Minimal workspace stub exposing the async ``read_file`` the reader uses."""
+
+    def __init__(self, raw: bytes) -> None:
+        self._raw = raw
+
+    async def read_file(self, _relative_path: str) -> bytes:
+        return self._raw
+
+
+def _log(n: int) -> bytes:
+    """A messages.jsonl with rows seq=1..n (ascending, as written on disk)."""
+    lines = [json.dumps({"seq": i, "payload": {"text": f"m{i}"}}) for i in range(1, n + 1)]
+    return ("\n".join(lines)).encode("utf-8")
+
+
+async def test_tail_returns_most_recent_page_ascending() -> None:
+    res = await _read_workspace_turn_log(
+        workspace=_FakeWorkspace(_log(10)),
+        relative_path="x",
+        limit=3,
+        offset=0,
+        since_seq=None,
+        tail=True,
+    )
+    assert res["total"] == 10
+    assert [it["seq"] for it in res["items"]] == [8, 9, 10]
+
+
+async def test_tail_offset_pages_older() -> None:
+    # offset counts rows from the end: the next-older page after the tail.
+    res = await _read_workspace_turn_log(
+        workspace=_FakeWorkspace(_log(10)),
+        relative_path="x",
+        limit=3,
+        offset=3,
+        since_seq=None,
+        tail=True,
+    )
+    assert [it["seq"] for it in res["items"]] == [5, 6, 7]
+
+
+async def test_non_tail_default_is_unchanged_oldest_first() -> None:
+    # Default (no tail) still returns the oldest window from offset 0.
+    res = await _read_workspace_turn_log(
+        workspace=_FakeWorkspace(_log(10)),
+        relative_path="x",
+        limit=3,
+        offset=0,
+        since_seq=None,
+    )
+    assert [it["seq"] for it in res["items"]] == [1, 2, 3]
+
+
+async def test_tail_clamps_when_offset_exceeds_total() -> None:
+    res = await _read_workspace_turn_log(
+        workspace=_FakeWorkspace(_log(5)),
+        relative_path="x",
+        limit=3,
+        offset=10,
+        since_seq=None,
+        tail=True,
+    )
+    assert res["items"] == []
+    assert res["total"] == 5
+
+
+async def test_tail_limit_larger_than_total_returns_all() -> None:
+    res = await _read_workspace_turn_log(
+        workspace=_FakeWorkspace(_log(4)),
+        relative_path="x",
+        limit=100,
+        offset=0,
+        since_seq=None,
+        tail=True,
+    )
+    assert [it["seq"] for it in res["items"]] == [1, 2, 3, 4]

--- a/tests/api/test_sessions.py
+++ b/tests/api/test_sessions.py
@@ -40,6 +40,40 @@ def _runtime_meta():
 # ===========================================================================
 
 
+class _FakeAgentSessionForSessions:
+    """Minimal AgentSession stand-in exposing the on-disk-name surface.
+
+    Backs ``get_session`` so the rename PATCH route (which calls
+    ``ws.get_session(sid).set_name(...)``) works against the fake backend,
+    round-tripping the friendly name through a real :class:`SessionInfo`.
+    """
+
+    def __init__(self, workspace_id: str, session_id: str, name=None) -> None:
+        now = datetime.now(timezone.utc)
+        from primer.model.workspace_session import SessionInfo, SessionStatus
+
+        self._info = SessionInfo(
+            session_id=session_id,
+            agent_id="ag1",
+            workspace_id=workspace_id,
+            name=name,
+            status=SessionStatus.RUNNING,
+            started_at=now,
+            last_activity_at=now,
+        )
+
+    async def set_name(self, name):
+        normalised = (name or "").strip() or None
+        self._info = self._info.model_copy(update={"name": normalised})
+        return self._info
+
+    async def info(self):
+        return self._info
+
+    async def status(self):
+        return self._info.status
+
+
 class _FakeWorkspaceForSessions:
     """Just enough of the :class:`Workspace` surface for session tests.
 
@@ -51,6 +85,7 @@ class _FakeWorkspaceForSessions:
         self.workspace_id = workspace_id
         self.id = workspace_id
         self.started_sessions: dict[str, dict] = {}
+        self._handles: dict[str, _FakeAgentSessionForSessions] = {}
 
     async def start_session(
         self,
@@ -59,6 +94,7 @@ class _FakeWorkspaceForSessions:
         id=None,
         instructions=None,
         parent_session_id=None,
+        name=None,
     ):
         if id is None:
             raise AssertionError(
@@ -72,16 +108,24 @@ class _FakeWorkspaceForSessions:
             "agent_binding": agent_binding,
             "instructions": instructions,
             "parent_session_id": parent_session_id,
+            "name": name,
         }
-        return object()  # AgentSession stand-in; the router ignores the return.
+        self._handles[id] = _FakeAgentSessionForSessions(
+            self.workspace_id, id, name=name
+        )
+        return self._handles[id]
+
+    async def get_session(self, session_id):
+        return self._handles.get(session_id)
 
     async def list_sessions(self, *, agent_id=None, status=None):
         out = []
-        for sid in self.started_sessions:
-            out.append(type("S", (), {"session_id": sid, "agent_id": "ag1", "status": "running"})())
+        for handle in self._handles.values():
+            out.append(await handle.info())
         return out
 
     async def remove_session(self, session_id):
+        self._handles.pop(session_id, None)
         return self.started_sessions.pop(session_id, None) is not None
 
     async def aclose(self):
@@ -1413,3 +1457,129 @@ async def test_find_sessions_cursor_pagination_covers_all_once(
     assert len(seen_ids) == len(set(seen_ids)), (
         f"duplicates in cursor walk: {seen_ids!r}"
     )
+
+
+# ===========================================================================
+# Session naming — create-with-name + PATCH rename (bug #22)
+# ===========================================================================
+
+
+async def test_create_session_with_name_persists_and_round_trips(
+    sessions_client, seeded_workspace, seeded_agent,
+):
+    resp = await sessions_client.post(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions",
+        json={
+            "binding": {"kind": "agent", "agent_id": seeded_agent.id},
+            "name": "My friendly run",
+            "auto_start": False,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    created = resp.json()
+    sid = created["id"]
+    # Name lands on the created scheduler row (the create response).
+    assert created["name"] == "My friendly run"
+
+    # ... and round-trips through the top-level GET /sessions/{id} row.
+    got = await sessions_client.get(f"/v1/sessions/{sid}")
+    assert got.status_code == 200, got.text
+    assert got.json()["name"] == "My friendly run"
+
+    # ... and shows on the on-disk SessionInfo via the workspace list.
+    listed = await sessions_client.get(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions"
+    )
+    assert listed.status_code == 200, listed.text
+    items = listed.json()["items"]
+    match = [i for i in items if i["session_id"] == sid]
+    assert match and match[0]["name"] == "My friendly run"
+
+
+async def test_create_session_without_name_defaults_none(
+    sessions_client, seeded_workspace, seeded_agent,
+):
+    resp = await sessions_client.post(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions",
+        json={
+            "binding": {"kind": "agent", "agent_id": seeded_agent.id},
+            "auto_start": False,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["name"] is None
+
+
+async def test_create_session_blank_name_defaults_none(
+    sessions_client, seeded_workspace, seeded_agent,
+):
+    resp = await sessions_client.post(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions",
+        json={
+            "binding": {"kind": "agent", "agent_id": seeded_agent.id},
+            "name": "   ",
+            "auto_start": False,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["name"] is None
+
+
+async def test_rename_session_updates_name(
+    sessions_client, seeded_workspace, seeded_agent,
+):
+    create = await sessions_client.post(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions",
+        json={
+            "binding": {"kind": "agent", "agent_id": seeded_agent.id},
+            "auto_start": False,
+        },
+    )
+    assert create.status_code == 201, create.text
+    sid = create.json()["id"]
+    assert create.json()["name"] is None
+
+    patched = await sessions_client.patch(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions/{sid}",
+        json={"name": "Renamed run"},
+    )
+    assert patched.status_code == 200, patched.text
+    # The PATCH returns the updated on-disk SessionInfo.
+    body = patched.json()
+    assert body["name"] == "Renamed run"
+    assert body["session_id"] == sid
+
+    # ... and the new name is mirrored onto the scheduler row too.
+    got = await sessions_client.get(f"/v1/sessions/{sid}")
+    assert got.status_code == 200, got.text
+    assert got.json()["name"] == "Renamed run"
+
+
+async def test_rename_session_clear_name(
+    sessions_client, seeded_workspace, seeded_agent,
+):
+    create = await sessions_client.post(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions",
+        json={
+            "binding": {"kind": "agent", "agent_id": seeded_agent.id},
+            "name": "Temp name",
+            "auto_start": False,
+        },
+    )
+    assert create.status_code == 201, create.text
+    sid = create.json()["id"]
+
+    patched = await sessions_client.patch(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions/{sid}",
+        json={"name": None},
+    )
+    assert patched.status_code == 200, patched.text
+    assert patched.json()["name"] is None
+
+
+async def test_rename_session_not_found(sessions_client, seeded_workspace):
+    resp = await sessions_client.patch(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions/sess-nope",
+        json={"name": "x"},
+    )
+    assert resp.status_code == 404, resp.text

--- a/tests/e2e/test_channel_event_action_inprocess_journey.py
+++ b/tests/e2e/test_channel_event_action_inprocess_journey.py
@@ -97,7 +97,7 @@ class _NoopWorkspace:
 
     async def start_session(
         self, binding: Any, *, id: str,
-        instructions: Any = None, parent_session_id: Any = None,
+        instructions: Any = None, parent_session_id: Any = None, name: Any = None,
     ) -> None:
         return None
 

--- a/tests/e2e/test_channel_event_to_action.py
+++ b/tests/e2e/test_channel_event_to_action.py
@@ -114,7 +114,7 @@ class _NoopWorkspace:
 
     async def start_session(
         self, binding: Any, *, id: str,
-        instructions: Any = None, parent_session_id: Any = None,
+        instructions: Any = None, parent_session_id: Any = None, name: Any = None,
     ) -> None:
         return None
 

--- a/tests/toolset/test_workspaces.py
+++ b/tests/toolset/test_workspaces.py
@@ -220,7 +220,7 @@ class _LiveWorkspace:
         return self._sessions.get(session_id)
 
     async def start_session(
-        self, binding, *, id, instructions=None, parent_session_id=None
+        self, binding, *, id, instructions=None, parent_session_id=None, name=None
     ):
         self._sessions[id] = _LiveSession(id)
         return self._sessions[id]

--- a/tests/trigger/conftest.py
+++ b/tests/trigger/conftest.py
@@ -73,6 +73,7 @@ class _FakeWorkspace:
         id: str,
         instructions: Any = None,
         parent_session_id: Any = None,
+        name: Any = None,
     ) -> None:
         self.started_slots.append(
             {

--- a/tests/ui/test_graph_canvas_controls.py
+++ b/tests/ui/test_graph_canvas_controls.py
@@ -1,11 +1,17 @@
 """Graph-canvas field-test fixes (fix/studio-ux-batch).
 
-Bug #6 — the dark/light toggle did not restyle the shared G6 canvas
-(graph-canvas.jsx, behind BOTH the graphs editor and the Studio run-view)
-because its styling used hardcoded hex literals. The palette is now read from
-the CSS design tokens via getComputedStyle (same pattern as
-studio-terminal.jsx's xterm theme) and re-applied on a data-theme change via a
-MutationObserver.
+Two bugs, both in the shared G6 renderer (graph-canvas.jsx) that backs BOTH
+the graphs editor and the Studio run-view:
+
+  #1 The run-view had no zoom / traverse controls. An overlaid button cluster
+     (zoom-in / zoom-out / fit / reset-100%) is now wired to the live G6 v5
+     instance via zoomBy / fitView / zoomTo. Shared component => works on both
+     surfaces.
+
+  #6 The dark/light toggle did not restyle the canvas because G6 styling used
+     hardcoded hex literals. The palette is now read from the CSS design tokens
+     via getComputedStyle (same pattern as studio-terminal.jsx's xterm theme)
+     and re-applied on a data-theme change via a MutationObserver.
 
 Static source-grep + a bundle-transpile gate, matching the other UI canvas
 tests (no browser needed to assert the wiring is present).
@@ -17,6 +23,44 @@ from pathlib import Path
 
 UI = Path(__file__).resolve().parents[2] / "ui"
 CANVAS = (UI / "components" / "graph-canvas.jsx").read_text(encoding="utf-8")
+STYLES = (UI / "styles.css").read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# #1 — zoom / traverse controls
+# --------------------------------------------------------------------------
+
+def test_control_testids_present() -> None:
+    for tid in ("graph-zoom-in", "graph-zoom-out", "graph-fit", "graph-zoom-reset"):
+        assert f'data-testid="{tid}"' in CANVAS, tid
+    # the cluster wrapper
+    assert 'data-testid="graph-controls"' in CANVAS
+
+
+def test_controls_are_keyboard_accessible_buttons() -> None:
+    # Real <button>s with aria-labels (not clickable divs) => keyboard reachable.
+    assert 'aria-label="Zoom in"' in CANVAS
+    assert 'aria-label="Zoom out"' in CANVAS
+    assert 'aria-label="Fit graph to view"' in CANVAS
+    assert 'aria-label="Reset zoom to 100%"' in CANVAS
+    assert CANVAS.count('type="button"') >= 4
+
+
+def test_controls_wired_to_g6_zoom_fit_apis() -> None:
+    # G6 v5 camera APIs (verified against the vendored g6.min.js).
+    assert "zoomBy(" in CANVAS      # zoom-in / zoom-out (relative ratio)
+    assert "fitView(" in CANVAS     # fit-to-view
+    assert "zoomTo(" in CANVAS      # reset to 100%
+    # wired through the live instance ref, not a fresh graph
+    assert "graphRef.current" in CANVAS
+
+
+def test_controls_have_themeable_styles() -> None:
+    assert ".gr-canvas-controls" in STYLES
+    assert ".gr-ctrl-btn" in STYLES
+    # themed off tokens so they follow dark/light
+    assert "var(--border)" in STYLES
+    assert "position: absolute" in STYLES
 
 
 # --------------------------------------------------------------------------

--- a/tests/ui/test_graph_canvas_controls.py
+++ b/tests/ui/test_graph_canvas_controls.py
@@ -1,0 +1,63 @@
+"""Graph-canvas field-test fixes (fix/studio-ux-batch).
+
+Bug #6 — the dark/light toggle did not restyle the shared G6 canvas
+(graph-canvas.jsx, behind BOTH the graphs editor and the Studio run-view)
+because its styling used hardcoded hex literals. The palette is now read from
+the CSS design tokens via getComputedStyle (same pattern as
+studio-terminal.jsx's xterm theme) and re-applied on a data-theme change via a
+MutationObserver.
+
+Static source-grep + a bundle-transpile gate, matching the other UI canvas
+tests (no browser needed to assert the wiring is present).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+UI = Path(__file__).resolve().parents[2] / "ui"
+CANVAS = (UI / "components" / "graph-canvas.jsx").read_text(encoding="utf-8")
+
+
+# --------------------------------------------------------------------------
+# #6 — theme-token driven palette + restyle-on-toggle
+# --------------------------------------------------------------------------
+
+def test_palette_read_from_css_tokens() -> None:
+    # Reads the live design tokens instead of hardcoding hex.
+    assert "getComputedStyle(document.documentElement)" in CANVAS
+    assert "getPropertyValue(" in CANVAS
+    for token in ("--green", "--amber", "--red", "--violet", "--bg", "--text", "--border"):
+        assert f'"{token}"' in CANVAS, token
+
+
+def test_hardcoded_g6_palette_removed() -> None:
+    # The old hardcoded palette object is gone and no G6 node/edge style still
+    # references it — the node/edge/state styles now flow from the token palette.
+    assert "_G6_COLORS" not in CANVAS
+    assert "const _G6_COLORS" not in CANVAS
+    # palette builder + token-driven style builders exist
+    assert "function _g6Palette(" in CANVAS
+    assert "_g6NodeStyle(P)" in CANVAS
+    assert "_g6EdgeStyle(P)" in CANVAS
+
+
+def test_restyle_observes_data_theme() -> None:
+    assert "MutationObserver" in CANVAS
+    assert '"data-theme"' in CANVAS
+    assert "attributeFilter" in CANVAS
+    # re-reads tokens + re-pushes styles on toggle, and is torn down on unmount
+    assert "setOptions(" in CANVAS
+    assert ".disconnect()" in CANVAS
+
+
+# --------------------------------------------------------------------------
+# bundle still transpiles with the changes
+# --------------------------------------------------------------------------
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    assert "/* === components/graph-canvas.jsx === */" in body.decode("utf-8")

--- a/tests/ui/test_session_token_meter_wiring.py
+++ b/tests/ui/test_session_token_meter_wiring.py
@@ -1,19 +1,34 @@
-"""Static JSX checks — session-detail.jsx wires read-only TokenMeter."""
+"""Static JSX checks — the read-only session TokenMeter.
+
+The live session transcript (SessionLiveStream) is now PURE CONTENT (#10): its
+header chrome — including the in-stream TokenMeter — was removed so session
+controls live in exactly one place (the Studio panel header). The read-only
+meter therefore lives in the Studio agent-panel header
+(studio-center.jsx :: ST_TokenMeterInline), which reuses the shared
+window.TokenMeter with onCompact={null}.
+"""
 
 from __future__ import annotations
 
 from pathlib import Path
 
+UI = Path(__file__).resolve().parents[2] / "ui"
+CENTER_JSX = UI / "components" / "studio-center.jsx"
+SESSION_JSX = UI / "components" / "session-detail.jsx"
 
-SESSION_JSX = Path(__file__).resolve().parents[2] / "ui" / "components" / "session-detail.jsx"
 
-
-def test_session_imports_token_meter() -> None:
-    src = SESSION_JSX.read_text(encoding="utf-8")
+def test_studio_header_imports_token_meter() -> None:
+    src = CENTER_JSX.read_text(encoding="utf-8")
     assert "TokenMeter" in src
 
 
-def test_session_meter_is_read_only() -> None:
+def test_studio_meter_is_read_only() -> None:
     """Read-only meter: onCompact must be null (no compact button on sessions)."""
-    src = SESSION_JSX.read_text(encoding="utf-8")
+    src = CENTER_JSX.read_text(encoding="utf-8")
     assert "onCompact={null}" in src or "onCompact=null" in src
+
+
+def test_embedded_stream_has_no_token_meter_chrome() -> None:
+    """The embedded live stream is pure content — no TokenMeter in its body (#10)."""
+    src = SESSION_JSX.read_text(encoding="utf-8")
+    assert "window.TokenMeter" not in src

--- a/tests/ui/test_studio_activity.py
+++ b/tests/ui/test_studio_activity.py
@@ -141,15 +141,21 @@ def test_cancel_yield_endpoint_present() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Live-reconcile strategy: EventSource on tap + debounce refetch
+# Live-reconcile strategy: SHARED workspace tap (one EventSource per Studio
+# view) + debounce refetch. ActionRequired no longer opens its own EventSource
+# — it reads the consolidated hub via useWorkspaceTapListener (#4 / fe-review
+# N4). The single EventSource lives in foundation/use-workspace-tap.js.
 # ---------------------------------------------------------------------------
 
-def test_live_reconcile_uses_tap_eventsource() -> None:
+def test_live_reconcile_uses_shared_tap_listener() -> None:
     src = _activity_src()
-    # ActionRequired opens an EventSource for live reconciliation
-    assert "new EventSource" in src
-    assert "/tap" in src
-    # Reconcile triggers on yielded/done events
+    # ActionRequired subscribes to the shared tap hub, NOT its own EventSource.
+    assert "useWorkspaceTapListener" in src
+    assert "new EventSource" not in src, (
+        "ActionRequired must read the shared workspace-tap hub, not open its "
+        "own EventSource (#4)"
+    )
+    # Reconcile still triggers on yielded/done events
     assert '"yielded"' in src
     assert '"done"' in src
     # Debounce prevents burst re-fetches

--- a/tests/ui/test_studio_center.py
+++ b/tests/ui/test_studio_center.py
@@ -230,3 +230,21 @@ def test_bundle_transpiles_with_studio_center() -> None:
     assert "/* === components/studio-center.jsx === */" in text
     assert "/* === components/studio.jsx === */" in text
     assert "/* === components/studio-sidebar.jsx === */" in text
+
+
+# ---------------------------------------------------------------------------
+# Close-all-tabs control (bug #21)
+# ---------------------------------------------------------------------------
+
+
+def test_center_close_all_testid_present() -> None:
+    src = _center_src()
+    assert 'data-testid="tabs-close-all"' in src
+
+
+def test_center_close_all_wired_to_state() -> None:
+    src = _center_src()
+    # CenterTabs takes an onCloseAll prop and StudioCenter feeds it the hook's
+    # closeAllTabs action.
+    assert "onCloseAll" in src
+    assert "onCloseAll={studio.closeAllTabs}" in src

--- a/tests/ui/test_studio_live_consolidation.py
+++ b/tests/ui/test_studio_live_consolidation.py
@@ -1,0 +1,162 @@
+"""Structural checks for the Studio live-stream consolidation batch.
+
+Covers the field-test fixes:
+  • #4  ONE shared workspace-tap EventSource per Studio view (fe-review N4).
+        A module-level hub in foundation/use-workspace-tap.js owns the single
+        EventSource; ActionRequired, WorkspaceTap and the graph run-view read
+        from it instead of each opening their own.
+  • #5  Workspace-activity rows expand to show the full event payload
+        (data-testid activity-event / activity-event-detail).
+  • #3/#7  The embedded live stream loads a bounded tail (tail=1) of history +
+        a "Load earlier" control, not the whole messages.jsonl (limit=1000).
+  • #10 The embedded SessionLiveStream is pure content — the Interrupt button
+        and header chrome were removed; controls live only in the panel header.
+
+Static-source checks (no React rendering), matching test_studio_activity.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+HOOK = UI / "foundation" / "use-workspace-tap.js"
+ACTIVITY = UI / "components" / "studio-activity.jsx"
+TAP = UI / "components" / "workspace-tap.jsx"
+DETAIL = UI / "components" / "session-detail.jsx"
+CENTER = UI / "components" / "studio-center.jsx"
+INDEX = UI / "index.html"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def _slice(src: str, start_marker: str, end_marker: str) -> str:
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+# ---------------------------------------------------------------------------
+# #4 — shared workspace-tap hub (one EventSource)
+# ---------------------------------------------------------------------------
+
+def test_shared_hook_exists_and_exports() -> None:
+    assert HOOK.exists(), "foundation/use-workspace-tap.js missing"
+    src = _read(HOOK)
+    assert "window.useWorkspaceTap = useWorkspaceTap;" in src
+    assert "window.useWorkspaceTapListener = useWorkspaceTapListener;" in src
+
+
+def test_shared_hook_has_exactly_one_eventsource() -> None:
+    # The whole point of the consolidation: the workspace-wide tap is opened in
+    # exactly ONE place (the shared hub).
+    assert _read(HOOK).count("new EventSource") == 1
+
+
+def test_shared_hook_registered_in_index() -> None:
+    order = [
+        line[line.index('src="') + 5 : line.index('"', line.index('src="') + 5)]
+        for line in _read(INDEX).splitlines()
+        if 'type="text/babel"' in line and "src=" in line
+    ]
+    assert "foundation/use-workspace-tap.js" in order
+    # Must load before the components that consume it.
+    hook_idx = order.index("foundation/use-workspace-tap.js")
+    assert hook_idx < order.index("components/workspace-tap.jsx")
+    assert hook_idx < order.index("components/studio-activity.jsx")
+    assert hook_idx < order.index("components/session-detail.jsx")
+
+
+def test_action_required_uses_shared_listener_not_own_eventsource() -> None:
+    src = _read(ACTIVITY)
+    assert "useWorkspaceTapListener" in src
+    assert "new EventSource" not in src
+
+
+def test_workspace_tap_uses_shared_hook_not_own_eventsource() -> None:
+    src = _read(TAP)
+    assert "useWorkspaceTap(" in src
+    assert "new EventSource" not in src
+
+
+def test_graph_run_view_uses_shared_listener_not_own_eventsource() -> None:
+    # The graph run-view's transition-refetch trigger reads the shared hub
+    # instead of opening a third EventSource. Scope to SD_GraphRunView only —
+    # SD_NodeInspector (which follows) keeps its own node-scoped, cursor-seam
+    # tap deliberately, and is not part of the workspace-wide consolidation.
+    body = _slice(_read(DETAIL), "function SD_GraphRunView(", "const SD_NODE_KIND_HINT")
+    assert "useWorkspaceTapListener" in body
+    assert "new EventSource" not in body
+
+
+def test_right_rail_opens_zero_independent_eventsources() -> None:
+    # Neither right-rail component constructs its own EventSource anymore.
+    assert _read(ACTIVITY).count("new EventSource") == 0
+    assert _read(TAP).count("new EventSource") == 0
+
+
+# ---------------------------------------------------------------------------
+# #5 — expandable workspace-activity events
+# ---------------------------------------------------------------------------
+
+def test_activity_events_are_expandable() -> None:
+    src = _read(TAP)
+    assert 'data-testid="activity-event"' in src
+    assert 'data-testid="activity-event-detail"' in src
+    # Accessible, keyboard-toggleable affordance, collapsed by default.
+    assert "aria-expanded" in src
+    assert "toggleExpand" in src
+    # The full payload detail is rendered from the whole event.
+    assert "WTP_detailJson" in src
+    # The e2e summary-row testid is preserved for existing journeys.
+    assert 'data-testid="tap-event-row"' in src
+
+
+# ---------------------------------------------------------------------------
+# #3 / #7 — bounded tail history + lazy older paging
+# ---------------------------------------------------------------------------
+
+def test_live_stream_loads_bounded_tail_not_whole_history() -> None:
+    body = _slice(_read(DETAIL), "function SessionLiveStream(", "window.SessionLiveStream = SessionLiveStream;")
+    assert "SLS_HISTORY_PAGE" in _read(DETAIL)
+    assert "tail=1" in body, "initial history load must request a bounded tail"
+    assert "limit=1000" not in body, "SessionLiveStream must not pull the whole log"
+    # Older rows load on demand.
+    assert 'data-testid="load-earlier"' in body
+    assert "loadEarlier" in body
+
+
+# ---------------------------------------------------------------------------
+# #10 — embedded stream is pure content; controls live only in the header
+# ---------------------------------------------------------------------------
+
+def test_interrupt_button_removed_from_embedded_stream() -> None:
+    body = _slice(_read(DETAIL), "function SessionLiveStream(", "window.SessionLiveStream = SessionLiveStream;")
+    assert ">Interrupt<" not in body
+    assert "sendInterrupt" not in body
+    assert "cancelMut" not in body
+    # No in-stream "Live stream" header chrome / TokenMeter.
+    assert "panel-h" not in body
+    assert "window.TokenMeter" not in body
+
+
+def test_session_controls_still_owned_by_panel_header() -> None:
+    src = _read(CENTER)
+    for testid in ("ctrl-pause", "ctrl-resume", "ctrl-steer", "ctrl-cancel"):
+        assert f'data-testid="{testid}"' in src
+
+
+# ---------------------------------------------------------------------------
+# Full bundle still transpiles with the new foundation module + edits
+# ---------------------------------------------------------------------------
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === foundation/use-workspace-tap.js === */" in text

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -212,3 +212,36 @@ def test_bundle_transpiles_with_studio() -> None:
     assert etag and body
     text = body.decode("utf-8")
     assert "/* === components/studio.jsx === */" in text
+
+
+# ---------------------------------------------------------------------------
+# closeAllTabs action + live ?open= URL reactivity (bugs #21, #11)
+# ---------------------------------------------------------------------------
+
+
+def test_state_hook_exposes_close_all_tabs() -> None:
+    src = _studio_src()
+    assert "var closeAllTabs = React.useCallback(" in src
+    assert "closeAllTabs: closeAllTabs" in src
+
+
+def test_close_all_tabs_clears_open_tabs_and_active() -> None:
+    src = _studio_src()
+    # Must clear both openTabs and activeTabId (localStorage then follows via
+    # the persist effect).
+    assert "openTabs: [], activeTabId: null" in src
+
+
+def test_url_reactivity_listens_for_hashchange_and_popstate() -> None:
+    src = _studio_src()
+    assert 'addEventListener("hashchange"' in src
+    assert 'addEventListener("popstate"' in src
+    # It re-parses the current ?open= via the existing helper.
+    assert "ST_tabFromUrl()" in src
+
+
+def test_url_reactivity_dedupes_against_active_tab() -> None:
+    src = _studio_src()
+    # No-op when the parsed tab is already active (prevents reopening a
+    # user-closed tab unless the URL truly changes).
+    assert "s.activeTabId === urlTab" in src

--- a/tests/ui/test_studio_sidebar.py
+++ b/tests/ui/test_studio_sidebar.py
@@ -183,3 +183,51 @@ def test_bundle_transpiles_with_studio_sidebar() -> None:
     text = body.decode("utf-8")
     assert "/* === components/studio-sidebar.jsx === */" in text
     assert "/* === components/studio.jsx === */" in text
+
+
+# ---------------------------------------------------------------------------
+# Graph-session glyph + delete + rename + create-name (bugs #9, #20, #22)
+# ---------------------------------------------------------------------------
+
+
+def test_sidebar_exports_session_kind_helpers() -> None:
+    src = _sidebar_src()
+    assert "window.ST_sessionKind = ST_sessionKind" in src
+    assert "window.ST_sessionGlyph = ST_sessionGlyph" in src
+
+
+def test_session_kind_detects_graph_prefix() -> None:
+    # Graph-bound sessions carry a synthetic agent_id "graph:<gid>" on the
+    # SessionInfo list shape (no binding field), so the prefix is the signal.
+    src = _sidebar_src()
+    assert 'indexOf("graph:") === 0' in src
+
+
+def test_sidebar_session_management_testids() -> None:
+    src = _sidebar_src()
+    for tid in (
+        'data-testid="session-delete"',
+        'data-testid="session-rename"',
+        'data-testid="new-session-name"',
+    ):
+        assert tid in src, f"Missing data-testid: {tid}"
+
+
+def test_sidebar_delete_uses_modal_not_native_confirm() -> None:
+    src = _sidebar_src()
+    # The delete confirm must go through the shared Modal, never window.confirm.
+    assert "ST_SessionDeleteDialog" in src
+    assert "window.confirm" not in src
+
+
+def test_sidebar_delete_stops_row_open_propagation() -> None:
+    src = _sidebar_src()
+    # The trash button must stopPropagation so the row's open-on-click
+    # doesn't fire when deleting.
+    assert "e.stopPropagation(); setPendingDelete(session)" in src
+
+
+def test_sidebar_rename_patches_session() -> None:
+    src = _sidebar_src()
+    assert "ST_SessionRenameDialog" in src
+    assert '"PATCH"' in src

--- a/tests/workspace/test_session.py
+++ b/tests/workspace/test_session.py
@@ -560,3 +560,58 @@ class TestAclose:
         await session.aclose()
         await session.aclose()  # no-op the second time
         assert await session.status() == SessionStatus.ENDED
+
+
+# ===========================================================================
+# set_name — friendly display name (bug #22)
+# ===========================================================================
+
+
+class TestSetName:
+    async def test_start_persists_name(
+        self, state_repo: StateRepo, truncation_store: TruncationStore
+    ) -> None:
+        session = await AgentSession.start(
+            session_id="sess-named",
+            workspace_id="ws-1",
+            agent_binding=_make_binding(),
+            state_repo=state_repo,
+            truncation_store=truncation_store,
+            name="First run",
+        )
+        assert (await session.info()).name == "First run"
+        # ... and it round-trips through session.json on disk.
+        disk = await state_repo.load_session_info("sess-named")
+        assert disk is not None and disk.name == "First run"
+
+    async def test_start_defaults_name_none(
+        self, state_repo: StateRepo, truncation_store: TruncationStore
+    ) -> None:
+        session = await _start_session(state_repo, truncation_store)
+        assert (await session.info()).name is None
+
+    async def test_set_name_rewrites_session_json(
+        self, state_repo: StateRepo, truncation_store: TruncationStore
+    ) -> None:
+        session = await _start_session(state_repo, truncation_store)
+        returned = await session.set_name("Renamed")
+        assert returned.name == "Renamed"
+        assert (await session.info()).name == "Renamed"
+        disk = await state_repo.load_session_info(session.session_id)
+        assert disk is not None and disk.name == "Renamed"
+
+    async def test_set_name_blank_clears(
+        self, state_repo: StateRepo, truncation_store: TruncationStore
+    ) -> None:
+        session = await AgentSession.start(
+            session_id="sess-clear",
+            workspace_id="ws-1",
+            agent_binding=_make_binding(),
+            state_repo=state_repo,
+            truncation_store=truncation_store,
+            name="To be cleared",
+        )
+        await session.set_name("   ")
+        assert (await session.info()).name is None
+        disk = await state_repo.load_session_info("sess-clear")
+        assert disk is not None and disk.name is None

--- a/tests/workspace/test_session_factory.py
+++ b/tests/workspace/test_session_factory.py
@@ -460,7 +460,7 @@ class _FakeLiveWorkspace:
         self.started: list[dict] = []
 
     async def start_session(
-        self, binding, *, id, instructions, parent_session_id
+        self, binding, *, id, instructions, parent_session_id, name=None
     ) -> None:
         self.started.append(
             {
@@ -468,6 +468,7 @@ class _FakeLiveWorkspace:
                 "id": id,
                 "instructions": instructions,
                 "parent_session_id": parent_session_id,
+                "name": name,
             }
         )
 

--- a/ui/components/graph-canvas.jsx
+++ b/ui/components/graph-canvas.jsx
@@ -1,4 +1,4 @@
-/* global React, G6 */
+/* global React, G6, Icon */
 // Unified AntV G6 (v5) graph canvas — the single renderer behind the graph
 // editor (interactive) and the session run-view (read-only + status). One
 // component, one place for the G6 logic; a `layout` prop forks between the
@@ -422,13 +422,54 @@ function GR_Canvas(props) {
     return () => clearInterval(id);
   }, [statusTint, selectedNodeId, draft]);
 
+  // Overlaid zoom / traverse controls (bug #1) — wired to the live G6 v5
+  // instance. zoomBy(ratio) is relative (>1 in, <1 out); fitView() frames the
+  // whole graph; zoomTo(1) resets to 100%. SHARED by both surfaces (editor +
+  // run-view) since the canvas is one component; the cluster sits over a corner
+  // and only its buttons capture pointer events, so node drags elsewhere are
+  // untouched. Each wraps a not-yet-ready graph as a no-op.
+  const _zoomBy = (ratio) => {
+    const g = graphRef.current;
+    if (!g) return;
+    try { Promise.resolve(g.zoomBy(ratio, true)).catch(() => {}); } catch (_e) { /* canvas */ }
+  };
+  const _fitView = () => {
+    const g = graphRef.current;
+    if (!g) return;
+    try { Promise.resolve(g.fitView({ when: "always", padding: 24 }, true)).catch(() => {}); }
+    catch (_e) { try { g.fitView(); } catch (_e2) { /* canvas */ } }
+  };
+  const _resetZoom = () => {
+    const g = graphRef.current;
+    if (!g) return;
+    try { Promise.resolve(g.zoomTo(1, true)).catch(() => {}); } catch (_e) { /* canvas */ }
+  };
+
   return (
-    <div style={{ minWidth: 0, overflow: "hidden" }}>
+    <div style={{ minWidth: 0, overflow: "hidden", position: "relative" }}>
       <div
         ref={containerRef}
         data-testid="graph-canvas"
         style={{ width: "100%", height: 500, minHeight: 500, background: "var(--bg)" }}
       />
+      <div className="gr-canvas-controls" data-testid="graph-controls">
+        <button type="button" className="gr-ctrl-btn" data-testid="graph-zoom-in"
+          aria-label="Zoom in" title="Zoom in" onClick={() => _zoomBy(1.2)}>
+          <Icon name="plus" size={15} />
+        </button>
+        <button type="button" className="gr-ctrl-btn" data-testid="graph-zoom-out"
+          aria-label="Zoom out" title="Zoom out" onClick={() => _zoomBy(1 / 1.2)}>
+          <Icon name="minus" size={15} />
+        </button>
+        <button type="button" className="gr-ctrl-btn" data-testid="graph-fit"
+          aria-label="Fit graph to view" title="Fit to view" onClick={_fitView}>
+          <Icon name="compress" size={15} />
+        </button>
+        <button type="button" className="gr-ctrl-btn gr-ctrl-btn-text" data-testid="graph-zoom-reset"
+          aria-label="Reset zoom to 100%" title="Reset zoom" onClick={_resetZoom}>
+          1:1
+        </button>
+      </div>
     </div>
   );
 }

--- a/ui/components/graph-canvas.jsx
+++ b/ui/components/graph-canvas.jsx
@@ -330,12 +330,23 @@ function GR_Canvas(props) {
         if (!gg) return;
         const P2 = _g6Palette();
         try {
+          // Preserve the user's zoom across a theme flip: render() re-applies
+          // the run-view's autoFit and would otherwise snap back to the fitted
+          // view, throwing away a zoom-in. Capture before, restore after.
+          // Fully wrapped — a G6 signature mismatch degrades to the old
+          // (reset) behavior rather than crashing.
+          var _zoom = null;
+          try { _zoom = gg.getZoom(); } catch (_z) { /* */ }
           gg.setOptions({
             background: P2.bg,
             node: { type: "rect", style: _g6NodeStyle(P2), state: _g6NodeStates(P2) },
             edge: { type: "polyline", style: _g6EdgeStyle(P2), state: _g6EdgeStateStyle(P2) },
           });
-          Promise.resolve(gg.render()).catch(() => {});
+          Promise.resolve(gg.render()).then(() => {
+            if (_zoom != null) {
+              try { gg.zoomTo(_zoom, false); } catch (_z) { /* */ }
+            }
+          }).catch(() => {});
         } catch (_e) { /* canvas */ }
       };
       themeObs = new MutationObserver(applyTheme);

--- a/ui/components/graph-canvas.jsx
+++ b/ui/components/graph-canvas.jsx
@@ -13,10 +13,36 @@
 // `draft` is { nodes:[{id,kind,x?,y?,...}], edges:[...] } (the editor draft
 // or the run-view graph — same shape). `layout`: "preset" | "dagre".
 
-const _G6_COLORS = {
-  neutral: "#3a3f47", green: "#34d399", amber: "#fbbf24", red: "#f87171",
-  violet: "#a78bfa", text: "#e6e8eb", sub: "#9aa4af", bg: "#0d0f12", edge: "#4b525c",
-};
+// Palette read LIVE from the Studio design tokens (styles.css :root[data-theme])
+// via getComputedStyle — the same pattern as studio-terminal.jsx's ST_xtermTheme
+// (~L52). Reading the CSS custom properties instead of hardcoding hex is what
+// lets a dark/light toggle restyle the G6 canvas (bug #6): both the init effect
+// and the theme MutationObserver call this to get the current-theme colours.
+// The `*Dim` entries pull the pre-baked translucent token variants
+// (oklch(... / a)) so we never string-append a hex alpha to an oklch() value.
+function _g6Palette() {
+  const css = window.getComputedStyle(document.documentElement);
+  const v = (name, fallback) => {
+    const val = css.getPropertyValue(name);
+    return val && val.trim() ? val.trim() : fallback;
+  };
+  return {
+    neutral: v("--border-strong", "#3a3f47"),
+    neutralDim: v("--bg-2", "#232428"),
+    green: v("--green", "#34d399"),
+    greenDim: v("--green-dim", "rgba(52,211,153,0.14)"),
+    amber: v("--amber", "#fbbf24"),
+    amberDim: v("--amber-dim", "rgba(251,191,36,0.14)"),
+    red: v("--red", "#f87171"),
+    redDim: v("--red-dim", "rgba(248,113,113,0.14)"),
+    violet: v("--violet", "#a78bfa"),
+    text: v("--text", "#e6e8eb"),
+    sub: v("--text-2", "#9aa4af"),
+    bg: v("--bg", "#0d0f12"),
+    edge: v("--border-strong", "#4b525c"),
+    edgeDim: v("--border", "#3b424b"),
+  };
+}
 
 // Node sizes by kind (also exported; consumers may read GR_NODE_SIZE).
 const GR_NODE_SIZE = {
@@ -40,25 +66,28 @@ function _g6IconUri(kind, stroke) {
   const inner = _G6_KIND_SVG[kind];
   if (!inner) return undefined;
   const svg = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="'
-    + (stroke || _G6_COLORS.text) + '" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">'
+    + (stroke || "#e6e8eb") + '" stroke-width="1.9" stroke-linecap="round" stroke-linejoin="round">'
     + inner + '</svg>';
   return "data:image/svg+xml," + encodeURIComponent(svg);
 }
 
 // Per-status node state styles (the live "glow"); G6 tweens state changes.
-function _g6NodeStates() {
-  const mk = (c, halo) => ({
-    stroke: c, lineWidth: 2, fill: c + "22",
+// Palette-driven (P from _g6Palette) so the theme observer can rebuild these
+// on a dark/light flip. The fill uses the pre-baked `*Dim` token variants
+// rather than appending a hex alpha (tokens are oklch(), not hex).
+function _g6NodeStates(P) {
+  const mk = (c, fillDim, halo) => ({
+    stroke: c, lineWidth: 2, fill: fillDim,
     halo, haloStroke: c, haloStrokeOpacity: 0.32, haloLineWidth: halo ? 10 : 0,
   });
   return {
-    pending: mk(_G6_COLORS.neutral, false),
-    running: mk(_G6_COLORS.green, true),
-    waiting: mk(_G6_COLORS.amber, true),
-    ended: mk(_G6_COLORS.green, false),
-    failed: mk(_G6_COLORS.red, true),
-    pulse: { halo: true, haloStroke: _G6_COLORS.green, haloLineWidth: 20, haloStrokeOpacity: 0.15 },
-    selected: { stroke: _G6_COLORS.violet, lineWidth: 3, halo: true, haloStroke: _G6_COLORS.violet, haloStrokeOpacity: 0.4 },
+    pending: mk(P.neutral, P.neutralDim, false),
+    running: mk(P.green, P.greenDim, true),
+    waiting: mk(P.amber, P.amberDim, true),
+    ended: mk(P.green, P.greenDim, false),
+    failed: mk(P.red, P.redDim, true),
+    pulse: { halo: true, haloStroke: P.green, haloLineWidth: 20, haloStrokeOpacity: 0.15 },
+    selected: { stroke: P.violet, lineWidth: 3, halo: true, haloStroke: P.violet, haloStrokeOpacity: 0.4 },
   };
 }
 
@@ -108,10 +137,50 @@ function _g6Edges(draft) {
   return out;
 }
 
-function _g6EdgeStateStyle() {
+function _g6EdgeStateStyle(P) {
   return {
-    selected: { stroke: _G6_COLORS.violet, lineWidth: 2.5 },
-    active: { stroke: _G6_COLORS.green, lineWidth: 2, lineDash: [6, 6], endArrow: true },
+    selected: { stroke: P.violet, lineWidth: 2.5 },
+    active: { stroke: P.green, lineWidth: 2, lineDash: [6, 6], endArrow: true },
+  };
+}
+
+// Base node / edge style builders — palette-driven so the initial G6 init and
+// the theme MutationObserver (restyle-on-toggle) share one source of truth.
+// iconSrc bakes the label colour into the SVG data-URI, so a re-theme must
+// rebuild these (not just swap a token) to recolour the node icons too.
+function _g6NodeStyle(P) {
+  return {
+    size: (d) => { const s = _g6Size(d.data.kind); return [s.w, s.h]; },
+    radius: (d) => (_g6Tiny(d.data.kind) ? 12 : 8),
+    fill: P.neutralDim,
+    stroke: P.neutral,
+    lineWidth: 2,
+    labelText: (d) => d.data.label,
+    labelPlacement: "center",
+    labelDx: 9,
+    labelFill: P.text,
+    labelFontSize: 12,
+    labelFontFamily: "IBM Plex Mono, monospace",
+    labelLineHeight: 15,
+    iconSrc: (d) => _g6IconUri(d.data.kind, P.text),
+    iconWidth: 15,
+    iconHeight: 15,
+    iconX: -57,
+  };
+}
+function _g6EdgeStyle(P) {
+  return {
+    stroke: (d) => (d.data.etype === "implicit" ? P.edgeDim : P.edge),
+    lineWidth: 1.5,
+    lineDash: (d) => (d.data.etype === "static" ? undefined : [5, 5]),
+    endArrow: true,
+    endArrowSize: 8,
+    radius: 8,
+    labelText: (d) => d.data.label || "",
+    labelFill: P.sub,
+    labelFontSize: 10,
+    labelBackground: true,
+    labelBackgroundFill: P.bg,
   };
 }
 
@@ -138,6 +207,10 @@ function GR_Canvas(props) {
     if (!containerRef.current || !window.G6 || !draft) return undefined;
     const G6 = window.G6;
     const preset = layout === "preset";
+    // Live theme palette — read fresh on every (re)init so the canvas is born
+    // in the current dark/light theme; the observer below keeps it in sync.
+    const P = _g6Palette();
+    let themeObs = null;
     // Mutating behaviors (drag/connect) only when the editor wires them;
     // the run-view passes no onMoveNode/onConnect and stays read-only.
     const interactive = !!(cb.current.onMoveNode || cb.current.onConnect);
@@ -163,7 +236,7 @@ function GR_Canvas(props) {
         // drag cleanly (no phantom edge, no onFinish) — a deliberate drag that
         // ends back on the source node never creates an edge.
         onCreate: (edge) => (edge && edge.source !== edge.target ? edge : false),
-        style: { stroke: _G6_COLORS.violet, lineWidth: 1.5, lineDash: [4, 4], endArrow: true },
+        style: { stroke: P.violet, lineWidth: 1.5, lineDash: [4, 4], endArrow: true },
       });
     }
     const nodes = (draft.nodes || []).map((n) => {
@@ -178,47 +251,10 @@ function GR_Canvas(props) {
       g = new G6.Graph({
         container: containerRef.current,
         autoResize: true,
-        background: _G6_COLORS.bg,
+        background: P.bg,
         data: { nodes, edges: _g6Edges(draft) },
-        node: {
-          type: "rect",
-          style: {
-            size: (d) => { const s = _g6Size(d.data.kind); return [s.w, s.h]; },
-            radius: (d) => (_g6Tiny(d.data.kind) ? 12 : 8),
-            fill: _G6_COLORS.neutral + "22",
-            stroke: _G6_COLORS.neutral,
-            lineWidth: 2,
-            labelText: (d) => d.data.label,
-            labelPlacement: "center",
-            labelDx: 9,
-            labelFill: _G6_COLORS.text,
-            labelFontSize: 12,
-            labelFontFamily: "IBM Plex Mono, monospace",
-            labelLineHeight: 15,
-            iconSrc: (d) => _g6IconUri(d.data.kind),
-            iconWidth: 15,
-            iconHeight: 15,
-            iconX: -57,
-          },
-          state: _g6NodeStates(),
-        },
-        edge: {
-          type: "polyline",
-          style: {
-            stroke: (d) => (d.data.etype === "implicit" ? "#3b424b" : _G6_COLORS.edge),
-            lineWidth: 1.5,
-            lineDash: (d) => (d.data.etype === "static" ? undefined : [5, 5]),
-            endArrow: true,
-            endArrowSize: 8,
-            radius: 8,
-            labelText: (d) => d.data.label || "",
-            labelFill: _G6_COLORS.sub,
-            labelFontSize: 10,
-            labelBackground: true,
-            labelBackgroundFill: _G6_COLORS.bg,
-          },
-          state: _g6EdgeStateStyle(),
-        },
+        node: { type: "rect", style: _g6NodeStyle(P), state: _g6NodeStates(P) },
+        edge: { type: "polyline", style: _g6EdgeStyle(P), state: _g6EdgeStateStyle(P) },
         layout: preset ? { type: "preset" } : { type: "dagre", rankdir: "LR", nodesep: 18, ranksep: 66 },
         behaviors,
         autoFit: preset ? undefined : "view",
@@ -281,12 +317,36 @@ function GR_Canvas(props) {
           }, 60);
         }
       }).catch(() => {});
+
+      // Bug #6 — restyle on dark/light toggle. G6's styles were hardcoded hex,
+      // so flipping data-theme left the canvas stuck on its old colours. Watch
+      // <html data-theme> (set by studio.jsx + the console theme effect on
+      // document.documentElement), re-read the tokens, and push fresh
+      // node/edge/background styles. Full re-render is fine here — a theme
+      // toggle is rare and re-baking the icon data-URIs needs the mappers to
+      // re-run. Disconnected on unmount below.
+      const applyTheme = () => {
+        const gg = graphRef.current;
+        if (!gg) return;
+        const P2 = _g6Palette();
+        try {
+          gg.setOptions({
+            background: P2.bg,
+            node: { type: "rect", style: _g6NodeStyle(P2), state: _g6NodeStates(P2) },
+            edge: { type: "polyline", style: _g6EdgeStyle(P2), state: _g6EdgeStateStyle(P2) },
+          });
+          Promise.resolve(gg.render()).catch(() => {});
+        } catch (_e) { /* canvas */ }
+      };
+      themeObs = new MutationObserver(applyTheme);
+      themeObs.observe(document.documentElement, { attributes: true, attributeFilter: ["data-theme"] });
     } catch (err) {
       console.error("[GR_Canvas] init failed:", err);  // eslint-disable-line no-console
     }
 
     return () => {
       readyRef.current = false;
+      try { themeObs && themeObs.disconnect(); } catch (_e) { /* no-op */ }
       try { graphRef.current && graphRef.current.destroy(); } catch (_e) { /* no-op */ }
       graphRef.current = null;
     };
@@ -367,7 +427,7 @@ function GR_Canvas(props) {
       <div
         ref={containerRef}
         data-testid="graph-canvas"
-        style={{ width: "100%", height: 500, minHeight: 500, background: _G6_COLORS.bg }}
+        style={{ width: "100%", height: 500, minHeight: 500, background: "var(--bg)" }}
       />
     </div>
   );

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -797,44 +797,64 @@ window.SessionDetail = SessionDetail;
 // known (session row has workspace_id).
 
 
+// #3/#7: bounded history page. The initial load fetches only the most-recent
+// SLS_HISTORY_PAGE recorded rows (a server-side `tail`) instead of the whole
+// messages.jsonl (previously limit=1000), so a long session's transcript
+// renders immediately and never blocks/times-out on one monolithic payload.
+// Older rows load on demand via the "Load earlier" control.
+const SLS_HISTORY_PAGE = 200;
+
 function SessionLiveStream({ sid, wid, session, pushToast }) {
   const [messages, setMessages] = React.useState([]);
   // Connection state of the tap EventSource: "connecting" | "open" | "closed".
   const [wsState, setWsState] = React.useState("connecting");
-  // Token-usage snapshot for the read-only header TokenMeter. Updated live
-  // from tap `done` frames whose payload now carries a `usage` envelope
-  // (input_tokens, output_tokens) written by translate_stream_event when a
-  // Usage event precedes the Done. Falls back to the most recent turn's
-  // tokens_in when the done frame has no envelope (e.g. graph sessions or
-  // non-LLM turns that never emitted a Usage event).
-  const [usage, setUsage] = React.useState({ input_tokens: 0, output_tokens: 0, context_length: 0 });
   const [historyLoaded, setHistoryLoaded] = React.useState(false);
-  const { useMutation, apiFetch } = window.primerApi;
+  // Whether older recorded rows exist beyond the loaded tail (#3/#7).
+  const [moreEarlier, setMoreEarlier] = React.useState(false);
+  const [loadingEarlier, setLoadingEarlier] = React.useState(false);
+  const { apiFetch } = window.primerApi;
   const scrollRef = React.useRef(null);
   const historyCursorRef = React.useRef(0);
+  // How many most-recent recorded rows we've fetched (the tail "offset" for
+  // paging older).
+  const historyLoadedCountRef = React.useRef(0);
+
+  // Merge a page of recorded rows into `messages`, de-duped by seq + sorted.
+  const _mergeHistory = React.useCallback((items) => {
+    setMessages((prev) => {
+      const seen = new Set(prev.map((p) => p.seq));
+      const merged = [...prev];
+      for (const it of items) {
+        if (seen.has(it.seq)) continue;
+        const payload = it.payload && typeof it.payload === "object" ? it.payload : {};
+        merged.push({ ...payload, ...it });
+      }
+      merged.sort((a, b) => (a.seq || 0) - (b.seq || 0));
+      return merged;
+    });
+  }, []);
+
   React.useEffect(() => {
     let alive = true;
     (async () => {
       try {
-        const res = await apiFetch("GET", `/sessions/${encodeURIComponent(sid)}/messages?limit=1000`);
+        const res = await apiFetch(
+          "GET",
+          `/sessions/${encodeURIComponent(sid)}/messages?limit=${SLS_HISTORY_PAGE}&tail=1`,
+        );
         if (!alive) return;
         const items = (res && res.items) || [];
         if (items.length) {
           let maxSeq = 0;
           for (const it of items) { if (typeof it.seq === "number" && it.seq > maxSeq) maxSeq = it.seq; }
+          // The tail includes the newest rows, so maxSeq is the true global
+          // high-water mark — the resume cursor stays gap-free.
           historyCursorRef.current = maxSeq;
-          setMessages((prev) => {
-            const seen = new Set(prev.map((p) => p.seq));
-            const merged = [...prev];
-            for (const it of items) {
-              if (seen.has(it.seq)) continue;
-              const payload = it.payload && typeof it.payload === "object" ? it.payload : {};
-              merged.push({ ...payload, ...it });
-            }
-            merged.sort((a, b) => (a.seq || 0) - (b.seq || 0));
-            return merged;
-          });
+          historyLoadedCountRef.current = items.length;
+          _mergeHistory(items);
         }
+        const total = (res && typeof res.total === "number") ? res.total : items.length;
+        setMoreEarlier(total > items.length);
         setHistoryLoaded(true);
       } catch (_e) {
         /* history is best-effort; the tap still tails for live runs */
@@ -843,6 +863,30 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
     })();
     return () => { alive = false; };
   }, [sid]);  // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Lazily fetch the next older page of recorded rows (#3/#7). Uses the tail
+  // offset so paging is anchored to the end of the log, not a shifting start.
+  const loadEarlier = React.useCallback(async () => {
+    setLoadingEarlier(true);
+    try {
+      const offset = historyLoadedCountRef.current;
+      const res = await apiFetch(
+        "GET",
+        `/sessions/${encodeURIComponent(sid)}/messages?limit=${SLS_HISTORY_PAGE}&tail=1&offset=${offset}`,
+      );
+      const items = (res && res.items) || [];
+      if (items.length) {
+        historyLoadedCountRef.current = offset + items.length;
+        _mergeHistory(items);
+      }
+      const total = (res && typeof res.total === "number") ? res.total : (offset + items.length);
+      setMoreEarlier(items.length > 0 && (offset + items.length) < total);
+    } catch (_e) {
+      /* best-effort — leave older rows unloaded on error */
+    } finally {
+      setLoadingEarlier(false);
+    }
+  }, [sid, _mergeHistory]);
   // Whether the session is terminal. A terminal run has no live frames to
   // tail — history already covers the full transcript — so we never open
   // the tap for it. Kept in a ref (seeded from the initial prop, refreshed
@@ -908,15 +952,6 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
         if (prev.some((p) => p.seq === frame.seq)) return prev;
         return [...prev, frame].sort((a, b) => (a.seq || 0) - (b.seq || 0));
       });
-      // Update the TokenMeter from the done frame's usage envelope (written by
-      // translate_stream_event when a Usage event preceded the Done event).
-      if (tev.class === "done" && payload.usage && typeof payload.usage === "object") {
-        setUsage((prev) => ({
-          ...prev,
-          input_tokens: Number(payload.usage.input_tokens) || 0,
-          output_tokens: Number(payload.usage.output_tokens) || 0,
-        }));
-      }
     };
 
     es.onerror = () => {
@@ -928,21 +963,11 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
     return () => { try { es.close(); } catch { /* no-op */ } };
   }, [wid, sid, historyLoaded]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // REST cancel — the tap stream is read-only, so the "Interrupt" control
-  // routes to the cancel endpoint (which sets cancel_requested_at + publishes
-  // the same session:{sid}:cancel the old WS interrupt frame did).
-  const cancelMut = useMutation(
-    () => apiFetch("POST", `/workspaces/${encodeURIComponent(wid)}/sessions/${encodeURIComponent(sid)}/cancel`),
-    {
-      invalidates: [`session-detail:${sid}`, "sessions:list"],
-      onSuccess: () => pushToast && pushToast({
-        kind: "warning",
-        title: "Interrupt sent",
-        detail: "Session will cancel after the current step.",
-      }),
-      onError: _sdToastErr(pushToast, "Interrupt failed"),
-    }
-  );
+  // #10: the embedded stream is PURE CONTENT — no header chrome and no
+  // Interrupt control. Session controls (Pause/Resume/Steer/Cancel) live in
+  // exactly one place, the parent panel header (ST_SessionControls in
+  // studio-center.jsx). The old in-stream "Interrupt" duplicated the header's
+  // Cancel and was removed along with the title/frame-count/token-meter/badge.
 
   // Stick-to-bottom auto-scroll.
   const stickRef = React.useRef(true);
@@ -958,74 +983,32 @@ function SessionLiveStream({ sid, wid, session, pushToast }) {
     return () => cancelAnimationFrame(raf);
   }, [messages, isRunning]);
 
-  const sendInterrupt = () => {
-    if (!wid) {
-      if (typeof pushToast === "function") {
-        pushToast({ kind: "error", title: "Cannot interrupt", detail: "Session has no workspace_id" });
-      }
-      return;
-    }
-    cancelMut.mutate();
-  };
-
-  const wsBadge = wsState === "open"
-    ? <span className="pill pill-running" title="Tap stream open"><span className="dot"></span>live</span>
-    : wsState === "connecting"
-      ? <span className="pill pill-paused" title="Tap stream connecting"><span className="dot"></span>connecting</span>
-      : <span className="pill pill-ended" title="Tap stream closed"><span className="dot"></span>offline</span>;
-
   const coalesced = _SLS_coalesceMessages(messages);
-  const isTerminalSession = session && SESSION_TERMINAL.has(session.status);
   const isGraph = (session?.binding?.kind || session?.binding_kind) === "graph";
 
-  // Fallback for the read-only TokenMeter when no done+usage frame has
-  // landed yet (e.g. graph sessions, non-LLM turns, or initial page load
-  // before the first turn completes). Uses the most recent turn's tokens_in
-  // so the meter surfaces something meaningful on first paint.
-  const fallbackUsage = React.useMemo(() => {
-    const turns = Array.isArray(session?.turns) ? session.turns : [];
-    const last = turns.length > 0 ? turns[turns.length - 1] : null;
-    return {
-      input_tokens: Number(last?.tokens_in) || 0,
-      context_length: Number(session?.context_length) || 0,
-    };
-  }, [session]);
-  const meterInput = usage.input_tokens || fallbackUsage.input_tokens;
-  const meterContext = usage.context_length || fallbackUsage.context_length;
-
   return (
-    <div className="panel" data-testid="session-live-stream" style={{ display: "flex", flexDirection: "column" }}>
-      <div className="panel-h">
-        <Icon name="zap" size={13} style={{ color: "var(--blue)" }} />
-        <span>Live stream</span>
-        <span className="sub">· {messages.length} frame{messages.length === 1 ? "" : "s"}</span>
-        <div className="right" style={{ display: "flex", gap: 8, alignItems: "center" }}>
-          {/* Read-only TokenMeter — workspace sessions surface context
-              pressure but don't expose an operator-triggered compact
-              action (those flow through the chat surface). */}
-          <window.TokenMeter
-            inputTokens={meterInput}
-            contextLength={meterContext}
-            onCompact={null}
-          />
-          {wsBadge}
-          {!isTerminalSession && (
-            <Btn
-              size="sm"
-              kind="danger"
-              icon="stop"
-              disabled={!wid || cancelMut.loading}
-              onClick={sendInterrupt}
-              title="Cancel the running turn (POST .../cancel)"
-            >Interrupt</Btn>
-          )}
-        </div>
-      </div>
+    <div
+      data-testid="session-live-stream"
+      style={{ display: "flex", flexDirection: "column", flex: 1, minHeight: 0 }}
+    >
       <div
         ref={scrollRef}
         onScroll={onScroll}
         style={{ flex: 1, overflow: "auto", padding: "14px 18px", minHeight: 120, maxHeight: 480 }}
       >
+        {/* #3/#7: page older recorded rows on demand rather than pulling the
+            full history at once. */}
+        {moreEarlier && (
+          <div style={{ textAlign: "center", padding: "2px 0 10px" }}>
+            <Btn
+              size="sm"
+              kind="ghost"
+              disabled={loadingEarlier}
+              onClick={loadEarlier}
+              data-testid="load-earlier"
+            >{loadingEarlier ? "Loading…" : "Load earlier"}</Btn>
+          </div>
+        )}
         {coalesced.length === 0 && (
           terminalRef.current ? (
             <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }}>
@@ -1160,32 +1143,20 @@ function SD_GraphRunView({ gid, rid, wid, session, pushToast }) {
   );
 
   // Tap events trigger an immediate refetch so node transitions feel live
-  // without a tight poll. We subscribe read-only to the workspace tap
-  // (session-scoped selector, live-from-now — no history/cursor needed
-  // because a missed event only delays a refetch and the 2 s poll backstops
-  // it) and refetch on graph_transition / done / error frames.
-  React.useEffect(() => {
-    if (!wid || !rid || isTerminal) return undefined;
-    const selector = window.WTP_buildSelector
-      ? window.WTP_buildSelector(null, rid)
-      : { sessions: { kind: "predicate", left: { kind: "field", name: "id" }, op: "=", right: { kind: "value", value: rid } } };
-    const url = `/v1/workspaces/${encodeURIComponent(wid)}/tap?selector=${encodeURIComponent(JSON.stringify(selector))}`;
-    let es;
-    try {
-      es = new EventSource(url, { withCredentials: true });
-    } catch { return undefined; }
-    es.onmessage = (ev) => {
-      let tev;
-      try { tev = JSON.parse(ev.data); } catch { return; }
-      if (!tev || typeof tev !== "object") return;
-      const cls = tev.class;
-      if (cls === "graph_transition" || cls === "done" || cls === "error") {
-        states.refetch();
-      }
-    };
-    return () => { try { es.close(); } catch { /* no-op */ } };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [wid, rid, isTerminal]);
+  // without a tight poll. We read the SHARED workspace tap
+  // (foundation/use-workspace-tap.js) rather than opening a dedicated
+  // EventSource — the same single connection that feeds the right-rail
+  // Activity + Action Required also drives this refetch. We filter client-side
+  // for this run's session and refetch on graph_transition / done / error;
+  // a missed frame only delays a refetch and the 2 s poll backstops it. The
+  // hook is passed a null wid once terminal so it detaches.
+  window.useWorkspaceTapListener(isTerminal ? null : wid, (tev) => {
+    if (!tev || typeof tev !== "object" || tev.session_id !== rid) return;
+    const cls = tev.class;
+    if (cls === "graph_transition" || cls === "done" || cls === "error") {
+      states.refetch();
+    }
+  });
 
   const items = states.data?.items || [];
   const statusByNode = React.useMemo(() => {

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -58,40 +58,23 @@ function ActionRequired({ wid, studio }) {
 
   var items = (pending.data && Array.isArray(pending.data.items)) ? pending.data.items : [];
 
-  // Live reconcile: subscribe to the workspace tap; refetch on yielded/done.
-  // We keep this EventSource independent of WorkspaceTap so it is always
-  // open regardless of the activity feed's filter state.
+  // Live reconcile via the SHARED workspace tap (foundation/use-workspace-tap.js).
+  // ONE EventSource for the whole Studio view feeds this reconcile listener,
+  // the WorkspaceTap activity feed, and the graph run-view — instead of each
+  // opening its own connection (fe-review N4). We debounce a refetch of the
+  // pending snapshot on yielded/done; the 15s pollMs backstops a dropped tap.
   var debounceRef = React.useRef(null);
-  React.useEffect(function() {
-    if (!wid) return;
-    var url = "/v1/workspaces/" + encodeURIComponent(wid) + "/tap";
-    var es;
-    try {
-      es = new EventSource(url, { withCredentials: true });
-    } catch (_e) {
-      return;
-    }
-    es.onmessage = function(e) {
-      var ev;
-      try { ev = JSON.parse(e.data); } catch (_) { return; }
-      if (!ev || typeof ev !== "object") return;
-      var cls = ev.class;
-      if (cls === "yielded" || cls === "done") {
-        clearTimeout(debounceRef.current);
-        debounceRef.current = setTimeout(function() {
-          pending.refetch();
-        }, 300);
-      }
-    };
-    // No-op on stream error: the 15s pollMs on the pending resource is the
-    // safety net, so a dropped/erroring tap still reconciles on the next poll
-    // (mirrors how WorkspaceTap tolerates stream errors).
-    es.onerror = function() { /* poll backstops a dropped tap */ };
-    return function() {
+  window.useWorkspaceTapListener(wid, function (ev) {
+    if (!ev || typeof ev !== "object") return;
+    var cls = ev.class;
+    if (cls === "yielded" || cls === "done") {
       clearTimeout(debounceRef.current);
-      try { es.close(); } catch (_) { /* no-op */ }
-    };
-  }, [wid]); // eslint-disable-line react-hooks/exhaustive-deps
+      debounceRef.current = setTimeout(function () { pending.refetch(); }, 300);
+    }
+  });
+  React.useEffect(function () {
+    return function () { clearTimeout(debounceRef.current); };
+  }, []);
 
   // Per-item respond state: { [item_id]: { draft, submitting, error } }
   var [respondState, setRespondState] = React.useState({});
@@ -205,15 +188,7 @@ function ActionRequired({ wid, studio }) {
 
   return (
     <div
-      className="st-section"
-      style={{
-        borderBottom: "1px solid var(--border)",
-        display: "flex",
-        flexDirection: "column",
-        flexShrink: 0,
-        maxHeight: count > 0 ? 320 : 60,
-        overflow: "hidden",
-      }}
+      className={"st-section st-action-required " + (count > 0 ? "has-items" : "is-empty")}
       data-testid="action-required"
     >
       {/* Section header */}
@@ -268,15 +243,7 @@ function ActionRequired({ wid, studio }) {
         style={{ overflowY: "auto", flex: 1 }}
       >
         {count === 0 && !pending.loading && (
-          <div
-            style={{
-              padding: "14px 12px",
-              fontSize: 12,
-              color: "var(--text-4)",
-              textAlign: "center",
-              lineHeight: 1.5,
-            }}
-          >
+          <div className="st-action-empty" data-testid="action-required-empty">
             No pending actions. Everything's running clean.
           </div>
         )}

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -87,8 +87,20 @@ var ST_EDIT_MAX_BYTES = 1024 * 1024;
 //   shown when there are no open tabs.
 // ---------------------------------------------------------------------------
 
-function CenterTabs({ openTabs, activeTabId, onFocus, onClose }) {
+function CenterTabs({ openTabs, activeTabId, onFocus, onClose, onCloseAll }) {
   var tabs = openTabs || [];
+
+  function handleCloseAll(e) {
+    e.stopPropagation();
+    if (!tabs.length) return; // no-op when there are no open tabs
+    // If any file tab has unsaved edits, confirm once before dropping them all.
+    var anyDirty = tabs.some(function (t) { return t.kind === "file" && t.dirty; });
+    if (anyDirty) {
+      var ok = window.confirm("Some files have unsaved changes. Close all tabs without saving?");
+      if (!ok) return;
+    }
+    onCloseAll && onCloseAll();
+  }
 
   if (tabs.length === 0) {
     return (
@@ -159,6 +171,18 @@ function CenterTabs({ openTabs, activeTabId, onFocus, onClose }) {
           </div>
         );
       })}
+      {/* Close-all control — pinned to the right edge so it stays reachable
+          even when the tab strip overflows and scrolls. */}
+      <button
+        className="st-tabs-close-all"
+        data-testid="tabs-close-all"
+        title="Close all tabs"
+        aria-label="Close all tabs"
+        onClick={handleCloseAll}
+      >
+        <Icon name="x" size={13} />
+        <span style={{ fontSize: 11 }}>Close all</span>
+      </button>
     </div>
   );
 }
@@ -867,6 +891,7 @@ function StudioCenter({ wid, studio }) {
         activeTabId={activeTabId}
         onFocus={studio.focusTab}
         onClose={studio.closeTab}
+        onCloseAll={studio.closeAllTabs}
       />
       <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
         {panel}

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -1,4 +1,4 @@
-/* global React, Icon */
+/* global React, Icon, Modal, Btn, Banner */
 // StudioSidebar — left sidebar for the Studio IDE shell (PR-B / B2).
 //
 // Contains two collapsible sections:
@@ -70,6 +70,34 @@ function ST_sessionStatus(session) {
   }
   // Fallback.
   return { tone: "dim", label: status, badge: null };
+}
+
+// ---------------------------------------------------------------------------
+// ST_sessionKind — classify a session row as "graph" or "agent".
+//
+// The workspace sessions list endpoint returns SessionInfo, which has NO
+// `binding` field — graph-bound sessions instead carry a SYNTHETIC
+// `agent_id = "graph:<graph_id>"` (see primer/workspace/session_factory.py:
+// the graph holder slot). So the prefix is the signal for the list shape.
+// We also honour the fuller WorkspaceSession / create-response shape
+// (`binding.kind` / `binding_kind` / bare `graph_id`) so the same helper
+// works wherever a session object comes from.
+//
+// Published as window.ST_sessionKind / window.ST_sessionGlyph for B3 reuse.
+// ---------------------------------------------------------------------------
+
+function ST_sessionKind(session) {
+  if (!session) return "agent";
+  var aid = session.agent_id || "";
+  if (typeof aid === "string" && aid.indexOf("graph:") === 0) return "graph";
+  if (session.binding && session.binding.kind === "graph") return "graph";
+  if (session.binding_kind === "graph") return "graph";
+  if (session.graph_id && !session.agent_id) return "graph";
+  return "agent";
+}
+
+function ST_sessionGlyph(session) {
+  return ST_sessionKind(session) === "graph" ? "◈" : "◆";
 }
 
 // ---------------------------------------------------------------------------
@@ -182,6 +210,7 @@ function NewSessionForm({ wid, onClose, onCreated }) {
   var [kind, setKind] = React.useState("agent");
   var [agentId, setAgentId] = React.useState("");
   var [graphId, setGraphId] = React.useState("");
+  var [name, setName] = React.useState("");
   var [instructions, setInstructions] = React.useState("");
   var [submitting, setSubmitting] = React.useState(false);
   var [error, setError] = React.useState(null);
@@ -214,6 +243,7 @@ function NewSessionForm({ wid, onClose, onCreated }) {
       ? { kind: "agent", agent_id: agentId }
       : { kind: "graph", graph_id: graphId };
     var body = { binding: binding, auto_start: true };
+    if (name.trim()) body.name = name.trim();
     if (instructions.trim()) body.initial_instructions = instructions.trim();
     try {
       var session = await apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions", body);
@@ -249,6 +279,20 @@ function NewSessionForm({ wid, onClose, onCreated }) {
           title="Cancel"
         >×</button>
       </div>
+
+      {/* Optional friendly name — persisted onto the session so the sidebar
+          shows it instead of the opaque sess-<hex> id. */}
+      <input
+        data-testid="new-session-name"
+        placeholder="Name (optional)"
+        value={name}
+        onChange={function(e) { setName(e.target.value); }}
+        style={{
+          width: "100%", padding: "5px 7px", fontSize: 12, background: "var(--bg-2)",
+          border: "1px solid var(--border)", borderRadius: 5, color: "var(--text)",
+          marginBottom: 8, outline: "none", fontFamily: "inherit",
+        }}
+      />
 
       {/* Binding kind toggle */}
       <div style={{ display: "flex", gap: 4, marginBottom: 8 }}>
@@ -355,6 +399,163 @@ function NewSessionForm({ wid, onClose, onCreated }) {
 }
 
 // ---------------------------------------------------------------------------
+// ST_SessionDeleteDialog — confirm + DELETE a session.
+//   DELETE /v1/workspaces/{wid}/sessions/{sid}. Uses the shared Modal (NOT
+//   native confirm()). On success the caller closes the matching center tab
+//   and refetches the sidebar list; failures surface inline + as a toast.
+// ---------------------------------------------------------------------------
+
+function ST_SessionDeleteDialog({ wid, session, onClose, onDeleted, pushToast }) {
+  var { apiFetch } = window.primerApi;
+  var sid = session.session_id || session.id;
+  var label = session.name || sid;
+  var [busy, setBusy] = React.useState(false);
+  var [error, setError] = React.useState(null);
+
+  var mountedRef = React.useRef(true);
+  React.useEffect(function () {
+    mountedRef.current = true;
+    return function () { mountedRef.current = false; };
+  }, []);
+
+  async function submit() {
+    setBusy(true);
+    setError(null);
+    try {
+      await apiFetch("DELETE", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid));
+      if (!mountedRef.current) return;
+      pushToast && pushToast({ kind: "success", title: "Session deleted", detail: label });
+      onDeleted && onDeleted(sid);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      var detail = (err && (err.detail || err.message)) || "Delete failed";
+      setError(detail);
+      setBusy(false);
+      pushToast && pushToast({
+        kind: "error",
+        title: "Delete failed",
+        detail: detail,
+        requestId: err && err.requestId,
+      });
+    }
+  }
+
+  return (
+    <Modal
+      title={"Delete session · " + label}
+      danger
+      onClose={onClose}
+      footer={
+        <>
+          <Btn kind="ghost" onClick={onClose} disabled={busy}>Cancel</Btn>
+          <Btn
+            kind="danger"
+            icon="trash"
+            onClick={submit}
+            disabled={busy}
+            data-testid="session-delete-confirm"
+          >
+            {busy ? "Deleting…" : "Delete session"}
+          </Btn>
+        </>
+      }
+    >
+      <div data-testid="session-delete-confirm-body">
+        <p>Permanently remove this session and its on-disk state. A running
+        session is cancelled first. This cannot be undone.</p>
+        {error && (
+          <Banner kind="error" title="Delete failed" detail={String(error)} />
+        )}
+      </div>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// ST_SessionRenameDialog — give a session a friendly name (or clear it).
+//   PATCH /v1/workspaces/{wid}/sessions/{sid} { name }. An empty value
+//   clears the name (server falls back to the id). Returns the updated
+//   SessionInfo; the caller refetches so the row reflects the new label.
+// ---------------------------------------------------------------------------
+
+function ST_SessionRenameDialog({ wid, session, onClose, onRenamed, pushToast }) {
+  var { apiFetch } = window.primerApi;
+  var sid = session.session_id || session.id;
+  var [name, setName] = React.useState(session.name || "");
+  var [busy, setBusy] = React.useState(false);
+  var [error, setError] = React.useState(null);
+
+  var mountedRef = React.useRef(true);
+  React.useEffect(function () {
+    mountedRef.current = true;
+    return function () { mountedRef.current = false; };
+  }, []);
+
+  async function submit(e) {
+    if (e && e.preventDefault) e.preventDefault();
+    setBusy(true);
+    setError(null);
+    var trimmed = name.trim();
+    try {
+      await apiFetch(
+        "PATCH",
+        "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid),
+        { name: trimmed ? trimmed : null }
+      );
+      if (!mountedRef.current) return;
+      pushToast && pushToast({ kind: "success", title: "Session renamed" });
+      onRenamed && onRenamed(sid);
+    } catch (err) {
+      if (!mountedRef.current) return;
+      var detail = (err && (err.detail || err.message)) || "Rename failed";
+      setError(detail);
+      setBusy(false);
+    }
+  }
+
+  return (
+    <Modal
+      title={"Rename session · " + sid}
+      onClose={onClose}
+      footer={
+        <>
+          <Btn kind="ghost" onClick={onClose} disabled={busy}>Cancel</Btn>
+          <Btn
+            kind="primary"
+            icon="edit"
+            onClick={submit}
+            disabled={busy}
+            data-testid="session-rename-confirm"
+          >
+            {busy ? "Saving…" : "Save name"}
+          </Btn>
+        </>
+      }
+    >
+      <form onSubmit={submit} data-testid="session-rename-body">
+        <input
+          data-testid="session-rename-input"
+          autoFocus
+          value={name}
+          onChange={function (e) { setName(e.target.value); }}
+          placeholder="Friendly name (leave blank to clear)"
+          style={{
+            width: "100%", padding: "7px 9px", fontSize: 13, background: "var(--bg-2)",
+            border: "1px solid var(--border)", borderRadius: 6, color: "var(--text)",
+            outline: "none", fontFamily: "inherit",
+          }}
+        />
+        {error && (
+          <div style={{ marginTop: 8 }}>
+            <Banner kind="error" title="Rename failed" detail={String(error)} />
+          </div>
+        )}
+      </form>
+    </Modal>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // SessionsSection
 // ---------------------------------------------------------------------------
 
@@ -375,15 +576,33 @@ function SessionsSection({ wid, studio }) {
   var sessions = ST_sessionSort(rawSessions);
 
   var [showNewForm, setShowNewForm] = React.useState(false);
+  // Session pending a delete confirm (the row whose trash button was hit),
+  // and the session being renamed inline. Both null when idle.
+  var [pendingDelete, setPendingDelete] = React.useState(null);
+  var [renaming, setRenaming] = React.useState(null);
+  var pushToast = studio.pushToast || (window.primerApi && window.primerApi.toastPush) || null;
+
+  // A session was deleted: close its center tab (if open) and refetch the
+  // sidebar list so the row disappears.
+  function onSessionDeleted(sid) {
+    setPendingDelete(null);
+    studio.closeTab && studio.closeTab("session:" + sid);
+    sessionsRes.refetch && sessionsRes.refetch();
+  }
+
+  // A session was renamed: clear the inline editor and refetch so the new
+  // name (persisted onto session.json) shows in the row.
+  function onSessionRenamed() {
+    setRenaming(null);
+    sessionsRes.refetch && sessionsRes.refetch();
+  }
 
   function openSession(session) {
     // The list endpoint returns SessionInfo (`session_id`); the create
     // response / detail fetch use the fuller shape (`id`). Resolve either.
     var sid = session.session_id || session.id;
-    var isGraph = (session.binding && session.binding.kind === "graph") ||
-                  session.binding_kind === "graph";
     var title = session.name || sid;
-    var glyph = isGraph ? "◈" : "◆";
+    var glyph = ST_sessionGlyph(session);
     studio.openTab({
       id: "session:" + sid,
       kind: "session",
@@ -454,6 +673,28 @@ function SessionsSection({ wid, studio }) {
         />
       )}
 
+      {/* Delete-session confirm (shared Modal, not native confirm()). */}
+      {pendingDelete && (
+        <ST_SessionDeleteDialog
+          wid={wid}
+          session={pendingDelete}
+          pushToast={pushToast}
+          onClose={function() { setPendingDelete(null); }}
+          onDeleted={onSessionDeleted}
+        />
+      )}
+
+      {/* Rename-session prompt. */}
+      {renaming && (
+        <ST_SessionRenameDialog
+          wid={wid}
+          session={renaming}
+          pushToast={pushToast}
+          onClose={function() { setRenaming(null); }}
+          onRenamed={onSessionRenamed}
+        />
+      )}
+
       {/* Session list */}
       {s.sessionsOpen && (
         <div className="st-section-body">
@@ -469,8 +710,7 @@ function SessionsSection({ wid, studio }) {
             // the create/detail shapes carry `id`. Resolve either so the
             // row key, tab id, title, and data-session-id are the real id.
             var sid = session.session_id || session.id;
-            var isGraph = (session.binding && session.binding.kind === "graph") ||
-                          session.binding_kind === "graph";
+            var isGraph = ST_sessionKind(session) === "graph";
             var tabId = "session:" + sid;
             var isActive = s.activeTabId === tabId;
             var title = session.name || sid;
@@ -521,6 +761,29 @@ function SessionsSection({ wid, studio }) {
                     {st.badge}
                   </span>
                 )}
+                {/* Hover/focus-revealed row actions (rename · delete). The
+                    stopPropagation keeps the row's open-on-click from firing
+                    when an action button is pressed. */}
+                <span className="st-row-actions">
+                  <button
+                    className="st-row-action"
+                    data-testid="session-rename"
+                    title="Rename session"
+                    aria-label="Rename session"
+                    onClick={function(e) { e.stopPropagation(); setRenaming(session); }}
+                  >
+                    <Icon name="edit" size={12} />
+                  </button>
+                  <button
+                    className="st-row-action is-danger"
+                    data-testid="session-delete"
+                    title="Delete session"
+                    aria-label="Delete session"
+                    onClick={function(e) { e.stopPropagation(); setPendingDelete(session); }}
+                  >
+                    <Icon name="trash" size={12} />
+                  </button>
+                </span>
                 <span style={{
                   fontSize: 9,
                   fontWeight: 700,
@@ -840,4 +1103,8 @@ function StudioSidebar({ wid, studio }) {
 window.StudioSidebar = StudioSidebar;
 window.SessionsSection = SessionsSection;
 window.FilesTree = FilesTree;
+window.ST_SessionDeleteDialog = ST_SessionDeleteDialog;
+window.ST_SessionRenameDialog = ST_SessionRenameDialog;
 window.ST_sessionStatus = ST_sessionStatus;
+window.ST_sessionKind = ST_sessionKind;
+window.ST_sessionGlyph = ST_sessionGlyph;

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -218,6 +218,43 @@ function useStudioState(wid) {
     ST_syncUrl(state.activeTabId);
   }, [wid, state]);
 
+  // React to ?open= changes that happen AFTER mount (deep-links followed
+  // while the Studio is already mounted — a same-page hash/query change).
+  // ST_applyUrlTab only runs on mount / wid-change, so without this a fresh
+  // ?open= would do nothing. We listen for hashchange + popstate (our own
+  // ST_syncUrl writes use replaceState, which fires neither, so this never
+  // loops on our own URL mirroring). Dedup: no-op when the parsed tab is
+  // already active — that both avoids redundant renders and, combined with
+  // the fact that a manual close clears ?open via replaceState (no event),
+  // stops a user-closed tab from reappearing unless the URL truly changes
+  // back to it. Mount-time deep-link handling is left untouched.
+  React.useEffect(function () {
+    function onUrlChange() {
+      var urlTab = ST_tabFromUrl();
+      if (!urlTab) return; // navigation dropped ?open= — don't clobber tabs
+      setState(function (s) {
+        if (s.activeTabId === urlTab) return s; // already active — no-op
+        var openTabs = s.openTabs || [];
+        var present = openTabs.some(function (t) { return t.id === urlTab; });
+        if (present) {
+          return Object.assign({}, s, { activeTabId: urlTab });
+        }
+        var tab = ST_tabFromUrlId(urlTab);
+        if (!tab) return s;
+        return Object.assign({}, s, {
+          openTabs: openTabs.concat([tab]),
+          activeTabId: urlTab,
+        });
+      });
+    }
+    window.addEventListener("hashchange", onUrlChange);
+    window.addEventListener("popstate", onUrlChange);
+    return function () {
+      window.removeEventListener("hashchange", onUrlChange);
+      window.removeEventListener("popstate", onUrlChange);
+    };
+  }, []);
+
   // Apply theme/density attrs to <html> so the design tokens resolve. The
   // Studio root <div> also carries them (see render) for scoped reads.
   React.useEffect(function () {
@@ -271,6 +308,17 @@ function useStudioState(wid) {
         }
       }
       return Object.assign({}, s, { openTabs: openTabs, activeTabId: activeTabId });
+    });
+  }, []);
+
+  // Close every open tab at once (the tab bar's "Close all" affordance).
+  // Clears openTabs + activeTabId; the persist effect then wipes them from
+  // localStorage too. No-op (returns the same state object) when already
+  // empty so it doesn't churn a render or the persisted blob.
+  var closeAllTabs = React.useCallback(function () {
+    setState(function (s) {
+      if (!(s.openTabs && s.openTabs.length) && s.activeTabId == null) return s;
+      return Object.assign({}, s, { openTabs: [], activeTabId: null });
     });
   }, []);
 
@@ -349,6 +397,7 @@ function useStudioState(wid) {
     openTab: openTab,
     focusTab: focusTab,
     closeTab: closeTab,
+    closeAllTabs: closeAllTabs,
     toggleSessions: toggleSessions,
     toggleFiles: toggleFiles,
     toggleHidden: toggleHidden,

--- a/ui/components/workspace-tap.jsx
+++ b/ui/components/workspace-tap.jsx
@@ -133,27 +133,54 @@ function WTP_buildSelector(selectedClasses, sessionId) {
 }
 
 // ---------------------------------------------------------------------------
-// WorkspaceTap — main component
+// Full-event detail (expand-to-inspect). Pretty-prints the whole TapEvent —
+// class, session/node ids, ts, seq, cursor, and the full payload (tool args,
+// tool result, token text, transition detail) — for the expandable rows.
 // ---------------------------------------------------------------------------
 
-var WTP_MAX_EVENTS = 500;
+function WTP_detailJson(ev) {
+  try {
+    return JSON.stringify(ev, null, 2);
+  } catch (_e) {
+    try { return String(ev); } catch (_e2) { return ""; }
+  }
+}
+
+// ---------------------------------------------------------------------------
+// WorkspaceTap — main component
+//
+// Reads the SHARED workspace tap (foundation/use-workspace-tap.js): ONE
+// EventSource per workspace feeds every consumer in a Studio view. Class /
+// session filtering is CLIENT-side over the shared buffer, so toggling a chip
+// is instant and never reconnects (previously each filter change re-opened a
+// server-selectored EventSource).
+// ---------------------------------------------------------------------------
 
 function WorkspaceTap({ wid, sessionId }) {
-  // selectedClasses: null means all; empty array (de-selected all) = all too.
-  // We initialise to null (all), and null means no filter is added.
-  var [events, setEvents] = React.useState([]);
-  var [connState, setConnState] = React.useState("connecting");
-  var [selectedClasses, setSelectedClasses] = React.useState(null);
+  var tap = window.useWorkspaceTap(wid);
+  var allEvents = tap.events;
+  var connState = tap.connState;
 
-  // Derived selector
-  var selector = React.useMemo(
-    function() { return WTP_buildSelector(selectedClasses, sessionId || null); },
-    [selectedClasses, sessionId]
-  );
+  // selectedClasses: null means all; a subset array filters client-side.
+  var [selectedClasses, setSelectedClasses] = React.useState(null);
+  // expanded: row key -> bool. Collapsed by default; only the open row renders
+  // its (potentially large) detail block, so long lists stay cheap.
+  var [expanded, setExpanded] = React.useState({});
 
   var scrollRef = React.useRef(null);
   var stickRef = React.useRef(true);
-  var esRef = React.useRef(null);
+
+  // Client-side filter over the shared buffer.
+  var events = React.useMemo(function () {
+    var out = allEvents;
+    if (sessionId) {
+      out = out.filter(function (ev) { return ev.session_id === sessionId; });
+    }
+    if (selectedClasses !== null) {
+      out = out.filter(function (ev) { return selectedClasses.indexOf(ev.class) >= 0; });
+    }
+    return out;
+  }, [allEvents, selectedClasses, sessionId]);
 
   // Auto-scroll stick-to-bottom
   var onScroll = React.useCallback(function() {
@@ -168,47 +195,6 @@ function WorkspaceTap({ wid, sessionId }) {
     var raf = requestAnimationFrame(function() { el.scrollTop = el.scrollHeight; });
     return function() { cancelAnimationFrame(raf); };
   }, [events]);
-
-  // EventSource lifecycle — re-opens when wid, selector, or sessionId changes
-  React.useEffect(function() {
-    if (!wid) return;
-
-    var url = "/v1/workspaces/" + encodeURIComponent(wid) + "/tap";
-    if (selector) {
-      url += "?selector=" + encodeURIComponent(JSON.stringify(selector));
-    }
-
-    var es = new EventSource(url, { withCredentials: true });
-    esRef.current = es;
-    setConnState("connecting");
-    setEvents([]);
-
-    es.onopen = function() {
-      setConnState("live");
-    };
-
-    es.onmessage = function(e) {
-      var ev;
-      try { ev = JSON.parse(e.data); } catch (_) { return; }
-      if (!ev || typeof ev !== "object") return;
-      setEvents(function(prev) {
-        var next = prev.concat(ev);
-        if (next.length > WTP_MAX_EVENTS) next = next.slice(next.length - WTP_MAX_EVENTS);
-        return next;
-      });
-    };
-
-    es.onerror = function() {
-      // EventSource handles reconnect natively via Last-Event-ID.
-      // We just update the indicator; onerror fires on temporary drops too.
-      setConnState("error");
-    };
-
-    return function() {
-      es.close();
-      esRef.current = null;
-    };
-  }, [wid, selector]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // Connection state badge
   var connBadge = connState === "live"
@@ -239,6 +225,15 @@ function WorkspaceTap({ wid, sessionId }) {
   }
 
   function selectAll() { setSelectedClasses(null); }
+
+  function toggleExpand(key) {
+    setExpanded(function (prev) {
+      var next = {};
+      for (var k in prev) next[k] = prev[k];
+      next[key] = !prev[key];
+      return next;
+    });
+  }
 
   var activeClasses = selectedClasses === null ? WTP_ALL_CLASSES : selectedClasses;
 
@@ -298,7 +293,7 @@ function WorkspaceTap({ wid, sessionId }) {
             size="sm"
             kind="ghost"
             icon="trash"
-            onClick={function() { setEvents([]); }}
+            onClick={function() { tap.clear(); }}
             title="Clear event list"
           >Clear</Btn>
         </div>
@@ -323,47 +318,84 @@ function WorkspaceTap({ wid, sessionId }) {
           </div>
         )}
         {events.map(function(ev, i) {
+          var key = ev.cursor != null ? String(ev.cursor) : ("i" + i);
+          var isOpen = !!expanded[key];
           var ts = ev.ts ? new Date(ev.ts) : null;
           var tsLabel = ts ? ts.toISOString().slice(11, 23) : "—";
           var sid = ev.session_id || "";
           var sidShort = sid.length > 16 ? sid.slice(0, 8) + "…" + sid.slice(-4) : sid;
           var summary = WTP_payloadSummary(ev.payload);
           return (
-            <div
-              key={ev.cursor != null ? ev.cursor : i}
-              data-testid="tap-event-row"
-              style={{
-                display: "flex",
-                alignItems: "baseline",
-                gap: 8,
-                padding: "4px 18px",
-                borderBottom: "1px solid var(--border)",
-                fontSize: 12,
-                lineHeight: 1.5,
-              }}
-            >
-              <span
-                className="mono muted"
-                style={{ fontSize: 10, flexShrink: 0, minWidth: 80 }}
-                title={ts ? ts.toISOString() : ""}
-              >{tsLabel}</span>
-              <WTP_ClassChip cls={ev.class} />
-              {sid && (
+            <div key={key} data-testid="activity-event" style={{ borderBottom: "1px solid var(--border)" }}>
+              {/* One-line summary — click / Enter / Space toggles the detail. */}
+              <div
+                data-testid="tap-event-row"
+                role="button"
+                tabIndex={0}
+                aria-expanded={isOpen}
+                onClick={function () { toggleExpand(key); }}
+                onKeyDown={function (e) {
+                  if (e.key === "Enter" || e.key === " ") { e.preventDefault(); toggleExpand(key); }
+                }}
+                style={{
+                  display: "flex",
+                  alignItems: "baseline",
+                  gap: 8,
+                  padding: "4px 18px",
+                  fontSize: 12,
+                  lineHeight: 1.5,
+                  cursor: "pointer",
+                  background: isOpen ? "var(--bg-2)" : "transparent",
+                }}
+              >
+                <span
+                  aria-hidden="true"
+                  className="mono muted"
+                  style={{ fontSize: 9, flexShrink: 0, width: 8, color: "var(--text-4)" }}
+                >{isOpen ? "▾" : "▸"}</span>
                 <span
                   className="mono muted"
-                  style={{ fontSize: 10, flexShrink: 0 }}
-                  title={sid}
-                >{sidShort}</span>
-              )}
-              {summary && (
-                <span
-                  className="mono"
-                  style={{ fontSize: 11, color: "var(--text-2)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}
-                  title={summary}
-                >{summary}</span>
-              )}
-              {ev.seq != null && (
-                <span className="mono muted" style={{ fontSize: 10, flexShrink: 0 }}>#{ev.seq}</span>
+                  style={{ fontSize: 10, flexShrink: 0, minWidth: 80 }}
+                  title={ts ? ts.toISOString() : ""}
+                >{tsLabel}</span>
+                <WTP_ClassChip cls={ev.class} />
+                {sid && (
+                  <span
+                    className="mono muted"
+                    style={{ fontSize: 10, flexShrink: 0 }}
+                    title={sid}
+                  >{sidShort}</span>
+                )}
+                {summary && (
+                  <span
+                    className="mono"
+                    style={{ fontSize: 11, color: "var(--text-2)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}
+                    title={summary}
+                  >{summary}</span>
+                )}
+                {ev.seq != null && (
+                  <span className="mono muted" style={{ fontSize: 10, flexShrink: 0 }}>#{ev.seq}</span>
+                )}
+              </div>
+              {isOpen && (
+                <div
+                  data-testid="activity-event-detail"
+                  style={{ padding: "2px 18px 10px 34px", background: "var(--bg-2)" }}
+                >
+                  <pre
+                    className="mono"
+                    style={{
+                      margin: 0,
+                      fontSize: 11,
+                      lineHeight: 1.5,
+                      color: "var(--text-2)",
+                      whiteSpace: "pre-wrap",
+                      wordBreak: "break-word",
+                      maxHeight: 320,
+                      overflow: "auto",
+                    }}
+                  >{WTP_detailJson(ev)}</pre>
+                </div>
               )}
             </div>
           );

--- a/ui/foundation/use-workspace-tap.js
+++ b/ui/foundation/use-workspace-tap.js
@@ -1,0 +1,199 @@
+/* global React */
+// use-workspace-tap.js — ONE shared EventSource per workspace, fanned out to
+// every consumer in a Studio view.
+//
+// PROBLEM (fe-review N4 "triple SSE per Studio view"): the right rail opened
+// two EventSources to the same GET /v1/workspaces/{wid}/tap — one in
+// ActionRequired (reconcile pending yields) and one in WorkspaceTap (the
+// activity feed) — and the graph run-view opened a third just to trigger a
+// node-state refetch. Same URL, same workspace, N connections.
+//
+// FIX: a module-level hub, keyed by workspace id, owns exactly ONE EventSource
+// and multiplexes its frames to all subscribers. The hub is ref-counted: it
+// opens on the first subscriber and closes + is discarded on the last. It is
+// deliberately a plain module singleton (not React context) so it works
+// identically inside the Studio and on the standalone /workspaces page, and so
+// no provider has to be threaded through studio.jsx.
+//
+// Two consumption hooks:
+//   • useWorkspaceTap(wid)         → { events, connState, clear }. Re-renders
+//     the caller when a frame arrives / the connection state changes. Used by
+//     the activity feed (WorkspaceTap) which renders the rolling buffer.
+//   • useWorkspaceTapListener(wid, onEvent) → fires onEvent(ev) per frame
+//     WITHOUT re-rendering the caller. Used by ActionRequired (refetch pending
+//     on yielded/done) and SD_GraphRunView (refetch node states on
+//     graph_transition/done/error). onEvent is held in a ref so an inline
+//     closure does not churn the subscription.
+//
+// No-build scope rules: top-level declarations use `var`; helpers are prefixed
+// WTAP_ to avoid global collisions; exported symbols are written to window.X.
+//
+// This mirrors the live-from-connect contract of the tap endpoint: with no
+// cursor the server starts each in-scope session at its high-water mark, so
+// history is NOT replayed — the shared buffer only accrues events from connect
+// onward. Session-scoped views that need a gap-free history seam (cursored
+// replay) still open their own tap; those are genuinely session-scoped and are
+// not part of this workspace-wide fan-out.
+
+// Rolling buffer cap — matches WorkspaceTap's prior WTP_MAX_EVENTS.
+var WTAP_MAX_EVENTS = 500;
+
+// wid -> hub. A hub = { es, refs, events, connState, renderSubs, eventSubs }.
+var WTAP_HUBS = {};
+
+function WTAP_getHub(wid) {
+  var hub = WTAP_HUBS[wid];
+  if (hub) return hub;
+  hub = {
+    wid: wid,
+    es: null,
+    refs: 0,
+    events: [],
+    connState: "connecting",
+    renderSubs: [], // fn(hub) — buffer/connState changed
+    eventSubs: [],  // fn(ev)  — one incoming frame
+  };
+  WTAP_HUBS[wid] = hub;
+  return hub;
+}
+
+function WTAP_notifyRender(hub) {
+  var subs = hub.renderSubs.slice();
+  for (var i = 0; i < subs.length; i++) {
+    try { subs[i](hub); } catch (_e) { /* no-op */ }
+  }
+}
+
+function WTAP_open(hub) {
+  if (hub.es || !hub.wid) return;
+  var url = "/v1/workspaces/" + encodeURIComponent(hub.wid) + "/tap";
+  var es;
+  try {
+    es = new EventSource(url, { withCredentials: true });
+  } catch (_e) {
+    hub.connState = "error";
+    WTAP_notifyRender(hub);
+    return;
+  }
+  hub.es = es;
+  hub.connState = "connecting";
+  es.onopen = function () {
+    hub.connState = "live";
+    WTAP_notifyRender(hub);
+  };
+  es.onmessage = function (e) {
+    var ev;
+    try { ev = JSON.parse(e.data); } catch (_) { return; }
+    if (!ev || typeof ev !== "object") return;
+    var next = hub.events.concat(ev);
+    if (next.length > WTAP_MAX_EVENTS) next = next.slice(next.length - WTAP_MAX_EVENTS);
+    hub.events = next;
+    // Per-frame listeners first (reconcile / refetch triggers), then renderers.
+    var esubs = hub.eventSubs.slice();
+    for (var i = 0; i < esubs.length; i++) {
+      try { esubs[i](ev); } catch (_e2) { /* no-op */ }
+    }
+    WTAP_notifyRender(hub);
+  };
+  es.onerror = function () {
+    // EventSource auto-reconnects natively via Last-Event-ID; reflect the drop.
+    hub.connState = "error";
+    WTAP_notifyRender(hub);
+  };
+}
+
+function WTAP_close(hub) {
+  if (hub.es) {
+    try { hub.es.close(); } catch (_e) { /* no-op */ }
+    hub.es = null;
+  }
+}
+
+function WTAP_retain(wid) {
+  var hub = WTAP_getHub(wid);
+  hub.refs += 1;
+  if (hub.refs === 1) WTAP_open(hub);
+  return hub;
+}
+
+function WTAP_release(wid) {
+  var hub = WTAP_HUBS[wid];
+  if (!hub) return;
+  hub.refs -= 1;
+  if (hub.refs <= 0) {
+    WTAP_close(hub);
+    delete WTAP_HUBS[wid];
+  }
+}
+
+function WTAP_clear(wid) {
+  var hub = WTAP_HUBS[wid];
+  if (!hub) return;
+  hub.events = [];
+  WTAP_notifyRender(hub);
+}
+
+// ---------------------------------------------------------------------------
+// Renderer hook — re-renders the caller on buffer / connection changes.
+// ---------------------------------------------------------------------------
+
+function useWorkspaceTap(wid) {
+  var setTick = React.useState(0)[1];
+  var hubRef = React.useRef(null);
+
+  React.useEffect(function () {
+    if (!wid) { hubRef.current = null; return undefined; }
+    var hub = WTAP_retain(wid);
+    hubRef.current = hub;
+    var sub = function () { setTick(function (n) { return (n + 1) & 0x3fffffff; }); };
+    hub.renderSubs.push(sub);
+    // Sync to whatever the shared buffer already holds (a late subscriber must
+    // not render an empty list while the hub is mid-stream).
+    sub();
+    return function () {
+      var idx = hub.renderSubs.indexOf(sub);
+      if (idx >= 0) hub.renderSubs.splice(idx, 1);
+      hubRef.current = null;
+      WTAP_release(wid);
+    };
+  }, [wid]);
+
+  var hub = hubRef.current || (wid ? WTAP_HUBS[wid] : null);
+  return {
+    events: hub ? hub.events : [],
+    connState: hub ? hub.connState : "connecting",
+    clear: function () { if (wid) WTAP_clear(wid); },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Listener hook — fires onEvent(ev) per frame, no re-render of the caller.
+// ---------------------------------------------------------------------------
+
+function useWorkspaceTapListener(wid, onEvent) {
+  var cbRef = React.useRef(onEvent);
+  cbRef.current = onEvent;
+
+  React.useEffect(function () {
+    if (!wid) return undefined;
+    var hub = WTAP_retain(wid);
+    var sub = function (ev) {
+      var f = cbRef.current;
+      if (typeof f === "function") f(ev);
+    };
+    hub.eventSubs.push(sub);
+    return function () {
+      var idx = hub.eventSubs.indexOf(sub);
+      if (idx >= 0) hub.eventSubs.splice(idx, 1);
+      WTAP_release(wid);
+    };
+  }, [wid]);
+}
+
+// ---------------------------------------------------------------------------
+// No-build window exports
+// ---------------------------------------------------------------------------
+window.useWorkspaceTap = useWorkspaceTap;
+window.useWorkspaceTapListener = useWorkspaceTapListener;
+// Test/introspection surface — how many live hubs (== EventSources) exist.
+window.__wtapHubCount = function () { return Object.keys(WTAP_HUBS).length; };

--- a/ui/index.html
+++ b/ui/index.html
@@ -63,6 +63,7 @@
 <script type="text/babel" src="foundation/toast.js"></script>
 <script type="text/babel" src="foundation/use-resource.js"></script>
 <script type="text/babel" src="foundation/use-mutation.js"></script>
+<script type="text/babel" src="foundation/use-workspace-tap.js"></script>
 <script type="text/babel" src="foundation/router.js"></script>
 <script type="text/babel" src="foundation/tweaks.js"></script>
 <script type="text/babel" src="foundation/idle.js"></script>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -283,6 +283,27 @@
 }
 .st-section-body { overflow: auto; flex: 1; min-height: 0; }
 
+/* Studio right-rail: Action Required section (B4). The empty-state text must
+   never be clipped — the section is content-sized when empty (no max-height
+   cap) and only capped-with-scroll once it holds pending items. Previously a
+   flat 60px cap squeezed the "No pending actions" line behind overflow:hidden. */
+.st-action-required {
+  display: flex;
+  flex-direction: column;
+  flex-shrink: 0;
+  overflow: hidden;
+  border-bottom: 1px solid var(--border);
+}
+.st-action-required.is-empty { max-height: none; }
+.st-action-required.has-items { max-height: 320px; }
+.st-action-empty {
+  padding: 16px 14px;
+  font-size: 12px;
+  line-height: 1.5;
+  color: var(--text-4);
+  text-align: center;
+}
+
 /* Center tab bar. */
 .st-tabbar {
   display: flex;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -293,6 +293,25 @@
   overflow-x: auto;
   flex: 0 0 auto;
 }
+/* "Close all" — pinned to the right edge (sticky) so it stays reachable when
+   the tab strip overflows horizontally. */
+.st-tabs-close-all {
+  position: sticky;
+  right: 0;
+  margin-left: auto;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 0 10px;
+  border: none;
+  border-left: 1px solid var(--border);
+  background: var(--bg-1);
+  color: var(--text-4);
+  cursor: pointer;
+  white-space: nowrap;
+}
+.st-tabs-close-all:hover { background: var(--bg-2); color: var(--text-2); }
 .st-tab {
   position: relative;
   display: flex;
@@ -327,6 +346,34 @@
   color: var(--text-4);
 }
 .st-tab-close:hover { background: var(--bg-active); color: var(--text); }
+
+/* Sidebar session-row inline actions (rename / delete). Hidden until the
+   row is hovered or something inside it is focused, so the row stays clean
+   but the affordances are keyboard-reachable. */
+.st-row-actions {
+  display: flex;
+  align-items: center;
+  gap: 2px;
+  flex-shrink: 0;
+  opacity: 0;
+  transition: opacity 0.12s ease;
+}
+.st-session-row:hover .st-row-actions,
+.st-session-row:focus-within .st-row-actions { opacity: 1; }
+.st-row-action {
+  width: 18px;
+  height: 18px;
+  display: grid;
+  place-items: center;
+  border: none;
+  background: none;
+  border-radius: 4px;
+  color: var(--text-4);
+  cursor: pointer;
+  padding: 0;
+}
+.st-row-action:hover { background: var(--bg-active); color: var(--text); }
+.st-row-action.is-danger:hover { color: var(--red); }
 
 /* Region placeholder (B2/B3/B4 fill these). */
 .st-placeholder {

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -443,6 +443,46 @@
   min-height: 280px !important;
 }
 
+/* Graph-canvas overlaid zoom / traverse controls (bug #1). Absolutely placed
+   in a corner of the shared GR_Canvas (editor + run-view); themed purely off
+   the design tokens so a dark/light toggle restyles them for free. */
+.gr-canvas-controls {
+  position: absolute;
+  right: 10px;
+  bottom: 10px;
+  z-index: 4;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.gr-ctrl-btn {
+  width: 28px;
+  height: 28px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  cursor: pointer;
+  border-radius: 6px;
+  border: 1px solid var(--border);
+  background: var(--bg-elev);
+  color: var(--text-2);
+  box-shadow: var(--shadow-sm);
+}
+.gr-ctrl-btn-text {
+  font: 600 10px/1 "IBM Plex Mono", monospace;
+  letter-spacing: 0.02em;
+}
+.gr-ctrl-btn:hover {
+  border-color: var(--border-strong);
+  background: var(--bg-hover);
+  color: var(--text);
+}
+.gr-ctrl-btn:focus-visible {
+  outline: 2px solid var(--accent-border);
+  outline-offset: 1px;
+}
+
 /* Integrated terminal — collapsible bottom panel spanning the center column
    (below StudioCenter's active panel), P7. Mounted only while
    studio.state.terminalOpen is true (see studio.jsx / studio-terminal.jsx),


### PR DESCRIPTION
## Studio UX batch — 11 field-test bugs (#1–7, 9–11, 20–22)

Follows the merged Studio program. Fixes the batch the user found field-testing, across sidebar/sessions, activity/streaming, and the graph canvas.

**Sidebar & sessions**
- **#9** graph sessions now show a graph glyph (detected via the synthetic `agent_id` `graph:` prefix; `SessionInfo` has no binding).
- **#20** delete a session (existing DELETE + `Modal` confirm; closes its tab).
- **#22** friendly session names — optional `name` at creation + a new `PATCH …/sessions/{id}` rename (backend `name` on `SessionInfo`/`WorkspaceSession`, new persisted `"rename"` op); sidebar shows `name` over `sess-<id>`.
- **#21** close-all-tabs control.
- **#11** `?open=` deep-link now applies while the Studio is already mounted (hashchange/popstate), not just on mount.

**Activity & streaming**
- **#4** consolidated 2–3 independent `/tap` EventSources into ONE ref-counted per-workspace hub (`ui/foundation/use-workspace-tap.js`); ActionRequired + WorkspaceTap + graph run-view share it.
- **#5** activity events are click-to-expand (full payload).
- **#10** removed the redundant Interrupt button/chrome from the embedded live-stream — session controls live only in the header.
- **#2** Action-Required empty-state no longer clipped.
- **#3/#7** slow-load/timeout fixed — `tail`-paged `GET …/messages` (offset-from-end) + a bounded "Load earlier" tail instead of a monolithic history GET.

**Graph canvas**
- **#1** overlaid zoom-in/out/fit/reset controls (G6 v5 `zoomBy/zoomTo/fitView`).
- **#6** dark/light toggle now restyles the canvas — palette read from CSS tokens via `getComputedStyle` + a `MutationObserver` on `data-theme` (replaces hardcoded hex). Applies to editor + run-view.

Tests: 533 `tests/ui` + 512 `tests/api` pass; new structural/api tests per area.

> ⚠️ **Recommended before merge:** a quick live browser smoke of the G6 zoom controls + dark-mode canvas restyle — those calls are source-verified (vendored g6 signatures) but not yet browser-run; all are defensively wrapped to no-op on any API mismatch rather than crash.
