### PR TITLE
feat(graph): expose ExecutionContext to node templates as ctx

### DIFF
--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -74,6 +74,7 @@ from primer.model.graph import (
     _JsonPathRouter,
     _StaticEdge,
     _ToolCallNode,
+    build_execution_context,
 )
 from primer.model.problem_details import ProblemDetails
 from primer.model.turn_log import (
@@ -186,6 +187,10 @@ class _BaseGraphExecutor(
         self._graph_resolver = graph_resolver
         self._router_registry = router_registry or RouterRegistry()
         self._principal = principal
+        # Ambient run context exposed to node templates as ``ctx``. The base
+        # executor is surface-agnostic, so default to an in-memory context;
+        # WorkspaceGraphExecutor overrides this with real workspace ids.
+        self._execution_context = build_execution_context()
         # Lookup helpers built once at construction.
         self._nodes_by_id = {n.id: n for n in graph.nodes}
         self._edges_by_from: dict[str, list] = {}
@@ -894,6 +899,7 @@ class _BaseGraphExecutor(
             initial_input=initial_input,
             iteration=0,
             nodes={},
+            ctx=self._execution_context,
         )
         ready: set[str] = {_resolve_initial_ready_node(self._graph)}
         self._admitted = set(ready)

--- a/primer/graph/template.py
+++ b/primer/graph/template.py
@@ -140,6 +140,7 @@ def render_input_template(
         "initial_input": context.initial_input,
         "iteration": context.iteration,
         "nodes": context.nodes,
+        "ctx": context.ctx,
     }
     if extra_scope:
         scope.update(extra_scope)
@@ -177,6 +178,7 @@ def render_template_safely(
         "initial_input": context.initial_input,
         "iteration": context.iteration,
         "nodes": context.nodes,
+        "ctx": context.ctx,
     }
     if extra_scope:
         scope.update(extra_scope)

--- a/primer/graph/workspace_executor.py
+++ b/primer/graph/workspace_executor.py
@@ -45,7 +45,13 @@ from primer.agent.tool_manager import ToolExecutionManager
 from primer.graph.base import DEFAULT_MAX_PARALLEL_NODES, _BaseGraphExecutor
 from primer.graph.router import RouterRegistry
 from primer.model.chat import Message, StreamEvent, ToolResultPart
-from primer.model.graph import Graph, NodeRuntimeState, _GraphNodeRef, _ToolCallNode
+from primer.model.graph import (
+    Graph,
+    NodeRuntimeState,
+    _GraphNodeRef,
+    _ToolCallNode,
+    build_execution_context,
+)
 from primer.model.workspace_session import SessionStatus
 from primer.observability.turn_log_writer import (
     TurnLogWriter,
@@ -123,6 +129,21 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
         self._state_repo = state_repo
         self._graph_session_id = graph_session_id
         self._workspace_session = workspace_session
+        # Override the base's in-memory context with real workspace ids so node
+        # templates can reference {{ ctx.artifact_dir }} etc. Subgraph children
+        # get their own scope automatically: _build_sub_executor constructs the
+        # child with the nested graph_session_id, so this runs per level.
+        self._execution_context = build_execution_context(
+            surface="workspace",
+            workspace_id=(
+                workspace_session.workspace_id
+                if workspace_session is not None
+                else None
+            ),
+            session_id=graph_session_id,
+            graph_id=graph.id,
+            principal=principal,
+        )
         # Only the top-level (worker-built) executor owns the on-disk
         # session holder's lifecycle. Subgraph child executors share the
         # parent's holder (see ``_build_sub_executor``) and must NOT end
@@ -323,6 +344,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
         wins — this is the documented precedence in spec §4.2:
         ``graph_input`` is preferred over ``initial_instructions``).
         """
+        await self._ensure_artifact_dir()
         if self._graph_input is not None:
             seed: Any = self._graph_input
         else:
@@ -593,6 +615,29 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
         )
 
     # ---- Public helpers --------------------------------------------------
+
+    async def _ensure_artifact_dir(self) -> None:
+        """Best-effort create ``<workspace_root>/artifacts/<gsid>/``.
+
+        Local repos only: the workspace root is the ``.state`` repo's parent.
+        Sandbox/container repos expose no local path (``getattr`` returns None)
+        and rely on create-on-write (the workspace write tool mkdirs parents).
+        Never fatal -- a failure here must not abort the graph.
+        """
+        state_path: Path | None = getattr(self._state_repo, "path", None)
+        if state_path is None:
+            return
+        artifact_dir = state_path.parent / "artifacts" / self._graph_session_id
+        try:
+            await asyncio.to_thread(
+                artifact_dir.mkdir, parents=True, exist_ok=True
+            )
+        except OSError as exc:  # noqa: BLE001 -- best-effort, never fatal
+            logger.warning(
+                "graph %s: best-effort artifact dir create failed: %s",
+                self._graph_session_id,
+                exc,
+            )
 
     async def load_state(self) -> dict | None:
         """Return the persisted ``state.json`` payload, or ``None`` if absent."""

--- a/primer/model/graph.py
+++ b/primer/model/graph.py
@@ -228,6 +228,15 @@ class GraphContext(BaseModel):
             "NodeOutput."
         ),
     )
+    ctx: ExecutionContext = Field(
+        default_factory=build_execution_context,
+        description=(
+            "Ambient run context exposed to templates as ``ctx``. Defaults to a "
+            "``surface='memory'`` context so in-memory graph runs and existing "
+            "GraphContext constructions keep working; the workspace executor "
+            "overrides it with real workspace ids."
+        ),
+    )
 
 
 # ===========================================================================

--- a/primer/model/graph.py
+++ b/primer/model/graph.py
@@ -12,7 +12,7 @@ the surrounding design.
 
 from __future__ import annotations
 
-from datetime import datetime
+from datetime import datetime, timezone
 from enum import Enum
 from typing import Annotated, Any, ClassVar, Literal, Union
 
@@ -126,6 +126,74 @@ class NodeOutput(BaseModel):
             "'tool_execution_failed'); populated when `error` is set. "
             "Mirrors WorkspaceSession.ended_detail's semantics."
         ),
+    )
+
+
+class ExecutionContext(BaseModel):
+    """Shared, always-present ambient run context, exposed to templates as ``ctx``.
+
+    One object is consumed by both templating layers — graph node templates (this
+    layer) and, in a companion effort, the agent ``system_prompt``. Node templates
+    only run inside graph execution, so ``surface`` is ``"workspace"`` (or
+    ``"memory"`` for in-memory graph runs); the load-bearing fields are the
+    identifiers, above all ``artifact_dir`` (the per-workflow directory downstream
+    nodes read/write artifacts from). Always present so ``{{ ctx.surface }}`` works
+    everywhere; frozen so a rendered context can't be mutated mid-run.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    surface: str = Field(
+        default="memory",
+        description=(
+            "'workspace' for workspace graph runs; 'memory' for in-memory runs."
+        ),
+    )
+    workspace_id: str | None = None
+    session_id: str | None = Field(
+        default=None,
+        description="The current (possibly nested) graph_session_id.",
+    )
+    graph_id: str | None = None
+    artifact_dir: str | None = Field(
+        default=None,
+        description=(
+            "Workspace-root-relative per-workflow dir: artifacts/<session_id>."
+        ),
+    )
+    principal: str | None = None
+    now: str | None = Field(
+        default=None, description="ISO-8601 UTC, captured once at construction."
+    )
+
+
+def build_execution_context(
+    *,
+    surface: str = "memory",
+    workspace_id: str | None = None,
+    session_id: str | None = None,
+    graph_id: str | None = None,
+    principal: str | None = None,
+    now: str | None = None,
+) -> "ExecutionContext":
+    """Single source of truth for an :class:`ExecutionContext`.
+
+    ``artifact_dir`` is derived as ``artifacts/<session_id>`` (workspace-root-
+    relative) when ``session_id`` is set, else ``None``. ``now`` defaults to the
+    current UTC time in ISO-8601, captured once here; callers pass an explicit
+    ``now`` for deterministic tests.
+    """
+    artifact_dir = f"artifacts/{session_id}" if session_id else None
+    if now is None:
+        now = datetime.now(timezone.utc).isoformat()
+    return ExecutionContext(
+        surface=surface,
+        workspace_id=workspace_id,
+        session_id=session_id,
+        graph_id=graph_id,
+        artifact_dir=artifact_dir,
+        principal=principal,
+        now=now,
     )
 
 
@@ -1088,8 +1156,10 @@ class GraphNodeMessage(Identifiable):
 
 __all__ = [
     "BranchCondition",
+    "ExecutionContext",
     "Graph",
     "GraphContext",
+    "build_execution_context",
     "GraphEdge",
     "GraphNode",
     "GraphNodeMessage",

--- a/tests/graph/test_execution_context.py
+++ b/tests/graph/test_execution_context.py
@@ -1,0 +1,53 @@
+"""Tests for ExecutionContext + build_execution_context (primer.model.graph)."""
+
+from __future__ import annotations
+
+from primer.model.graph import ExecutionContext, build_execution_context
+
+
+class TestBuildExecutionContext:
+    def test_memory_default_has_null_workspace_fields(self) -> None:
+        ctx = build_execution_context()
+        assert isinstance(ctx, ExecutionContext)
+        assert ctx.surface == "memory"
+        assert ctx.workspace_id is None
+        assert ctx.session_id is None
+        assert ctx.graph_id is None
+        assert ctx.artifact_dir is None
+        assert ctx.principal is None
+        assert ctx.now is not None  # defaulted to an ISO timestamp
+
+    def test_workspace_fields_and_derived_artifact_dir(self) -> None:
+        ctx = build_execution_context(
+            surface="workspace",
+            workspace_id="ws-1",
+            session_id="gsid-1",
+            graph_id="g-1",
+            principal="operator",
+            now="2026-07-03T00:00:00+00:00",
+        )
+        assert ctx.surface == "workspace"
+        assert ctx.workspace_id == "ws-1"
+        assert ctx.session_id == "gsid-1"
+        assert ctx.graph_id == "g-1"
+        assert ctx.artifact_dir == "artifacts/gsid-1"
+        assert ctx.principal == "operator"
+        assert ctx.now == "2026-07-03T00:00:00+00:00"
+
+    def test_nested_session_id_nests_artifact_dir(self) -> None:
+        ctx = build_execution_context(
+            surface="workspace", session_id="gsid-1__research"
+        )
+        assert ctx.artifact_dir == "artifacts/gsid-1__research"
+
+    def test_explicit_now_is_passed_through(self) -> None:
+        ctx = build_execution_context(now="FIXED")
+        assert ctx.now == "FIXED"
+
+    def test_model_is_frozen(self) -> None:
+        import pytest
+        from pydantic import ValidationError
+
+        ctx = build_execution_context()
+        with pytest.raises((ValidationError, TypeError, AttributeError)):
+            ctx.surface = "workspace"  # type: ignore[misc]

--- a/tests/graph/test_node_template_execution_context_e2e.py
+++ b/tests/graph/test_node_template_execution_context_e2e.py
@@ -1,0 +1,166 @@
+"""ExecutionContext (`ctx`) is threaded into a real workspace graph run.
+
+Covers: the workspace executor builds ``ctx`` with real ids; a subgraph child
+executor gets its OWN nested scope; an End ``output_template`` that references
+``{{ ctx.artifact_dir }}`` renders successfully end-to-end (proven by the run
+reaching ``completed`` under StrictUndefined semantics); and the per-workflow
+artifact directory is created on disk.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from primer.graph.workspace_executor import WorkspaceGraphExecutor
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import Message, StreamEvent
+from primer.model.graph import (
+    Graph,
+    _BeginNode,
+    _EndNode,
+    _GraphNodeRef,
+    _StaticEdge,
+)
+from primer.model.provider import LLMModel
+from primer.workspace.local.state import LocalStateRepo as StateRepo
+
+
+class _FakeLLM:
+    """Minimal LLM stub — Begin/End graphs never invoke it."""
+
+    async def list_models(self) -> list[str]:
+        return ["m"]
+
+    def stream(self, **kwargs: Any) -> AsyncIterator[StreamEvent]:
+        async def _empty() -> AsyncIterator[StreamEvent]:
+            if False:
+                yield  # pragma: no cover
+
+        return _empty()
+
+
+class _FakeWorkspaceSession:
+    """AgentSession-shaped double exposing the ids build_execution_context reads."""
+
+    workspace_id = "ws-fake"
+    session_id = "sess-fake"
+    agent_id = "agent-fake"
+    system_prompt_fragment = "<<WORKSPACE FRAGMENT>>"
+
+    def __init__(self) -> None:
+        self.workspace_tools: list = []
+
+
+def _model() -> LLMModel:
+    return LLMModel(name="m", context_length=128_000)
+
+
+def _agent(agent_id: str) -> Agent:
+    return Agent(
+        id=agent_id,
+        description=f"agent {agent_id}",
+        model=AgentModel(provider_id="p", model_name="m"),
+    )
+
+
+async def _make_state_repo(tmp_path: Path) -> StateRepo:
+    repo = StateRepo(tmp_path / ".state", workspace_id="ws-fake")
+    await repo.initialize()
+    return repo
+
+
+async def _agent_resolver(agent_id: str) -> Agent:
+    return _agent(agent_id)
+
+
+async def _llm_resolver(_a: Agent) -> tuple[_FakeLLM, LLMModel]:
+    return (_FakeLLM(), _model())
+
+
+async def _drain(it: AsyncIterator[StreamEvent]) -> list[StreamEvent]:
+    return [ev async for ev in it]
+
+
+def _begin_end_graph(graph_id: str, *, output_template: str = "done") -> Graph:
+    return Graph(
+        id=graph_id,
+        description="Begin -> End",
+        nodes=[
+            _BeginNode(id="begin"),
+            _EndNode(id="end", output_template=output_template),
+        ],
+        edges=[_StaticEdge(from_node="begin", to_node="end")],
+    )
+
+
+@pytest.mark.asyncio
+async def test_workspace_executor_context_has_real_ids(tmp_path: Path) -> None:
+    repo = await _make_state_repo(tmp_path)
+    executor = WorkspaceGraphExecutor(
+        graph=_begin_end_graph("g-ctx-top"),
+        agent_resolver=_agent_resolver,
+        llm_resolver=_llm_resolver,  # type: ignore[arg-type]
+        state_repo=repo,
+        graph_session_id="gsid-ctx-top",
+        workspace_session=_FakeWorkspaceSession(),  # type: ignore[arg-type]
+    )
+    ctx = executor._execution_context
+    assert ctx.surface == "workspace"
+    assert ctx.workspace_id == "ws-fake"
+    assert ctx.session_id == "gsid-ctx-top"
+    assert ctx.graph_id == "g-ctx-top"
+    assert ctx.artifact_dir == "artifacts/gsid-ctx-top"
+
+
+@pytest.mark.asyncio
+async def test_subgraph_child_context_is_nested(tmp_path: Path) -> None:
+    repo = await _make_state_repo(tmp_path)
+    parent = WorkspaceGraphExecutor(
+        graph=_begin_end_graph("g-ctx-parent"),
+        agent_resolver=_agent_resolver,
+        llm_resolver=_llm_resolver,  # type: ignore[arg-type]
+        state_repo=repo,
+        graph_session_id="gsid-parent",
+        workspace_session=_FakeWorkspaceSession(),  # type: ignore[arg-type]
+    )
+    sub_graph = _begin_end_graph("g-ctx-sub")
+    parent_node = _GraphNodeRef(id="child", graph_id="g-ctx-sub")
+
+    child = await parent._build_sub_executor(parent_node, sub_graph)
+
+    child_ctx = child._execution_context
+    assert child_ctx.surface == "workspace"
+    assert child_ctx.session_id == "gsid-parent__child"
+    assert child_ctx.artifact_dir == "artifacts/gsid-parent__child"
+
+
+@pytest.mark.asyncio
+async def test_end_template_renders_ctx_and_artifact_dir_created(
+    tmp_path: Path,
+) -> None:
+    # End template references ctx.artifact_dir. Under StrictUndefined, a missing
+    # ctx would terminate the graph `failed` (template_error); reaching
+    # `completed` proves ctx.artifact_dir rendered successfully.
+    graph = _begin_end_graph("g-ctx-e2e", output_template="{{ ctx.artifact_dir }}")
+    repo = await _make_state_repo(tmp_path)
+    executor = WorkspaceGraphExecutor(
+        graph=graph,
+        agent_resolver=_agent_resolver,
+        llm_resolver=_llm_resolver,  # type: ignore[arg-type]
+        state_repo=repo,
+        graph_session_id="gsid-ctx-e2e",
+        workspace_session=_FakeWorkspaceSession(),  # type: ignore[arg-type]
+        graph_input="seed",
+    )
+    await _drain(executor.invoke([]))
+
+    state = await executor.load_state()
+    assert state is not None
+    assert state["status"] == "ended"
+    assert state["ended_reason"] == "completed"
+    # Best-effort artifact dir created at the workspace root (state repo parent).
+    assert (tmp_path / "artifacts" / "gsid-ctx-e2e").is_dir()

--- a/tests/graph/test_template.py
+++ b/tests/graph/test_template.py
@@ -4,10 +4,10 @@ from __future__ import annotations
 
 import pytest
 
-from primer.graph.template import render_input_template
+from primer.graph.template import render_input_template, render_template_safely
 from primer.model.chat import Message, TextPart
 from primer.model.except_ import BadRequestError
-from primer.model.graph import GraphContext, NodeOutput
+from primer.model.graph import GraphContext, NodeOutput, build_execution_context
 
 
 def _ctx(
@@ -196,3 +196,43 @@ class TestErrors:
             render_input_template(
                 "{{ ''.__class__ }}", context=_ctx()
             )
+
+
+class TestCtx:
+    def test_default_ctx_surface_is_memory(self) -> None:
+        result = render_input_template("s={{ ctx.surface }}", context=_ctx())
+        assert result == "s=memory"
+
+    def test_default_ctx_artifact_dir_is_none_renders_none(self) -> None:
+        # Null field must render the string "None", NOT raise (StrictUndefined
+        # only fires on missing *names*, not on defined-but-None values).
+        result = render_input_template(
+            "dir={{ ctx.artifact_dir }}", context=_ctx()
+        )
+        assert result == "dir=None"
+
+    def test_ctx_artifact_dir_renders_when_set(self) -> None:
+        ctx = GraphContext(
+            initial_input=[Message(role="user", parts=[TextPart(text="hi")])],
+            iteration=0,
+            nodes={},
+            ctx=build_execution_context(surface="workspace", session_id="gsid-1"),
+        )
+        result = render_input_template(
+            "write {{ ctx.artifact_dir }}/plan.md", context=ctx
+        )
+        assert result == "write artifacts/gsid-1/plan.md"
+
+    def test_ctx_typo_field_still_raises(self) -> None:
+        with pytest.raises(BadRequestError):
+            render_input_template("{{ ctx.artifactdir }}", context=_ctx())
+
+    def test_ctx_available_in_render_template_safely(self) -> None:
+        ctx = GraphContext(
+            initial_input=[Message(role="user", parts=[TextPart(text="hi")])],
+            iteration=0,
+            nodes={},
+            ctx=build_execution_context(surface="workspace", session_id="gsid-2"),
+        )
+        result = render_template_safely("{{ ctx.artifact_dir }}", ctx)
+        assert result == "artifacts/gsid-2"


### PR DESCRIPTION
## Summary

Gives graph node-level Jinja templates access to a shared, always-present `ExecutionContext` under a single `ctx` namespace. Templates can now interpolate ambient run values — above all `{{ ctx.artifact_dir }}` — into node inputs, `tool_call` arguments, fan-in aggregates, and end outputs. This unlocks the artifact-passing pattern: a node writes a detailed artifact to a per-workflow directory and downstream nodes reference it by path instead of re-threading blobs through node text.

Design spec: `docs/superpowers/specs/2026-07-03-node-template-execution-context-design.md`.

## What changed

- **`ExecutionContext` model + `build_execution_context` builder** (`primer/model/graph.py`) — one frozen model, single-source-of-truth builder (pure, no workspace deps). Fields: `surface`, `workspace_id`, `session_id`, `graph_id`, `artifact_dir`, `principal`, `now`.
- **`ctx` on `GraphContext`** — defaulted to a `surface="memory"` context so every existing construction and in-memory run keeps working; exposed in both `render_input_template` and `render_template_safely` (`primer/graph/template.py`).
- **Executor threading** — the base `GraphExecutor` stores `self._execution_context` (memory default); `WorkspaceGraphExecutor` overrides it with real ids. Subgraphs get their own nested scope for free — `_build_sub_executor` already constructs the child with the nested `graph_session_id`, so the child's `__init__` builds its own `ctx`.
- **Artifact dir** — `ctx.artifact_dir == artifacts/<session_id>` (workspace-root-relative), so it drops straight into the workspace file tools. Best-effort mkdir at graph start (local repos; sandbox/container relies on create-on-write).

`StrictUndefined` is preserved: a null field renders the string `None`, a typo (`{{ ctx.artifactdir }}`) still raises. `ctx` is always present, never `None`.

Out of scope (companion effort): Jinja-ifying the agent `system_prompt` — `primer/agent/base.py` is untouched.

## Test plan

- `tests/graph/test_execution_context.py` — builder + memory default + nesting + frozen (5)
- `tests/graph/test_template.py::TestCtx` — memory default, null→`None`, path render, typo raises, `render_template_safely` path (5)
- `tests/graph/test_node_template_execution_context_e2e.py` — real ids, nested subgraph scope, end-to-end End-template render + on-disk mkdir (3)
- Full `tests/graph tests/model` suite: **500 passed, 0 failures**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
