### PR TITLE
feat(studio): enlarge New session into a modal + file attachments

### DIFF
--- a/tests/ui/test_new_session_modal_attach.py
+++ b/tests/ui/test_new_session_modal_attach.py
@@ -1,7 +1,9 @@
 """The Studio "New session" create form was enlarged from a small positioned
 overlay into a proper centered Modal (reusing the shared ``Modal`` from
-shared.jsx) with a LARGE multi-line instructions box so a detailed prompt can
-be pasted.
+shared.jsx) with a LARGE multi-line instructions box, and gained a multi-file
+"Attach files" control whose files are base64-uploaded into the workspace
+(``attachments/<name>``) BEFORE the session is created and then referenced in
+the initial instructions so the agent knows about them.
 
 These are structural (source-text) checks, matching the style of the other
 new-session-form tests in this suite.
@@ -56,6 +58,62 @@ def test_form_keeps_testid_and_name_field() -> None:
     # Testids preserved through the enlargement.
     assert 'data-testid="new-session-form"' in src
     assert 'data-testid="new-session-name"' in src
+
+
+# ---------------------------------------------------------------------------
+# 2. Multi-file "Attach files" control
+# ---------------------------------------------------------------------------
+
+
+def test_attach_input_is_multi_file() -> None:
+    src = _src()
+    # A multi-file <input type="file"> exists for picking attachments.
+    assert 'data-testid="new-session-attach-input"' in src
+    assert 'type="file"' in src
+    assert "multiple" in src
+
+
+def test_attach_list_and_remove_exist() -> None:
+    src = _src()
+    # Picked files are listed, each with a remove control.
+    assert 'data-testid="new-session-attach-list"' in src
+    assert 'data-testid="new-session-attach-item"' in src
+    assert 'data-testid="new-session-attach-remove"' in src
+    assert "removeAttachment(" in src
+
+
+# ---------------------------------------------------------------------------
+# 3. Create uploads (base64 PUT) BEFORE creating the session + references paths
+# ---------------------------------------------------------------------------
+
+
+def test_upload_is_base64_put_before_create() -> None:
+    src = _src()
+    up = src.index('"PUT"')
+    create = src.index("create.mutate(body)")
+    assert up < create, "attachments must be PUT-uploaded before the session is created"
+    # Base64 upload to the workspace files API, under attachments/.
+    assert 'encoding: "base64"' in src
+    assert '"attachments/" + att.name' in src
+    assert "SharedNewSessionFileToBase64" in src
+
+
+def test_upload_failure_blocks_session_create() -> None:
+    src = _src()
+    # A failed upload surfaces a toast and returns WITHOUT creating the session.
+    assert "Attachment upload failed" in src
+    # The early-return guard sits before the create call in source order.
+    guard = src.index("submittingRef.current = false;\n        return;")
+    create = src.index("create.mutate(body)")
+    assert guard < create
+
+
+def test_uploaded_paths_referenced_in_instructions() -> None:
+    src = _src()
+    # The uploaded paths are appended to initial_instructions.
+    assert '"Attached files: "' in src
+    assert "uploadedPaths" in src
+    assert "body.initial_instructions = instrText" in src
 
 
 def test_bundle_transpiles_with_enlarged_form() -> None:

--- a/tests/ui/test_new_session_modal_attach.py
+++ b/tests/ui/test_new_session_modal_attach.py
@@ -1,0 +1,66 @@
+"""The Studio "New session" create form was enlarged from a small positioned
+overlay into a proper centered Modal (reusing the shared ``Modal`` from
+shared.jsx) with a LARGE multi-line instructions box so a detailed prompt can
+be pasted.
+
+These are structural (source-text) checks, matching the style of the other
+new-session-form tests in this suite.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SHARED_FORM = UI / "components" / "new-session-form.jsx"
+
+
+def _src() -> str:
+    return SHARED_FORM.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# 1. Enlarged into a proper centered Modal
+# ---------------------------------------------------------------------------
+
+
+def test_form_renders_via_shared_modal() -> None:
+    src = _src()
+    # The form body is rendered inside the shared <Modal> (centered overlay
+    # with Escape / backdrop-click / Cancel close), titled "New session".
+    assert "<Modal" in src
+    assert 'title="New session"' in src
+    # The old positioned "inline" overlay chrome is gone.
+    assert 'if (variant === "inline")' not in src
+    assert 'position: "absolute"' not in src
+
+
+def test_modal_is_comfortably_wide() -> None:
+    src = _src()
+    # A width override opts out of the default 420px .modal cap so the form is
+    # wide enough to paste a detailed prompt.
+    assert 'width="min(94vw, 640px)"' in src
+
+
+def test_instructions_textarea_is_large() -> None:
+    src = _src()
+    # The Initial instructions box is multi-line, tall, and resizable.
+    assert 'data-testid="new-session-instructions"' in src
+    assert "rows={8}" in src
+    assert 'resize: "vertical"' in src
+
+
+def test_form_keeps_testid_and_name_field() -> None:
+    src = _src()
+    # Testids preserved through the enlargement.
+    assert 'data-testid="new-session-form"' in src
+    assert 'data-testid="new-session-name"' in src
+
+
+def test_bundle_transpiles_with_enlarged_form() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    assert "/* === components/new-session-form.jsx === */" in body.decode("utf-8")

--- a/ui/components/new-session-form.jsx
+++ b/ui/components/new-session-form.jsx
@@ -132,6 +132,23 @@ function SharedNewSessionSchemaField({ propKey, schema, value, onChange }) {
   );
 }
 
+// Read a File as raw base64 — the data: URL payload minus its
+// "data:<mime>;base64," prefix — so it can be PUT with encoding:"base64",
+// mirroring the Studio Files-tree Upload. Unique top-level name so the
+// flat-bundle dup-decl lint (FD3) stays green.
+function SharedNewSessionFileToBase64(file) {
+  return new Promise(function (resolve, reject) {
+    var reader = new FileReader();
+    reader.onload = function () {
+      var result = String(reader.result || "");
+      var comma = result.indexOf(",");
+      resolve(comma >= 0 ? result.slice(comma + 1) : result);
+    };
+    reader.onerror = function () { reject(reader.error || new Error("read failed")); };
+    reader.readAsDataURL(file);
+  });
+}
+
 function SharedNewSessionForm(props) {
   var fixedWid = props.wid || null;
   var onCreated = props.onCreated || function () {};
@@ -176,6 +193,14 @@ function SharedNewSessionForm(props) {
   // Dynamic Begin.input_schema form state for the graph binding, keyed by
   // property name. Reset whenever the selected graph (or kind) changes.
   var [graphInputDraft, setGraphInputDraft] = React.useState({});
+  // Files to attach: each is uploaded into the workspace (base64 PUT) BEFORE
+  // the session is created, then its path is referenced in the initial
+  // instructions so the agent knows about it. `key` gives each row a stable
+  // identity for the list + remove control.
+  var [attachments, setAttachments] = React.useState([]);
+  var [uploading, setUploading] = React.useState(false);
+  var attachInputRef = React.useRef(null);
+  var attachSeqRef = React.useRef(0);
 
   // Look up the selected graph + its Begin node to drive the dynamic form.
   var selectedGraph = graphItems.find(function (g) { return g.id === graphId; }) || null;
@@ -229,13 +254,75 @@ function SharedNewSessionForm(props) {
   var canSubmit =
     !loading
     && !create.loading
+    && !uploading
     && effectiveWid
     && (kind === "agent" ? !!agentId : !!graphId);
+
+  // Append newly-picked files to the attachment list. The input is reset so
+  // re-picking the SAME file fires another change event.
+  function onAttachChange(e) {
+    var input = e.target;
+    var picked = (input && input.files) ? Array.prototype.slice.call(input.files) : [];
+    if (picked.length > 0) {
+      setAttachments(function (prev) {
+        var next = prev.slice();
+        picked.forEach(function (f) {
+          attachSeqRef.current += 1;
+          next.push({ key: "att-" + attachSeqRef.current, file: f, name: f.name });
+        });
+        return next;
+      });
+    }
+    if (input) input.value = "";
+  }
+
+  function removeAttachment(key) {
+    setAttachments(function (prev) {
+      return prev.filter(function (a) { return a.key !== key; });
+    });
+  }
 
   async function onSubmit(e) {
     if (e && e.preventDefault) e.preventDefault();
     if (!canSubmit || submittingRef.current) return;
     submittingRef.current = true;
+
+    // Attachments only apply to the free-text instructions flow (a graph's
+    // Begin.input_schema form submits structured `graph_input` instead, with
+    // no instructions to reference the files from). Upload each file into the
+    // workspace FIRST — if ANY upload fails, surface it and DO NOT create the
+    // session, so a run never starts against a half-uploaded set of files.
+    var uploadedPaths = [];
+    if (!usesGraphInputForm && attachments.length > 0) {
+      setUploading(true);
+      var failures = [];
+      for (var i = 0; i < attachments.length; i++) {
+        var att = attachments[i];
+        var relPath = "attachments/" + att.name;
+        try {
+          var b64 = await SharedNewSessionFileToBase64(att.file);
+          await apiFetch(
+            "PUT",
+            "/workspaces/" + encodeURIComponent(effectiveWid) + "/files?path=" + encodeURIComponent(relPath),
+            { content: b64, encoding: "base64" }
+          );
+          uploadedPaths.push(relPath);
+        } catch (err) {
+          failures.push(att.name + ": " + ((err && (err.detail || err.message)) || "upload failed"));
+        }
+      }
+      setUploading(false);
+      if (failures.length > 0) {
+        pushToast && pushToast({
+          kind: "error",
+          title: "Attachment upload failed",
+          detail: failures.join("; "),
+        });
+        submittingRef.current = false;
+        return;
+      }
+    }
+
     var binding = kind === "agent"
       ? { kind: "agent", agent_id: agentId }
       : { kind: "graph", graph_id: graphId };
@@ -245,8 +332,15 @@ function SharedNewSessionForm(props) {
       // Submit the schema-driven object as `graph_input`; the server validates
       // against Begin.input_schema at session-create time.
       body.graph_input = graphInputDraft;
-    } else if (instructions.trim()) {
-      body.initial_instructions = instructions.trim();
+    } else {
+      // Reference the uploaded attachment paths in the instructions so the
+      // agent knows the files exist in its workspace.
+      var instrText = instructions.trim();
+      if (uploadedPaths.length > 0) {
+        var refLine = "Attached files: " + uploadedPaths.join(", ");
+        instrText = instrText ? (instrText + "\n\n" + refLine) : refLine;
+      }
+      if (instrText) body.initial_instructions = instrText;
     }
     try {
       var session = await create.mutate(body);
@@ -262,8 +356,7 @@ function SharedNewSessionForm(props) {
     ? (createErr.detail || createErr.message || "Failed to create session")
     : null;
 
-  // Shared field body — identical markup for both variants (design-system
-  // classes); only the outer chrome + action buttons differ.
+  // Field body rendered inside the Modal (design-system classes).
   var fields = (
     <>
       <div className="field">
@@ -363,18 +456,78 @@ function SharedNewSessionForm(props) {
           );
         })
       ) : (
-        <div className="field">
-          <label className="field-label">Initial instructions</label>
-          <textarea
-            data-testid="new-session-instructions"
-            className="textarea"
-            value={instructions}
-            onChange={function (e) { setInstructions(e.target.value); }}
-            rows={8}
-            style={{ minHeight: 150, resize: "vertical" }}
-            placeholder="Tell the agent what to do — paste a detailed prompt here…"
-          />
-        </div>
+        <>
+          <div className="field">
+            <label className="field-label">Initial instructions</label>
+            <textarea
+              data-testid="new-session-instructions"
+              className="textarea"
+              value={instructions}
+              onChange={function (e) { setInstructions(e.target.value); }}
+              rows={8}
+              style={{ minHeight: 150, resize: "vertical" }}
+              placeholder="Tell the agent what to do — paste a detailed prompt here…"
+            />
+          </div>
+          <div className="field">
+            <label className="field-label">Attach files</label>
+            {/* Hidden multi-file input driven by the button (mirrors the Studio
+                Files-tree Upload). Hidden inputs (display:none) are skipped by
+                the Modal focus-trap, so they won't steal focus. */}
+            <input
+              ref={attachInputRef}
+              type="file"
+              multiple
+              data-testid="new-session-attach-input"
+              style={{ display: "none" }}
+              onChange={onAttachChange}
+            />
+            <Btn
+              kind="ghost"
+              size="sm"
+              icon="paperclip"
+              onClick={function () { if (attachInputRef.current) attachInputRef.current.click(); }}
+            >
+              Attach files
+            </Btn>
+            {attachments.length > 0 && (
+              <ul
+                data-testid="new-session-attach-list"
+                style={{ listStyle: "none", margin: "8px 0 0", padding: 0, display: "flex", flexDirection: "column", gap: 4 }}
+              >
+                {attachments.map(function (att) {
+                  return (
+                    <li
+                      key={att.key}
+                      data-testid="new-session-attach-item"
+                      style={{
+                        display: "flex", alignItems: "center", gap: 7, fontSize: 12,
+                        background: "var(--bg-2)", border: "1px solid var(--border)",
+                        borderRadius: 6, padding: "5px 8px",
+                      }}
+                    >
+                      <Icon name="file" size={12} />
+                      <span style={{ flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                        {att.name}
+                      </span>
+                      <button
+                        type="button"
+                        data-testid="new-session-attach-remove"
+                        title="Remove attachment"
+                        aria-label={"Remove " + att.name}
+                        onClick={function () { removeAttachment(att.key); }}
+                        style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-3)", fontSize: 14, lineHeight: 1, padding: "0 2px" }}
+                      >×</button>
+                    </li>
+                  );
+                })}
+              </ul>
+            )}
+            <div className="field-help">
+              Uploaded to <code>attachments/</code> in the workspace and referenced in the instructions.
+            </div>
+          </div>
+        </>
       )}
       <div className="field">
         <label style={{ display: "inline-flex", alignItems: "center", gap: 8, cursor: "pointer" }}>
@@ -408,7 +561,7 @@ function SharedNewSessionForm(props) {
         <>
           <Btn kind="ghost" onClick={onCancel}>Cancel</Btn>
           <Btn kind="primary" icon="plus" onClick={onSubmit} disabled={!canSubmit}>
-            {create.loading ? "Creating…" : "Create"}
+            {uploading ? "Uploading…" : create.loading ? "Creating…" : "Create"}
           </Btn>
         </>
       }

--- a/ui/components/new-session-form.jsx
+++ b/ui/components/new-session-form.jsx
@@ -15,7 +15,10 @@
 // Props:
 //   wid        (string?)   — fixed workspace. When omitted, a workspace
 //                            selector is shown (the app-modal flow).
-//   variant    ("modal" | "inline", default "modal") — outer chrome.
+//   variant    (accepted for back-compat; the form now ALWAYS renders as a
+//               comfortably-sized centered Modal — the old "inline" positioned
+//               overlay used by the Studio sidebar was enlarged into this modal
+//               so a detailed prompt can be pasted into the big instructions box.)
 //   onCreated  (fn)        — called with the created session on success.
 //   onCancel   (fn)        — cancel / close.
 //   pushToast  (fn?)       — toast enqueuer; falls back to primerApi.toastPush.
@@ -130,7 +133,6 @@ function SharedNewSessionSchemaField({ propKey, schema, value, onChange }) {
 }
 
 function SharedNewSessionForm(props) {
-  var variant = props.variant || "modal";
   var fixedWid = props.wid || null;
   var onCreated = props.onCreated || function () {};
   var onCancel = props.onCancel || function () {};
@@ -364,11 +366,13 @@ function SharedNewSessionForm(props) {
         <div className="field">
           <label className="field-label">Initial instructions</label>
           <textarea
+            data-testid="new-session-instructions"
             className="textarea"
             value={instructions}
             onChange={function (e) { setInstructions(e.target.value); }}
-            rows={variant === "inline" ? 3 : 4}
-            placeholder="Tell the agent what to do…"
+            rows={8}
+            style={{ minHeight: 150, resize: "vertical" }}
+            placeholder="Tell the agent what to do — paste a detailed prompt here…"
           />
         </div>
       )}
@@ -390,48 +394,15 @@ function SharedNewSessionForm(props) {
     </>
   );
 
-  if (variant === "inline") {
-    // Positioned overlay chrome for the Studio sidebar's Sessions section.
-    return (
-      <div
-        style={{
-          position: "absolute",
-          top: 32,
-          left: 0,
-          right: 0,
-          zIndex: 20,
-          background: "var(--bg-elev)",
-          border: "1px solid var(--border-strong)",
-          borderRadius: 9,
-          boxShadow: "var(--shadow)",
-          padding: "12px 12px 10px",
-          margin: "4px 6px",
-        }}
-        data-testid="new-session-form"
-      >
-        <div className="st-row" style={{ marginBottom: 10 }}>
-          <span style={{ fontSize: 11, fontWeight: 700, textTransform: "uppercase", letterSpacing: "0.06em", color: "var(--text-3)", flex: 1 }}>New session</span>
-          <button
-            style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-3)", fontSize: 14, padding: "0 2px", lineHeight: 1 }}
-            onClick={onCancel}
-            title="Cancel"
-          >×</button>
-        </div>
-        {fields}
-        <div style={{ display: "flex", gap: 6, justifyContent: "flex-end", marginTop: 6 }}>
-          <Btn kind="ghost" size="sm" onClick={onCancel}>Cancel</Btn>
-          <Btn kind="primary" size="sm" icon="plus" onClick={onSubmit} disabled={!canSubmit}>
-            {create.loading ? "Creating…" : "Create"}
-          </Btn>
-        </div>
-      </div>
-    );
-  }
-
-  // Default: modal chrome (the app's global "New session" dialog).
+  // Enlarged, centered Modal chrome for BOTH call sites — the Studio sidebar's
+  // "+" / ⌘K palette "New session" (formerly a small positioned overlay) and
+  // the app-level global "New session" dialog. Comfortably wide, with a large
+  // multi-line Initial instructions box so a detailed prompt can be pasted.
+  // Escape / backdrop-click / Cancel all close via the shared Modal.
   return (
     <Modal
       title="New session"
+      width="min(94vw, 640px)"
       onClose={onCancel}
       footer={
         <>
@@ -442,7 +413,9 @@ function SharedNewSessionForm(props) {
         </>
       }
     >
-      {fields}
+      <div data-testid="new-session-form">
+        {fields}
+      </div>
     </Modal>
   );
 }


### PR DESCRIPTION
Enlarges the Studio 'New session' form and adds attachments (0.2.0 batch, bug #7).

- Renders via the shared `Modal` (min(94vw, 640px)) with a large 8-row instructions textarea.
- **Attach files:** multi-file input + list; on Create, each file is uploaded into the workspace (`attachments/<name>`, base64 PUT) BEFORE the session is created, an upload failure blocks create, and the uploaded paths are referenced in the instructions.

Applies to both the sidebar '+' and the ⌘K 'New session' (shared component).
Verified: 11 new tests, tests/ui green; live-smoke confirmed the modal, the 8-row textarea, and the attach input.