### PR TITLE
fix(backend): review housekeeping — sqlite snapshot, pg_notify payload guard, terminal-fragility doc (BE10)

### DIFF
--- a/primer/api/routers/terminal.py
+++ b/primer/api/routers/terminal.py
@@ -76,6 +76,21 @@ class _RuntimePtyAdapter:
         return None
 
     async def output(self) -> AsyncIterator[bytes]:
+        # KNOWN FRAGILITY (BE10c): a transient runtime WS drop ends the
+        # container terminal, and it is NOT resumable in v1.
+        #
+        # On any runtime WebSocket drop, RuntimeClient._on_disconnect ->
+        # _close_all_streams pushes a stream-closed sentinel into every open
+        # PTY stream (runtime_client.py). ``self._handle.events()`` then ends
+        # WITHOUT ever yielding an "exit" frame, so ``_exit_code`` stays None.
+        # The endpoint's _send_loop consequently reports ``{"exit": -1}`` and
+        # closes the browser socket. A brief runtime blip therefore drops the
+        # whole terminal even though the runtime may reconnect moments later.
+        #
+        # This is an accepted limitation for v1: the terminal is not reattached
+        # across a runtime reconnect (there is no PTY session-resume protocol).
+        # The reconnect loop keeps the RuntimeClient itself healthy; only this
+        # one terminal stream is lost, and the user reopens the terminal.
         async for frame in self._handle.events():
             if frame.kind == "data":
                 yield frame.data

--- a/primer/bus/postgres.py
+++ b/primer/bus/postgres.py
@@ -36,6 +36,7 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
 from primer.int.event_bus import Event, EventBus, EventSubscription
+from primer.model.except_ import ProviderError
 
 if TYPE_CHECKING:
     from primer.storage.postgres import PostgresStorageProvider
@@ -48,6 +49,17 @@ YIELD_EVENTS_CHANNEL = "primer_yield_events"
 """Postgres NOTIFY channel name. Distinct from session_ready so the
 existing scheduler wake-up traffic doesn't double-trigger yield
 resumes."""
+
+
+MAX_NOTIFY_PAYLOAD_BYTES = 7900
+"""Safe upper bound (UTF-8 bytes) for a single NOTIFY payload.
+
+Postgres caps NOTIFY payloads at 8000 bytes and raises an opaque
+``payload string too long`` above that. We guard slightly under 8000 (a
+little headroom) and raise a clear domain error instead. Yield payloads
+are meant to be small routing keys -- the real data is re-read from
+storage -- so exceeding this signals a caller sending far too much, not a
+legitimate large message."""
 
 
 DEFAULT_LISTEN_RECONNECT_SECONDS = 2.0
@@ -289,6 +301,24 @@ class PostgresEventBus(EventBus):
             "event_key": event_key,
             "payload": payload or {},
         })
+        # Postgres NOTIFY caps payloads at 8000 bytes; beyond that asyncpg
+        # raises an opaque "payload string too long". Guard here so an
+        # oversized body surfaces as a clear domain error BEFORE we acquire a
+        # connection or hit the wire (BE10b). Yield payloads are meant to be
+        # small routing keys (large data is re-read from storage), so this
+        # only fires on a caller bug -- and we raise rather than silently
+        # dropping the payload, which could strip routing fields a subscriber
+        # depends on.
+        encoded_len = len(body.encode("utf-8"))
+        if encoded_len > MAX_NOTIFY_PAYLOAD_BYTES:
+            raise ProviderError(
+                f"PostgresEventBus NOTIFY payload for event_key "
+                f"{event_key!r} is {encoded_len} bytes, over the "
+                f"{MAX_NOTIFY_PAYLOAD_BYTES}-byte safe limit (Postgres caps "
+                f"NOTIFY at 8000 bytes). Yield payloads must be small routing "
+                f"keys; re-read large data from storage instead.",
+                code="notify_payload_too_long",
+            )
         async with self._storage.pool.acquire() as conn:
             await conn.execute(
                 f"SELECT pg_notify('{YIELD_EVENTS_CHANNEL}', $1)",

--- a/primer/storage/sqlite.py
+++ b/primer/storage/sqlite.py
@@ -193,6 +193,44 @@ class SqliteStorageProvider(StorageProvider):
                 finally:
                     self._txn_task = None
 
+    @asynccontextmanager
+    async def read_snapshot(self):
+        """Group a set of reads into ONE consistent snapshot.
+
+        Holds ``_write_lock`` (and issues ``BEGIN``..``COMMIT``) across the
+        enclosed reads so no foreign write can commit between them. Motivating
+        case: a paginated ``list()`` runs its page ``SELECT`` and its
+        ``COUNT(*)`` as two statements on the shared connection with an
+        ``await`` between them; without this a concurrent ``create``/``delete``
+        could slip in and make the reported ``total`` disagree with the page it
+        accompanies. Because every write goes through :meth:`_write_guard`
+        (which acquires the same lock), holding it here freezes the data set for
+        the whole read pair.
+
+        When the caller is already inside its OWN :meth:`transaction`, the reads
+        are already serialised under the held lock, so run them inline --
+        opening a nested ``BEGIN`` would fail and the outer unit owns the
+        commit. This makes the snapshot re-entrant and deadlock-free.
+        """
+        if self._in_own_transaction():
+            yield
+            return
+        async with self._write_lock:
+            conn = self.connection
+            await conn.execute("BEGIN")
+            try:
+                yield
+            except BaseException:
+                # Read-only unit, but roll back to close the snapshot txn
+                # cleanly on error (mirrors :meth:`transaction`).
+                await conn.rollback()
+                raise
+            else:
+                # Nothing to persist, but COMMIT ends the snapshot transaction
+                # so the connection returns to autocommit and never lingers
+                # with an open BEGIN.
+                await conn.commit()
+
     @property
     def in_transaction(self) -> bool:
         """True while any :meth:`transaction` block is open on this provider.
@@ -613,11 +651,18 @@ class SqliteStorage(Storage[ModelT]):
             f'SELECT count(*) FROM "{self._table}" WHERE {where_sql}'
         )
         try:
-            cur = await self._provider.connection.execute(select_sql, params)
-            rows = await cur.fetchall()
-            cur = await self._provider.connection.execute(count_sql, count_params)
-            row = await cur.fetchone()
-            total = int(row[0]) if row is not None else None
+            # Run the page SELECT and its COUNT(*) inside ONE consistent read
+            # snapshot so a concurrent write can't slip between the two
+            # statements and make ``total`` disagree with the returned page
+            # (BE10a). ``read_snapshot`` holds the shared write lock for both.
+            async with self._provider.read_snapshot():
+                cur = await self._provider.connection.execute(select_sql, params)
+                rows = await cur.fetchall()
+                cur = await self._provider.connection.execute(
+                    count_sql, count_params,
+                )
+                row = await cur.fetchone()
+                total = int(row[0]) if row is not None else None
         except Exception as exc:
             raise _wrap_sqlite_error(
                 exc, model_name=self._model.__name__, op="list",

--- a/tests/bus/test_postgres_publish.py
+++ b/tests/bus/test_postgres_publish.py
@@ -1,0 +1,127 @@
+"""Unit tests for PostgresEventBus.publish, including the NOTIFY payload cap.
+
+Postgres NOTIFY caps payloads at 8000 bytes and otherwise raises an opaque
+``payload string too long``. The bus guards slightly under that
+(``MAX_NOTIFY_PAYLOAD_BYTES``) and raises a clear domain error BEFORE touching
+a connection (BE10b). These tests drive that guard, and the happy path, with a
+fake pool -- no real Postgres server.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from primer.bus.postgres import (
+    MAX_NOTIFY_PAYLOAD_BYTES,
+    PostgresEventBus,
+    YIELD_EVENTS_CHANNEL,
+)
+from primer.model.except_ import ProviderError
+
+pytestmark = pytest.mark.asyncio
+
+
+class _RecordingConn:
+    """Records every ``execute`` (the NOTIFY) issued against it."""
+
+    def __init__(self) -> None:
+        self.executed: list[tuple[str, tuple]] = []
+
+    async def execute(self, sql: str, *args) -> None:  # noqa: ANN002
+        self.executed.append((sql, args))
+
+
+class _AcquireCtx:
+    """Async context manager mirroring asyncpg ``pool.acquire()``."""
+
+    def __init__(self, pool: "_PublishPool") -> None:
+        self._pool = pool
+
+    async def __aenter__(self) -> _RecordingConn:
+        conn = _RecordingConn()
+        self._pool.acquired.append(conn)
+        return conn
+
+    async def __aexit__(self, *exc) -> bool:  # noqa: ANN002
+        return False
+
+
+class _PublishPool:
+    """Records each acquire so a test can assert the pool was (not) touched."""
+
+    def __init__(self) -> None:
+        self.acquired: list[_RecordingConn] = []
+
+    def acquire(self) -> _AcquireCtx:
+        return _AcquireCtx(self)
+
+
+class _PublishStorage:
+    def __init__(self, pool: _PublishPool) -> None:
+        self.pool = pool
+
+
+async def test_publish_rejects_oversized_payload() -> None:
+    """A NOTIFY payload over the safe byte cap raises a clear ProviderError
+    before any connection is acquired -- not an opaque asyncpg error."""
+    pool = _PublishPool()
+    bus = PostgresEventBus(_PublishStorage(pool))
+    await bus.initialize()
+    try:
+        big = {"blob": "x" * (MAX_NOTIFY_PAYLOAD_BYTES + 1000)}
+        with pytest.raises(ProviderError) as ei:
+            await bus.publish("ask_user:1", big)
+        assert ei.value.code == "notify_payload_too_long"
+        assert str(MAX_NOTIFY_PAYLOAD_BYTES) in ei.value.message
+        # The guard fired BEFORE touching the pool: no connection acquired,
+        # so no opaque "payload string too long" ever reached asyncpg.
+        assert pool.acquired == []
+    finally:
+        await bus.aclose()
+
+
+async def test_publish_small_payload_notifies() -> None:
+    """A small routing-key payload publishes normally: the guard does not
+    false-positive and a NOTIFY is issued on an acquired connection."""
+    pool = _PublishPool()
+    bus = PostgresEventBus(_PublishStorage(pool))
+    await bus.initialize()
+    try:
+        await bus.publish("ask_user:1", {"session_id": "s-1"})
+        assert len(pool.acquired) == 1
+        sql, args = pool.acquired[0].executed[0]
+        assert "pg_notify" in sql
+        assert YIELD_EVENTS_CHANNEL in sql
+        body = json.loads(args[0])
+        assert body == {
+            "event_key": "ask_user:1",
+            "payload": {"session_id": "s-1"},
+        }
+    finally:
+        await bus.aclose()
+
+
+async def test_publish_at_threshold_is_allowed() -> None:
+    """A payload whose encoded body is exactly at the cap is allowed; one byte
+    over is rejected. Pins the boundary so the guard neither over- nor
+    under-shoots."""
+    pool = _PublishPool()
+    bus = PostgresEventBus(_PublishStorage(pool))
+    await bus.initialize()
+    try:
+        # Craft a body whose UTF-8 length lands exactly on the cap. The wrapper
+        # JSON around the "blob" value has a fixed byte overhead; size the value
+        # so the whole body == MAX_NOTIFY_PAYLOAD_BYTES.
+        base = json.dumps({"event_key": "k", "payload": {"blob": ""}})
+        overhead = len(base.encode("utf-8"))
+        fill = MAX_NOTIFY_PAYLOAD_BYTES - overhead
+        await bus.publish("k", {"blob": "x" * fill})
+        assert len(pool.acquired) == 1
+
+        # One byte over the cap is rejected.
+        with pytest.raises(ProviderError):
+            await bus.publish("k", {"blob": "x" * (fill + 1)})
+    finally:
+        await bus.aclose()

--- a/tests/storage/test_sqlite_transaction_safety.py
+++ b/tests/storage/test_sqlite_transaction_safety.py
@@ -28,12 +28,14 @@ from __future__ import annotations
 
 import asyncio
 from pathlib import Path
+from typing import Any
 
 import pytest
 import pytest_asyncio
 
 from primer.model.common import Identifiable
 from primer.model.provider import SqliteConfig
+from primer.model.storage import OffsetPage, OffsetPageResponse
 from primer.storage.sqlite import SqliteStorageProvider
 
 
@@ -180,3 +182,76 @@ async def test_concurrent_txns_no_spurious_reentrancy(
     for i in range(5):
         assert (await things.get(f"t-{i}")) is not None
         assert (await content.get(f"d-{i}")) == str(i)
+
+
+async def test_offset_count_and_page_are_one_snapshot(
+    provider: SqliteStorageProvider,
+) -> None:
+    """A paginated ``list()``'s ``total`` and its page must be ONE consistent
+    snapshot: a write that races the pagination must not land BETWEEN the page
+    ``SELECT`` and the ``COUNT(*)`` and make them disagree (BE10a).
+
+    The race is made deterministic by wrapping the shared connection so the
+    competitor is released right before the ``COUNT(*)`` runs -- i.e. exactly
+    "between" the two statements. Under the read snapshot the competitor blocks
+    on the write lock and only lands after the pair has been read together.
+    """
+    things = provider.get_storage(_Thing)
+    for i in range(5):
+        await things.create(_Thing(id=f"t{i}", value=str(i)))
+
+    real_conn = provider._conn  # noqa: SLF001
+    released = asyncio.Event()
+
+    class _ReleaseBeforeCount:
+        """Wrap the shared aiosqlite connection: when the paginated
+        ``COUNT(*)`` is about to run, release the competitor and yield so it is
+        scheduled (and blocks on the write lock) 'between' the page ``SELECT``
+        and the ``COUNT``."""
+
+        def __init__(self, real: Any) -> None:
+            self._real = real
+
+        async def execute(self, sql: str, *args: Any, **kwargs: Any):  # noqa: ANN201
+            if "count(*)" in sql.lower() and not released.is_set():
+                released.set()
+                # Yield repeatedly so the competitor task runs and parks on the
+                # write lock before we read the count.
+                for _ in range(10):
+                    await asyncio.sleep(0)
+            return await self._real.execute(sql, *args, **kwargs)
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._real, name)
+
+    provider._conn = _ReleaseBeforeCount(real_conn)  # noqa: SLF001
+
+    async def competitor() -> None:
+        await released.wait()
+        # These inserts block on the write lock held by the list's read
+        # snapshot, so they can only land AFTER the page + count are read
+        # together -- never interleaved between them.
+        await things.create(_Thing(id="t5", value="5"))
+        await things.create(_Thing(id="t6", value="6"))
+
+    comp = asyncio.ensure_future(competitor())
+    try:
+        page = await things.list(OffsetPage(offset=0, length=100))
+        await comp
+    finally:
+        provider._conn = real_conn  # noqa: SLF001
+
+    assert isinstance(page, OffsetPageResponse)
+    # The page and its total saw the SAME world: neither reflects the
+    # competitor's two inserts (serialised behind the snapshot's write lock).
+    assert page.total == 5
+    assert page.length == 5
+    assert len(page.items) == 5
+    assert page.total == page.length
+
+    # The competitor's writes DID happen (the race was real): a fresh,
+    # post-snapshot list sees all seven rows -- the guard reordered the write to
+    # AFTER the snapshot, it did not drop it.
+    after = await things.list(OffsetPage(offset=0, length=100))
+    assert after.total == 7
+    assert after.length == 7


### PR DESCRIPTION
## Backend review — remaining housekeeping (BE10 + BE9 assessment)

Completes the tractable tail of `docs/superpowers/reviews/2026-07-03-backend-review.md` (§4/§5/§7).

- **BE10a (S3)** — SQLite list+count consistent snapshot. `_page_offset` ran the page `SELECT` and its `COUNT(*)` as two statements with an `await` between them, so a concurrent write could make `total` disagree with the page. New re-entrant `read_snapshot()` holds the write-lock across `BEGIN..COMMIT`. Test deterministically releases a competing writer between the two reads (verified fails-without-fix: total=6 vs items=5).
- **BE10b (S3)** — pg_notify 8000-byte cap guard. `PostgresEventBus.publish` now rejects an oversized encoded body with a clear `ProviderError(notify_payload_too_long)` **before** acquiring a connection, instead of an opaque asyncpg "payload string too long". Tests: oversized rejection (pool untouched), happy path, exact boundary.
- **BE10c (S3)** — documented the runtime-reconnect-kills-terminal fragility (transient runtime WS drop → `{"exit": -1}`, not resumable in v1) as an accepted known limitation. Comment only.
- **BE9 (S3) — assessed + SKIPPED.** A dedicated long-lived NOTIFY connection is not cleanly safe: `publish` has many concurrent hot-path callers (asyncpg connections can't be used concurrently), and a held connection would wedge ALL publishing on a transient drop unless the full LISTEN-supervisor reconnect logic is duplicated. The pooled `acquire()` is inherently more drop-robust. Per "don't risk the bus," left unchanged and flagged.

**BE11** (splitting `worker/pool.py` 1614L / `_app_lifespan.py` 1219L) intentionally deferred — a large high-risk core refactor for a human, per the review's own guidance.

Tests: `tests/storage tests/bus` → 211 passed, 0 failed; ruff clean.
