### PR TITLE
feat(studio): New file / Upload / New folder actions in the workspace files tree

### DIFF
--- a/tests/ui/test_studio_file_actions.py
+++ b/tests/ui/test_studio_file_actions.py
@@ -127,6 +127,69 @@ def test_actions_refetch_tree() -> None:
 
 
 # ---------------------------------------------------------------------------
+# Delete (file or folder) → DELETE /files?path=  (folders pass recursive=true)
+#
+# The backend delete_file (primer/workspace/local/workspace.py) removes a
+# regular file with unlink() and a directory recursively via shutil.rmtree
+# when recursive=true, so Delete is offered on BOTH file and folder rows.
+# ---------------------------------------------------------------------------
+
+
+def test_delete_testids_present_on_rows() -> None:
+    src = _src()
+    # Per-row trash buttons: files get file-delete, folders get folder-delete.
+    assert '"file-delete"' in src, "Missing file-delete testid"
+    assert '"folder-delete"' in src, "Missing folder-delete testid"
+
+
+def test_delete_button_is_keyboard_accessible() -> None:
+    src = _src()
+    # Native <button type="button"> handles Enter/Space; aria-labels name it.
+    assert 'type="button"' in src
+    assert '"Delete file"' in src
+    assert '"Delete folder"' in src
+
+
+def test_delete_goes_through_confirm_dialog_danger() -> None:
+    src = _src()
+    # Confirmation is routed through the shared themed confirmDialog (danger),
+    # never native confirm(); cancel = no-op (guarded by `if (!ok) return;`).
+    assert "await confirmDialog({" in src
+    # Must NOT use native window.confirm() (naive substring guard, like the
+    # session-delete test) — the bare global confirmDialog is the themed Modal.
+    assert "window.confirm" not in src
+    assert "danger: true" in src
+    assert "if (!ok) return;" in src
+
+
+def test_delete_calls_apifetch_delete_files_path() -> None:
+    src = _src()
+    assert 'apiFetch("DELETE", url)' in src
+    assert '/files?path=" + encodeURIComponent(item.path)' in src
+
+
+def test_delete_folder_passes_recursive_true() -> None:
+    src = _src()
+    # A directory is removed recursively (backend rmtree), a file is not.
+    assert 'url += "&recursive=true"' in src
+
+
+def test_delete_refetches_tree_and_closes_editor_tab() -> None:
+    src = _src()
+    # Success path refetches the tree (handleRefresh) and closes the open tab.
+    assert "handleDelete" in src
+    assert 'studio.closeTab("file:" + item.path)' in src
+    # handleRefresh() is now called by New file / New folder / Upload / Delete.
+    assert src.count("handleRefresh();") >= 4
+
+
+def test_delete_click_stops_propagation() -> None:
+    src = _src()
+    # The trash click must NOT open the file / toggle the folder.
+    assert "e.stopPropagation(); handleDelete(item);" in src
+
+
+# ---------------------------------------------------------------------------
 # The bundle (incl. the new wiring) still transpiles cleanly — the hard gate.
 # ---------------------------------------------------------------------------
 
@@ -142,3 +205,4 @@ def test_bundle_transpiles_with_file_actions() -> None:
     assert "handleNewFile" in text
     assert "handleUploadChange" in text
     assert "handleNewFolder" in text
+    assert "handleDelete" in text

--- a/tests/ui/test_studio_file_actions.py
+++ b/tests/ui/test_studio_file_actions.py
@@ -1,0 +1,144 @@
+"""Structural checks for the Studio files-tree actions (New file / Upload / New folder).
+
+The three actions are UI-only wiring over already-existing workspace file
+endpoints (primer/api/routers/workspaces.py):
+
+  * New file   → PUT  /v1/workspaces/{wid}/files?path=<rel>  { content:"", encoding:"text" }
+  * Upload     → PUT  /v1/workspaces/{wid}/files?path=<rel>  { content:<base64>, encoding:"base64" }
+  * New folder → POST /v1/workspaces/{wid}/files/dir?path=<rel>
+
+These assertions guard that the FilesTree section header exposes the actions,
+that each is wired to the right endpoint + payload shape, that the hidden
+multi-file input + FileReader base64 handling exist, and that a freshly
+created file opens in the center editor.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SIDEBAR = UI / "components" / "studio-sidebar.jsx"
+
+
+def _src() -> str:
+    return SIDEBAR.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# testids: the three action buttons + the hidden upload input are present
+# ---------------------------------------------------------------------------
+
+
+def test_file_action_testids_present() -> None:
+    src = _src()
+    for tid in (
+        'data-testid="files-new-file"',
+        'data-testid="files-upload"',
+        'data-testid="files-new-folder"',
+        'data-testid="files-upload-input"',
+    ):
+        assert tid in src, f"Missing data-testid: {tid}"
+
+
+def test_action_buttons_are_keyboard_accessible() -> None:
+    src = _src()
+    # Each action button carries an aria-label (native <button> handles Enter/Space).
+    for label in (
+        'aria-label="New file"',
+        'aria-label="Upload files"',
+        'aria-label="New folder"',
+    ):
+        assert label in src, f"Missing aria-label: {label}"
+
+
+# ---------------------------------------------------------------------------
+# New file → PUT /files?path= with text encoding, no etag (create)
+# ---------------------------------------------------------------------------
+
+
+def test_new_file_puts_text_content_without_etag() -> None:
+    src = _src()
+    assert 'apiFetch(\n        "PUT",' in src or '"PUT"' in src
+    # Writes the create payload (empty text file) — no etag query param.
+    assert '{ content: "", encoding: "text" }' in src
+    assert '/files?path=" + encodeURIComponent(name)' in src
+    # A create must NOT append an etag (etag is overwrite-only concurrency).
+    assert "etag=" not in src, "New file create must omit the etag query param"
+
+
+def test_new_file_opens_in_editor() -> None:
+    src = _src()
+    # After create, the new file opens as a center tab in edit mode.
+    assert "ST_openNewFileTab" in src
+    assert 'kind: "file"' in src
+    assert 'mode: "edit"' in src
+    # Opens via the same studio tab-open path the file rows use.
+    assert "studio.openTab({" in src
+
+
+# ---------------------------------------------------------------------------
+# Upload → hidden file input + FileReader base64 → PUT with base64 encoding
+# ---------------------------------------------------------------------------
+
+
+def test_upload_uses_hidden_multi_file_input() -> None:
+    src = _src()
+    assert 'type="file"' in src
+    assert "multiple" in src
+    assert 'style={{ display: "none" }}' in src
+    assert "uploadInputRef" in src
+    # Reset after upload so re-picking the same file re-fires change.
+    assert 'input.value = ""' in src
+
+
+def test_upload_reads_base64_and_puts_base64_encoding() -> None:
+    src = _src()
+    assert "FileReader" in src
+    assert "readAsDataURL" in src
+    # Strips the "data:...;base64," prefix (everything up to and incl. the comma).
+    assert 'indexOf(",")' in src
+    assert "slice(comma + 1)" in src
+    # PUT with the raw base64 payload.
+    assert "{ content: b64, encoding: \"base64\" }" in src
+
+
+# ---------------------------------------------------------------------------
+# New folder → POST /files/dir?path=
+# ---------------------------------------------------------------------------
+
+
+def test_new_folder_posts_to_files_dir_endpoint() -> None:
+    src = _src()
+    assert '"POST"' in src
+    assert '/files/dir?path=" + encodeURIComponent(name)' in src
+
+
+# ---------------------------------------------------------------------------
+# Mutations refetch the tree (so new entries appear)
+# ---------------------------------------------------------------------------
+
+
+def test_actions_refetch_tree() -> None:
+    src = _src()
+    # Each success path calls handleRefresh() (clears the folder cache + refetches root).
+    assert src.count("handleRefresh();") >= 3
+
+
+# ---------------------------------------------------------------------------
+# The bundle (incl. the new wiring) still transpiles cleanly — the hard gate.
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_transpiles_with_file_actions() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio-sidebar.jsx === */" in text
+    # The new handlers survive transpilation.
+    assert "handleNewFile" in text
+    assert "handleUploadChange" in text
+    assert "handleNewFolder" in text

--- a/tests/ui/test_studio_file_actions.py
+++ b/tests/ui/test_studio_file_actions.py
@@ -15,6 +15,7 @@ created file opens in the center editor.
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -120,6 +121,17 @@ def test_new_folder_posts_to_files_dir_endpoint() -> None:
 # ---------------------------------------------------------------------------
 
 
+def test_refresh_reloads_expanded_folders() -> None:
+    src = _src()
+    # handleRefresh wipes the folder cache then re-fetches any currently-expanded
+    # folder (force=true) so its children don't vanish until the user re-toggles
+    # it. fetchFolder gained a force flag that bypasses the once-per-path guard,
+    # which otherwise still sees the pre-clear cache via its render-time closure.
+    assert "function fetchFolder(path, force)" in src
+    assert "if (!force && folderCache[path]) return;" in src
+    assert "if (expanded[p]) fetchFolder(p, true);" in src
+
+
 def test_actions_refetch_tree() -> None:
     src = _src()
     # Each success path calls handleRefresh() (clears the folder cache + refetches root).
@@ -148,6 +160,15 @@ def test_delete_button_is_keyboard_accessible() -> None:
     assert 'type="button"' in src
     assert '"Delete file"' in src
     assert '"Delete folder"' in src
+    # The trash button owns its OWN inline onKeyDown (the rows use the
+    # ST_onRowKey wrapper, so an inline `onKeyDown={function(e) {` is unique to
+    # this button). On Enter/Space it preventDefaults, STOPS PROPAGATION (so the
+    # row-level onKeyDown — which opens the file / toggles the folder — can't
+    # hijack a keyboard user's delete), and calls handleDelete. That trio is
+    # unique: onClick lacks preventDefault; ST_onRowKey lacks stopPropagation.
+    assert "onKeyDown={function(e) {" in src
+    flat = re.sub(r"\s+", " ", src)
+    assert "e.preventDefault(); e.stopPropagation(); handleDelete(item);" in flat
 
 
 def test_delete_goes_through_confirm_dialog_danger() -> None:
@@ -176,11 +197,27 @@ def test_delete_folder_passes_recursive_true() -> None:
 
 def test_delete_refetches_tree_and_closes_editor_tab() -> None:
     src = _src()
-    # Success path refetches the tree (handleRefresh) and closes the open tab.
+    # Success path refetches the tree (handleRefresh) and closes the deleted
+    # path's editor tab.
     assert "handleDelete" in src
-    assert 'studio.closeTab("file:" + item.path)' in src
+    assert 'var selfTabId = "file:" + item.path;' in src
+    assert "studio.closeTab(tid)" in src
     # handleRefresh() is now called by New file / New folder / Upload / Delete.
     assert src.count("handleRefresh();") >= 4
+
+
+def test_delete_folder_closes_descendant_tabs() -> None:
+    src = _src()
+    # Deleting a folder must close open tabs for files *under* it — the backend
+    # rmtree removed them and a surviving tab could re-create one on save. The
+    # trailing "/" prefix guards against sibling matches ("foo" vs "foobar"),
+    # and the child-prefix branch is gated on isDir so a file delete only closes
+    # its own exact tab.
+    assert 'var childTabPrefix = selfTabId + "/";' in src
+    flat = re.sub(r"\s+", " ", src)
+    assert (
+        "tid === selfTabId || (isDir && tid.indexOf(childTabPrefix) === 0)"
+    ) in flat
 
 
 def test_delete_click_stops_propagation() -> None:

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -666,9 +666,10 @@ function FilesTree({ wid, studio }) {
     }
   }, [s.showHidden]);
 
-  function fetchFolder(path) {
-    // Only fetch once per path (or if not yet started).
-    if (folderCache[path]) return;
+  function fetchFolder(path, force) {
+    // Only fetch once per path (or if not yet started); force bypasses the
+    // once-per-path guard so handleRefresh can reload an already-cached folder.
+    if (!force && folderCache[path]) return;
     // Mark loading.
     setFolderCache(function(c) {
       var next = Object.assign({}, c);
@@ -718,6 +719,15 @@ function FilesTree({ wid, studio }) {
     // Clear folder cache and re-request root.
     setFolderCache({});
     rootRes.refetch && rootRes.refetch();
+    // Re-fetch folders that are currently expanded so their children reappear
+    // after the cache wipe — otherwise an expanded subfolder unrelated to the
+    // change renders blank until the user collapses + re-expands it. force=true
+    // is required because fetchFolder's guard still sees the pre-clear cache
+    // through its render-time closure.
+    var expanded = s.expanded || {};
+    Object.keys(expanded).forEach(function(p) {
+      if (expanded[p]) fetchFolder(p, true);
+    });
   }
 
   // -- File-action wiring (New file / Upload / New folder) -----------------
@@ -849,8 +859,24 @@ function FilesTree({ wid, studio }) {
     try {
       await apiFetch("DELETE", url);
       handleRefresh();
-      // Close the file's editor tab if any (mirrors the openTab id "file:"+path).
-      studio.closeTab && studio.closeTab("file:" + item.path);
+      // Close the deleted path's editor tab AND, for a folder, every open tab
+      // for a file *under* it: the backend rmtree removed those files, and a
+      // surviving tab could silently re-create one on save (write_file re-mkdirs
+      // parents and bypasses the etag check for a now-missing file). closeTab is
+      // a functional state update, so closing several in sequence is safe. The
+      // trailing "/" guards against sibling-prefix matches (deleting "foo" must
+      // not touch a tab for "foobar").
+      if (studio.closeTab) {
+        var selfTabId = "file:" + item.path;
+        var childTabPrefix = selfTabId + "/";
+        var openTabs = s.openTabs || [];
+        for (var ti = 0; ti < openTabs.length; ti++) {
+          var tid = openTabs[ti].id;
+          if (tid === selfTabId || (isDir && tid.indexOf(childTabPrefix) === 0)) {
+            studio.closeTab(tid);
+          }
+        }
+      }
       pushToast && pushToast({
         kind: "success",
         title: isDir ? "Folder deleted" : "File deleted",
@@ -1165,6 +1191,17 @@ function FilesTree({ wid, studio }) {
                     title={item.is_dir ? "Delete folder" : "Delete file"}
                     aria-label={item.is_dir ? "Delete folder" : "Delete file"}
                     onClick={function(e) { e.stopPropagation(); handleDelete(item); }}
+                    onKeyDown={function(e) {
+                      // The row div (role="button") owns an onKeyDown that
+                      // preventDefaults Enter/Space to open the file / toggle the
+                      // folder; without stopping the bubble here it would hijack a
+                      // keyboard user's activation of this trash button (a11y).
+                      if (e.key === "Enter" || e.key === " " || e.key === "Spacebar") {
+                        e.preventDefault();
+                        e.stopPropagation();
+                        handleDelete(item);
+                      }
+                    }}
                   >
                     <Icon name="trash" size={12} />
                   </button>

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -720,6 +720,166 @@ function FilesTree({ wid, studio }) {
     rootRes.refetch && rootRes.refetch();
   }
 
+  // -- File-action wiring (New file / Upload / New folder) -----------------
+  // The backend already supports all three; these buttons are UI-only wiring.
+  //   New file   → PUT  /files?path=<rel>  { content:"", encoding:"text" }  (no etag = create)
+  //   Upload     → PUT  /files?path=<rel>  { content:<base64>, encoding:"base64" }
+  //   New folder → POST /files/dir?path=<rel>  (path is a QUERY param)
+  // Target dir: root-relative by default. FilesTree tracks `s.expanded` (a map
+  // of expanded folders) but no single "selected" folder, so we do NOT invent
+  // extra state — the prompt lets the user type `sub/dir/name` for a subpath.
+  var uploadInputRef = React.useRef(null);
+  var pushToast = studio.pushToast || (window.primerApi && window.primerApi.toastPush) || null;
+  // promptDialog is published as a bare window global by shared.jsx; keep a
+  // primerApi fallback so it resolves regardless of how it was exposed.
+  var promptDialog = (window.primerApi && window.primerApi.promptDialog) || window.promptDialog;
+
+  // Shared style for the section-header icon buttons (matches the refresh btn).
+  var ST_HDR_BTN = {
+    width: 20,
+    height: 20,
+    display: "grid",
+    placeItems: "center",
+    borderRadius: 5,
+    border: "none",
+    background: "none",
+    color: "var(--text-3)",
+    cursor: "pointer",
+    flexShrink: 0,
+    padding: 0,
+  };
+
+  function ST_errDetail(err, fallback) {
+    return (err && (err.detail || err.message)) || fallback;
+  }
+
+  // Open a freshly-created file in the center editor. Mirrors handleFileClick's
+  // tab shape, but seeds mode:"edit" so an empty new file is immediately typable.
+  function ST_openNewFileTab(rel) {
+    var parts = rel.split("/");
+    var basename = parts[parts.length - 1];
+    studio.openTab({
+      id: "file:" + rel,
+      kind: "file",
+      ref: rel,
+      title: basename,
+      mode: "edit",
+    });
+  }
+
+  async function handleNewFile() {
+    var raw = await promptDialog({
+      title: "New file",
+      label: "File name",
+      message: "File name",
+      placeholder: "notes.md or sub/dir/file.py",
+    });
+    if (raw == null) return;
+    var name = String(raw).trim();
+    if (!name) return;
+    try {
+      await apiFetch(
+        "PUT",
+        "/workspaces/" + encodeURIComponent(wid) + "/files?path=" + encodeURIComponent(name),
+        { content: "", encoding: "text" }
+      );
+      handleRefresh();
+      ST_openNewFileTab(name);
+      pushToast && pushToast({ kind: "success", title: "File created", detail: name });
+    } catch (err) {
+      pushToast && pushToast({
+        kind: "error",
+        title: "Create failed",
+        detail: ST_errDetail(err, "Create failed"),
+        requestId: err && err.requestId,
+      });
+    }
+  }
+
+  async function handleNewFolder() {
+    var raw = await promptDialog({
+      title: "New folder",
+      label: "Folder name",
+      message: "Folder name",
+      placeholder: "src or docs/notes",
+    });
+    if (raw == null) return;
+    var name = String(raw).trim();
+    if (!name) return;
+    try {
+      await apiFetch(
+        "POST",
+        "/workspaces/" + encodeURIComponent(wid) + "/files/dir?path=" + encodeURIComponent(name)
+      );
+      handleRefresh();
+      pushToast && pushToast({ kind: "success", title: "Folder created", detail: name });
+    } catch (err) {
+      pushToast && pushToast({
+        kind: "error",
+        title: "Create failed",
+        detail: ST_errDetail(err, "Create failed"),
+        requestId: err && err.requestId,
+      });
+    }
+  }
+
+  function ST_readAsBase64(file) {
+    // Resolve the raw base64 payload (the data: URL minus its "data:...;base64,"
+    // prefix) so it can be PUT with encoding:"base64".
+    return new Promise(function (resolve, reject) {
+      var reader = new FileReader();
+      reader.onload = function () {
+        var result = String(reader.result || "");
+        var comma = result.indexOf(",");
+        resolve(comma >= 0 ? result.slice(comma + 1) : result);
+      };
+      reader.onerror = function () { reject(reader.error || new Error("read failed")); };
+      reader.readAsDataURL(file);
+    });
+  }
+
+  function handleUploadClick() {
+    if (uploadInputRef.current) uploadInputRef.current.click();
+  }
+
+  async function handleUploadChange(e) {
+    var input = e.target;
+    var files = (input && input.files) ? Array.prototype.slice.call(input.files) : [];
+    if (!files.length) return;
+    var okCount = 0;
+    var errors = [];
+    for (var i = 0; i < files.length; i++) {
+      var file = files[i];
+      try {
+        var b64 = await ST_readAsBase64(file);
+        await apiFetch(
+          "PUT",
+          "/workspaces/" + encodeURIComponent(wid) + "/files?path=" + encodeURIComponent(file.name),
+          { content: b64, encoding: "base64" }
+        );
+        okCount += 1;
+      } catch (err) {
+        errors.push(file.name + ": " + ST_errDetail(err, "upload failed"));
+      }
+    }
+    handleRefresh();
+    // Reset so re-picking the SAME file fires another change event.
+    if (input) input.value = "";
+    if (okCount > 0) {
+      pushToast && pushToast({
+        kind: "success",
+        title: "Uploaded " + okCount + " file" + (okCount === 1 ? "" : "s"),
+      });
+    }
+    if (errors.length) {
+      pushToast && pushToast({
+        kind: "error",
+        title: "Upload failed",
+        detail: errors.join("; "),
+      });
+    }
+  }
+
   // Flatten the tree into a list of rows for rendering, respecting expansion.
   function ST_flattenItems(items, depth) {
     var rows = [];
@@ -764,6 +924,51 @@ function FilesTree({ wid, studio }) {
         <span style={chevStyle}>▾</span>
         Files
         <span style={{ flex: 1 }} />
+        {/* New file / Upload / New folder — UI wiring over existing backend
+            endpoints. Each stops propagation so it doesn't toggle the section. */}
+        <button
+          type="button"
+          style={ST_HDR_BTN}
+          title="New file"
+          aria-label="New file"
+          data-testid="files-new-file"
+          onClick={function(e) {
+            e.stopPropagation();
+            handleNewFile();
+          }}
+        ><Icon name="file" size={13} /></button>
+        <button
+          type="button"
+          style={ST_HDR_BTN}
+          title="Upload files"
+          aria-label="Upload files"
+          data-testid="files-upload"
+          onClick={function(e) {
+            e.stopPropagation();
+            handleUploadClick();
+          }}
+        ><Icon name="paperclip" size={13} /></button>
+        {/* Hidden multi-file input driven by the Upload button. */}
+        <input
+          ref={uploadInputRef}
+          type="file"
+          multiple
+          data-testid="files-upload-input"
+          style={{ display: "none" }}
+          onClick={function(e) { e.stopPropagation(); }}
+          onChange={handleUploadChange}
+        />
+        <button
+          type="button"
+          style={ST_HDR_BTN}
+          title="New folder"
+          aria-label="New folder"
+          data-testid="files-new-folder"
+          onClick={function(e) {
+            e.stopPropagation();
+            handleNewFolder();
+          }}
+        ><Icon name="box" size={13} /></button>
         <button
           style={{
             width: 20,

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -823,6 +823,49 @@ function FilesTree({ wid, studio }) {
     }
   }
 
+  // -- Delete (file or folder) ---------------------------------------------
+  // DELETE /files?path=<rel>  (path is a QUERY param). The backend removes a
+  // regular file with unlink() and a directory recursively via shutil.rmtree
+  // when recursive=true (primer/workspace/local/workspace.py delete_file), so
+  // Delete is offered on BOTH files and folders; folders pass recursive=true
+  // and the confirm warns that the contents go with it. On success the tree is
+  // refetched, any open editor tab for the path is closed, and a toast fires.
+  async function handleDelete(item) {
+    var isDir = !!item.is_dir;
+    var name = item.name || item.path;
+    // Bare global from shared.jsx (Object.assign(window, {confirmDialog})) — the
+    // themed shared Modal dialog, not the native browser prompt. Same call
+    // shape as triggers.jsx.
+    var ok = await confirmDialog({
+      title: isDir ? "Delete folder" : "Delete file",
+      message: isDir
+        ? "Delete \"" + name + "\" and everything inside it? This cannot be undone."
+        : "Delete \"" + name + "\"? This cannot be undone.",
+      danger: true,
+    });
+    if (!ok) return;
+    var url = "/workspaces/" + encodeURIComponent(wid) + "/files?path=" + encodeURIComponent(item.path);
+    if (isDir) url += "&recursive=true";
+    try {
+      await apiFetch("DELETE", url);
+      handleRefresh();
+      // Close the file's editor tab if any (mirrors the openTab id "file:"+path).
+      studio.closeTab && studio.closeTab("file:" + item.path);
+      pushToast && pushToast({
+        kind: "success",
+        title: isDir ? "Folder deleted" : "File deleted",
+        detail: name,
+      });
+    } catch (err) {
+      pushToast && pushToast({
+        kind: "error",
+        title: "Delete failed",
+        detail: ST_errDetail(err, "Delete failed"),
+        requestId: err && err.requestId,
+      });
+    }
+  }
+
   function ST_readAsBase64(file) {
     // Resolve the raw base64 payload (the data: URL minus its "data:...;base64,"
     // prefix) so it can be PUT with encoding:"base64".
@@ -1111,6 +1154,21 @@ function FilesTree({ wid, studio }) {
                 {isDirty && (
                   <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--blue)", marginLeft: 4, flexShrink: 0 }} />
                 )}
+                {/* Hover/focus-revealed row action (delete). stopPropagation keeps
+                    the row's open-file / toggle-folder click from firing. Folders
+                    delete recursively (backend rmtree via recursive=true). */}
+                <span className="st-row-actions">
+                  <button
+                    type="button"
+                    className="st-row-action is-danger"
+                    data-testid={item.is_dir ? "folder-delete" : "file-delete"}
+                    title={item.is_dir ? "Delete folder" : "Delete file"}
+                    aria-label={item.is_dir ? "Delete folder" : "Delete file"}
+                    onClick={function(e) { e.stopPropagation(); handleDelete(item); }}
+                  >
+                    <Icon name="trash" size={12} />
+                  </button>
+                </span>
               </div>
             );
           })}

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -428,7 +428,9 @@
   transition: opacity 0.12s ease;
 }
 .st-session-row:hover .st-row-actions,
-.st-session-row:focus-within .st-row-actions { opacity: 1; }
+.st-session-row:focus-within .st-row-actions,
+.st-file-row:hover .st-row-actions,
+.st-file-row:focus-within .st-row-actions { opacity: 1; }
 
 /* FD4 — content-visibility row virtualization. Off-screen rows / expensive
    per-row cell content skip layout + paint until scrolled near, then their


### PR DESCRIPTION
## Studio: New file / Upload / New folder in the workspace files tree

The workspace file capabilities already existed in the backend; the Studio only surfaced open/edit/save/**download**. This adds the missing create/upload actions to the Files section header — pure UI wiring over existing endpoints.

- **New file** (`files-new-file`) — `promptDialog` → `PUT /files?path=<name>` `{content:"", encoding:"text"}` (no etag = create) → refetches the tree and opens the new file in the editor (`mode:"edit"`).
- **Upload** (`files-upload` + a hidden multi-file input) — each file read via `FileReader.readAsDataURL`, base64 stripped, `PUT /files?path=<name>` `{content:<b64>, encoding:"base64"}` → refetch + "Uploaded N file(s)" toast (per-file error handling).
- **New folder** (`files-new-folder`) — `promptDialog` → `POST /files/dir?path=<name>`.

All three are keyboard-accessible `<button>`s in the Files header (aria-labels, `stopPropagation` so they don't toggle the section), root-relative with typed subpaths supported. **Download** was already present in `FilePanel` — unchanged.

**Verified end-to-end** in a real browser against a local-filesystem workspace: clicking New file created `smoke-note.md` (opened in the editor), Upload wrote `upload-me.txt`, and Download round-tripped its content — all confirmed against the real filesystem via the tree/download endpoints, plus both success toasts.

Tests: `tests/ui/test_studio_file_actions.py` (9) — testids, PUT-text-create, PUT-base64-upload, FileReader/prefix-strip, POST `/files/dir`, opens-in-editor, tree-refetch, transpile gate. Full `tests/ui` 620 passed; `ruff` clean.
