### PR TITLE
feat(studio): workspace activity rework — User Interaction, compact rows, event history

### DIFF
--- a/primer/api/_app_routes.py
+++ b/primer/api/_app_routes.py
@@ -120,6 +120,8 @@ def _mount_routers(
     app.include_router(workspaces_router.files_router, prefix=prefix, dependencies=auth_dep)
     app.include_router(workspaces_router.log_router, prefix=prefix, dependencies=auth_dep)
     app.include_router(workspaces_router.yields_pending_router, prefix=prefix, dependencies=auth_dep)
+    # Workspace events history — bounded backfill for the Studio activity stream.
+    app.include_router(workspaces_router.events_router, prefix=prefix, dependencies=auth_dep)
     # Sessions.
     app.include_router(sessions_router.nested_session_router, prefix=prefix, dependencies=auth_dep)
     app.include_router(sessions_router.top_session_router, prefix=prefix, dependencies=auth_dep)

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -1340,6 +1340,101 @@ async def list_pending_yields(
 
 
 # ===========================================================================
+# Workspace events history sub-resource (Studio activity backfill)
+# ===========================================================================
+
+events_router = APIRouter(tags=["workspace-events"])
+
+
+@events_router.get(
+    "/workspaces/{workspace_id}/events",
+    summary="Recent workspace-scoped tap events across all sessions (Studio activity backfill)",
+    responses=common_responses(404, 500),
+)
+async def list_workspace_events(
+    workspace_id: str = Path(..., description="Workspace id"),
+    limit: int = Query(
+        default=200,
+        ge=1,
+        le=500,
+        description=(
+            "Maximum number of most-recent events to return, aggregated across "
+            "all of the workspace's sessions."
+        ),
+    ),
+    session_storage=Depends(get_session_storage),
+    registry: WorkspaceRegistry = Depends(get_workspace_registry),
+) -> dict:
+    """Return the most-recent ``limit`` tap events across ALL sessions in the
+    workspace, oldest-first.
+
+    The workspace tap SSE stream connects **live-from-now**, so a panel that
+    opens after events already happened (e.g. a completed session) sees nothing.
+    This bounded backfill seeds the Studio activity stream on open; the live tap
+    then tails from now and the client dedupes the seam by ``(session_id, seq)``.
+
+    Each item is a wire-shape :class:`~primer.tap.event.TapEvent`
+    (``class`` / ``ts`` / ``seq`` / ``session_id`` / ``payload`` …) so it merges
+    1:1 with live tap frames — the same reader (:func:`read_session_since`) that
+    backs the SSE tick loop produces these, just drained from byte 0.
+
+    Response shape::
+
+        {"items": [ {"class": str, "seq": int, "session_id": str,
+                     "ts": str, "payload": {...}, ...}, … ]}
+
+    Events are ordered ascending by ``(ts, session_id, seq)`` and the newest
+    ``limit`` are returned. A missing ``messages.jsonl`` (a session that has not
+    flushed yet) contributes nothing rather than erroring.
+    """
+    from primer.model.storage import OffsetPage
+    from primer.storage.q import Q
+    from primer.model.workspace_session import WorkspaceSession
+    from primer.tap.reader import read_session_since
+    from primer.tap.selector import TapSelector
+
+    # Resolve the live workspace IO handle (read_file + state_path). A missing
+    # workspace raises NotFoundError → 404, mirroring the tap SSE surface.
+    workspace_io = await registry.get_workspace(workspace_id)
+
+    predicate = Q(WorkspaceSession).where("workspace_id", workspace_id).build()
+    selector = TapSelector()  # empty = pass-through (every session + event)
+
+    collected = []
+    offset = 0
+    page_size = 200
+    while True:
+        resp = await session_storage.find(
+            predicate, OffsetPage(offset=offset, length=page_size)
+        )
+        for sess in resp.items:
+            events, _ = await read_session_since(
+                workspace_io,
+                workspace_id=workspace_id,
+                session=sess,
+                after_seq=0,
+                selector=selector,
+                from_offset=0,
+            )
+            # Keep only each session's most-recent `limit` events: the global
+            # recent-N is a subset of the union of per-session tails, so this
+            # bounds memory without dropping any event that could land in the
+            # final window.
+            if len(events) > limit:
+                events = events[-limit:]
+            collected.extend(events)
+        if len(resp.items) < page_size:
+            break
+        offset += page_size
+
+    # Global order by (ts, session_id, seq); return the most-recent `limit`
+    # oldest-first so the client appends them like the live tail.
+    collected.sort(key=lambda e: (e.ts, e.session_id, e.seq))
+    recent = collected[-limit:]
+    return {"items": [ev.model_dump(mode="json", by_alias=True) for ev in recent]}
+
+
+# ===========================================================================
 # Helpers
 # ===========================================================================
 
@@ -1377,6 +1472,7 @@ def _content_disposition(filename: str) -> str:
 
 
 __all__ = [
+    "events_router",
     "files_router",
     "log_router",
     "provider_router",

--- a/tests/api/test_workspace_events_history.py
+++ b/tests/api/test_workspace_events_history.py
@@ -1,0 +1,300 @@
+"""Tests for the workspace events-history backfill endpoint:
+
+    GET /v1/workspaces/{workspace_id}/events?limit=N
+
+Part C of the studio-activity rework. The workspace tap SSE stream connects
+live-from-now, so a panel opened after events happened sees nothing; this
+bounded REST endpoint returns the most-recent N events across ALL of the
+workspace's sessions (wire-shape TapEvents) so the panel can seed its stream on
+open, then tail the live tap and dedupe by (session_id, seq).
+
+Exercised in-process through the real FastAPI app + fake in-memory storage +
+a fake workspace backend exposing ``read_file`` over an in-memory
+``messages.jsonl`` — mirrors tests/api/test_workspace_tap_sse.py's fakes but
+drives a plain (non-streaming) REST request.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timedelta, timezone
+
+import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
+from pydantic import SecretStr
+
+from primer.api.app import create_test_app
+from primer.api.registries import ProviderRegistry, WorkspaceRegistry
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+
+pytestmark = pytest.mark.asyncio
+
+_NOW = datetime(2026, 7, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+
+# ===========================================================================
+# Fakes — in-memory workspace (messages.jsonl), backend, registry.
+# ===========================================================================
+
+
+class _FakeTemplate:
+    state_path = ".state"
+
+
+class _FakeWorkspaceForEvents:
+    state_path = ".state"
+
+    def __init__(self, workspace_id: str) -> None:
+        self.workspace_id = workspace_id
+        self.id = workspace_id
+        self._files: dict[str, bytes] = {}
+        self._template = _FakeTemplate()
+
+    async def read_file(self, path: str) -> bytes:
+        from primer.model.except_ import NotFoundError
+
+        if path not in self._files:
+            raise NotFoundError(f"{path!r} not found")
+        return self._files[path]
+
+    def append_record(
+        self,
+        session_id: str,
+        *,
+        seq: int,
+        kind: str,
+        created_at: datetime,
+        **payload,
+    ) -> None:
+        path = f".state/sessions/{session_id}/messages.jsonl"
+        rec = {
+            "seq": seq,
+            "kind": kind,
+            "payload": payload,
+            "created_at": created_at.isoformat(),
+        }
+        self._files[path] = self._files.get(path, b"") + (
+            json.dumps(rec).encode() + b"\n"
+        )
+
+    async def aclose(self) -> None:
+        pass
+
+
+class _FakeBackendForEvents:
+    def __init__(self, _provider) -> None:
+        self._workspaces: dict[str, _FakeWorkspaceForEvents] = {}
+
+    async def initialize(self) -> None:
+        pass
+
+    async def aclose(self) -> None:
+        pass
+
+    async def get(self, workspace_id, *, template=None):
+        if workspace_id not in self._workspaces:
+            self._workspaces[workspace_id] = _FakeWorkspaceForEvents(workspace_id)
+        return self._workspaces[workspace_id]
+
+    async def list(self):
+        return list(self._workspaces.keys())
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+@pytest.fixture
+def fake_provider_registry(fake_storage_provider):
+    return ProviderRegistry(
+        fake_storage_provider,
+        llm_factory=lambda p: object(),
+        embedder_factory=lambda p: object(),
+        cross_encoder_factory=lambda p: object(),
+        toolset_factory=lambda p: object(),
+    )
+
+
+@pytest.fixture
+def workspace_registry(fake_storage_provider):
+    return WorkspaceRegistry(fake_storage_provider, factory=_FakeBackendForEvents)
+
+
+@pytest.fixture
+def app(fake_storage_provider, fake_provider_registry, workspace_registry):
+    return create_test_app(
+        storage_provider=fake_storage_provider,
+        provider_registry=fake_provider_registry,
+        workspace_registry=workspace_registry,
+    )
+
+
+async def _ensure_workspace(app, workspace_registry, wid: str) -> _FakeWorkspaceForEvents:
+    from primer.model.workspace import (
+        LocalWorkspaceConfig,
+        Workspace,
+        WorkspaceProvider,
+        WorkspaceProviderType,
+        WorkspaceRuntimeMeta,
+    )
+
+    sp = app.state.storage_provider
+    try:
+        await sp.get_storage(WorkspaceProvider).create(
+            WorkspaceProvider(
+                id="p-ws",
+                provider=WorkspaceProviderType.LOCAL,
+                config=LocalWorkspaceConfig(root_path="/tmp/primer-events-test"),
+            )
+        )
+    except Exception:
+        pass
+    try:
+        await sp.get_storage(Workspace).create(
+            Workspace(
+                id=wid,
+                template_id="t-noop",
+                provider_id="p-ws",
+                created_at=_NOW,
+                runtime_meta=WorkspaceRuntimeMeta(
+                    url="ws://127.0.0.1:5959/", token=SecretStr("t")
+                ),
+            )
+        )
+    except Exception:
+        pass
+    return await workspace_registry.get_workspace(wid)
+
+
+async def _seed_session(app, *, workspace_id: str, session_id: str) -> None:
+    sp = app.state.storage_provider
+    session = WorkspaceSession(
+        id=session_id,
+        workspace_id=workspace_id,
+        binding=AgentSessionBinding(agent_id="ag-1"),
+        status=SessionStatus.RUNNING,
+        created_at=_NOW,
+        last_seq=0,
+    )
+    await sp.get_storage(WorkspaceSession).create(session)
+
+
+async def _client(app) -> AsyncClient:
+    c = AsyncClient(transport=ASGITransport(app=app), base_url="http://test")
+    try:
+        await c.post(
+            "/v1/auth/register",
+            json={"username": "eventsuser", "password": "eventspassword"},
+        )
+    except Exception:
+        pass
+    resp = await c.post(
+        "/v1/auth/login",
+        json={"username": "eventsuser", "password": "eventspassword"},
+    )
+    assert resp.status_code == 200, resp.text
+    return c
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+@pytest_asyncio.fixture
+async def seeded(app, workspace_registry):
+    """Workspace w1 with two sessions whose events interleave in time."""
+    wid = "w1"
+    ws = await _ensure_workspace(app, workspace_registry, wid)
+    await _seed_session(app, workspace_id=wid, session_id="s1")
+    await _seed_session(app, workspace_id=wid, session_id="s2")
+
+    t = _NOW
+    # s1: seq 1..3 at T+1, T+2, T+3
+    ws.append_record("s1", seq=1, kind="user_input", created_at=t + timedelta(seconds=1), text="hi")
+    ws.append_record("s1", seq=2, kind="assistant_token", created_at=t + timedelta(seconds=2), text="working")
+    ws.append_record("s1", seq=3, kind="done", created_at=t + timedelta(seconds=3), stop_reason="end_turn")
+    # s2: seq 1..2 at T+1.5, T+2.5 (interleaves with s1)
+    ws.append_record("s2", seq=1, kind="tool_call", created_at=t + timedelta(seconds=1.5), id="tc1", arguments={"x": 1})
+    ws.append_record("s2", seq=2, kind="tool_result", created_at=t + timedelta(seconds=2.5), call_id="tc1", output={"ok": True})
+    return wid
+
+
+async def test_returns_all_events_sorted_oldest_first(app, seeded):
+    c = await _client(app)
+    try:
+        r = await c.get(f"/v1/workspaces/{seeded}/events?limit=100")
+        assert r.status_code == 200, r.text
+        items = r.json()["items"]
+        # 5 events across both sessions, sorted by ts ascending (oldest first).
+        keys = [(it["session_id"], it["seq"]) for it in items]
+        assert keys == [
+            ("s1", 1),
+            ("s2", 1),
+            ("s1", 2),
+            ("s2", 2),
+            ("s1", 3),
+        ]
+    finally:
+        await c.aclose()
+
+
+async def test_items_are_wire_shape_tap_events(app, seeded):
+    c = await _client(app)
+    try:
+        r = await c.get(f"/v1/workspaces/{seeded}/events?limit=100")
+        items = r.json()["items"]
+        first = items[0]
+        # `class` (aliased), ts, seq, session_id, payload — merges 1:1 with live
+        # tap frames so the client can dedupe by (session_id, seq).
+        assert first["class"] == "user_input"
+        assert first["session_id"] == "s1"
+        assert first["seq"] == 1
+        assert isinstance(first["ts"], str)
+        assert first["payload"]["text"] == "hi"
+        # tool_call payload carried through verbatim.
+        tc = next(it for it in items if it["class"] == "tool_call")
+        assert tc["payload"]["arguments"] == {"x": 1}
+    finally:
+        await c.aclose()
+
+
+async def test_limit_returns_most_recent(app, seeded):
+    c = await _client(app)
+    try:
+        r = await c.get(f"/v1/workspaces/{seeded}/events?limit=2")
+        assert r.status_code == 200, r.text
+        items = r.json()["items"]
+        assert len(items) == 2
+        # The two most-recent by ts: s2#2 (T+2.5) then s1#3 (T+3), oldest-first.
+        assert [(it["session_id"], it["seq"]) for it in items] == [("s2", 2), ("s1", 3)]
+    finally:
+        await c.aclose()
+
+
+async def test_empty_workspace_returns_empty_items(app, workspace_registry):
+    wid = "w-empty"
+    await _ensure_workspace(app, workspace_registry, wid)
+    c = await _client(app)
+    try:
+        r = await c.get(f"/v1/workspaces/{wid}/events")
+        assert r.status_code == 200, r.text
+        assert r.json() == {"items": []}
+    finally:
+        await c.aclose()
+
+
+async def test_limit_is_bounded(app, seeded):
+    c = await _client(app)
+    try:
+        # Above the cap → 422 (Query le=500).
+        r = await c.get(f"/v1/workspaces/{seeded}/events?limit=100000")
+        assert r.status_code == 422
+    finally:
+        await c.aclose()

--- a/tests/ui/test_studio_activity.py
+++ b/tests/ui/test_studio_activity.py
@@ -110,6 +110,66 @@ def test_action_required_testids() -> None:
         assert f'data-testid="{testid}"' in src, f"Missing data-testid: {testid}"
 
 
+# ---------------------------------------------------------------------------
+# "Action Required" → "User Interaction" rename (holds ask_user + inform_user)
+# ---------------------------------------------------------------------------
+
+def test_user_interaction_label() -> None:
+    src = _activity_src()
+    # Visible section header is renamed; the section holds both ask_user AND
+    # inform_user, so "User Interaction" is the accessible label. The label is
+    # rendered inside the section-label span carrying the new testid.
+    assert 'data-testid="user-interaction-label"' in src
+    label_idx = src.index('data-testid="user-interaction-label"')
+    # The visible text follows within the same span element.
+    assert "User Interaction" in src[label_idx:label_idx + 120]
+
+
+def test_user_interaction_empty_copy_updated() -> None:
+    src = _activity_src()
+    assert "No pending interactions." in src
+
+
+# ---------------------------------------------------------------------------
+# inform_user handling — surfaces as a tap tool_call, dismissed client-side
+# ---------------------------------------------------------------------------
+
+def test_inform_user_detection_helper_present() -> None:
+    src = _activity_src()
+    # Helper that classifies an inform_user tool_call frame off the tap.
+    assert "function SA_informFromEvent(" in src
+    # Detected off a tool_call frame (inform_user is non-yielding — never a
+    # pending yield), keyed on the tool name OR the inform arg signature.
+    assert 'ev.class !== "tool_call"' in src
+    assert "inform_user" in src
+
+
+def test_inform_user_item_rendered_with_dismiss() -> None:
+    src = _activity_src()
+    for testid in ("inform-item", "inform-message", "inform-dismiss"):
+        assert f'data-testid="{testid}"' in src, f"Missing inform testid: {testid}"
+    # Dismiss is a client-side removal (no backend ack endpoint for inform).
+    assert "dismissInform" in src
+
+
+def test_inform_items_counted_in_section() -> None:
+    src = _activity_src()
+    # The section count/has-items sizing includes inform items, not just yields.
+    assert "visibleInform" in src
+    assert "visibleItems.length + visibleInform.length" in src
+
+
+# ---------------------------------------------------------------------------
+# Auto-resize — the section grows to fit its items (not a fixed tiny height)
+# ---------------------------------------------------------------------------
+
+def test_action_required_auto_resizes() -> None:
+    css = (UI / "styles.css").read_text(encoding="utf-8")
+    # Content-sized when empty, grows (capped + internal scroll) when populated.
+    assert ".st-action-required.is-empty { max-height: none; }" in css
+    assert ".st-action-required.has-items { max-height: 50vh; }" in css
+
+
 def test_ask_user_send_button_wired() -> None:
     """FB7 — the ask-user respond input was Enter-only (undiscoverable). A
     visible Send button must call the same submit path as Enter."""

--- a/tests/ui/test_workspace_tap_backfill.py
+++ b/tests/ui/test_workspace_tap_backfill.py
@@ -1,0 +1,58 @@
+"""Structural checks for the WorkspaceTap history backfill (Part C).
+
+The workspace tap connects live-from-now, so the activity stream shows nothing
+for events that happened before it opened. WorkspaceTap now fetches a bounded
+history snapshot on mount (GET /v1/workspaces/{wid}/events) and merges it below
+the live tail, deduped by (session_id, seq). Static-source checks only.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+TAP = UI / "components" / "workspace-tap.jsx"
+
+
+def _tap_src() -> str:
+    return TAP.read_text(encoding="utf-8")
+
+
+def test_history_backfill_fetch_on_mount() -> None:
+    src = _tap_src()
+    # Fetches the bounded workspace events history via apiFetch on mount.
+    assert "window.primerApi.apiFetch" in src
+    assert '"/workspaces/" + encodeURIComponent(wid) + "/events?limit=200"' in src
+    # Held in local state seeded from the response items.
+    assert "setHistory" in src
+
+
+def test_history_merged_and_deduped_by_session_seq() -> None:
+    src = _tap_src()
+    # Stable seam key is (session_id, seq), NOT the per-frame cursor.
+    assert "function WTP_eventKey(" in src
+    # History + live are merged into one buffer.
+    assert "history" in src and "liveEvents" in src
+    # Deduped (first-seen wins) and time-ordered so history sorts above live.
+    assert "seen[k]" in src
+    assert "Date.parse(a.ts)" in src
+
+
+def test_clear_also_clears_history() -> None:
+    src = _tap_src()
+    assert "tap.clear(); setHistory([]);" in src
+
+
+def test_filter_still_applies_over_merged_buffer() -> None:
+    src = _tap_src()
+    # The class/session filter runs over the merged (history+live) buffer.
+    assert "var out = allEvents;" in src
+
+
+def test_bundle_transpiles_with_backfill() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    assert "/* === components/workspace-tap.jsx === */" in body.decode("utf-8")

--- a/tests/ui/test_workspace_tap_content_rows.py
+++ b/tests/ui/test_workspace_tap_content_rows.py
@@ -1,0 +1,135 @@
+"""Structural checks for the compact, content-aware WorkspaceTap event rows.
+
+Part B of the studio-activity rework: each tap event row shows a MINIMAL
+timestamp + class chip + a class-tuned payload PREVIEW with VARIABLE height
+(not uniform boxes). These are static-source checks (no React render), matching
+the approach in test_studio_activity.py / test_studio_live_consolidation.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+TAP = UI / "components" / "workspace-tap.jsx"
+
+
+def _tap_src() -> str:
+    return TAP.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Content-aware preview builder
+# ---------------------------------------------------------------------------
+
+def test_content_aware_preview_helper_present() -> None:
+    src = _tap_src()
+    assert "function WTP_eventContent(" in src
+    # The old one-line summary is replaced.
+    assert "function WTP_payloadSummary(" not in src
+
+
+def test_preview_handles_each_class() -> None:
+    src = _tap_src()
+    body = src[src.index("function WTP_eventContent("):]
+    # Cut the helper body at the next top-level function.
+    end = body.index("\nfunction ", 1)
+    body = body[:end]
+    for cls in (
+        "assistant_token",
+        "user_input",
+        "tool_call",
+        "tool_result",
+        "graph_transition",
+        "done",
+        "error",
+    ):
+        assert f'"{cls}"' in body, f"WTP_eventContent does not handle {cls}"
+
+
+def test_preview_shows_type_specific_fields() -> None:
+    src = _tap_src()
+    # assistant / user text
+    assert "p.text" in src
+    # tool_call args / tool name
+    assert "p.arguments" in src
+    assert "p.tool_name" in src
+    # tool_result output / error
+    assert "p.output" in src
+    # graph transition
+    assert "p.node_id" in src and "p.phase" in src
+    # done outcome + usage
+    assert "p.stop_reason" in src
+    assert "p.usage" in src
+    # error outcome
+    assert "p.message" in src
+
+
+def test_preview_truncates_long_payloads() -> None:
+    src = _tap_src()
+    # A clamp helper bounds long payloads.
+    assert "function WTP_clip(" in src
+
+
+# ---------------------------------------------------------------------------
+# Variable-height rows (not uniform boxes)
+# ---------------------------------------------------------------------------
+
+def test_rows_have_variable_height() -> None:
+    src = _tap_src()
+    # Per-class line clamp drives variable height.
+    assert "clampLines" in src
+    assert "WebkitLineClamp" in src
+    # A distinct number of clamp lines is chosen per class.
+    assert "clampLines: 3" in src
+    assert "clampLines: 1" in src
+
+
+def test_minimal_timestamp() -> None:
+    src = _tap_src()
+    # HH:MM:SS (minimal) rather than the old HH:MM:SS.mmm.
+    assert "slice(11, 19)" in src
+
+
+# ---------------------------------------------------------------------------
+# Preserved contract: testids, class chip, filter chips, detail JSON
+# ---------------------------------------------------------------------------
+
+def test_preserved_testids_and_chip() -> None:
+    src = _tap_src()
+    for testid in (
+        "workspace-tap-root",
+        "tap-filter-bar",
+        "tap-event-list",
+        "activity-event",
+        "tap-event-row",
+        "activity-event-detail",
+        "tap-event-preview",
+    ):
+        assert f'data-testid="{testid}"' in src, f"Missing testid: {testid}"
+    # Class chip stays a `.pill` (e2e asserts >=1 pill per row).
+    assert 'className="pill"' in src
+    # Full-event detail JSON is still available on expand.
+    assert "WTP_detailJson" in src
+
+
+def test_filter_chips_preserved() -> None:
+    src = _tap_src()
+    assert "WTP_ALL_CLASSES" in src
+    assert '"tap-filter-" + cls' in src
+    # Client-side filter over the shared buffer still applies.
+    assert "selectedClasses" in src
+
+
+# ---------------------------------------------------------------------------
+# Full bundle still transpiles
+# ---------------------------------------------------------------------------
+
+def test_bundle_transpiles_with_content_rows() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/workspace-tap.jsx === */" in text

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -39,6 +39,57 @@ function SA_short(sid) {
   return sid.slice(0, 10) + "…" + sid.slice(-6);
 }
 
+// inform_user surfacing (investigated for PR "studio-activity-rework"):
+//   inform_user is a NON-yielding tool — it relays a one-way message via
+//   ctx.inform (SessionInformSink → channels) and returns immediately. It does
+//   NOT park the session, so it NEVER appears in /workspaces/{wid}/yields/
+//   pending. Its only observable trace is a `tool_call` frame in the workspace
+//   tap: payload = {id, arguments:{message, files?}}. The persisted tool_call
+//   record does not always carry the tool NAME (only ToolCallEnd's id+arguments
+//   are recorded; the named ToolCallStart is dropped — see
+//   primer/session/persistence.py), so we detect an inform by tool name when
+//   present, else by the exact inform_user argument signature. Because inform
+//   is fire-and-forget there is NO backend ack endpoint, so "Dismiss" is a
+//   client-side removal only.
+//
+// Returns { key, session_id, message, ts } for an inform tool_call, else null.
+function SA_informFromEvent(ev) {
+  if (!ev || typeof ev !== "object" || ev.class !== "tool_call") return null;
+  var payload = ev.payload && typeof ev.payload === "object" ? ev.payload : {};
+  var args = payload.arguments != null ? payload.arguments : payload.args;
+  if (typeof args === "string") {
+    try { args = JSON.parse(args); } catch (_e) { args = null; }
+  }
+  if (!args || typeof args !== "object") return null;
+  var message = typeof args.message === "string" ? args.message : "";
+  if (!message.trim()) return null;
+
+  var name = payload.tool_name || payload.name || args.name || "";
+  var isInform = false;
+  if (name) {
+    // A named tool_call: accept only inform_user (e.g. "misc__inform_user").
+    if (String(name).indexOf("inform_user") < 0) return null;
+    isInform = true;
+  } else {
+    // No recorded name: accept ONLY the exact inform_user arg signature
+    // ({message} plus at most a `files` companion) so a generic message-
+    // bearing tool_call is never misclassified as an inform.
+    var extra = Object.keys(args).filter(function (k) {
+      return k !== "message" && k !== "files";
+    });
+    isInform = extra.length === 0;
+  }
+  if (!isInform) return null;
+
+  var idPart = ev.seq != null ? ev.seq : (payload.id || "");
+  return {
+    key: (ev.session_id || "") + ":" + idPart,
+    session_id: ev.session_id || "",
+    message: message,
+    ts: ev.ts || null,
+  };
+}
+
 // ---------------------------------------------------------------------------
 // ActionRequired
 // ---------------------------------------------------------------------------
@@ -63,6 +114,12 @@ function ActionRequired({ wid, studio }) {
   // the WorkspaceTap activity feed, and the graph run-view — instead of each
   // opening its own connection (fe-review N4). We debounce a refetch of the
   // pending snapshot on yielded/done; the 15s pollMs backstops a dropped tap.
+  // inform_user items captured LIVE from the tap (see SA_informFromEvent).
+  // They have no pending-yield backing, so they live in local state and are
+  // dismissed client-side. Bounded so a chatty agent can't grow it unbounded.
+  var [informItems, setInformItems] = React.useState([]);
+  var [informDismissed, setInformDismissed] = React.useState({});
+
   var debounceRef = React.useRef(null);
   window.useWorkspaceTapListener(wid, function (ev) {
     if (!ev || typeof ev !== "object") return;
@@ -71,10 +128,30 @@ function ActionRequired({ wid, studio }) {
       clearTimeout(debounceRef.current);
       debounceRef.current = setTimeout(function () { pending.refetch(); }, 300);
     }
+    var inform = SA_informFromEvent(ev);
+    if (inform) {
+      setInformItems(function (prev) {
+        for (var i = 0; i < prev.length; i++) {
+          if (prev[i].key === inform.key) return prev;
+        }
+        var next = prev.concat(inform);
+        if (next.length > 30) next = next.slice(next.length - 30);
+        return next;
+      });
+    }
   });
   React.useEffect(function () {
     return function () { clearTimeout(debounceRef.current); };
   }, []);
+
+  function dismissInform(key) {
+    setInformDismissed(function (prev) {
+      var next = {};
+      for (var k in prev) next[k] = prev[k];
+      next[key] = true;
+      return next;
+    });
+  }
 
   // Per-item respond state: { [item_id]: { draft, submitting, error } }
   var [respondState, setRespondState] = React.useState({});
@@ -184,7 +261,8 @@ function ActionRequired({ wid, studio }) {
   }
 
   var visibleItems = items.filter(function(it) { return !hidden[it.tool_call_id]; });
-  var count = visibleItems.length;
+  var visibleInform = informItems.filter(function (it) { return !informDismissed[it.key]; });
+  var count = visibleItems.length + visibleInform.length;
 
   return (
     <div
@@ -196,9 +274,9 @@ function ActionRequired({ wid, studio }) {
         className="st-panel-bar"
         style={{ borderBottom: count > 0 ? "1px solid var(--border)" : "none" }}
       >
-        <span style={{ color: "var(--amber)", fontSize: 13 }}>⚠</span>
-        <span className="st-section-label">
-          Action Required
+        <span style={{ color: "var(--amber)", fontSize: 13 }} aria-hidden="true">⚠</span>
+        <span className="st-section-label" data-testid="user-interaction-label">
+          User Interaction
         </span>
         {count > 0 && (
           <span
@@ -227,7 +305,7 @@ function ActionRequired({ wid, studio }) {
       >
         {count === 0 && !pending.loading && (
           <div className="st-action-empty" data-testid="action-required-empty">
-            No pending actions. Everything's running clean.
+            No pending interactions.
           </div>
         )}
 
@@ -434,6 +512,95 @@ function ActionRequired({ wid, studio }) {
                   </button>
                 </div>
               )}
+            </div>
+          );
+        })}
+
+        {/* inform_user items — one-way messages surfaced live from the tap.
+            No pending yield backs them, so Dismiss is a client-side removal. */}
+        {visibleInform.map(function (inf) {
+          return (
+            <div
+              key={"inform:" + inf.key}
+              data-testid="inform-item"
+              style={{
+                padding: "10px 12px",
+                borderBottom: "1px solid var(--border)",
+                display: "flex",
+                flexDirection: "column",
+                gap: 6,
+              }}
+            >
+              {/* Session label + kind */}
+              <div className="st-row" style={{ gap: 6 }}>
+                <button
+                  type="button"
+                  data-testid="action-session-link"
+                  onClick={function() { handleFocusSession(inf.session_id); }}
+                  style={{
+                    background: "none",
+                    border: "none",
+                    padding: 0,
+                    cursor: "pointer",
+                    color: "var(--accent)",
+                    fontFamily: "IBM Plex Mono, monospace",
+                    fontSize: 11,
+                    textDecoration: "underline",
+                    textUnderlineOffset: 2,
+                  }}
+                  title={inf.session_id}
+                >
+                  {SA_short(inf.session_id)}
+                </button>
+                <span
+                  style={{
+                    color: "var(--blue)",
+                    fontSize: 10,
+                    textTransform: "uppercase",
+                    letterSpacing: "0.05em",
+                    fontWeight: 600,
+                  }}
+                >
+                  inform_user
+                </span>
+              </div>
+
+              {/* Message body — grows to fit, scrolls past a sensible cap. */}
+              <div
+                data-testid="inform-message"
+                style={{
+                  fontSize: 12,
+                  lineHeight: 1.5,
+                  color: "var(--text-2)",
+                  wordBreak: "break-word",
+                  whiteSpace: "pre-wrap",
+                  maxHeight: 140,
+                  overflowY: "auto",
+                }}
+              >
+                {inf.message}
+              </div>
+
+              {/* Ack — inform has no backend ack endpoint (fire-and-forget),
+                  so this only clears it from the panel. */}
+              <div>
+                <button
+                  type="button"
+                  data-testid="inform-dismiss"
+                  onClick={function() { dismissInform(inf.key); }}
+                  style={{
+                    padding: "4px 10px",
+                    borderRadius: 6,
+                    border: "1px solid var(--border)",
+                    background: "transparent",
+                    color: "var(--text-3)",
+                    cursor: "pointer",
+                    fontSize: 12,
+                  }}
+                >
+                  Dismiss
+                </button>
+              </div>
             </div>
           );
         })}

--- a/ui/components/workspace-tap.jsx
+++ b/ui/components/workspace-tap.jsx
@@ -58,30 +58,84 @@ var WTP_ALL_CLASSES = [
 ];
 
 // ---------------------------------------------------------------------------
-// One-line payload summary
+// Content-aware, per-class payload preview (compact + information-dense).
+//
+// Each frame gets a preview tuned to its class so the row shows the MOST useful
+// info without expanding: assistant text lines, a tool's args/result, a graph
+// transition, the outcome of a done/error, etc. `clampLines` varies per class
+// so rows have VARIABLE height (not uniform boxes) — markers stay one line,
+// content frames span a few clamped lines.
 // ---------------------------------------------------------------------------
 
-function WTP_payloadSummary(payload) {
-  if (!payload || typeof payload !== "object") return "";
-  // tool_call / tool_result
-  if (payload.tool_name) return payload.tool_name;
-  if (payload.name) return payload.name;
-  // assistant_token: show up to 60 chars of text
-  if (typeof payload.text === "string") {
-    var t = payload.text.replace(/\n/g, " ").trim();
-    return t.length > 60 ? t.slice(0, 60) + "…" : t;
-  }
-  // graph_transition
-  if (payload.node_id) return payload.node_id + (payload.phase ? " · " + payload.phase : "");
-  // yielded
-  if (payload.tool) return "yielded · " + payload.tool;
-  // generic: stringify up to 80 chars
+function WTP_clip(s, max) {
+  if (typeof s !== "string") return "";
+  var t = s.trim();
+  return t.length > max ? t.slice(0, max) + "…" : t;
+}
+
+function WTP_argsPreview(obj, max) {
+  if (obj == null) return "";
+  if (typeof obj === "string") return WTP_clip(obj, max);
   try {
-    var s = JSON.stringify(payload);
-    return s.length > 80 ? s.slice(0, 80) + "…" : s;
-  } catch (_) {
+    return WTP_clip(JSON.stringify(obj), max);
+  } catch (_e) {
     return "";
   }
+}
+
+// Returns { label, text, clampLines, err } for one TapEvent:
+//   label      — optional bold prefix (tool name / node id)
+//   text       — the payload preview (may wrap to `clampLines` lines)
+//   clampLines — max preview lines before clamp (variable height per class)
+//   err        — render in the error colour
+function WTP_eventContent(ev) {
+  var cls = ev && ev.class;
+  var p = (ev && ev.payload && typeof ev.payload === "object") ? ev.payload : {};
+
+  if (cls === "assistant_token") {
+    var text = typeof p.text === "string" ? p.text
+             : (typeof p.delta === "string" ? p.delta : "");
+    return { label: "", text: WTP_clip(text, 400), clampLines: 3, err: false };
+  }
+  if (cls === "user_input") {
+    var ut = p.text || p.content || p.message || "";
+    return { label: "", text: WTP_clip(String(ut), 400), clampLines: 3, err: false };
+  }
+  if (cls === "tool_call") {
+    var name = p.tool_name || p.name || "";
+    var args = p.arguments != null ? p.arguments : p.args;
+    return { label: name || "", text: WTP_argsPreview(args, 220), clampLines: 2, err: false };
+  }
+  if (cls === "tool_result") {
+    var rname = p.tool_name || p.name || "";
+    if (p.error) {
+      return { label: rname || "", text: WTP_argsPreview(p.error, 220), clampLines: 2, err: true };
+    }
+    var out = p.output != null ? p.output : (p.result != null ? p.result : "");
+    return { label: rname || "", text: WTP_argsPreview(out, 220), clampLines: 2, err: false };
+  }
+  if (cls === "graph_transition") {
+    var node = p.node_id || "";
+    var phase = p.phase || "";
+    var status = p.status ? " (" + p.status + ")" : "";
+    var trans = (phase + status).trim();
+    return { label: node, text: trans, clampLines: 1, err: false };
+  }
+  if (cls === "done") {
+    var reason = p.stop_reason || p.raw_reason || "done";
+    var u = p.usage || {};
+    var toks = (u.input_tokens != null || u.output_tokens != null)
+      ? " · " + (u.input_tokens || 0) + " in / " + (u.output_tokens || 0) + " out"
+      : "";
+    return { label: "", text: reason + toks, clampLines: 1, err: false };
+  }
+  if (cls === "error") {
+    var msg = p.message || p.error || p.detail || "error";
+    var code = p.code ? " [" + p.code + "]" : "";
+    return { label: "", text: WTP_clip(String(msg) + code, 240), clampLines: 2, err: true };
+  }
+  // yielded / resumed / cancelled / unknown: a compact generic preview.
+  return { label: "", text: WTP_argsPreview(p, 160), clampLines: 1, err: false };
 }
 
 // ---------------------------------------------------------------------------
@@ -321,13 +375,16 @@ function WorkspaceTap({ wid, sessionId }) {
           var key = ev.cursor != null ? String(ev.cursor) : ("i" + i);
           var isOpen = !!expanded[key];
           var ts = ev.ts ? new Date(ev.ts) : null;
-          var tsLabel = ts ? ts.toISOString().slice(11, 23) : "—";
+          // Minimal timestamp: HH:MM:SS (full ISO on hover).
+          var tsLabel = ts ? ts.toISOString().slice(11, 19) : "—";
           var sid = ev.session_id || "";
           var sidShort = sid.length > 16 ? sid.slice(0, 8) + "…" + sid.slice(-4) : sid;
-          var summary = WTP_payloadSummary(ev.payload);
+          var content = WTP_eventContent(ev);
           return (
             <div key={key} data-testid="activity-event" style={{ borderBottom: "1px solid var(--border)" }}>
-              {/* One-line summary — click / Enter / Space toggles the detail. */}
+              {/* Compact, content-aware row — click / Enter / Space expands it.
+                  A minimal timestamp + class chip + session on the header line,
+                  then a class-tuned payload preview with VARIABLE height. */}
               <div
                 data-testid="tap-event-row"
                 role="button"
@@ -339,42 +396,67 @@ function WorkspaceTap({ wid, sessionId }) {
                 }}
                 style={{
                   display: "flex",
-                  alignItems: "baseline",
-                  gap: 8,
-                  padding: "4px 18px",
-                  fontSize: 12,
-                  lineHeight: 1.5,
+                  flexDirection: "column",
+                  gap: 2,
+                  padding: "5px 18px",
                   cursor: "pointer",
                   background: isOpen ? "var(--bg-2)" : "transparent",
                 }}
               >
-                <span
-                  aria-hidden="true"
-                  className="mono muted"
-                  style={{ fontSize: 9, flexShrink: 0, width: 8, color: "var(--text-4)" }}
-                >{isOpen ? "▾" : "▸"}</span>
-                <span
-                  className="mono muted"
-                  style={{ fontSize: 10, flexShrink: 0, minWidth: 80 }}
-                  title={ts ? ts.toISOString() : ""}
-                >{tsLabel}</span>
-                <WTP_ClassChip cls={ev.class} />
-                {sid && (
+                {/* Header line: chevron · timestamp · class · session · seq */}
+                <div style={{ display: "flex", alignItems: "baseline", gap: 8, lineHeight: 1.4 }}>
+                  <span
+                    aria-hidden="true"
+                    className="mono muted"
+                    style={{ fontSize: 9, flexShrink: 0, width: 8, color: "var(--text-4)" }}
+                  >{isOpen ? "▾" : "▸"}</span>
                   <span
                     className="mono muted"
-                    style={{ fontSize: 10, flexShrink: 0 }}
-                    title={sid}
-                  >{sidShort}</span>
-                )}
-                {summary && (
-                  <span
-                    className="mono"
-                    style={{ fontSize: 11, color: "var(--text-2)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", flex: 1 }}
-                    title={summary}
-                  >{summary}</span>
-                )}
-                {ev.seq != null && (
-                  <span className="mono muted" style={{ fontSize: 10, flexShrink: 0 }}>#{ev.seq}</span>
+                    style={{ fontSize: 10, flexShrink: 0, minWidth: 56 }}
+                    title={ts ? ts.toISOString() : ""}
+                  >{tsLabel}</span>
+                  <WTP_ClassChip cls={ev.class} />
+                  {sid && (
+                    <span
+                      className="mono muted"
+                      style={{ fontSize: 10, flexShrink: 0 }}
+                      title={sid}
+                    >{sidShort}</span>
+                  )}
+                  {ev.seq != null && (
+                    <span className="mono muted" style={{ fontSize: 10, flexShrink: 0, marginLeft: "auto" }}>#{ev.seq}</span>
+                  )}
+                </div>
+                {/* Payload preview — variable height, class-tuned line clamp. */}
+                {(content.label || content.text) && (
+                  <div
+                    data-testid="tap-event-preview"
+                    style={{ display: "flex", gap: 6, paddingLeft: 26, minWidth: 0 }}
+                  >
+                    {content.label && (
+                      <span
+                        className="mono"
+                        style={{ fontSize: 11, fontWeight: 600, flexShrink: 0, color: content.err ? "var(--red)" : "var(--violet)" }}
+                      >{content.label}</span>
+                    )}
+                    {content.text && (
+                      <span
+                        className="mono"
+                        style={{
+                          fontSize: 11,
+                          color: content.err ? "var(--red)" : "var(--text-2)",
+                          whiteSpace: "pre-wrap",
+                          wordBreak: "break-word",
+                          overflow: "hidden",
+                          display: "-webkit-box",
+                          WebkitLineClamp: content.clampLines,
+                          WebkitBoxOrient: "vertical",
+                          minWidth: 0,
+                        }}
+                        title={content.text}
+                      >{content.text}</span>
+                    )}
+                  </div>
                 )}
               </div>
               {isOpen && (

--- a/ui/components/workspace-tap.jsx
+++ b/ui/components/workspace-tap.jsx
@@ -200,6 +200,18 @@ function WTP_detailJson(ev) {
   }
 }
 
+// Stable cross-source dedupe/React key. Per-session `seq` is NOT unique across
+// the workspace, so the key is (session_id, seq) — the one identity a history
+// backfill row and a live tap frame share (the live frame's `cursor` is a
+// per-frame multi-session token; the history row's is a "<sid>:<seq>"
+// placeholder — they never match, so cursor cannot be the seam key).
+function WTP_eventKey(ev) {
+  if (!ev || typeof ev !== "object") return "";
+  var sid = ev.session_id != null ? ev.session_id : "";
+  var seq = ev.seq != null ? ev.seq : (ev.cursor != null ? ev.cursor : "");
+  return sid + ":" + seq;
+}
+
 // ---------------------------------------------------------------------------
 // WorkspaceTap — main component
 //
@@ -212,7 +224,7 @@ function WTP_detailJson(ev) {
 
 function WorkspaceTap({ wid, sessionId }) {
   var tap = window.useWorkspaceTap(wid);
-  var allEvents = tap.events;
+  var liveEvents = tap.events;
   var connState = tap.connState;
 
   // selectedClasses: null means all; a subset array filters client-side.
@@ -221,10 +233,57 @@ function WorkspaceTap({ wid, sessionId }) {
   // its (potentially large) detail block, so long lists stay cheap.
   var [expanded, setExpanded] = React.useState({});
 
+  // HISTORY BACKFILL: the tap connects live-from-now, so anything that
+  // happened before the panel opened (e.g. a completed session) is invisible.
+  // On mount we fetch a bounded snapshot of recent workspace-scoped events and
+  // merge it below the live tail, deduped by (session_id, seq) — same
+  // history→live seam as SessionLiveStream, just workspace-wide.
+  var [history, setHistory] = React.useState([]);
+  React.useEffect(function () {
+    if (!wid) { setHistory([]); return undefined; }
+    var alive = true;
+    setHistory([]);
+    window.primerApi.apiFetch(
+      "GET",
+      "/workspaces/" + encodeURIComponent(wid) + "/events?limit=200"
+    ).then(function (res) {
+      if (!alive) return;
+      setHistory((res && Array.isArray(res.items)) ? res.items : []);
+    }).catch(function () {
+      /* best-effort — the live tap still tails for in-flight runs */
+    });
+    return function () { alive = false; };
+  }, [wid]);
+
   var scrollRef = React.useRef(null);
   var stickRef = React.useRef(true);
 
-  // Client-side filter over the shared buffer.
+  // Merge history + live buffer, dedupe by (session_id, seq), order by ts so
+  // pre-connect history sorts above the live tail.
+  var allEvents = React.useMemo(function () {
+    var seen = {};
+    var merged = [];
+    function add(ev) {
+      if (!ev || typeof ev !== "object") return;
+      var k = WTP_eventKey(ev);
+      if (seen[k]) return;
+      seen[k] = true;
+      merged.push(ev);
+    }
+    for (var i = 0; i < history.length; i++) add(history[i]);
+    for (var j = 0; j < liveEvents.length; j++) add(liveEvents[j]);
+    merged.sort(function (a, b) {
+      var ta = a.ts ? Date.parse(a.ts) : 0;
+      var tb = b.ts ? Date.parse(b.ts) : 0;
+      if (ta !== tb) return ta - tb;
+      var sa = a.session_id || "", sb = b.session_id || "";
+      if (sa !== sb) return sa < sb ? -1 : 1;
+      return (a.seq || 0) - (b.seq || 0);
+    });
+    return merged;
+  }, [history, liveEvents]);
+
+  // Client-side filter over the merged buffer.
   var events = React.useMemo(function () {
     var out = allEvents;
     if (sessionId) {
@@ -347,7 +406,7 @@ function WorkspaceTap({ wid, sessionId }) {
             size="sm"
             kind="ghost"
             icon="trash"
-            onClick={function() { tap.clear(); }}
+            onClick={function() { tap.clear(); setHistory([]); }}
             title="Clear event list"
           >Clear</Btn>
         </div>
@@ -372,7 +431,7 @@ function WorkspaceTap({ wid, sessionId }) {
           </div>
         )}
         {events.map(function(ev, i) {
-          var key = ev.cursor != null ? String(ev.cursor) : ("i" + i);
+          var key = WTP_eventKey(ev) || ("i" + i);
           var isOpen = !!expanded[key];
           var ts = ev.ts ? new Date(ev.ts) : null;
           // Minimal timestamp: HH:MM:SS (full ISO on hover).

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -331,10 +331,13 @@
   flex-shrink: 0;
 }
 
-/* Studio right-rail: Action Required section (B4). The empty-state text must
-   never be clipped — the section is content-sized when empty (no max-height
-   cap) and only capped-with-scroll once it holds pending items. Previously a
-   flat 60px cap squeezed the "No pending actions" line behind overflow:hidden. */
+/* Studio right-rail: User Interaction section (Action Required + inform_user).
+   AUTO-RESIZE: the section is content-sized, so it stays compact when empty
+   (just the "No pending interactions." line) and GROWS to fit its items when
+   an ask_user input or an inform_user message lands — up to ~50vh, after which
+   the item list scrolls internally. `flex-shrink: 0` keeps the activity feed
+   below from squeezing it once populated. The empty-state text must never be
+   clipped (a flat px cap previously squeezed it behind overflow:hidden). */
 .st-action-required {
   display: flex;
   flex-direction: column;
@@ -343,7 +346,7 @@
   border-bottom: 1px solid var(--border);
 }
 .st-action-required.is-empty { max-height: none; }
-.st-action-required.has-items { max-height: 320px; }
+.st-action-required.has-items { max-height: 50vh; }
 .st-action-empty {
   padding: 16px 14px;
   font-size: 12px;


### PR DESCRIPTION
Reworks the Studio right-rail activity panel (0.2.0 batch, bugs #4/#5/#6).

- **#6** "Action Required" -> **"User Interaction"**; adds `inform_user` (message card + client-side dismiss; conservative detection off the tap), and the section auto-resizes to fit ask/inform items (up to 50vh) instead of collapsing.
- **#5** compact, content-aware event rows: minimal timestamp + type + per-class payload preview, variable height (line-clamped by class).
- **#4** history backfill: new `GET /v1/workspaces/{id}/events?limit=N` (reuses `read_session_since`, bounded, newest-N oldest-first) merged with the live tap deduped by `(session_id, seq)` — so a completed session's past events now show.

Verified: tests/ui 649 + 5 new backend tests; live-smoke confirmed the 'User Interaction' header and the panel fetching /events on load.