### PR TITLE
feat(agent): render system_prompt against ExecutionContext (chat/workspace switch)

### DIFF
--- a/primer/agent/base.py
+++ b/primer/agent/base.py
@@ -50,6 +50,7 @@ from primer.agent.events import (
     Subscription,
     _ExecutorToolResult,
 )
+from primer.agent.prompt_render import render_system_prompt
 from primer.agent.tool_manager import ToolExecutionManager
 from primer.model.chat import (
     ExtendedEvent,
@@ -66,6 +67,7 @@ from primer.model.except_ import (
     BadRequestError,
     PrimerError,
 )
+from primer.model.graph import build_execution_context
 
 
 if TYPE_CHECKING:
@@ -120,6 +122,10 @@ class _BaseAgentExecutor(ABC):
         self._tool_manager = tool_manager
         self._compaction = compaction or CompactionStrategy()
         self._principal = principal
+        # Ambient run context exposed to the system prompt as ``ctx``. Base is
+        # surface-agnostic -> memory default; subclasses override with the real
+        # surface (AgentExecutor -> "chat", WorkspaceAgentExecutor -> "workspace").
+        self._execution_context = build_execution_context()
         self._subscribers: dict[str, AgentEventSubscriber] = {}
         self._subscriber_lock = asyncio.Lock()
         self._last_input_tokens: int | None = None
@@ -329,7 +335,9 @@ class _BaseAgentExecutor(ABC):
         """Assemble the full prompt: system + history + new user input."""
         parts: list[Message] = []
         if self._agent.system_prompt:
-            sys_text = "\n\n".join(self._agent.system_prompt)
+            sys_text = render_system_prompt(
+                self._agent.system_prompt, self._execution_context
+            )
             parts.append(
                 Message(role="system", parts=[TextPart(text=sys_text)])
             )

--- a/primer/agent/executor.py
+++ b/primer/agent/executor.py
@@ -23,6 +23,7 @@ from primer.agent.compaction import CompactionStrategy
 from primer.agent.tool_manager import ToolExecutionManager
 from primer.model.chat import Message
 from primer.model.except_ import NotFoundError
+from primer.model.graph import build_execution_context
 from primer.model.storage import (
     CursorPage,
     FieldRef,
@@ -78,6 +79,9 @@ class AgentExecutor(_BaseAgentExecutor):
         self._thread_id = thread_id
         self._threads = thread_storage
         self._messages = message_storage
+        self._execution_context = build_execution_context(
+            surface="chat", principal=principal
+        )
 
     @property
     def thread_id(self) -> str:

--- a/primer/agent/prompt_render.py
+++ b/primer/agent/prompt_render.py
@@ -1,0 +1,86 @@
+"""Jinja renderer for agent system prompts (surface-aware via ExecutionContext).
+
+Mirrors the sandbox / StrictUndefined surface of :mod:`primer.graph.template`
+so agent system prompts and graph node templates share one Jinja vocabulary.
+The ``system_prompt`` list is joined with ``"\n\n"`` (unchanged join semantics)
+and rendered against the :class:`ExecutionContext`, exposed to the template as
+``ctx`` -- so a prompt can branch on ``ctx.surface`` ("chat" vs "workspace")
+and interpolate ``ctx.artifact_dir`` etc.
+
+The Jinja env is intentionally a sibling of the graph node-template env rather
+than a shared import: ``agent/`` must not import ``graph/`` (``graph/`` imports
+``agent/``). A future refactor may extract a common env factory.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from typing import Any
+
+from jinja2 import StrictUndefined, TemplateError
+from jinja2.exceptions import TemplateSyntaxError
+from jinja2.sandbox import SandboxedEnvironment
+
+from primer.model.except_ import BadRequestError
+from primer.model.graph import ExecutionContext
+
+
+def _fromjson(value: Any) -> Any:
+    if isinstance(value, str):
+        try:
+            return json.loads(value)
+        except json.JSONDecodeError as exc:
+            raise TemplateError(f"fromjson: invalid JSON: {exc}") from exc
+    return value
+
+
+_FENCE_BLOCK_RE = re.compile(r"```[^\n]*\n(.*?)```", re.DOTALL)
+_FENCE_LINE_RE = re.compile(r"^\s*```")
+
+
+def _strip_fences(value: Any) -> Any:
+    if not isinstance(value, str):
+        return value
+    blocks = _FENCE_BLOCK_RE.findall(value)
+    if blocks:
+        return "\n\n".join(b.strip("\n") for b in blocks)
+    if "```" in value:
+        kept = [ln for ln in value.splitlines() if not _FENCE_LINE_RE.match(ln)]
+        return "\n".join(kept)
+    return value
+
+
+_ENV: SandboxedEnvironment = SandboxedEnvironment(
+    undefined=StrictUndefined,
+    autoescape=False,
+    trim_blocks=False,
+    lstrip_blocks=False,
+)
+_ENV.filters["fromjson"] = _fromjson
+_ENV.filters["strip_fences"] = _strip_fences
+
+
+def render_system_prompt(
+    system_prompt: list[str], ctx: ExecutionContext
+) -> str:
+    """Join ``system_prompt`` with blank lines and render it against ``ctx``.
+
+    ``ctx`` is exposed to the template as ``ctx``. Raises
+    :class:`BadRequestError` on template syntax or render error (e.g. a
+    StrictUndefined miss), mirroring :mod:`primer.graph.template`.
+    """
+    joined = "\n\n".join(system_prompt)
+    try:
+        compiled = _ENV.from_string(joined)
+    except TemplateSyntaxError as exc:
+        raise BadRequestError(
+            f"render_system_prompt: template syntax error at line "
+            f"{exc.lineno}: {exc.message}"
+        ) from exc
+    try:
+        return compiled.render(ctx=ctx)
+    except TemplateError as exc:
+        raise BadRequestError(
+            f"render_system_prompt: render error: {exc!s}"
+        ) from exc

--- a/primer/agent/workspace_executor.py
+++ b/primer/agent/workspace_executor.py
@@ -25,6 +25,7 @@ from primer.agent.compaction import CompactionStrategy
 from primer.agent.tool_manager import ToolExecutionManager
 from primer.model.chat import Message
 from primer.model.except_ import ConflictError
+from primer.model.graph import build_execution_context
 from primer.model.workspace_session import (
     SessionStatus,
     _UserInputWaiting,
@@ -90,6 +91,12 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
             principal=principal,
         )
         self._session = session
+        self._execution_context = build_execution_context(
+            surface="workspace",
+            workspace_id=session.workspace_id,
+            session_id=session.session_id,
+            principal=principal,
+        )
         # Trailing :class:`Done.stop_reason` from the most recent
         # :meth:`invoke` call. ``None`` until the first invoke completes.
         # The worker pool's post-turn status mapper reads this to decide
@@ -165,10 +172,32 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
             files={"messages.jsonl": new_jsonl},
         )
 
+    async def _ensure_artifact_dir(self) -> None:
+        """Best-effort create ``<workspace_root>/artifacts/<session_id>/``.
+
+        Local repos only (sandbox repos have no local path and rely on
+        create-on-write via the workspace write tool). Never fatal.
+        """
+        root = self._session.workspace_root
+        if root is None:
+            return
+        artifact_dir = root / "artifacts" / self._session.session_id
+        try:
+            await asyncio.to_thread(
+                artifact_dir.mkdir, parents=True, exist_ok=True
+            )
+        except OSError as exc:  # noqa: BLE001 -- best-effort, never fatal
+            logger.warning(
+                "session %s: best-effort artifact dir create failed: %s",
+                self._session.session_id,
+                exc,
+            )
+
     # ---- Public surface override (drives session status) -----------------
 
     async def invoke(self, messages, *, response_format=None):
         """Drive the session through one user-driven turn."""
+        await self._ensure_artifact_dir()
         # Pre-turn boundary checks against the session's lifecycle.
         status = await self._session.status()
         if status == SessionStatus.ENDED:

--- a/primer/graph/_agent_node.py
+++ b/primer/graph/_agent_node.py
@@ -25,6 +25,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from primer.agent.loop import run_agent_turn
+from primer.agent.prompt_render import render_system_prompt
 from primer.agent.tool_manager import ToolExecutionManager
 from primer.graph._node_refs import _NodeDone, _PendingAgentYield
 from primer.graph.template import render_input_template
@@ -141,7 +142,7 @@ class _AgentNodeMixin:
         history = await self._load_node_history(node.id)
         prompt: list[Message] = []
         if agent.system_prompt:
-            sys_text = "\n\n".join(agent.system_prompt)
+            sys_text = render_system_prompt(agent.system_prompt, context.ctx)
             prompt.append(
                 Message(role="system", parts=[TextPart(text=sys_text)])
             )

--- a/primer/workspace/session.py
+++ b/primer/workspace/session.py
@@ -27,7 +27,7 @@ import json
 import logging
 import uuid
 from datetime import datetime, timezone
-from pathlib import PurePosixPath
+from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Literal
 
 from pydantic import TypeAdapter
@@ -256,6 +256,17 @@ class AgentSession:
     @property
     def workspace_id(self) -> str:
         return self._info.workspace_id
+
+    @property
+    def workspace_root(self) -> Path | None:
+        """Absolute workspace root (the ``.state`` repo's parent), or None.
+
+        Local repos expose ``.path`` (the ``.state/`` dir); its parent is the
+        workspace working root where ``artifacts/`` lives. Sandbox repos have no
+        local path -> None (callers rely on create-on-write).
+        """
+        state_path = getattr(self._state, "path", None)
+        return state_path.parent if state_path is not None else None
 
     @property
     def workspace_tools(self) -> list["WorkspaceTool"]:

--- a/tests/agent/test_executor_execution_context.py
+++ b/tests/agent/test_executor_execution_context.py
@@ -1,0 +1,34 @@
+"""Executors build the right ExecutionContext and render system prompts by surface.
+
+Reuses the chat-executor fixture from ``tests.agent.test_executor`` (established
+cross-module test-helper import pattern in this repo).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.agent.test_executor import _FakeLLM, _build_executor
+
+_WS_BLOCK = (
+    "Base prompt.\n\n"
+    "{% if ctx.surface == 'workspace' %}USE FILES {{ ctx.artifact_dir }}{% endif %}"
+)
+
+
+@pytest.mark.asyncio
+async def test_chat_execution_context_surface() -> None:
+    ex, *_ = await _build_executor(llm=_FakeLLM(scripts=[]), system_prompt=["hi"])
+    assert ex._execution_context.surface == "chat"
+    assert ex._execution_context.artifact_dir is None
+
+
+@pytest.mark.asyncio
+async def test_chat_build_prompt_omits_workspace_block() -> None:
+    ex, *_ = await _build_executor(
+        llm=_FakeLLM(scripts=[]), system_prompt=[_WS_BLOCK]
+    )
+    prompt = ex._build_prompt(history=[], new_messages=[])
+    sys_text = prompt[0].parts[0].text
+    assert "Base prompt." in sys_text
+    assert "USE FILES" not in sys_text

--- a/tests/agent/test_prompt_render.py
+++ b/tests/agent/test_prompt_render.py
@@ -1,0 +1,56 @@
+"""Tests for primer.agent.prompt_render.render_system_prompt."""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.agent.prompt_render import render_system_prompt
+from primer.model.except_ import BadRequestError
+from primer.model.graph import build_execution_context
+
+_BLOCK = (
+    "You are helpful.\n\n"
+    "{% if ctx.surface == 'workspace' %}"
+    "Persist work under {{ ctx.artifact_dir }} and reply with file refs. "
+    "Use inform_user and ask_user."
+    "{% endif %}"
+)
+
+
+def test_workspace_surface_renders_block() -> None:
+    ctx = build_execution_context(surface="workspace", session_id="sess-1")
+    out = render_system_prompt([_BLOCK], ctx)
+    assert "Persist work under artifacts/sess-1 and reply with file refs." in out
+    assert "inform_user and ask_user" in out
+
+
+def test_chat_surface_omits_block() -> None:
+    ctx = build_execution_context(surface="chat")
+    out = render_system_prompt([_BLOCK], ctx)
+    assert "You are helpful." in out
+    assert "Persist work under" not in out
+    assert "inform_user" not in out
+
+
+def test_join_semantics_preserved_for_plain_prompt() -> None:
+    ctx = build_execution_context(surface="chat")
+    out = render_system_prompt(["one", "two"], ctx)
+    assert out == "one\n\ntwo"
+
+
+def test_null_field_renders_none_not_raises() -> None:
+    ctx = build_execution_context(surface="chat")  # artifact_dir is None
+    out = render_system_prompt(["dir={{ ctx.artifact_dir }}"], ctx)
+    assert out == "dir=None"
+
+
+def test_typo_field_raises_bad_request() -> None:
+    ctx = build_execution_context(surface="workspace", session_id="s")
+    with pytest.raises(BadRequestError):
+        render_system_prompt(["{{ ctx.surfce }}"], ctx)  # typo: surfce
+
+
+def test_raw_block_passes_literal_braces() -> None:
+    ctx = build_execution_context(surface="chat")
+    out = render_system_prompt(["{% raw %}{{ literal }}{% endraw %}"], ctx)
+    assert out == "{{ literal }}"

--- a/tests/agent/test_workspace_executor_execution_context.py
+++ b/tests/agent/test_workspace_executor_execution_context.py
@@ -1,0 +1,69 @@
+"""WorkspaceAgentExecutor builds a workspace ExecutionContext and creates the
+per-session artifact directory. Reuses the live-session fixture from
+``tests.agent.test_workspace_executor`` (established cross-module pattern)."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from primer.agent.tool_manager import ToolExecutionManager
+from primer.agent.workspace_executor import WorkspaceAgentExecutor
+from primer.model.chat import Done, Message, TextDelta, TextPart
+from tests.agent.test_workspace_executor import (
+    _FakeLLM,
+    _agent,
+    _build_session,
+    _model,
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git CLI not available on PATH (StateRepo needs it)",
+)
+
+
+@pytest.mark.asyncio
+async def test_workspace_execution_context_and_artifact_dir(tmp_path: Path) -> None:
+    _backend, _workspace, session = await _build_session(tmp_path)
+    mgr = ToolExecutionManager.for_workspace(toolset_providers={}, session=session)
+    ex = WorkspaceAgentExecutor(
+        agent=_agent(system_prompt=["base"]),
+        llm=_FakeLLM(scripts=[]),  # type: ignore[arg-type]
+        llm_model=_model(),
+        tool_manager=mgr,
+        session=session,
+    )
+    ctx = ex._execution_context
+    assert ctx.surface == "workspace"
+    assert ctx.workspace_id == session.workspace_id
+    assert ctx.session_id == session.session_id
+    assert ctx.artifact_dir == f"artifacts/{session.session_id}"
+
+
+@pytest.mark.asyncio
+async def test_workspace_invoke_creates_artifact_dir(tmp_path: Path) -> None:
+    _backend, _workspace, session = await _build_session(tmp_path)
+    mgr = ToolExecutionManager.for_workspace(toolset_providers={}, session=session)
+    ex = WorkspaceAgentExecutor(
+        agent=_agent(system_prompt=["base"]),
+        llm=_FakeLLM(
+            scripts=[
+                [
+                    TextDelta(text="ok", index=0),
+                    Done(stop_reason="stop", raw_reason="stop"),
+                ]
+            ]
+        ),  # type: ignore[arg-type]
+        llm_model=_model(),
+        tool_manager=mgr,
+        session=session,
+    )
+    async for _ in ex.invoke([Message(role="user", parts=[TextPart(text="hi")])]):
+        pass
+
+    root = session.workspace_root
+    assert root is not None
+    assert (root / "artifacts" / session.session_id).is_dir()

--- a/tests/graph/test_agent_node_system_prompt_ctx.py
+++ b/tests/graph/test_agent_node_system_prompt_ctx.py
@@ -1,0 +1,99 @@
+"""A graph agent-node renders its agent's system_prompt against context.ctx,
+so a workspace run includes the {% if ctx.surface == 'workspace' %} block.
+
+Reuses the capturing _FakeLLM (records stream() messages) + _make_state_repo
+from tests.graph.test_workspace_executor."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from primer.graph.workspace_executor import WorkspaceGraphExecutor
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import Done, StreamEvent, TextDelta
+from primer.model.graph import (
+    Graph,
+    _AgentNodeRef,
+    _BeginNode,
+    _EndNode,
+    _StaticEdge,
+)
+from primer.model.provider import LLMModel
+from tests.graph.test_workspace_executor import _FakeLLM, _make_state_repo
+
+_WS_BLOCK = (
+    "Base.\n\n{% if ctx.surface == 'workspace' %}"
+    "USE-FILES {{ ctx.artifact_dir }}{% endif %}"
+)
+
+
+class _FakeWorkspaceSession:
+    workspace_id = "ws-test"
+    session_id = "sess-test"
+    agent_id = "agent-fake"
+    system_prompt_fragment = "<<FRAGMENT>>"
+
+    def __init__(self) -> None:
+        self.workspace_tools: list = []
+
+
+async def _drain(it) -> list[StreamEvent]:
+    return [ev async for ev in it]
+
+
+@pytest.mark.asyncio
+async def test_graph_agent_node_includes_workspace_block(tmp_path: Path) -> None:
+    graph = Graph(
+        id="g-anode-ctx",
+        description="Begin -> Agent -> End",
+        nodes=[
+            _BeginNode(id="begin"),
+            _AgentNodeRef(id="A", agent_id="x", input_template="go"),
+            _EndNode(id="end", output_template="{{ nodes.A.text }}"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="A"),
+            _StaticEdge(from_node="A", to_node="end"),
+        ],
+    )
+    repo = await _make_state_repo(tmp_path, workspace_id="ws-test")
+    llm = _FakeLLM(
+        scripts=[
+            [
+                TextDelta(text="ok", index=0),
+                Done(stop_reason="stop", raw_reason="stop"),
+            ]
+        ]
+    )
+
+    async def agent_resolver(agent_id: str) -> Agent:
+        return Agent(
+            id="x",
+            description="x",
+            model=AgentModel(provider_id="p", model_name="m"),
+            system_prompt=[_WS_BLOCK],
+        )
+
+    async def llm_resolver(_a: Agent):
+        return (llm, LLMModel(name="m", context_length=128_000))
+
+    executor = WorkspaceGraphExecutor(
+        graph=graph,
+        agent_resolver=agent_resolver,
+        llm_resolver=llm_resolver,  # type: ignore[arg-type]
+        state_repo=repo,
+        graph_session_id="gsid-anode",
+        workspace_session=_FakeWorkspaceSession(),  # type: ignore[arg-type]
+        graph_input="seed",
+    )
+    await _drain(executor.invoke([]))
+
+    sys_texts: list[str] = []
+    for call in llm.calls:
+        for m in call["messages"]:
+            if getattr(m, "role", None) == "system":
+                sys_texts.append(m.parts[0].text)
+    joined = "\n".join(sys_texts)
+    assert "USE-FILES artifacts/gsid-anode" in joined


### PR DESCRIPTION
## Summary

Renders each agent's `system_prompt` through Jinja against the shared `ExecutionContext`, so a prompt can adapt to the surface it runs on — `{% if ctx.surface == 'workspace' %}…{% endif %}` — and interpolate `{{ ctx.artifact_dir }}` etc. This is the "companion effort" to PR #83 (node-template `ctx`): the model was built to serve both layers; this wires the agent side.

The motivating use: agents used as **graph nodes** on a workspace can now be told to persist detailed work to files and reply with file references, and to use `inform_user`/`ask_user` — behavior that switches off automatically in chat (where those tools don't exist). The behavioral prompt content itself is applied to agents as a separate data change.

Design spec: `docs/superpowers/specs/2026-07-04-agent-system-prompt-workspace-switch-design.md`.

## What changed

- **New shared renderer** `primer/agent/prompt_render.py` — `render_system_prompt(system_prompt, ctx)` joins with `"\n\n"` (unchanged) and renders through a `SandboxedEnvironment` + `StrictUndefined` configured identically to `primer/graph/template.py` (same `fromjson`/`strip_fences` filters), exposing only `ctx`. Lives in `agent/` (a leaf; `graph/` imports `agent/`, not vice-versa) → no circular import.
- **Centralized** across all three system-prompt assembly points: `_BaseAgentExecutor._build_prompt` (standalone chat + workspace) and `_agent_node.py` (graph agent-node, reusing `context.ctx`).
- **`ctx` per surface:** `AgentExecutor` → `surface="chat"`; `WorkspaceAgentExecutor` → `surface="workspace"` with `workspace_id`, `session_id`, `artifact_dir="artifacts/<session_id>"`, plus a best-effort mkdir at the workspace root; graph agent-node reuses the `context.ctx` PR #83 already threads.
- **`AgentSession.workspace_root`** — new public property (the `.state` repo's parent) backing the mkdir.
- **Unchanged (by design):** the workspace `system_prompt_fragment` (still tool-registration; plain text, renders as a Jinja no-op) and node-template rendering.

`StrictUndefined` preserved: a null field renders `None`, a typo raises; 0/20 live agents contain colliding tokens, and literal double-brace content wraps in `{% raw %}`.

## Test plan

- `tests/agent/test_prompt_render.py` — renderer: workspace block renders + `ctx.artifact_dir`, chat omits, null→`None`, typo raises, `{% raw %}` literal (6)
- `tests/agent/test_executor_execution_context.py` — chat surface ctx + `_build_prompt` omits the block (2)
- `tests/agent/test_workspace_executor_execution_context.py` — workspace surface ctx + `artifact_dir` + on-disk mkdir (2)
- `tests/graph/test_agent_node_system_prompt_ctx.py` — a graph agent-node's system prompt includes the block via `context.ctx` (1)
- Full `tests/agent tests/graph`: **507 passed, 0 failures**

## Follow-on (not in this PR)

Authoring the workspace behavioral block into the participating agents is a live **data** change applied after this merges and the server restarts on the new code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
