### PR TITLE
docs(embeds): render the workspace Studio in the sessions-list + session-detail embeds

### DIFF
--- a/scripts/docs/embed_harness/index.html
+++ b/scripts/docs/embed_harness/index.html
@@ -119,6 +119,27 @@
       if (typeof iwin.DocsMakeStubApi !== "function") throw new Error("DocsMakeStubApi missing");
       if (typeof iwin[entry.component] !== "function") throw new Error(entry.component + " not defined in iframe after bundle load");
       iwin.primerApi = iwin.DocsMakeStubApi(fixtures);
+      // The build-only harness has no SSE backend. Studio-family embeds open a
+      // workspace/session "tap" via EventSource; unstubbed, that surfaces a
+      // "reconnecting" error in the activity panel. Install a benign
+      // EventSource that connects (fires onopen) and stays open with zero
+      // events, matching an idle workspace, so captures show a clean live state.
+      iwin.EventSource = function (url) {
+        this.url = url; this.readyState = 1; this.withCredentials = false;
+        var self = this;
+        this._t = iwin.setTimeout(function () {
+          if (typeof self.onopen === "function") self.onopen({ type: "open" });
+        }, 0);
+      };
+      iwin.EventSource.prototype.addEventListener = function () {};
+      iwin.EventSource.prototype.removeEventListener = function () {};
+      iwin.EventSource.prototype.close = function () {
+        this.readyState = 2;
+        if (this._t) { iwin.clearTimeout(this._t); this._t = null; }
+      };
+      iwin.EventSource.CONNECTING = 0;
+      iwin.EventSource.OPEN = 1;
+      iwin.EventSource.CLOSED = 2;
       var root = iwin.ReactDOM.createRoot(idoc.getElementById("embed-root"));
       root.render(iwin.React.createElement(iwin[entry.component], entry.props || {}));
       // Give React effects (useResource fetchers, per-row effects) a beat to

--- a/ui/components/docs/embed-registry.jsx
+++ b/ui/components/docs/embed-registry.jsx
@@ -41,24 +41,27 @@
       props: { onOpen: function () {}, pushToast: function () {} },
     },
     "sessions-list": {
-      component: "SessionsList",
+      // The global sessions list/detail pages were retired: sessions now live
+      // inside the workspace Studio (studio.jsx). This embed renders the Studio
+      // for the fixture workspace, so it shows the left sidebar's Sessions list
+      // + Files tree over fixture data. `wid` must match the workspace + session
+      // rows in sessions-list.json.
+      component: "Studio",
       fixtures: "sessions-list",
-      props: {
-        onOpenSession: function () {},
-        onNewSession: function () {},
-      },
+      props: { wid: "ws-blogassistant", pushToast: function () {} },
     },
     "session-detail": {
-      // SessionsList shows the list including the fixture session row;
-      // session-detail.json is keyed by GET /sessions/{id} which maps to
-      // that single session via the stub's query-insensitive fallback.
-      // NOTE: rendered as SessionsList (page-level) because SessionDetail
-      // requires an explicit sid prop to start fetching.
-      component: "SessionsList",
+      // Same Studio render, but `initialOpen` seeds an open session tab so the
+      // capture shows the center transcript panel (SessionLiveStream). The
+      // session in session-detail.json is terminal (ended), so the transcript
+      // renders fully from GET /sessions/{sid}/messages history with no live
+      // tap (the harness has no SSE backend).
+      component: "Studio",
       fixtures: "session-detail",
       props: {
-        onOpenSession: function () {},
-        onNewSession: function () {},
+        wid: "ws-blogassistant",
+        initialOpen: "session:sess-briefwriter",
+        pushToast: function () {},
       },
     },
     "chat-stream": {

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -116,8 +116,8 @@ function ST_tabFromUrlId(urlTab) {
 // synthesize a minimal tab, append it, and activate it. With activeTabId set
 // on mount, the first persist effect's ST_syncUrl re-writes the same ?open=
 // value instead of deleting it (so deep-links survive the mount).
-function ST_applyUrlTab(base) {
-  var urlTab = ST_tabFromUrl();
+function ST_applyUrlTab(base, fallbackOpen) {
+  var urlTab = ST_tabFromUrl() || (fallbackOpen || null);
   if (!urlTab) return base;
   var openTabs = base.openTabs || [];
   var present = openTabs.some(function (t) { return t.id === urlTab; });
@@ -195,11 +195,14 @@ function ST_defaultState() {
 // B2–B4 consume the action callbacks (openTab/focusTab/closeTab/toggle*).
 // ---------------------------------------------------------------------------
 
-function useStudioState(wid) {
+function useStudioState(wid, initialOpen) {
   // Initial state: defaults <- persisted(wid) <- url(?open=). Computed once
   // per wid via the lazy initialiser; re-keyed below when wid changes.
+  // `initialOpen` (a "session:<id>" / "file:<path>" string) is a fallback used
+  // only when the URL has no ?open= deep-link: it lets a host that mounts the
+  // Studio directly (e.g. the docs embed harness) seed an initial open tab.
   var [state, setState] = React.useState(function () {
-    return ST_applyUrlTab(Object.assign(ST_defaultState(), ST_loadPersisted(wid)));
+    return ST_applyUrlTab(Object.assign(ST_defaultState(), ST_loadPersisted(wid)), initialOpen);
   });
 
   // New-session form visibility, lifted out of the sidebar so BOTH the sidebar
@@ -215,7 +218,7 @@ function useStudioState(wid) {
   React.useEffect(function () {
     if (widRef.current === wid) return;
     widRef.current = wid;
-    setState(ST_applyUrlTab(Object.assign(ST_defaultState(), ST_loadPersisted(wid))));
+    setState(ST_applyUrlTab(Object.assign(ST_defaultState(), ST_loadPersisted(wid)), initialOpen));
   }, [wid]);
 
   // Persist + URL-mirror after every committed state change.
@@ -604,8 +607,8 @@ function ST_RegionPlaceholder({ kind, label, testid }) {
 // Studio — route shell. Header + 3-column resizable body with placeholders.
 // ---------------------------------------------------------------------------
 
-function Studio({ wid, pushToast }) {
-  var studio = useStudioState(wid);
+function Studio({ wid, pushToast, initialOpen }) {
+  var studio = useStudioState(wid, initialOpen);
   var s = studio.state;
 
   // Thread pushToast into the studio object so StudioCenter / StudioActivity


### PR DESCRIPTION
The global sessions-list and session-detail pages were retired when sessions moved into the workspace **Studio**, so both docs embeds still rendered the dead `SessionsList` component (an empty "No sessions yet" placeholder). This re-points them at the real Studio.

## Changes
- **embed-registry**: `sessions-list` + `session-detail` now render `Studio` for a fixture workspace. `sessions-list` shows the populated sidebar (Sessions list + Files tree); `session-detail` seeds an open session tab (via a new `initialOpen`) so the capture shows the transcript panel + controls.
- **studio.jsx**: thread an optional `initialOpen` (`"session:<id>"` / `"file:<path>"`) through `Studio` -> `useStudioState` -> `ST_applyUrlTab`. It is a fallback used **only** when the URL has no `?open=` deep-link, so the routed app is unaffected (`initialOpen` is `undefined` there); a host that mounts the Studio directly (the docs embed harness) can seed an initial open tab.
- **embed harness**: stub `EventSource` so Studio-family embeds render a clean "live" activity panel instead of a "reconnecting" error (the build-only harness has no SSE backend).

The matching docs corpus change (new Studio fixtures + refreshed PNGs + Studio narrative) is a separate PR in `primerhq/primerhq.github.io`.

## Verification
- `capture_embeds` regenerates all 56 PNGs; `sessions-list` + `session-detail` now show the Studio in both themes (verified visually).
- `tests/ui`: 629 passed, 1 skipped. JSX bundle builds clean.