### PR TITLE
feat(studio): Files-tree right-click menu, rename, and drag-and-drop

### DIFF
--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -1035,6 +1035,41 @@ async def delete_file(
     await ws.delete_file(path, recursive=recursive)
 
 
+@files_router.post(
+    "/workspaces/{workspace_id}/files/move",
+    status_code=204,
+    summary="Move or rename a file or directory within the workspace",
+    responses=common_responses(400, 404, 409, 500),
+)
+async def move_file(
+    workspace_id: str = Path(...),
+    src: str = Query(..., description="Source workspace-relative path"),
+    dst: str = Query(..., description="Destination workspace-relative path"),
+    registry: WorkspaceRegistry = Depends(get_workspace_registry),
+) -> None:
+    """Move / rename ``src`` to ``dst`` within one workspace.
+
+    Query params ``src`` + ``dst`` mirror the other file endpoints' use of
+    ``path``. The backend enforces the safety envelope (root-relative, no
+    reserved-tree escape, no clobber of an existing ``dst``, no dir-into-its-
+    own-descendant); violations surface as 400 / 404 / 409. Backends that do
+    not implement move return 501.
+    """
+    ws = await registry.get_workspace(workspace_id)
+    try:
+        await ws.move_file(src, dst)
+    except NotImplementedError as exc:
+        raise HTTPException(
+            status_code=501,
+            detail={
+                "error": "not_implemented",
+                "message": str(exc) or (
+                    "move_file is not implemented for this workspace backend"
+                ),
+            },
+        ) from exc
+
+
 @files_router.put(
     "/workspaces/{workspace_id}/files",
     status_code=204,

--- a/primer/int/workspace.py
+++ b/primer/int/workspace.py
@@ -309,6 +309,32 @@ class Workspace(ABC):
         :class:`primer.model.except_.BadRequestError`.
         """
 
+    async def move_file(self, src: str, dst: str) -> None:
+        """Move / rename the file or directory at ``src`` to ``dst``.
+
+        A single primitive for both rename (same parent dir, new basename)
+        and move (different parent dir) within the workspace filesystem.
+
+        Mirrors :meth:`delete_file`'s safety envelope: both paths must stay
+        inside the workspace root and outside the reserved ``.state`` /
+        ``.tmp`` trees; ``src`` must exist; ``src`` must not be the workspace
+        root; ``dst`` must NOT already exist (no silent overwrite); and a
+        directory may not be moved onto itself or into one of its own
+        descendants. Violations raise
+        :class:`primer.model.except_.BadRequestError` /
+        :class:`primer.model.except_.NotFoundError` /
+        :class:`primer.model.except_.ConflictError` as appropriate.
+
+        Default implementation raises :class:`NotImplementedError`; concrete
+        backends override. Intentionally NOT ``@abstractmethod`` so
+        pre-existing backends + duck-typed test fakes that predate this
+        method remain instantiable while the implementation is rolled out
+        (same convention as :meth:`diagnostic_exec`).
+        """
+        raise NotImplementedError(
+            f"{type(self).__name__} does not implement move_file"
+        )
+
     @abstractmethod
     async def log(self, *, limit: int = 50) -> "list[CommitInfo]":
         """Return up to ``limit`` recent commits from the ``.state`` repo.

--- a/primer/workspace/local/workspace.py
+++ b/primer/workspace/local/workspace.py
@@ -433,6 +433,50 @@ class LocalWorkspace(Workspace):
         else:
             await asyncio.to_thread(target.unlink)
 
+    async def move_file(self, src: str, dst: str) -> None:
+        """Move / rename ``src`` to ``dst`` within the workspace.
+
+        Mirrors :meth:`delete_file`'s safety envelope (root-relative,
+        no reserved-tree escapes, no clobber, no dir-into-itself) — see the
+        ABC docstring. Uses ``shutil.move`` so a rename and a cross-directory
+        move share one primitive.
+        """
+        src_target = self._resolve_path(src)
+        dst_target = self._resolve_path(dst)
+        if not await asyncio.to_thread(src_target.exists):
+            raise NotFoundError(f"{src!r} not found")
+        if src_target == self._root.resolve():
+            raise BadRequestError("refusing to move workspace root")
+        # Both endpoints must stay outside the reserved .state / .tmp trees so
+        # the API can't shuffle the backend's bookkeeping around.
+        self._refuse_reserved(src_target, src)
+        self._refuse_reserved(dst_target, dst)
+        if await asyncio.to_thread(dst_target.exists):
+            raise ConflictError(
+                f"{dst!r} already exists; refusing to overwrite it"
+            )
+        # A directory may not be moved onto itself or into one of its own
+        # descendants (that would orphan the subtree). dst_target need not
+        # exist for this pure-path check.
+        if await asyncio.to_thread(src_target.is_dir):
+            try:
+                dst_target.relative_to(src_target)
+            except ValueError:
+                pass
+            else:
+                raise BadRequestError(
+                    f"cannot move directory {src!r} into itself or a "
+                    f"descendant ({dst!r})"
+                )
+        parent = dst_target.parent
+        try:
+            await asyncio.to_thread(parent.mkdir, parents=True, exist_ok=True)
+            await asyncio.to_thread(shutil.move, str(src_target), str(dst_target))
+        except OSError as exc:
+            raise BadRequestError(
+                f"cannot move {src!r} to {dst!r}: {exc.strerror or exc}"
+            ) from exc
+
     async def log(self, *, limit: int = 50) -> list[CommitInfo]:
         try:
             return await self._state.history(limit=limit)

--- a/tests/api/test_workspace_files_studio.py
+++ b/tests/api/test_workspace_files_studio.py
@@ -176,6 +176,36 @@ class _FakeWorkspace:
             return
         raise NotFoundError(f"{path!r} not found")
 
+    async def move_file(self, src, dst):
+        for p in (src, dst):
+            if ".." in p.split("/") or p.startswith("/") or "\x00" in p:
+                raise BadRequestError(f"invalid path: {p!r}")
+        is_file = src in self._files
+        is_dir = src in self._dirs
+        if not is_file and not is_dir:
+            raise NotFoundError(f"{src!r} not found")
+        if dst in self._files or dst in self._dirs:
+            raise ConflictError(f"{dst!r} already exists")
+        if is_dir and (dst == src or dst.startswith(src + "/")):
+            raise BadRequestError(
+                "cannot move a directory into itself or a descendant"
+            )
+        if is_file:
+            self._files[dst] = self._files.pop(src)
+            self._mtimes[dst] = self._mtimes.pop(
+                src, datetime.now(timezone.utc)
+            )
+            return
+        # Directory: remap the dir entry and everything nested under it.
+        for coll in (self._files, self._mtimes):
+            for key in list(coll.keys()):
+                if key == src or key.startswith(src + "/"):
+                    coll[dst + key[len(src):]] = coll.pop(key)
+        for d in list(self._dirs):
+            if d == src or d.startswith(src + "/"):
+                self._dirs.discard(d)
+                self._dirs.add(dst + d[len(src):])
+
     async def aclose(self):
         return
 
@@ -732,3 +762,101 @@ class TestWatchWakeOnWrite:
             json={"content": "print(1)", "encoding": "text"},
         )
         assert resp.status_code == 204
+
+
+# ===========================================================================
+# Feature: POST /v1/workspaces/{id}/files/move  (move / rename)
+# ===========================================================================
+
+
+class TestFileMove:
+    @pytest.mark.asyncio
+    async def test_move_renames_file(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._files["a.txt"] = b"hello"
+
+        resp = await client.post(
+            f"/v1/workspaces/{wid}/files/move",
+            params={"src": "a.txt", "dst": "b.txt"},
+        )
+        assert resp.status_code == 204, resp.text
+
+        # New path reads back; old path is gone.
+        moved = await client.get(
+            f"/v1/workspaces/{wid}/files/read", params={"path": "b.txt"}
+        )
+        assert moved.status_code == 200
+        assert moved.json()["content"] == "hello"
+        gone = await client.get(
+            f"/v1/workspaces/{wid}/files/read", params={"path": "a.txt"}
+        )
+        assert gone.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_move_file_into_subdir(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._files["note.md"] = b"# n"
+        ws._dirs.add("docs")
+
+        resp = await client.post(
+            f"/v1/workspaces/{wid}/files/move",
+            params={"src": "note.md", "dst": "docs/note.md"},
+        )
+        assert resp.status_code == 204, resp.text
+        assert "docs/note.md" in ws._files
+        assert "note.md" not in ws._files
+
+    @pytest.mark.asyncio
+    async def test_move_missing_src_404(self, client, wsr) -> None:
+        wid, _ = await _setup(client, wsr)
+        resp = await client.post(
+            f"/v1/workspaces/{wid}/files/move",
+            params={"src": "nope.txt", "dst": "there.txt"},
+        )
+        assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_move_onto_existing_dst_409(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._files["a.txt"] = b"a"
+        ws._files["b.txt"] = b"b"
+        resp = await client.post(
+            f"/v1/workspaces/{wid}/files/move",
+            params={"src": "a.txt", "dst": "b.txt"},
+        )
+        assert resp.status_code == 409
+
+    @pytest.mark.asyncio
+    async def test_move_traversal_dst_400(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._files["a.txt"] = b"a"
+        resp = await client.post(
+            f"/v1/workspaces/{wid}/files/move",
+            params={"src": "a.txt", "dst": "../escape.txt"},
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_move_dir_into_own_descendant_400(self, client, wsr) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._dirs.add("src")
+        resp = await client.post(
+            f"/v1/workspaces/{wid}/files/move",
+            params={"src": "src", "dst": "src/inner"},
+        )
+        assert resp.status_code == 400
+
+    @pytest.mark.asyncio
+    async def test_move_renames_directory_with_children(
+        self, client, wsr
+    ) -> None:
+        wid, ws = await _setup(client, wsr)
+        ws._dirs.add("old")
+        ws._files["old/a.txt"] = b"a"
+        resp = await client.post(
+            f"/v1/workspaces/{wid}/files/move",
+            params={"src": "old", "dst": "new"},
+        )
+        assert resp.status_code == 204, resp.text
+        assert "new/a.txt" in ws._files
+        assert "old/a.txt" not in ws._files

--- a/tests/ui/test_studio_file_dragdrop.py
+++ b/tests/ui/test_studio_file_dragdrop.py
@@ -1,0 +1,233 @@
+"""Structural checks for the Studio Files-tree context menu + drag-and-drop.
+
+These features are UI wiring in ``ui/components/studio-sidebar.jsx`` over the
+workspace file endpoints, plus the new move endpoint:
+
+  * Right-click context menu (ST_FileContextMenu) with per-kind actions.
+  * Rename via promptDialog → POST /files/move?src=&dst= → tab remap + refresh.
+  * Drag-drop upload: OS files onto a folder row / tree root → base64 PUT.
+  * Drag-to-move: a row onto a folder row → POST /files/move.
+
+The bundle has no module system (flat global scope), so these are source-level
+structural assertions plus a hard transpile gate — the same pattern used by
+test_studio_file_actions.py.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SIDEBAR = UI / "components" / "studio-sidebar.jsx"
+STUDIO = UI / "components" / "studio.jsx"
+
+
+def _src() -> str:
+    return SIDEBAR.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Context menu: component + per-kind action testids
+# ---------------------------------------------------------------------------
+
+
+def test_context_menu_component_and_testid() -> None:
+    src = _src()
+    assert "function ST_FileContextMenu(" in src
+    assert 'data-testid="file-context-menu"' in src
+    # testids are built as "ctx-" + <action key>.
+    assert '"ctx-" + a.key' in src
+
+
+def test_context_menu_has_all_action_keys() -> None:
+    src = _src()
+    # file: Open / Download / Rename / Delete ; folder: New file here /
+    # New folder here / Upload here / Rename / Delete.
+    for key in (
+        'key: "open"',
+        'key: "download"',
+        'key: "rename"',
+        'key: "delete"',
+        'key: "new-file"',
+        'key: "new-folder"',
+        'key: "upload"',
+    ):
+        assert key in src, f"Missing context-menu action {key}"
+
+
+def test_context_menu_opens_on_row_right_click() -> None:
+    src = _src()
+    flat = re.sub(r"\s+", " ", src)
+    # onContextMenu preventDefaults the native menu, stops the row's
+    # open/toggle click, and opens the positioned menu at the cursor.
+    assert "onContextMenu={function(e) {" in src
+    assert "setCtxMenu({ item: item, x: e.clientX, y: e.clientY });" in flat
+    assert "e.preventDefault(); e.stopPropagation(); setCtxMenu(" in flat
+
+
+def test_context_menu_closes_on_outside_click_and_escape() -> None:
+    src = _src()
+    assert 'document.addEventListener("mousedown"' in src
+    assert 'e.key === "Escape"' in src
+    # The menu action dispatches then closes.
+    assert "onAction(a.key, item);" in src
+    assert "onClose();" in src
+
+
+def test_context_menu_dispatch_wires_existing_handlers() -> None:
+    src = _src()
+    assert "function handleCtxAction(action, item) {" in src
+    # Each action routes to the right handler (Open=handleFileClick,
+    # Download=ST_triggerDownload, Delete=handleDelete, create/upload targeted).
+    assert 'if (action === "open") handleFileClick(item);' in src
+    assert 'else if (action === "download") ST_triggerDownload(wid, item.path);' in src
+    assert 'else if (action === "rename") handleRename(item);' in src
+    assert 'else if (action === "delete") handleDelete(item);' in src
+    assert 'else if (action === "new-file") handleNewFileIn(item.path);' in src
+    assert 'else if (action === "new-folder") handleNewFolderIn(item.path);' in src
+    assert 'else if (action === "upload") handleUploadIn(item.path);' in src
+
+
+def test_download_action_reuses_download_url() -> None:
+    src = _src()
+    # ST_triggerDownload builds the SAME /files/download URL the center editor's
+    # download button uses, and clicks a synthesized anchor.
+    assert "function ST_triggerDownload(wid, path) {" in src
+    assert '"/files/download?path=" +' in src
+    assert 'a.click();' in src
+
+
+# ---------------------------------------------------------------------------
+# Backend move endpoint (query params) — used by rename + drag-move
+# ---------------------------------------------------------------------------
+
+
+def test_rename_calls_move_endpoint_and_remaps_tab() -> None:
+    src = _src()
+    assert "async function handleRename(item) {" in src
+    # promptDialog seeded with the current basename as the default value.
+    assert "defaultValue: base," in src
+    # POST /files/move?src=<old>&dst=<newpath>
+    assert '/files/move?src=" +' in src
+    assert '"&dst=" + encodeURIComponent(dst)' in src
+    # Open editor tab is repointed to the new path.
+    assert "ST_remapTabsForMove(oldPath, dst, isDir);" in src
+    assert "studio.renameTab(" in src
+    assert "handleRefresh();" in src
+
+
+def test_rename_tab_remap_covers_folder_descendants() -> None:
+    src = _src()
+    # A folder rename repoints every open tab under it (prefix "file:<old>/").
+    assert 'var childPrefix = "file:" + oldPath + "/";' in src
+    assert 'tid.indexOf(childPrefix) === 0' in src
+
+
+def test_studio_state_exposes_rename_tab() -> None:
+    txt = STUDIO.read_text(encoding="utf-8")
+    assert "var renameTab = React.useCallback(" in txt
+    assert "renameTab: renameTab," in txt
+
+
+# ---------------------------------------------------------------------------
+# Drag-drop upload (OS files) vs drag-to-move (internal row)
+# ---------------------------------------------------------------------------
+
+
+def test_rows_are_draggable_and_stamp_source_path() -> None:
+    src = _src()
+    assert "draggable={true}" in src
+    assert "onDragStart={function(e) { ST_dragStartRow(item, e); }}" in src
+    # dragstart records the source path + kind on a custom DataTransfer type so
+    # a drop can tell an internal move from an OS-file upload.
+    assert '"application/x-primer-file"' in src
+    assert 'effectAllowed = "move"' in src
+
+
+def test_file_drag_vs_move_is_distinguished_by_files() -> None:
+    src = _src()
+    # OS-file drags carry dataTransfer.files / a "Files" type; internal moves
+    # carry the custom x-primer-file payload instead.
+    assert "function ST_isFileDrag(e) {" in src
+    assert '"Files"' in src
+    # The folder drop branches on files first (upload), else parses the move
+    # payload.
+    assert "if (dt && dt.files && dt.files.length) {" in src
+    assert "await ST_uploadInto(item.path, dt.files);" in src
+    assert 'dt.getData("application/x-primer-file")' in src
+    assert "await doMove(src.path, !!src.is_dir, item.path);" in src
+
+
+def test_folder_rows_are_drop_targets_with_highlight() -> None:
+    src = _src()
+    assert "onDragOver={function(e) { ST_dragOverFolder(item, e); }}" in src
+    assert "onDrop={function(e) { ST_dropOnFolder(item, e); }}" in src
+    # Highlight only a folder row that is the active drop target.
+    assert "var isDropTarget = item.is_dir && dropTarget === item.path;" in src
+
+
+def test_tree_root_accepts_os_file_upload() -> None:
+    src = _src()
+    assert 'data-testid="files-tree-body"' in src
+    assert "onDragOver={ST_dragOverRoot}" in src
+    assert "onDrop={ST_dropOnRoot}" in src
+    # Root drop uploads into "" (workspace root); guarded to OS-file drags only.
+    assert 'await ST_uploadInto("", dt.files);' in src
+    assert "if (!ST_isFileDrag(e)) return;" in src
+
+
+def test_upload_put_is_shared_and_base64() -> None:
+    src = _src()
+    # The base64 PUT lives in one shared helper reused by the picker + drag-drop.
+    assert "async function ST_putUpload(dir, file) {" in src
+    assert '{ content: b64, encoding: "base64" }' in src
+    # Drag-drop and the picker both funnel through ST_uploadInto.
+    assert "async function ST_uploadInto(dir, fileList) {" in src
+
+
+def test_move_no_op_guards() -> None:
+    src = _src()
+    # doMove refuses self/descendant drops and same-dir drops (no-op).
+    assert 'if (folderPath === srcPath || folderPath.indexOf(srcPath + "/") === 0) return;' in src
+    assert "if (ST_pathDir(srcPath) === folderPath) return;" in src
+
+
+# ---------------------------------------------------------------------------
+# The existing header quick-buttons + their tests must be untouched.
+# ---------------------------------------------------------------------------
+
+
+def test_header_quick_buttons_retained() -> None:
+    src = _src()
+    for tid in (
+        'data-testid="files-new-file"',
+        'data-testid="files-upload"',
+        'data-testid="files-new-folder"',
+        'data-testid="files-upload-input"',
+    ):
+        assert tid in src
+
+
+# ---------------------------------------------------------------------------
+# Hard gate: the bundle still transpiles with all the new wiring.
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_transpiles_with_dragdrop() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio-sidebar.jsx === */" in text
+    for name in (
+        "ST_FileContextMenu",
+        "handleRename",
+        "handleCtxAction",
+        "ST_dropOnFolder",
+        "doMove",
+        "ST_putUpload",
+    ):
+        assert name in text, f"{name} missing from transpiled bundle"

--- a/tests/workspace/test_local.py
+++ b/tests/workspace/test_local.py
@@ -10,7 +10,7 @@ from pathlib import Path
 
 import pytest
 
-from primer.model.except_ import BadRequestError, NotFoundError
+from primer.model.except_ import BadRequestError, ConflictError, NotFoundError
 from primer.model.workspace_session import AgentBinding, SessionStatus
 from primer.model.workspace import (
     FileMount,
@@ -591,6 +591,78 @@ class TestWorkspaceFiles:
         await ws.delete_file("d", recursive=True)
         with pytest.raises(NotFoundError):
             await ws.file_info("d")
+
+    async def test_move_renames_file(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        await ws.write_file("a.txt", b"hello")
+        await ws.move_file("a.txt", "b.txt")
+        assert await ws.read_file("b.txt") == b"hello"
+        with pytest.raises(NotFoundError):
+            await ws.file_info("a.txt")
+
+    async def test_move_file_into_subdir(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        await ws.write_file("note.md", b"# n")
+        # Parent dir is created on demand by move.
+        await ws.move_file("note.md", "docs/note.md")
+        assert await ws.read_file("docs/note.md") == b"# n"
+
+    async def test_move_renames_dir_with_children(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        await ws.make_dir("old")
+        await ws.write_file("old/a.txt", b"a")
+        await ws.move_file("old", "new")
+        assert await ws.read_file("new/a.txt") == b"a"
+        with pytest.raises(NotFoundError):
+            await ws.file_info("old")
+
+    async def test_move_missing_src_raises(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        with pytest.raises(NotFoundError):
+            await ws.move_file("nope.txt", "there.txt")
+
+    async def test_move_onto_existing_dst_conflicts(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        await ws.write_file("a.txt", b"a")
+        await ws.write_file("b.txt", b"b")
+        with pytest.raises(ConflictError):
+            await ws.move_file("a.txt", "b.txt")
+        # The source is untouched by a rejected move.
+        assert await ws.read_file("a.txt") == b"a"
+
+    async def test_move_rejects_escape(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        await ws.write_file("a.txt", b"a")
+        with pytest.raises(BadRequestError, match="outside workspace"):
+            await ws.move_file("a.txt", "../escape.txt")
+
+    async def test_move_rejects_reserved_dst(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        await ws.write_file("a.txt", b"a")
+        with pytest.raises(BadRequestError, match="reserved"):
+            await ws.move_file("a.txt", ".state/a.txt")
+
+    async def test_move_dir_into_own_descendant_rejected(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        await ws.make_dir("src")
+        with pytest.raises(BadRequestError, match="itself or a"):
+            await ws.move_file("src", "src/inner")
 
     async def test_write_file_is_atomic_no_torn_read(
         self, provider: LocalWorkspaceBackend

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -199,6 +199,178 @@ function ST_onRowKey(activate) {
 }
 
 // ---------------------------------------------------------------------------
+// ST_pathBase / ST_pathDir / ST_pathJoin — workspace-relative path helpers.
+// Paths are always POSIX "/"-separated (see FileEntry.path). basename returns
+// the last segment; dirname returns the parent ("" for a top-level entry);
+// join glues a dir + name, tolerating an empty dir (root) so it never emits a
+// leading "/". Shared by the context-menu rename, the "… here" create actions,
+// and the drag-to-move destination computation.
+// ---------------------------------------------------------------------------
+
+function ST_pathBase(path) {
+  var p = String(path || "");
+  var i = p.lastIndexOf("/");
+  return i >= 0 ? p.slice(i + 1) : p;
+}
+
+function ST_pathDir(path) {
+  var p = String(path || "");
+  var i = p.lastIndexOf("/");
+  return i >= 0 ? p.slice(0, i) : "";
+}
+
+function ST_pathJoin(dir, name) {
+  var d = String(dir || "");
+  var n = String(name || "");
+  return d ? d + "/" + n : n;
+}
+
+// ---------------------------------------------------------------------------
+// ST_triggerDownload — kick off a browser download of a workspace file.
+// Mirrors the center editor's <a href=…/files/download> affordance (same URL)
+// but drives it programmatically so the Files-tree context menu's "Download"
+// action can reuse the exact same flow without a persistent anchor.
+// ---------------------------------------------------------------------------
+
+function ST_triggerDownload(wid, path) {
+  var url =
+    "/v1/workspaces/" +
+    encodeURIComponent(wid) +
+    "/files/download?path=" +
+    encodeURIComponent(path);
+  var a = document.createElement("a");
+  a.href = url;
+  a.target = "_blank";
+  a.rel = "noreferrer noopener";
+  a.download = ST_pathBase(path);
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+}
+
+// ---------------------------------------------------------------------------
+// ST_FileContextMenu — small absolutely-positioned right-click menu for a
+// file / folder row in the Files tree. The action set differs by kind:
+//   file   → Open · Download · Rename · Delete
+//   folder → New file here · New folder here · Upload here · Rename · Delete
+// It closes on outside-click (mousedown) or Escape, and each item fires
+// onAction(<key>, item) then onClose(). Positioned at the cursor via
+// position:fixed (clientX/clientY). testids: file-context-menu + ctx-<key>.
+// ---------------------------------------------------------------------------
+
+function ST_FileContextMenu({ menu, onAction, onClose }) {
+  React.useEffect(function () {
+    function onDocDown(e) {
+      // A click INSIDE the menu is handled by the item's own onClick; anything
+      // else dismisses. Guard on the container via a data attribute lookup.
+      var el = e.target;
+      while (el) {
+        if (el.getAttribute && el.getAttribute("data-testid") === "file-context-menu") {
+          return;
+        }
+        el = el.parentNode;
+      }
+      onClose();
+    }
+    function onKey(e) {
+      if (e.key === "Escape") { e.preventDefault(); onClose(); }
+    }
+    document.addEventListener("mousedown", onDocDown, true);
+    document.addEventListener("keydown", onKey, true);
+    return function () {
+      document.removeEventListener("mousedown", onDocDown, true);
+      document.removeEventListener("keydown", onKey, true);
+    };
+  }, [onClose]);
+
+  if (!menu) return null;
+  var item = menu.item;
+  var isDir = !!item.is_dir;
+  var actions = isDir
+    ? [
+        { key: "new-file", label: "New file here", icon: "file" },
+        { key: "new-folder", label: "New folder here", icon: "box" },
+        { key: "upload", label: "Upload here", icon: "paperclip" },
+        { key: "rename", label: "Rename", icon: "edit" },
+        { key: "delete", label: "Delete", icon: "trash", danger: true },
+      ]
+    : [
+        { key: "open", label: "Open", icon: "doc" },
+        { key: "download", label: "Download", icon: "external" },
+        { key: "rename", label: "Rename", icon: "edit" },
+        { key: "delete", label: "Delete", icon: "trash", danger: true },
+      ];
+
+  // Keep the menu inside the viewport: nudge left/up when it would overflow.
+  var MENU_W = 176;
+  var estH = actions.length * 30 + 8;
+  var vw = typeof window !== "undefined" ? window.innerWidth : 1024;
+  var vh = typeof window !== "undefined" ? window.innerHeight : 768;
+  var left = Math.min(menu.x, Math.max(8, vw - MENU_W - 8));
+  var top = Math.min(menu.y, Math.max(8, vh - estH - 8));
+
+  return (
+    <div
+      data-testid="file-context-menu"
+      role="menu"
+      onContextMenu={function (e) { e.preventDefault(); }}
+      style={{
+        position: "fixed",
+        left: left,
+        top: top,
+        zIndex: 1000,
+        minWidth: MENU_W,
+        background: "var(--bg-2)",
+        border: "1px solid var(--border)",
+        borderRadius: 8,
+        boxShadow: "0 8px 24px rgba(0,0,0,0.35)",
+        padding: 4,
+        fontSize: 12.5,
+      }}
+    >
+      {actions.map(function (a) {
+        return (
+          <button
+            key={a.key}
+            type="button"
+            role="menuitem"
+            data-testid={"ctx-" + a.key}
+            onClick={function (e) {
+              e.preventDefault();
+              e.stopPropagation();
+              onAction(a.key, item);
+              onClose();
+            }}
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 8,
+              width: "100%",
+              textAlign: "left",
+              padding: "6px 10px",
+              borderRadius: 6,
+              border: "none",
+              background: "none",
+              cursor: "pointer",
+              color: a.danger ? "var(--red)" : "var(--text)",
+              fontSize: 12.5,
+              fontFamily: "inherit",
+            }}
+            onMouseEnter={function (e) { e.currentTarget.style.background = "var(--bg-active)"; }}
+            onMouseLeave={function (e) { e.currentTarget.style.background = "none"; }}
+          >
+            <span style={{ width: 14, display: "grid", placeItems: "center", flexShrink: 0 }}>
+              <Icon name={a.icon} size={12} />
+            </span>
+            {a.label}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
 // NewSessionForm — inline modal-style form for creating a session.
 // Renders as a positioned overlay inside the sessions section.
 // POST /v1/workspaces/{wid}/sessions with the SessionCreateBody shape:
@@ -739,6 +911,16 @@ function FilesTree({ wid, studio }) {
   // of expanded folders) but no single "selected" folder, so we do NOT invent
   // extra state — the prompt lets the user type `sub/dir/name` for a subpath.
   var uploadInputRef = React.useRef(null);
+  // Which directory a hidden-input upload lands in. "" = workspace root (the
+  // header Upload button); the context-menu "Upload here" sets it to a folder
+  // path before clicking the SAME hidden input, and handleUploadChange reads +
+  // resets it. A ref (not state) so it's read synchronously in the change
+  // handler without a re-render race.
+  var uploadTargetRef = React.useRef("");
+  // Right-click context menu: { item, x, y } or null. Drop-target highlight:
+  // the folder path (or "." for the tree root) currently under a drag, or null.
+  var [ctxMenu, setCtxMenu] = React.useState(null);
+  var [dropTarget, setDropTarget] = React.useState(null);
   var pushToast = studio.pushToast || (window.primerApi && window.primerApi.toastPush) || null;
   // promptDialog is published as a bare window global by shared.jsx; keep a
   // primerApi fallback so it resolves regardless of how it was exposed.
@@ -907,37 +1089,41 @@ function FilesTree({ wid, studio }) {
     });
   }
 
-  function handleUploadClick() {
-    if (uploadInputRef.current) uploadInputRef.current.click();
+  // Shared single-file base64 PUT, targeted at a directory. `dir` "" = root.
+  // The one place the base64 upload payload is written — reused by the hidden
+  // <input> flow (header + "Upload here") AND the drag-drop-from-OS flow.
+  async function ST_putUpload(dir, file) {
+    var b64 = await ST_readAsBase64(file);
+    var rel = dir ? dir + "/" + file.name : file.name;
+    await apiFetch(
+      "PUT",
+      "/workspaces/" + encodeURIComponent(wid) + "/files?path=" + encodeURIComponent(rel),
+      { content: b64, encoding: "base64" }
+    );
   }
 
-  async function handleUploadChange(e) {
-    var input = e.target;
-    var files = (input && input.files) ? Array.prototype.slice.call(input.files) : [];
+  // Upload a batch of File objects into `dir`, then refresh + toast. Used by
+  // both the file-picker change handler and the drag-drop-from-OS handler.
+  async function ST_uploadInto(dir, fileList) {
+    var files = Array.prototype.slice.call(fileList || []);
     if (!files.length) return;
     var okCount = 0;
     var errors = [];
     for (var i = 0; i < files.length; i++) {
       var file = files[i];
       try {
-        var b64 = await ST_readAsBase64(file);
-        await apiFetch(
-          "PUT",
-          "/workspaces/" + encodeURIComponent(wid) + "/files?path=" + encodeURIComponent(file.name),
-          { content: b64, encoding: "base64" }
-        );
+        await ST_putUpload(dir, file);
         okCount += 1;
       } catch (err) {
         errors.push(file.name + ": " + ST_errDetail(err, "upload failed"));
       }
     }
     handleRefresh();
-    // Reset so re-picking the SAME file fires another change event.
-    if (input) input.value = "";
     if (okCount > 0) {
       pushToast && pushToast({
         kind: "success",
         title: "Uploaded " + okCount + " file" + (okCount === 1 ? "" : "s"),
+        detail: dir ? "into " + dir : undefined,
       });
     }
     if (errors.length) {
@@ -947,6 +1133,269 @@ function FilesTree({ wid, studio }) {
         detail: errors.join("; "),
       });
     }
+  }
+
+  function handleUploadClick() {
+    // Header Upload button → target the workspace root.
+    uploadTargetRef.current = "";
+    if (uploadInputRef.current) uploadInputRef.current.click();
+  }
+
+  function handleUploadIn(dir) {
+    // Context-menu "Upload here" → target this folder, reusing the same input.
+    uploadTargetRef.current = dir || "";
+    if (uploadInputRef.current) uploadInputRef.current.click();
+  }
+
+  async function handleUploadChange(e) {
+    var input = e.target;
+    var files = (input && input.files) ? Array.prototype.slice.call(input.files) : [];
+    var dir = uploadTargetRef.current || "";
+    uploadTargetRef.current = "";
+    // Reset so re-picking the SAME file fires another change event.
+    if (input) input.value = "";
+    await ST_uploadInto(dir, files);
+  }
+
+  // -- Targeted create actions (context-menu "… here") --------------------
+  // Same endpoints as the header buttons, but rooted at a folder path instead
+  // of the workspace root.
+  async function handleNewFileIn(dir) {
+    var raw = await promptDialog({
+      title: "New file",
+      label: "File name",
+      message: "New file in " + (dir || "root"),
+      placeholder: "notes.md",
+    });
+    if (raw == null) return;
+    var name = String(raw).trim();
+    if (!name) return;
+    var rel = ST_pathJoin(dir, name);
+    try {
+      await apiFetch(
+        "PUT",
+        "/workspaces/" + encodeURIComponent(wid) + "/files?path=" + encodeURIComponent(rel),
+        { content: "", encoding: "text" }
+      );
+      handleRefresh();
+      ST_openNewFileTab(rel);
+      pushToast && pushToast({ kind: "success", title: "File created", detail: rel });
+    } catch (err) {
+      pushToast && pushToast({
+        kind: "error",
+        title: "Create failed",
+        detail: ST_errDetail(err, "Create failed"),
+        requestId: err && err.requestId,
+      });
+    }
+  }
+
+  async function handleNewFolderIn(dir) {
+    var raw = await promptDialog({
+      title: "New folder",
+      label: "Folder name",
+      message: "New folder in " + (dir || "root"),
+      placeholder: "src",
+    });
+    if (raw == null) return;
+    var name = String(raw).trim();
+    if (!name) return;
+    var rel = ST_pathJoin(dir, name);
+    try {
+      await apiFetch(
+        "POST",
+        "/workspaces/" + encodeURIComponent(wid) + "/files/dir?path=" + encodeURIComponent(rel)
+      );
+      handleRefresh();
+      pushToast && pushToast({ kind: "success", title: "Folder created", detail: rel });
+    } catch (err) {
+      pushToast && pushToast({
+        kind: "error",
+        title: "Create failed",
+        detail: ST_errDetail(err, "Create failed"),
+        requestId: err && err.requestId,
+      });
+    }
+  }
+
+  // -- Rename / move tab remap --------------------------------------------
+  // After a rename/move, repoint any OPEN editor tab at the file's new path so
+  // a surviving tab doesn't go stale (a stale tab could silently re-create the
+  // old file on save). For a file we remap its exact tab; for a folder we remap
+  // every descendant file tab (prefix "file:<old>/"), keeping their basenames.
+  function ST_remapTabsForMove(oldPath, newPath, isDir) {
+    if (!studio.renameTab) return;
+    var openTabs = s.openTabs || [];
+    var selfId = "file:" + oldPath;
+    var childPrefix = "file:" + oldPath + "/";
+    for (var i = 0; i < openTabs.length; i++) {
+      var tid = openTabs[i].id;
+      if (!isDir && tid === selfId) {
+        studio.renameTab(tid, { id: "file:" + newPath, ref: newPath, title: ST_pathBase(newPath) });
+      } else if (isDir && tid.indexOf(childPrefix) === 0) {
+        var oldFilePath = tid.slice("file:".length); // oldPath + "/sub/x"
+        var suffix = oldFilePath.slice(oldPath.length); // "/sub/x"
+        var newFilePath = newPath + suffix;
+        studio.renameTab(tid, { id: "file:" + newFilePath, ref: newFilePath });
+      }
+    }
+  }
+
+  // -- Rename (context-menu action) ----------------------------------------
+  // Prompt for a new basename (default = current), POST the move within the
+  // same parent dir, remap open tabs, refresh, toast. No move endpoint existed
+  // before this feature (see POST /files/move); the backend rejects a collision
+  // / escape, surfaced here as an error toast.
+  async function handleRename(item) {
+    var isDir = !!item.is_dir;
+    var oldPath = item.path;
+    var base = ST_pathBase(oldPath);
+    var dir = ST_pathDir(oldPath);
+    var raw = await promptDialog({
+      title: isDir ? "Rename folder" : "Rename file",
+      label: "New name",
+      message: "Rename \"" + base + "\" to:",
+      defaultValue: base,
+      placeholder: base,
+    });
+    if (raw == null) return;
+    var name = String(raw).trim();
+    if (!name || name === base) return;
+    var dst = ST_pathJoin(dir, name);
+    try {
+      await apiFetch(
+        "POST",
+        "/workspaces/" + encodeURIComponent(wid) + "/files/move?src=" +
+          encodeURIComponent(oldPath) + "&dst=" + encodeURIComponent(dst)
+      );
+      ST_remapTabsForMove(oldPath, dst, isDir);
+      handleRefresh();
+      pushToast && pushToast({
+        kind: "success",
+        title: isDir ? "Folder renamed" : "File renamed",
+        detail: name,
+      });
+    } catch (err) {
+      pushToast && pushToast({
+        kind: "error",
+        title: "Rename failed",
+        detail: ST_errDetail(err, "Rename failed"),
+        requestId: err && err.requestId,
+      });
+    }
+  }
+
+  // -- Drag-to-move --------------------------------------------------------
+  // Move `srcPath` into `folderPath` via the move endpoint. Guards no-ops:
+  // dropping onto itself, into a descendant of itself, or into the folder it
+  // already lives in.
+  async function doMove(srcPath, isDir, folderPath) {
+    if (folderPath === srcPath || folderPath.indexOf(srcPath + "/") === 0) return; // self/descendant
+    if (ST_pathDir(srcPath) === folderPath) return; // already here
+    var dst = ST_pathJoin(folderPath, ST_pathBase(srcPath));
+    try {
+      await apiFetch(
+        "POST",
+        "/workspaces/" + encodeURIComponent(wid) + "/files/move?src=" +
+          encodeURIComponent(srcPath) + "&dst=" + encodeURIComponent(dst)
+      );
+      ST_remapTabsForMove(srcPath, dst, isDir);
+      handleRefresh();
+      pushToast && pushToast({
+        kind: "success",
+        title: "Moved",
+        detail: ST_pathBase(srcPath) + " → " + folderPath,
+      });
+    } catch (err) {
+      pushToast && pushToast({
+        kind: "error",
+        title: "Move failed",
+        detail: ST_errDetail(err, "Move failed"),
+        requestId: err && err.requestId,
+      });
+    }
+  }
+
+  // -- Context-menu action dispatch ----------------------------------------
+  function handleCtxAction(action, item) {
+    if (action === "open") handleFileClick(item);
+    else if (action === "download") ST_triggerDownload(wid, item.path);
+    else if (action === "rename") handleRename(item);
+    else if (action === "delete") handleDelete(item);
+    else if (action === "new-file") handleNewFileIn(item.path);
+    else if (action === "new-folder") handleNewFolderIn(item.path);
+    else if (action === "upload") handleUploadIn(item.path);
+  }
+
+  // -- Drag helpers (rows are drag SOURCES; folders + root are drop TARGETS) --
+  // dragstart stamps the source path/kind onto the DataTransfer so a drop can
+  // tell an internal row-move from an external OS-file upload.
+  function ST_dragStartRow(item, e) {
+    if (!e.dataTransfer) return;
+    e.dataTransfer.setData(
+      "application/x-primer-file",
+      JSON.stringify({ path: item.path, is_dir: !!item.is_dir })
+    );
+    e.dataTransfer.setData("text/plain", item.path);
+    e.dataTransfer.effectAllowed = "move";
+  }
+
+  // True when the drag carries OS files (upload) vs an internal row (move).
+  function ST_isFileDrag(e) {
+    var types = e.dataTransfer ? e.dataTransfer.types : null;
+    if (!types) return false;
+    if (types.indexOf) return types.indexOf("Files") !== -1;
+    if (types.contains) return types.contains("Files");
+    return false;
+  }
+
+  function ST_dragOverFolder(item, e) {
+    if (!item.is_dir) return; // only folders accept drops
+    e.preventDefault();
+    e.stopPropagation();
+    if (e.dataTransfer) e.dataTransfer.dropEffect = ST_isFileDrag(e) ? "copy" : "move";
+    setDropTarget(item.path);
+  }
+
+  function ST_dragLeaveFolder(item) {
+    setDropTarget(function (cur) { return cur === item.path ? null : cur; });
+  }
+
+  async function ST_dropOnFolder(item, e) {
+    if (!item.is_dir) return;
+    e.preventDefault();
+    e.stopPropagation();
+    setDropTarget(null);
+    var dt = e.dataTransfer;
+    if (dt && dt.files && dt.files.length) {
+      // OS files → upload INTO this folder.
+      await ST_uploadInto(item.path, dt.files);
+      return;
+    }
+    // Internal row → move INTO this folder.
+    var raw = dt ? dt.getData("application/x-primer-file") : "";
+    if (!raw) return;
+    var src = null;
+    try { src = JSON.parse(raw); } catch (_e) { return; }
+    if (!src || !src.path) return;
+    await doMove(src.path, !!src.is_dir, item.path);
+  }
+
+  // Tree-root drop target ("." sentinel): OS-file drops only (upload to root).
+  function ST_dragOverRoot(e) {
+    if (!ST_isFileDrag(e)) return; // internal moves need a folder target
+    e.preventDefault();
+    setDropTarget(".");
+  }
+  function ST_dragLeaveRoot() {
+    setDropTarget(function (cur) { return cur === "." ? null : cur; });
+  }
+  async function ST_dropOnRoot(e) {
+    var dt = e.dataTransfer;
+    if (!(dt && dt.files && dt.files.length)) return;
+    e.preventDefault();
+    setDropTarget(null);
+    await ST_uploadInto("", dt.files);
   }
 
   // Flatten the tree into a list of rows for rendering, respecting expansion.
@@ -1083,7 +1532,19 @@ function FilesTree({ wid, studio }) {
 
       {/* File tree */}
       {s.filesOpen && (
-        <div className="st-section-body" style={{ paddingBottom: 6 }}>
+        <div
+          className="st-section-body"
+          data-testid="files-tree-body"
+          onDragOver={ST_dragOverRoot}
+          onDragLeave={ST_dragLeaveRoot}
+          onDrop={ST_dropOnRoot}
+          style={{
+            paddingBottom: 6,
+            outline: dropTarget === "." ? "1px solid var(--accent)" : "none",
+            outlineOffset: "-2px",
+            background: dropTarget === "." ? "var(--accent-dim)" : undefined,
+          }}
+        >
           {rootRes.loading && flatRows.length === 0 && (
             <div style={{ padding: "8px 12px", fontSize: 11, color: "var(--text-4)" }}>Loading…</div>
           )}
@@ -1123,6 +1584,8 @@ function FilesTree({ wid, studio }) {
             var isExpanded = !!s.expanded[item.path];
             var iconColor = ST_fileIconColor(item);
             var iconName = ST_fileIconName(item);
+            // Highlight a folder row while a drag hovers it (upload or move).
+            var isDropTarget = item.is_dir && dropTarget === item.path;
 
             return (
               <div
@@ -1131,6 +1594,7 @@ function FilesTree({ wid, studio }) {
                 data-testid="file-row"
                 role="button"
                 tabIndex={0}
+                draggable={true}
                 onClick={function() {
                   if (item.is_dir) {
                     handleFolderClick(item);
@@ -1145,6 +1609,18 @@ function FilesTree({ wid, studio }) {
                     handleFileClick(item);
                   }
                 })}
+                onContextMenu={function(e) {
+                  // Open the right-click menu; preventDefault suppresses the
+                  // native browser menu, stopPropagation keeps the row's
+                  // open/toggle click from firing.
+                  e.preventDefault();
+                  e.stopPropagation();
+                  setCtxMenu({ item: item, x: e.clientX, y: e.clientY });
+                }}
+                onDragStart={function(e) { ST_dragStartRow(item, e); }}
+                onDragOver={function(e) { ST_dragOverFolder(item, e); }}
+                onDragLeave={function() { ST_dragLeaveFolder(item); }}
+                onDrop={function(e) { ST_dropOnFolder(item, e); }}
                 style={{
                   display: "flex",
                   alignItems: "center",
@@ -1152,7 +1628,11 @@ function FilesTree({ wid, studio }) {
                   paddingLeft: (depth * 16 + 8) + "px",
                   paddingRight: 8,
                   cursor: "pointer",
-                  background: isActive ? "var(--bg-active)" : "transparent",
+                  background: isDropTarget
+                    ? "var(--accent-dim)"
+                    : (isActive ? "var(--bg-active)" : "transparent"),
+                  outline: isDropTarget ? "1px solid var(--accent)" : "none",
+                  outlineOffset: "-1px",
                 }}
               >
                 {/* Chevron column */}
@@ -1211,6 +1691,17 @@ function FilesTree({ wid, studio }) {
           })}
         </div>
       )}
+
+      {/* Right-click context menu (file/folder actions). Rendered last so its
+          position:fixed overlay sits above the tree; closes on outside-click
+          or Escape (handled inside ST_FileContextMenu). */}
+      {ctxMenu && (
+        <ST_FileContextMenu
+          menu={ctxMenu}
+          onAction={handleCtxAction}
+          onClose={function() { setCtxMenu(null); }}
+        />
+      )}
     </div>
   );
 }
@@ -1238,6 +1729,7 @@ function StudioSidebar({ wid, studio }) {
 window.StudioSidebar = StudioSidebar;
 window.SessionsSection = SessionsSection;
 window.FilesTree = FilesTree;
+window.ST_FileContextMenu = ST_FileContextMenu;
 window.ST_SessionDeleteDialog = ST_SessionDeleteDialog;
 window.ST_SessionRenameDialog = ST_SessionRenameDialog;
 window.ST_sessionStatus = ST_sessionStatus;

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -331,6 +331,35 @@ function useStudioState(wid, initialOpen) {
     });
   }, []);
 
+  // Rename an open tab in place: remap its id/ref/title (and carry its
+  // fileMode across to the new id) WITHOUT changing its position in the tab
+  // bar or its preview/edit mode. Used by the Files tree when a file/folder is
+  // renamed or moved on disk so an already-open editor tab keeps pointing at
+  // the file's new path instead of going stale (a stale tab could silently
+  // re-create the old file on save). No-op when no tab matches `oldId`.
+  var renameTab = React.useCallback(function (oldId, patchTab) {
+    setState(function (s) {
+      var prev = s.openTabs || [];
+      var idx = prev.findIndex(function (t) { return t.id === oldId; });
+      if (idx < 0) return s;
+      var newId = patchTab && patchTab.id ? patchTab.id : oldId;
+      var openTabs = prev.slice();
+      openTabs[idx] = Object.assign({}, openTabs[idx], patchTab);
+      var fileModes = s.fileModes;
+      if (fileModes && fileModes[oldId] !== undefined && newId !== oldId) {
+        fileModes = Object.assign({}, fileModes);
+        fileModes[newId] = fileModes[oldId];
+        delete fileModes[oldId];
+      }
+      var activeTabId = s.activeTabId === oldId ? newId : s.activeTabId;
+      return Object.assign({}, s, {
+        openTabs: openTabs,
+        activeTabId: activeTabId,
+        fileModes: fileModes,
+      });
+    });
+  }, []);
+
   // ---- left sidebar toggles ----
   var toggleSessions = React.useCallback(function () {
     setState(function (s) { return Object.assign({}, s, { sessionsOpen: !s.sessionsOpen }); });
@@ -411,6 +440,7 @@ function useStudioState(wid, initialOpen) {
     focusTab: focusTab,
     closeTab: closeTab,
     closeAllTabs: closeAllTabs,
+    renameTab: renameTab,
     toggleSessions: toggleSessions,
     toggleFiles: toggleFiles,
     toggleHidden: toggleHidden,


### PR DESCRIPTION
Adds rich file interactions to the Studio Files tree (0.2.0 batch, bug #3).

- **Right-click context menu** on rows: files -> Open/Download/Rename/Delete; folders -> New file/folder here, Upload here, Rename, Delete.
- **Rename** and **drag-to-move** via a new backend endpoint `POST /v1/workspaces/{id}/files/move?src=&dst=` (`Workspace.move_file`; safety mirrors delete: in-root, reserved-path + conflict + self/descendant guards).
- **Drag-drop upload:** OS files dropped on a folder upload into it (base64 PUT); drag distinguishes OS-file drops from in-tree row moves via a typed dataTransfer payload.

Verified: 18 UI + 16 backend tests; live-smoke confirmed the right-click menu with all four actions.