### PR TITLE
perf(ui): content-visibility row virtualization for long lists (FD4)

### DIFF
--- a/tests/ui/test_fd4_virtualization.py
+++ b/tests/ui/test_fd4_virtualization.py
@@ -1,0 +1,30 @@
+"""FD4 — content-visibility row virtualization.
+
+Off-screen div rows + the expensive per-row block content inside table cells
+skip layout/paint until scrolled near. content-visibility is a verified no-op
+on <tr> (table-internal elements aren't size-containable), so it is applied to
+the div-based lists (Studio sidebar rows, activity-event stream) and to the
+workers CapacityBar (a <div> inside its <td>, which DOES skip)."""
+
+from pathlib import Path
+
+_UI = Path(__file__).resolve().parents[2] / "ui"
+STYLES = (_UI / "styles.css").read_text()
+WORKERS = (_UI / "components" / "workers.jsx").read_text()
+
+
+def test_content_visibility_rules_present() -> None:
+    # Div-based long lists get row-level virtualization.
+    for sel in (".st-session-row", ".st-file-row", '[data-testid="activity-event"]', ".cv-auto"):
+        assert sel in STYLES, f"missing {sel} rule"
+    # Each uses content-visibility + a contain-intrinsic-size placeholder so
+    # the scrollbar/layout stays stable while rows are skipped.
+    cv_count = STYLES.count("content-visibility: auto")
+    assert cv_count >= 4, f"expected >=4 content-visibility rules, got {cv_count}"
+    assert "contain-intrinsic-size: auto" in STYLES
+
+
+def test_workers_capacity_bar_is_virtualized() -> None:
+    # The per-row capacity segments (up to `capacity` divs each) skip when the
+    # row is off-screen — the div-inside-td case that content-visibility covers.
+    assert 'className="cv-auto"' in WORKERS

--- a/ui/components/workers.jsx
+++ b/ui/components/workers.jsx
@@ -496,7 +496,7 @@ function CapacityBar({ inFlight, capacity }) {
   const safe = Math.max(0, capacity | 0);
   const segments = Array.from({ length: safe });
   return (
-    <div style={{ display: "flex", gap: 2 }}>
+    <div className="cv-auto" style={{ display: "flex", gap: 2 }}>
       {segments.map((_, i) => {
         const filled = i < inFlight;
         return (

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -429,6 +429,18 @@
 }
 .st-session-row:hover .st-row-actions,
 .st-session-row:focus-within .st-row-actions { opacity: 1; }
+
+/* FD4 — content-visibility row virtualization. Off-screen rows / expensive
+   per-row cell content skip layout + paint until scrolled near, then their
+   real size is remembered (contain-intrinsic-size: auto). Verified
+   empirically that content-visibility is a NO-OP on <tr> (table-internal
+   elements aren't size-containable), so this is applied only to div rows and
+   to block content inside table cells — both of which DO skip. Focus/scroll
+   auto-reveals a skipped row, so keyboard nav (FC5c) is unaffected. */
+.st-session-row { content-visibility: auto; contain-intrinsic-size: auto var(--row-h, 36px); }
+.st-file-row    { content-visibility: auto; contain-intrinsic-size: auto var(--frow-h, 30px); }
+[data-testid="activity-event"] { content-visibility: auto; contain-intrinsic-size: auto 44px; }
+.cv-auto { content-visibility: auto; contain-intrinsic-size: auto 12px; }
 .st-row-action {
   width: 18px;
   height: 18px;


### PR DESCRIPTION
## FD4 — list virtualization (content-visibility)

The last FE-review structural item (`§8`). Rather than JS windowing or a risky `<table>`→div rewrite, this uses browser-native `content-visibility: auto`: off-screen rows skip layout + paint until scrolled near, then remember their measured size (`contain-intrinsic-size: auto`). No scroll handlers, so live-updating tables (workers @2s) are unaffected, and focus/scroll auto-reveals a skipped row so the FC5c keyboard rows still work.

**Empirically validated first** (Playwright + `element.checkVisibility({contentVisibilityAuto:true})`): `content-visibility` is a **no-op on `<tr>`** (table-internal elements can't take size containment) but **does skip** on div rows and on a `<div>` inside a `<td>`. So it's applied where it actually works:
- `.st-session-row` / `.st-file-row` — the Studio sidebar's div-based session + file lists (can grow long).
- `[data-testid="activity-event"]` — the workspace activity stream (long live feeds).
- `.cv-auto` on the workers `CapacityBar` — the per-row capacity-segment `<div>` (up to `capacity` segments each) skips when its row is off-screen.

**Scope note:** the main list tables (agents/graphs/chats/…) are already bounded by the merged pagination (#19, 50/page), so this targets the *un*paginated / high-per-row-cost surfaces. A full `<table>`-row virtualization would need a markup rewrite or JS windowing — deliberately not taken (disproportionate risk for the remaining exposure).

Verified: `tests/ui` 611 passed; workers page renders correctly with the capacity bar intact (browser-checked, no layout regression); `ruff` clean.
