### PR TITLE
ci(release): push the release commit + tag with a GitHub App token

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,15 +107,26 @@ jobs:
       version: ${{ steps.psr.outputs.version }}
       tag: ${{ steps.psr.outputs.tag }}
     steps:
+      # Mint a short-lived installation token from the release GitHub App. The
+      # default GITHUB_TOKEN cannot push the chore(release) commit + tag to the
+      # protected `main` branch (GH006); the App is on main's push-restriction
+      # and required-PR bypass lists, so its token can. Requires the org/repo
+      # to provide RELEASE_APP_ID (variable) + RELEASE_APP_PRIVATE_KEY (secret).
+      - name: Mint release app token
+        id: app-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ vars.RELEASE_APP_ID }}
+          private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ steps.app-token.outputs.token }}
       - name: Python Semantic Release
         id: psr
         uses: python-semantic-release/python-semantic-release@v10.5.3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          github_token: ${{ steps.app-token.outputs.token }}
           # The first release spans ~1785 commits; the auto-generated
           # notes exceed the GitHub release-body size limit (125k chars, 422).
           # Skip the VCS release object here; the tag still pushes and PyPI +


### PR DESCRIPTION
The release workflow has never been able to cut a release: python-semantic-release pushes the `chore(release)` version-bump commit + tag to `main`, but the default `GITHUB_TOKEN` can't push to the protected branch (`GH006: Protected branch update failed`), so the `release` job failed before tagging or publishing (both v0.1.0 and the recent 0.2.0 attempt hit this).

## Change
Mint a short-lived installation token from a release **GitHub App** (`actions/create-github-app-token@v1`) and use it for the `actions/checkout` token + PSR `github_token`. The App is installed with `contents:write` and added to `main`'s push-restriction + required-PR bypass lists, so its token can push.

`publish-images` keeps `GITHUB_TOKEN` for GHCR login (`packages:write` is enough there); `publish-pypi` keeps `PYPI_TOKEN`.

## Required settings (must exist before dispatch)
- `RELEASE_APP_ID` — **variable** (the App id)
- `RELEASE_APP_PRIVATE_KEY` — **secret** (the App private key)

If you named them differently, rename the var/secret to match or adjust the two references in the `release` job.

## After merge
Re-dispatch **Release** (`gh workflow run release.yml`); it should compute `0.2.0`, push the tag, and publish to PyPI + GHCR.