### PR TITLE
test: raise LLM-adapter and channel-factory coverage (~81% -> mid-80s)

### DIFF
--- a/tests/channel/discord/test_factory.py
+++ b/tests/channel/discord/test_factory.py
@@ -1,0 +1,830 @@
+"""Unit tests for the Discord adapter factory and installed gateway handlers.
+
+Covers ``primer.channel.discord.factory``: ``_route_channel_event``, the
+``on_message`` / ``on_interaction`` gateway handlers, the application-command
+callbacks (``/agent``, ``/help``, autocomplete), the tree-sync ``on_ready``
+hook, and the ``_discord_factory`` builder.
+
+A real (never-connected) ``discord.Client`` is used so the CommandTree and the
+ui.View / ui.Modal builders behave exactly as in production; the shared
+connection registry and the storage-backed command handlers are faked.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+discord = pytest.importorskip("discord")
+from discord import app_commands
+
+from pydantic import SecretStr
+
+from primer.channel.discord import factory as discord_factory
+from primer.channel.commands import CommandResult
+from primer.model.channel import (
+    Channel,
+    ChannelProvider,
+    ChannelProviderType,
+    DiscordChannelProviderConfig,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / helpers
+# --------------------------------------------------------------------------- #
+def _provider(pid: str = "cp-discord") -> ChannelProvider:
+    return ChannelProvider(
+        id=pid,
+        provider=ChannelProviderType.DISCORD,
+        config=DiscordChannelProviderConfig(
+            bot_token=SecretStr("x" * 40)),
+    )
+
+
+def _channel(cid: str = "ch-1", ext: str = "500") -> Channel:
+    return Channel(
+        id=cid, provider_id="cp-discord",
+        provider=ChannelProviderType.DISCORD, external_id=ext,
+    )
+
+
+class _FakeEntry:
+    def __init__(self, adapters: dict | None = None) -> None:
+        self.adapters_by_channel_id = adapters or {}
+
+
+class _FakeRegistry:
+    def __init__(self, entry) -> None:
+        self._entry = entry
+
+    def entry(self, provider_id):
+        return self._entry
+
+
+_UID = [0]
+
+
+def _uid() -> str:
+    _UID[0] += 1
+    return f"discord-prov-{_UID[0]}"
+
+
+def _fake_thread(tid: int, parent_id: int):
+    """A real ``discord.Thread`` instance (isinstance passes) without running
+    its heavy __init__ — a no-__slots__ subclass gives it a writable __dict__."""
+    cls = type("_FakeThread", (discord.Thread,), {})
+    obj = cls.__new__(cls)
+    obj.id = tid
+    obj.parent_id = parent_id
+    return obj
+
+
+def _fake_dm(cid: int = 321):
+    cls = type("_FakeDM", (discord.DMChannel,), {})
+    obj = cls.__new__(cls)
+    obj.id = cid
+    return obj
+
+
+def _mock_adapter(sp: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(
+        _sp=object() if sp else None,
+        _channel=_channel(),
+        _handle_decision=AsyncMock(),
+        _handle_text_reply=AsyncMock(),
+        handle_inbound_chat_message=AsyncMock(),
+    )
+
+
+def _client():
+    return discord.Client(intents=discord.Intents.none())
+
+
+def _install(monkeypatch, entry, channel=None):
+    pid = _uid()
+    monkeypatch.setattr(
+        discord_factory, "DISCORD_CONNECTIONS", _FakeRegistry(entry))
+    client = _client()
+    discord_factory._install_handlers(pid, client, channel or _channel())
+    return pid, client
+
+
+def _install_tree(monkeypatch, entry, channel=None):
+    pid = _uid()
+    monkeypatch.setattr(
+        discord_factory, "DISCORD_CONNECTIONS", _FakeRegistry(entry))
+    captured: list = []
+    real_cls = app_commands.CommandTree
+
+    def _cap(client, *a, **k):
+        tr = real_cls(client, *a, **k)
+        captured.append(tr)
+        return tr
+
+    monkeypatch.setattr(discord_factory.app_commands, "CommandTree", _cap)
+    client = _client()
+    discord_factory._install_handlers(pid, client, channel or _channel())
+    return pid, client, captured[0]
+
+
+def _message(channel, content="hi", bot=False, mid=42):
+    author = SimpleNamespace(bot=bot, id=1, display_name="Dee", name="dee")
+    return SimpleNamespace(
+        channel=channel, author=author, id=mid,
+        content=content, attachments=[])
+
+
+def _interaction(custom_id=None, parent_id=None, channel_id=100,
+                 msg_content="body", user_id=7):
+    data = {"custom_id": custom_id} if custom_id is not None else {}
+    return SimpleNamespace(
+        data=data,
+        channel=SimpleNamespace(parent_id=parent_id),
+        channel_id=channel_id,
+        response=SimpleNamespace(
+            edit_message=AsyncMock(), send_modal=AsyncMock(),
+            send_message=AsyncMock()),
+        message=SimpleNamespace(content=msg_content),
+        user=SimpleNamespace(id=user_id),
+    )
+
+
+# --------------------------------------------------------------------------- #
+# _route_channel_event
+# --------------------------------------------------------------------------- #
+def _patch_normalizer(monkeypatch, result):
+    class _N:
+        def __init__(self, provider_id):
+            pass
+
+        async def normalize(self, envelope):
+            return result
+
+    monkeypatch.setattr(
+        "primer.channel.discord.normalizer.DiscordEventNormalizer", _N)
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_no_router_returns_false():
+    adapter = SimpleNamespace(_event_router=lambda: None, _channel=_channel())
+    msg = _message(SimpleNamespace(id=1))
+    assert await discord_factory._route_channel_event(adapter, "p", msg) is False
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_normalized_none(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=True), route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, None)
+    msg = _message(SimpleNamespace(id=1))
+    assert await discord_factory._route_channel_event(adapter, "p", msg) is False
+    router.has_matching_rule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_text_no_match(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=False), route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, {"norm": True})
+    msg = _message(SimpleNamespace(id=9), content="text")
+    assert await discord_factory._route_channel_event(adapter, "p", msg) is False
+    router.route_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_thread_match_dispatches(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=True), route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, {"norm": True})
+    msg = _message(_fake_thread(11, 22))
+    assert await discord_factory._route_channel_event(adapter, "p", msg) is True
+    router.route_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_dm_channel_kind(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=True), route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    captured: dict = {}
+
+    class _N:
+        def __init__(self, provider_id):
+            pass
+
+        async def normalize(self, envelope):
+            captured.update(envelope["payload"]["channel"])
+            return {"norm": True}
+
+    monkeypatch.setattr(
+        "primer.channel.discord.normalizer.DiscordEventNormalizer", _N)
+    msg = _message(_fake_dm())
+    assert await discord_factory._route_channel_event(adapter, "p", msg) is True
+    assert captured["kind"] == "dm"
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_swallows_exception(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(side_effect=RuntimeError("boom")),
+        route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, {"norm": True})
+    msg = _message(SimpleNamespace(id=1))
+    assert await discord_factory._route_channel_event(adapter, "p", msg) is False
+
+
+# --------------------------------------------------------------------------- #
+# on_message
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_on_message_ignores_bot(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"555": adapter}))
+    await client.on_message(_message(SimpleNamespace(id=555), bot=True))
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_toplevel_chat_dispatch(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"555": adapter}))
+    monkeypatch.setattr(
+        discord_factory, "_route_channel_event", AsyncMock(return_value=False))
+    await client.on_message(_message(SimpleNamespace(id=555), content="hey", mid=42))
+    adapter.handle_inbound_chat_message.assert_awaited_once()
+    kw = adapter.handle_inbound_chat_message.await_args.kwargs
+    assert kw["thread_id"] is None
+    assert kw["message_id"] == "42"
+    assert kw["sender_name"] == "Dee"
+    assert kw["text"] == "hey"
+
+
+@pytest.mark.asyncio
+async def test_on_message_toplevel_rule_match_skips(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"555": adapter}))
+    monkeypatch.setattr(
+        discord_factory, "_route_channel_event", AsyncMock(return_value=True))
+    await client.on_message(_message(SimpleNamespace(id=555)))
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_toplevel_without_storage_is_noop(monkeypatch):
+    adapter = _mock_adapter(sp=False)
+    _, client = _install(monkeypatch, _FakeEntry({"555": adapter}))
+    await client.on_message(_message(SimpleNamespace(id=555)))
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_unknown_entry_is_noop(monkeypatch):
+    _, client = _install(monkeypatch, None)  # registry.entry -> None
+    # Should simply return without raising.
+    await client.on_message(_message(SimpleNamespace(id=1)))
+
+
+@pytest.mark.asyncio
+async def test_on_message_thread_session_reply(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"999": adapter}))
+    rec = SimpleNamespace(
+        kind="session", workspace_id="w", session_id="s", tool_call_id="t")
+    cleared: list = []
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            return rec
+
+        async def clear(self, cid, key):
+            cleared.append(key)
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    msg = _message(_fake_thread(777, 999), content="answer", mid=8)
+    await client.on_message(msg)
+    adapter._handle_text_reply.assert_awaited_once()
+    assert adapter._handle_text_reply.await_args.kwargs["text"] == "answer"
+    assert cleared == ["777"]
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_thread_chat_dispatch(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"999": adapter}))
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            return None
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    monkeypatch.setattr(
+        discord_factory, "_route_channel_event", AsyncMock(return_value=False))
+    msg = _message(_fake_thread(777, 999), content="chat", mid=8)
+    await client.on_message(msg)
+    adapter.handle_inbound_chat_message.assert_awaited_once()
+    kw = adapter.handle_inbound_chat_message.await_args.kwargs
+    assert kw["thread_id"] == "777"
+    assert kw["message_id"] == "8"
+
+
+@pytest.mark.asyncio
+async def test_on_message_thread_unknown_parent_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"999": adapter}))
+    # parent_id 12345 is not registered -> adapter None -> return.
+    await client.on_message(_message(_fake_thread(1, 12345)))
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+    adapter._handle_text_reply.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# on_interaction
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_on_interaction_no_custom_id_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    await client.on_interaction(_interaction(custom_id=None))
+    adapter._handle_decision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_interaction_undecodable_custom_id_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    await client.on_interaction(_interaction(custom_id="garbage"))
+    adapter._handle_decision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_interaction_approve(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    inter = _interaction(custom_id="approve:w:s:t", parent_id=None, channel_id=100)
+    await client.on_interaction(inter)
+    inter.response.edit_message.assert_awaited_once()
+    adapter._handle_decision.assert_awaited_once()
+    kw = adapter._handle_decision.await_args.kwargs
+    assert kw["decision"] == "approved"
+    assert kw["workspace_id"] == "w"
+    assert kw["user_id"] == 7
+
+
+@pytest.mark.asyncio
+async def test_on_interaction_approve_resolves_thread_parent(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"555": adapter}))
+    # parent_id set -> adapter resolved via the thread's parent channel id.
+    inter = _interaction(custom_id="approve:w:s:t", parent_id=555)
+    await client.on_interaction(inter)
+    adapter._handle_decision.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_on_interaction_approve_unknown_channel_is_noop(monkeypatch):
+    _, client = _install(monkeypatch, _FakeEntry({}))
+    inter = _interaction(custom_id="approve:w:s:t")
+    await client.on_interaction(inter)
+    inter.response.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_interaction_reject_opens_modal(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    inter = _interaction(custom_id="reject:w:s:t", channel_id=100)
+    await client.on_interaction(inter)
+    inter.response.send_modal.assert_awaited_once()
+    modal = inter.response.send_modal.await_args.args[0]
+    assert "reject" in modal.custom_id
+
+
+@pytest.mark.asyncio
+async def test_on_interaction_reject_unknown_channel_is_noop(monkeypatch):
+    _, client = _install(monkeypatch, _FakeEntry({}))
+    inter = _interaction(custom_id="reject:w:s:t")
+    await client.on_interaction(inter)
+    inter.response.send_modal.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# /agent application command
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_cmd_agent_not_configured(monkeypatch):
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({}))
+    cmd = tree.get_command("agent")
+    inter = _interaction(channel_id=1)
+    await cmd.callback(inter, value="")
+    inter.response.send_message.assert_awaited_once()
+    assert "not configured" in inter.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_cmd_agent_requires_thread(monkeypatch):
+    adapter = _mock_adapter()
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": adapter}))
+    cmd = tree.get_command("agent")
+    inter = _interaction(channel_id=1)  # channel is not a Thread
+    await cmd.callback(inter, value="")
+    msg = inter.response.send_message.await_args.args[0]
+    assert "chat thread" in msg
+
+
+@pytest.mark.asyncio
+async def test_cmd_agent_notice(monkeypatch):
+    adapter = _mock_adapter()
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": adapter}))
+    monkeypatch.setattr(
+        discord_factory, "handle_app_command",
+        AsyncMock(return_value=CommandResult(kind="notice", text="Switched.")))
+    cmd = tree.get_command("agent")
+    inter = _interaction()
+    inter.channel = _fake_thread(50, 1)
+    await cmd.callback(inter, value="a1")
+    inter.response.send_message.assert_awaited_once()
+    assert inter.response.send_message.await_args.args[0] == "Switched."
+
+
+@pytest.mark.asyncio
+async def test_cmd_agent_renders_picker(monkeypatch):
+    adapter = _mock_adapter()
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": adapter}))
+    monkeypatch.setattr(
+        discord_factory, "handle_app_command",
+        AsyncMock(return_value=CommandResult(
+            kind="agent_picker",
+            items=[{"label": "Agent A", "agent_id": "a1"}])))
+    cmd = tree.get_command("agent")
+    inter = _interaction()
+    inter.channel = _fake_thread(50, 1)
+    await cmd.callback(inter, value="")
+    inter.response.send_message.assert_awaited_once()
+    assert "view" in inter.response.send_message.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_cmd_agent_picker_empty(monkeypatch):
+    adapter = _mock_adapter()
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": adapter}))
+    monkeypatch.setattr(
+        discord_factory, "handle_app_command",
+        AsyncMock(return_value=CommandResult(kind="agent_picker", items=[])))
+    cmd = tree.get_command("agent")
+    inter = _interaction()
+    inter.channel = _fake_thread(50, 1)
+    await cmd.callback(inter, value="")
+    assert inter.response.send_message.await_args.args[0] == "No agents."
+
+
+@pytest.mark.asyncio
+async def test_cmd_agent_handler_error_surfaced(monkeypatch):
+    adapter = _mock_adapter()
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": adapter}))
+    monkeypatch.setattr(
+        discord_factory, "handle_app_command",
+        AsyncMock(side_effect=RuntimeError("boom")))
+    cmd = tree.get_command("agent")
+    inter = _interaction()
+    inter.channel = _fake_thread(50, 1)
+    await cmd.callback(inter, value="a1")
+    assert inter.response.send_message.await_args.args[0] == "boom"
+
+
+# --------------------------------------------------------------------------- #
+# /help application command
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_cmd_help_notice(monkeypatch):
+    adapter = _mock_adapter()
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": adapter}))
+    monkeypatch.setattr(
+        discord_factory, "handle_app_command",
+        AsyncMock(return_value=CommandResult(kind="notice", text="help stuff")))
+    cmd = tree.get_command("help")
+    inter = _interaction()
+    await cmd.callback(inter)
+    assert inter.response.send_message.await_args.args[0] == "help stuff"
+
+
+@pytest.mark.asyncio
+async def test_cmd_help_fallback_on_error(monkeypatch):
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({}))
+    monkeypatch.setattr(
+        discord_factory, "handle_app_command",
+        AsyncMock(side_effect=RuntimeError("x")))
+    cmd = tree.get_command("help")
+    inter = _interaction()
+    await cmd.callback(inter)
+    text = inter.response.send_message.await_args.args[0]
+    assert "Commands:" in text  # local help_text() fallback
+
+
+# --------------------------------------------------------------------------- #
+# agent autocomplete
+# --------------------------------------------------------------------------- #
+def _autocomplete(tree):
+    return tree.get_command("agent")._params["value"].autocomplete
+
+
+@pytest.mark.asyncio
+async def test_agent_autocomplete_no_storage_returns_empty(monkeypatch):
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({}))
+    ac = _autocomplete(tree)
+    assert await ac(SimpleNamespace(), "a") == []
+
+
+@pytest.mark.asyncio
+async def test_agent_autocomplete_maps_choices(monkeypatch):
+    adapter = _mock_adapter()
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": adapter}))
+    monkeypatch.setattr(
+        discord_factory, "agent_autocomplete_choices",
+        AsyncMock(return_value=[{"name": "Agent A", "value": "a1"}]))
+    ac = _autocomplete(tree)
+    out = await ac(SimpleNamespace(), "ag")
+    assert len(out) == 1
+    assert out[0].name == "Agent A"
+    assert out[0].value == "a1"
+
+
+@pytest.mark.asyncio
+async def test_agent_autocomplete_error_returns_empty(monkeypatch):
+    adapter = _mock_adapter()
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": adapter}))
+    monkeypatch.setattr(
+        discord_factory, "agent_autocomplete_choices",
+        AsyncMock(side_effect=RuntimeError("x")))
+    ac = _autocomplete(tree)
+    assert await ac(SimpleNamespace(), "ag") == []
+
+
+# --------------------------------------------------------------------------- #
+# tree sync via on_ready
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_on_ready_syncs_to_guild(monkeypatch):
+    adapter = _mock_adapter()
+    _, client, tree = _install_tree(
+        monkeypatch, _FakeEntry({"1": adapter}), channel=_channel(ext="500"))
+    guild = SimpleNamespace(id=99)
+    monkeypatch.setattr(client, "get_channel", lambda cid: SimpleNamespace(guild=guild))
+    monkeypatch.setattr(tree, "copy_global_to", MagicMock())
+    monkeypatch.setattr(tree, "sync", AsyncMock())
+    await client.on_ready()
+    tree.copy_global_to.assert_called_once()
+    tree.sync.assert_awaited_once()
+    # Second on_ready is a no-op (guarded so we sync once per provider).
+    await client.on_ready()
+    tree.sync.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_on_ready_global_sync_when_no_guild(monkeypatch):
+    _, client, tree = _install_tree(monkeypatch, _FakeEntry({}))
+    # get_channel returns an object with no guild attribute -> global sync.
+    monkeypatch.setattr(client, "get_channel", lambda cid: SimpleNamespace())
+    monkeypatch.setattr(tree, "sync", AsyncMock())
+    await client.on_ready()
+    tree.sync.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_on_ready_sync_error_resets_flag(monkeypatch):
+    _, client, tree = _install_tree(monkeypatch, _FakeEntry({}))
+    monkeypatch.setattr(client, "get_channel", lambda cid: SimpleNamespace())
+    calls = {"n": 0}
+
+    async def _boom(*a, **k):
+        calls["n"] += 1
+        raise RuntimeError("sync failed")
+
+    monkeypatch.setattr(tree, "sync", _boom)
+    await client.on_ready()  # error swallowed, flag reset
+    await client.on_ready()  # retried because previous attempt failed
+    assert calls["n"] == 2
+
+
+# --------------------------------------------------------------------------- #
+# extra branch coverage
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_on_interaction_no_entry_is_noop(monkeypatch):
+    _, client = _install(monkeypatch, None)  # registry.entry -> None
+    inter = _interaction(custom_id="approve:w:s:t")
+    await client.on_interaction(inter)
+    inter.response.edit_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_thread_without_storage_is_noop(monkeypatch):
+    adapter = _mock_adapter(sp=False)
+    _, client = _install(monkeypatch, _FakeEntry({"999": adapter}))
+    await client.on_message(_message(_fake_thread(777, 999)))
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_thread_rule_match_skips(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"999": adapter}))
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            return None
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    monkeypatch.setattr(
+        discord_factory, "_route_channel_event", AsyncMock(return_value=True))
+    await client.on_message(_message(_fake_thread(777, 999)))
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_on_message_thread_lookup_error_falls_through(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"999": adapter}))
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            raise RuntimeError("store down")
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    monkeypatch.setattr(
+        discord_factory, "_route_channel_event", AsyncMock(return_value=False))
+    await client.on_message(_message(_fake_thread(777, 999), content="c", mid=3))
+    adapter.handle_inbound_chat_message.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_on_message_thread_clear_error_swallowed(monkeypatch):
+    adapter = _mock_adapter()
+    _, client = _install(monkeypatch, _FakeEntry({"999": adapter}))
+    rec = SimpleNamespace(
+        kind="session", workspace_id="w", session_id="s", tool_call_id="t")
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            return rec
+
+        async def clear(self, cid, key):
+            raise RuntimeError("clear failed")
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    await client.on_message(_message(_fake_thread(777, 999), content="a"))
+    adapter._handle_text_reply.assert_awaited_once()
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_cmd_agent_no_channel_not_configured(monkeypatch):
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": _mock_adapter()}))
+    cmd = tree.get_command("agent")
+    inter = _interaction(channel_id=None)  # channel_id None -> parent None
+    await cmd.callback(inter, value="")
+    assert "not configured" in inter.response.send_message.await_args.args[0]
+
+
+@pytest.mark.asyncio
+async def test_cmd_agent_pick_applies_switch(monkeypatch):
+    adapter = _mock_adapter()
+    _, _, tree = _install_tree(monkeypatch, _FakeEntry({"1": adapter}))
+    handler = AsyncMock(return_value=CommandResult(
+        kind="agent_picker", items=[{"label": "A", "agent_id": "a1"}]))
+    monkeypatch.setattr(discord_factory, "handle_app_command", handler)
+    cmd = tree.get_command("agent")
+    inter = _interaction()
+    inter.channel = _fake_thread(50, 1)
+    await cmd.callback(inter, value="")
+    view = inter.response.send_message.await_args.kwargs["view"]
+    select = view.children[0]
+    # Simulate the user choosing agent "a1" from the dropdown.
+    handler.return_value = CommandResult(kind="notice", text="Switched to a1.")
+    pick_inter = SimpleNamespace(response=SimpleNamespace(
+        edit_message=AsyncMock(), send_message=AsyncMock()))
+    await select._on_pick(pick_inter, "a1")
+    pick_inter.response.edit_message.assert_awaited_once()
+    assert "Switched to a1." in pick_inter.response.edit_message.await_args.kwargs["content"]
+
+
+def test_install_handlers_tree_failure_is_safe(monkeypatch):
+    pid = _uid()
+    monkeypatch.setattr(
+        discord_factory, "DISCORD_CONNECTIONS", _FakeRegistry(_FakeEntry()))
+
+    def _boom(client, *a, **k):
+        raise RuntimeError("no tree")
+
+    monkeypatch.setattr(discord_factory.app_commands, "CommandTree", _boom)
+    client = _client()
+    discord_factory._install_handlers(pid, client, _channel())  # must not raise
+    assert hasattr(client, "on_message")  # handlers bound before tree creation
+
+
+@pytest.mark.asyncio
+async def test_on_ready_syncs_via_fetch_channel(monkeypatch):
+    _, client, tree = _install_tree(
+        monkeypatch, _FakeEntry({}), channel=_channel(ext="500"))
+    guild = SimpleNamespace(id=7)
+    monkeypatch.setattr(client, "get_channel", lambda cid: None)
+    monkeypatch.setattr(
+        client, "fetch_channel",
+        AsyncMock(return_value=SimpleNamespace(guild=guild)))
+    monkeypatch.setattr(tree, "copy_global_to", MagicMock())
+    monkeypatch.setattr(tree, "sync", AsyncMock())
+    await client.on_ready()
+    client.fetch_channel.assert_awaited_once()
+    tree.sync.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# idempotent install + _discord_factory
+# --------------------------------------------------------------------------- #
+def test_install_handlers_is_idempotent(monkeypatch):
+    pid = _uid()
+    monkeypatch.setattr(
+        discord_factory, "DISCORD_CONNECTIONS", _FakeRegistry(_FakeEntry()))
+    c1 = _client()
+    discord_factory._install_handlers(pid, c1, _channel())
+    assert hasattr(c1, "on_message")
+    c2 = _client()
+    discord_factory._install_handlers(pid, c2, _channel())  # same pid
+    assert not hasattr(c2, "on_message")
+
+
+@pytest.mark.asyncio
+async def test_discord_factory_builds_and_installs(monkeypatch):
+    created: dict = {}
+
+    class _FakeAdapter:
+        def __init__(self, **kw):
+            created.update(kw)
+            self.initialized = False
+
+        async def initialize(self):
+            self.initialized = True
+
+    installed: list = []
+    monkeypatch.setattr(discord_factory, "DiscordChannelAdapter", _FakeAdapter)
+    monkeypatch.setattr(
+        discord_factory, "_install_handlers",
+        lambda pid, client, channel: installed.append((pid, client, channel)))
+    client_obj = object()
+    entry = SimpleNamespace(client=client_obj)
+    monkeypatch.setattr(
+        discord_factory, "DISCORD_CONNECTIONS", _FakeRegistry(entry))
+
+    provider = _provider("cp-d")
+    channel = _channel()
+    adapter = await discord_factory._discord_factory(
+        provider, channel, object(), storage_provider="SP",
+        event_bus="EB", claim_engine="CE", artifact_registry="AR")
+
+    assert isinstance(adapter, _FakeAdapter)
+    assert adapter.initialized is True
+    assert created["provider"] is provider
+    assert created["storage_provider"] == "SP"
+    assert installed == [(provider.id, client_obj, channel)]
+
+
+@pytest.mark.asyncio
+async def test_discord_factory_without_connection_skips_handlers(monkeypatch):
+    class _FakeAdapter:
+        def __init__(self, **kw):
+            pass
+
+        async def initialize(self):
+            pass
+
+    installed: list = []
+    monkeypatch.setattr(discord_factory, "DiscordChannelAdapter", _FakeAdapter)
+    monkeypatch.setattr(
+        discord_factory, "_install_handlers",
+        lambda *a: installed.append(a))
+    monkeypatch.setattr(
+        discord_factory, "DISCORD_CONNECTIONS", _FakeRegistry(None))
+    await discord_factory._discord_factory(_provider("cp-e"), _channel(), object())
+    assert installed == []

--- a/tests/channel/slack/test_factory.py
+++ b/tests/channel/slack/test_factory.py
@@ -1,0 +1,800 @@
+"""Unit tests for the Slack adapter factory and its installed bolt handlers.
+
+Covers ``primer.channel.slack.factory``: the ``_route_channel_event`` helper,
+every handler installed by ``_install_handlers`` (action / view / command /
+event), and the ``_slack_factory`` builder. The slack_bolt ``app`` and the
+shared-connection registry are faked so no network / real SDK client is used.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+import pytest
+
+pytest.importorskip("slack_bolt")
+
+from pydantic import SecretStr
+
+from primer.channel.slack import factory as slack_factory
+from primer.channel.commands import CommandResult
+from primer.model.channel import (
+    Channel,
+    ChannelProvider,
+    ChannelProviderType,
+    SlackChannelProviderConfig,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / helpers
+# --------------------------------------------------------------------------- #
+def _provider(pid: str = "cp-slack") -> ChannelProvider:
+    return ChannelProvider(
+        id=pid,
+        provider=ChannelProviderType.SLACK,
+        config=SlackChannelProviderConfig(
+            app_token=SecretStr("xapp-1-test"),
+            bot_token=SecretStr("xoxb-test"),
+        ),
+    )
+
+
+def _channel(cid: str = "ch-1", ext: str = "C123") -> Channel:
+    return Channel(
+        id=cid, provider_id="cp-slack",
+        provider=ChannelProviderType.SLACK, external_id=ext,
+    )
+
+
+class _FakeApp:
+    """Captures the bolt handlers registered by ``_install_handlers``."""
+
+    def __init__(self) -> None:
+        self.actions: dict[str, object] = {}
+        self.views: dict[str, object] = {}
+        self.commands: dict[str, object] = {}
+        self.events: dict[str, object] = {}
+
+    def action(self, name):
+        def deco(fn):
+            self.actions[name] = fn
+            return fn
+        return deco
+
+    def view(self, name):
+        def deco(fn):
+            self.views[name] = fn
+            return fn
+        return deco
+
+    def command(self, name):
+        def deco(fn):
+            self.commands[name] = fn
+            return fn
+        return deco
+
+    def event(self, name):
+        def deco(fn):
+            self.events[name] = fn
+            return fn
+        return deco
+
+
+class _FakeEntry:
+    def __init__(self, adapters: dict | None = None) -> None:
+        self.adapters_by_channel_id = adapters or {}
+
+
+class _FakeRegistry:
+    def __init__(self, entry) -> None:
+        self._entry = entry
+
+    def entry(self, provider_id):
+        return self._entry
+
+
+_UID = [0]
+
+
+def _uid() -> str:
+    _UID[0] += 1
+    return f"slack-prov-{_UID[0]}"
+
+
+def _mock_adapter(sp: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(
+        _sp=object() if sp else None,
+        _channel=_channel(),
+        _handle_decision=AsyncMock(),
+        _handle_text_reply=AsyncMock(),
+        handle_inbound_chat_message=AsyncMock(),
+    )
+
+
+def _install(monkeypatch, entry) -> tuple[str, _FakeApp]:
+    """Install handlers on a fresh FakeApp under a unique provider id and point
+    the module ``SLACK_CONNECTIONS`` at a registry returning *entry*."""
+    pid = _uid()
+    monkeypatch.setattr(slack_factory, "SLACK_CONNECTIONS", _FakeRegistry(entry))
+    app = _FakeApp()
+    slack_factory._install_handlers(pid, app)
+    return pid, app
+
+
+# --------------------------------------------------------------------------- #
+# _route_channel_event
+# --------------------------------------------------------------------------- #
+class _Normalizer:
+    result: object = None
+
+    def __init__(self, provider_id):
+        self.provider_id = provider_id
+
+    async def normalize(self, envelope):
+        return type(self).result
+
+
+def _patch_normalizer(monkeypatch, result):
+    cls = type("N", (_Normalizer,), {"result": result})
+    monkeypatch.setattr(
+        "primer.channel.slack.normalizer.SlackEventNormalizer", cls)
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_no_router_returns_false():
+    adapter = SimpleNamespace(_event_router=lambda: None, _channel=_channel())
+    assert await slack_factory._route_channel_event(adapter, "p", {}) is False
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_normalized_none(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=True),
+        route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, None)
+    assert await slack_factory._route_channel_event(adapter, "p", {}) is False
+    router.has_matching_rule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_no_matching_rule(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=False),
+        route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, {"norm": True})
+    assert await slack_factory._route_channel_event(adapter, "p", {}) is False
+    router.route_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_match_dispatches(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=True),
+        route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, {"norm": True})
+    assert await slack_factory._route_channel_event(adapter, "p", {}) is True
+    router.route_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_swallows_exception(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(side_effect=RuntimeError("boom")),
+        route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, {"norm": True})
+    assert await slack_factory._route_channel_event(adapter, "p", {}) is False
+
+
+# --------------------------------------------------------------------------- #
+# action: approve
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_action_approve_records_decision_and_updates(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    ack = AsyncMock()
+    client = SimpleNamespace(chat_update=AsyncMock())
+    body = {
+        "actions": [{"value": "approve:ws1:sid1:tc1"}],
+        "channel": {"id": "C123"},
+        "user": {"id": "U9"},
+        "message": {"ts": "111.222", "blocks": [{"type": "actions"}]},
+    }
+    await app.actions["approve"](ack, body, client)
+    ack.assert_awaited_once()
+    adapter._handle_decision.assert_awaited_once()
+    kw = adapter._handle_decision.await_args.kwargs
+    assert kw["workspace_id"] == "ws1"
+    assert kw["session_id"] == "sid1"
+    assert kw["tool_call_id"] == "tc1"
+    assert kw["decision"] == "approved"
+    assert kw["reason"] is None
+    assert kw["user_id"] == "U9"
+    client.chat_update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_action_approve_malformed_value_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    ack = AsyncMock()
+    client = SimpleNamespace(chat_update=AsyncMock())
+    await app.actions["approve"](ack, {"actions": [{"value": "oops"}]}, client)
+    ack.assert_awaited_once()
+    adapter._handle_decision.assert_not_awaited()
+    client.chat_update.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_action_approve_unknown_channel_is_noop(monkeypatch):
+    _, app = _install(monkeypatch, _FakeEntry({}))
+    ack = AsyncMock()
+    client = SimpleNamespace(chat_update=AsyncMock())
+    body = {
+        "actions": [{"value": "approve:w:s:t"}],
+        "channel": {"id": "C123"}, "user": {"id": "U"}, "message": {},
+    }
+    await app.actions["approve"](ack, body, client)
+    ack.assert_awaited_once()
+    client.chat_update.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# action: reject
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_action_reject_opens_reject_modal(monkeypatch):
+    _, app = _install(monkeypatch, _FakeEntry({"C123": _mock_adapter()}))
+    ack = AsyncMock()
+    client = SimpleNamespace(views_open=AsyncMock())
+    body = {
+        "actions": [{"value": "reject:ws:sid:tc"}],
+        "channel": {"id": "C123"},
+        "message": {"ts": "9.9"},
+        "trigger_id": "trig-1",
+    }
+    await app.actions["reject"](ack, body, client)
+    ack.assert_awaited_once()
+    client.views_open.assert_awaited_once()
+    view = client.views_open.await_args.kwargs["view"]
+    assert view["callback_id"] == slack_factory.REJECT_MODAL_CALLBACK_ID
+    assert "reject:ws:sid:tc" in view["private_metadata"]
+
+
+@pytest.mark.asyncio
+async def test_action_reject_malformed_value_is_noop(monkeypatch):
+    _, app = _install(monkeypatch, _FakeEntry({"C123": _mock_adapter()}))
+    ack = AsyncMock()
+    client = SimpleNamespace(views_open=AsyncMock())
+    await app.actions["reject"](ack, {"actions": [{"value": "nope"}]}, client)
+    client.views_open.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# action: pick_agent
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_action_pick_agent_posts_notice(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        "primer.channel.slack.blocks.parse_agent_selection",
+        AsyncMock(return_value="Switched agent to X."))
+    ack = AsyncMock()
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    body = {
+        "actions": [{"selected_option": {"value": "chat1:agent1"}}],
+        "channel": {"id": "C123"},
+        "message": {"thread_ts": "tt-1"},
+    }
+    await app.actions["pick_agent"](ack, body, client)
+    client.chat_postMessage.assert_awaited_once()
+    kw = client.chat_postMessage.await_args.kwargs
+    assert kw["text"] == "Switched agent to X."
+    assert kw["thread_ts"] == "tt-1"
+
+
+@pytest.mark.asyncio
+async def test_action_pick_agent_malformed_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    ack = AsyncMock()
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    await app.actions["pick_agent"](
+        ack, {"actions": [{}], "channel": {"id": "C123"}}, client)
+    client.chat_postMessage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_action_pick_agent_without_storage_is_noop(monkeypatch):
+    adapter = _mock_adapter(sp=False)
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    ack = AsyncMock()
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    body = {
+        "actions": [{"selected_option": {"value": "c:a"}}],
+        "channel": {"id": "C123"}, "message": {},
+    }
+    await app.actions["pick_agent"](ack, body, client)
+    client.chat_postMessage.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# view: reject-modal submit
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_view_reject_modal_records_and_updates(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    ack = AsyncMock()
+    client = SimpleNamespace(
+        conversations_history=AsyncMock(
+            return_value={"messages": [{"blocks": [{"type": "actions"}]}]}),
+        chat_update=AsyncMock())
+    view = {
+        "private_metadata": "reject:ws:sid:tc:C123:111.2",
+        "state": {"values": {"reason": {"reason_text": {"value": "no good"}}}},
+    }
+    handler = app.views[slack_factory.REJECT_MODAL_CALLBACK_ID]
+    await handler(ack, {"user": {"id": "U1"}}, view, client)
+    ack.assert_awaited_once()
+    adapter._handle_decision.assert_awaited_once()
+    kw = adapter._handle_decision.await_args.kwargs
+    assert kw["decision"] == "rejected"
+    assert kw["reason"] == "no good"
+    client.conversations_history.assert_awaited_once()
+    client.chat_update.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_view_reject_modal_short_metadata_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    handler = app.views[slack_factory.REJECT_MODAL_CALLBACK_ID]
+    await handler(AsyncMock(), {"user": {}},
+                  {"private_metadata": "reject:only"}, SimpleNamespace())
+    adapter._handle_decision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_view_reject_modal_no_entry_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, None)  # registry.entry -> None
+    handler = app.views[slack_factory.REJECT_MODAL_CALLBACK_ID]
+    view = {
+        "private_metadata": "reject:w:s:t",
+        "state": {"values": {"reason": {"reason_text": {"value": "x"}}}},
+    }
+    await handler(AsyncMock(), {"user": {"id": "U"}}, view, SimpleNamespace())
+    adapter._handle_decision.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# command: /agent (modal opener)
+# --------------------------------------------------------------------------- #
+class _FakeExec:
+    switch_allowed = True
+
+    def __init__(self, *, storage_provider):
+        self.sp = storage_provider
+
+    async def agent_switch_allowed(self, channel_id):
+        return type(self).switch_allowed
+
+    async def list_chats(self, *, channel_id):
+        return SimpleNamespace(
+            items=[{"chat_id": "c1", "title": "Chat 1", "agent_id": "a1"}])
+
+    async def agent_picker(self, *, channel_id):
+        return SimpleNamespace(items=[{"agent_id": "a1", "label": "Agent 1"}])
+
+
+@pytest.mark.asyncio
+async def test_command_agent_opens_modal(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        "primer.channel.commands.CommandExecutor",
+        type("E", (_FakeExec,), {"switch_allowed": True}))
+    ack = AsyncMock()
+    client = SimpleNamespace(views_open=AsyncMock(), chat_postEphemeral=AsyncMock())
+    body = {"channel_id": "C123", "trigger_id": "tg-1", "user_id": "U"}
+    await app.commands["/agent"](ack, body, client)
+    ack.assert_awaited_once()
+    client.views_open.assert_awaited_once()
+    assert "view" in client.views_open.await_args.kwargs
+
+
+@pytest.mark.asyncio
+async def test_command_agent_disabled_posts_ephemeral(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        "primer.channel.commands.CommandExecutor",
+        type("E", (_FakeExec,), {"switch_allowed": False}))
+    ack = AsyncMock()
+    client = SimpleNamespace(views_open=AsyncMock(), chat_postEphemeral=AsyncMock())
+    body = {"channel_id": "C123", "trigger_id": "tg-1", "user_id": "U7"}
+    await app.commands["/agent"](ack, body, client)
+    client.views_open.assert_not_awaited()
+    client.chat_postEphemeral.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_command_agent_without_storage_is_noop(monkeypatch):
+    adapter = _mock_adapter(sp=False)
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    ack = AsyncMock()
+    client = SimpleNamespace(views_open=AsyncMock(), chat_postEphemeral=AsyncMock())
+    await app.commands["/agent"](
+        ack, {"channel_id": "C123", "trigger_id": "t"}, client)
+    client.views_open.assert_not_awaited()
+    client.chat_postEphemeral.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# command: /help  (exercises the shared _run_slash body)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_command_help_posts_notice_text(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        "primer.channel.slack.commands.handle_slash_command",
+        AsyncMock(return_value=CommandResult(kind="notice", text="help!")))
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    await app.commands["/help"](AsyncMock(), {"channel_id": "C123", "text": ""}, client)
+    client.chat_postMessage.assert_awaited_once()
+    assert client.chat_postMessage.await_args.kwargs["text"] == "help!"
+
+
+@pytest.mark.asyncio
+async def test_command_help_renders_chat_list(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        "primer.channel.slack.commands.handle_slash_command",
+        AsyncMock(return_value=CommandResult(
+            kind="list",
+            items=[{"title": "T", "chat_id": "c9", "agent_id": "a9"}])))
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    await app.commands["/help"](AsyncMock(), {"channel_id": "C123"}, client)
+    text = client.chat_postMessage.await_args.kwargs["text"]
+    assert text.startswith("Chats on this channel:")
+    assert "T (c9) -> a9" in text
+
+
+@pytest.mark.asyncio
+async def test_command_help_renders_empty_chat_list(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        "primer.channel.slack.commands.handle_slash_command",
+        AsyncMock(return_value=CommandResult(kind="list", items=[])))
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    await app.commands["/help"](AsyncMock(), {"channel_id": "C123"}, client)
+    assert client.chat_postMessage.await_args.kwargs["text"] == \
+        "No chats yet on this channel."
+
+
+@pytest.mark.asyncio
+async def test_command_help_empty_text_skips_post(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        "primer.channel.slack.commands.handle_slash_command",
+        AsyncMock(return_value=CommandResult(kind="notice", text="")))
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    await app.commands["/help"](AsyncMock(), {"channel_id": "C123"}, client)
+    client.chat_postMessage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_command_help_without_storage_is_noop(monkeypatch):
+    adapter = _mock_adapter(sp=False)
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    called = AsyncMock()
+    monkeypatch.setattr(
+        "primer.channel.slack.commands.handle_slash_command", called)
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    await app.commands["/help"](AsyncMock(), {"channel_id": "C123"}, client)
+    called.assert_not_awaited()
+    client.chat_postMessage.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# event: message
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_event_message_ignores_bot(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    await app.events["message"]({"bot_id": "B1"}, SimpleNamespace())
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_event_message_ignores_edit_subtype(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    await app.events["message"](
+        {"subtype": "message_changed", "channel": "C123"}, SimpleNamespace())
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_event_message_unknown_channel_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    await app.events["message"](
+        {"channel": "OTHER", "ts": "1"}, SimpleNamespace())
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_event_message_session_reply(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    rec = SimpleNamespace(
+        kind="session", workspace_id="w", session_id="s", tool_call_id="t")
+    cleared: list[str] = []
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            return rec
+
+        async def clear(self, cid, key):
+            cleared.append(key)
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    event = {"channel": "C123", "thread_ts": "TT",
+             "text": "answer", "user": "U", "ts": "1"}
+    await app.events["message"](event, SimpleNamespace())
+    adapter._handle_text_reply.assert_awaited_once()
+    assert adapter._handle_text_reply.await_args.kwargs["text"] == "answer"
+    assert cleared == ["TT"]
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_event_message_chat_dispatch(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        slack_factory, "_route_channel_event", AsyncMock(return_value=False))
+    event = {"channel": "C123", "text": "hello",
+             "user": "U2", "ts": "9", "files": None}
+    await app.events["message"](event, SimpleNamespace())
+    adapter.handle_inbound_chat_message.assert_awaited_once()
+    kw = adapter.handle_inbound_chat_message.await_args.kwargs
+    assert kw["text"] == "hello"
+    assert kw["sender_name"] == "U2"
+    assert kw["message_ts"] == "9"
+
+
+@pytest.mark.asyncio
+async def test_event_message_rule_match_skips_chat_dispatch(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        slack_factory, "_route_channel_event", AsyncMock(return_value=True))
+    event = {"channel": "C123", "text": "trigger", "user": "U2", "ts": "9"}
+    await app.events["message"](event, SimpleNamespace())
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_event_message_without_storage_is_noop(monkeypatch):
+    adapter = _mock_adapter(sp=False)
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    event = {"channel": "C123", "text": "hi", "user": "U", "ts": "1"}
+    await app.events["message"](event, SimpleNamespace())
+    adapter.handle_inbound_chat_message.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# view: agent-switch modal submit
+# --------------------------------------------------------------------------- #
+def _switch_view(chat="c1", agent="a1", meta="C123") -> dict:
+    return {
+        "private_metadata": meta,
+        "state": {"values": {
+            "chat_b": {"chat_s": {"selected_option": {"value": chat}}},
+            "agent_b": {"agent_s": {"selected_option": {"value": agent}}},
+        }},
+    }
+
+
+class _ExecSetAgent:
+    def __init__(self, *, storage_provider):
+        pass
+
+    async def set_agent(self, *, chat_id, agent_id, channel_id):
+        return SimpleNamespace(text=f"Switched to {agent_id}.")
+
+
+@pytest.mark.asyncio
+async def test_view_agent_switch_confirms_in_thread(monkeypatch):
+    chat = SimpleNamespace(
+        channel_binding=SimpleNamespace(thread_external_id="TT"))
+    storage = SimpleNamespace(get=AsyncMock(return_value=chat))
+    adapter = SimpleNamespace(
+        _sp=SimpleNamespace(get_storage=lambda model: storage),
+        _channel=_channel())
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    monkeypatch.setattr(
+        "primer.channel.commands.CommandExecutor", _ExecSetAgent)
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    handler = app.views[slack_factory.AGENT_SWITCH_MODAL_CALLBACK_ID]
+    await handler(AsyncMock(), {}, _switch_view(agent="a1"), client)
+    client.chat_postMessage.assert_awaited_once()
+    kw = client.chat_postMessage.await_args.kwargs
+    assert kw["thread_ts"] == "TT"
+    assert kw["text"] == "Switched to a1."
+
+
+@pytest.mark.asyncio
+async def test_view_agent_switch_info_only_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    handler = app.views[slack_factory.AGENT_SWITCH_MODAL_CALLBACK_ID]
+    # No "state" -> read_agent_switch_submission returns None.
+    await handler(AsyncMock(), {}, {"private_metadata": "C123"}, client)
+    client.chat_postMessage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_view_agent_switch_unknown_channel_is_noop(monkeypatch):
+    _, app = _install(monkeypatch, _FakeEntry({}))
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    handler = app.views[slack_factory.AGENT_SWITCH_MODAL_CALLBACK_ID]
+    await handler(AsyncMock(), {}, _switch_view(meta="MISSING"), client)
+    client.chat_postMessage.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_view_agent_switch_set_agent_error_swallowed(monkeypatch):
+    adapter = SimpleNamespace(
+        _sp=SimpleNamespace(get_storage=lambda m: None), _channel=_channel())
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+
+    class _Boom:
+        def __init__(self, *, storage_provider):
+            pass
+
+        async def set_agent(self, **kw):
+            raise RuntimeError("nope")
+
+    monkeypatch.setattr("primer.channel.commands.CommandExecutor", _Boom)
+    client = SimpleNamespace(chat_postMessage=AsyncMock())
+    handler = app.views[slack_factory.AGENT_SWITCH_MODAL_CALLBACK_ID]
+    await handler(AsyncMock(), {}, _switch_view(), client)
+    client.chat_postMessage.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# idempotent handler installation + exception swallowing
+# --------------------------------------------------------------------------- #
+def test_install_handlers_is_idempotent(monkeypatch):
+    pid = _uid()
+    monkeypatch.setattr(
+        slack_factory, "SLACK_CONNECTIONS", _FakeRegistry(_FakeEntry()))
+    app1 = _FakeApp()
+    slack_factory._install_handlers(pid, app1)
+    assert app1.actions  # first install populated the app
+    app2 = _FakeApp()
+    slack_factory._install_handlers(pid, app2)  # same pid -> early return
+    assert app2.actions == {}
+
+
+@pytest.mark.asyncio
+async def test_action_approve_chat_update_error_swallowed(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+    client = SimpleNamespace(chat_update=AsyncMock(side_effect=RuntimeError("x")))
+    body = {
+        "actions": [{"value": "approve:w:s:t"}],
+        "channel": {"id": "C123"}, "user": {"id": "U"},
+        "message": {"ts": "1", "blocks": []},
+    }
+    # Must not raise even though chat.update fails; decision still recorded.
+    await app.actions["approve"](AsyncMock(), body, client)
+    adapter._handle_decision.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_event_message_correlation_lookup_error_falls_through(monkeypatch):
+    adapter = _mock_adapter()
+    _, app = _install(monkeypatch, _FakeEntry({"C123": adapter}))
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            raise RuntimeError("store down")
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    monkeypatch.setattr(
+        slack_factory, "_route_channel_event", AsyncMock(return_value=False))
+    event = {"channel": "C123", "thread_ts": "TT",
+             "text": "hi", "user": "U", "ts": "2"}
+    await app.events["message"](event, SimpleNamespace())
+    # lookup failed -> rec None -> chat-surface dispatch owns delivery.
+    adapter.handle_inbound_chat_message.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# _slack_factory
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_slack_factory_builds_adapter_and_installs_handlers(monkeypatch):
+    created: dict = {}
+
+    class _FakeAdapter:
+        def __init__(self, **kw):
+            created.update(kw)
+            self.initialized = False
+
+        async def initialize(self):
+            self.initialized = True
+
+    installed: list = []
+    monkeypatch.setattr(slack_factory, "SlackChannelAdapter", _FakeAdapter)
+    monkeypatch.setattr(
+        slack_factory, "_install_handlers",
+        lambda pid, app: installed.append((pid, app)))
+    app_obj = object()
+    entry = SimpleNamespace(conn=SimpleNamespace(app=app_obj))
+    monkeypatch.setattr(slack_factory, "SLACK_CONNECTIONS", _FakeRegistry(entry))
+
+    provider = _provider("cp-x")
+    channel = _channel()
+    inbox = object()
+    adapter = await slack_factory._slack_factory(
+        provider, channel, inbox,
+        storage_provider="SP", event_bus="EB",
+        claim_engine="CE", artifact_registry="AR")
+
+    assert isinstance(adapter, _FakeAdapter)
+    assert adapter.initialized is True
+    assert created["provider"] is provider
+    assert created["channel"] is channel
+    assert created["inbox"] is inbox
+    assert created["storage_provider"] == "SP"
+    assert created["event_bus"] == "EB"
+    assert created["claim_engine"] == "CE"
+    assert created["artifact_registry"] == "AR"
+    assert installed == [(provider.id, app_obj)]
+
+
+@pytest.mark.asyncio
+async def test_slack_factory_without_connection_skips_handlers(monkeypatch):
+    class _FakeAdapter:
+        def __init__(self, **kw):
+            pass
+
+        async def initialize(self):
+            pass
+
+    installed: list = []
+    monkeypatch.setattr(slack_factory, "SlackChannelAdapter", _FakeAdapter)
+    monkeypatch.setattr(
+        slack_factory, "_install_handlers",
+        lambda pid, app: installed.append(pid))
+    monkeypatch.setattr(slack_factory, "SLACK_CONNECTIONS", _FakeRegistry(None))
+
+    adapter = await slack_factory._slack_factory(
+        _provider("cp-y"), _channel(), object())
+    assert isinstance(adapter, _FakeAdapter)
+    assert installed == []

--- a/tests/channel/telegram/test_factory.py
+++ b/tests/channel/telegram/test_factory.py
@@ -1,0 +1,556 @@
+"""Unit tests for the Telegram adapter factory and installed PTB handlers.
+
+Covers ``primer.channel.telegram.factory``: ``_route_channel_event``, the
+``_on_callback`` (inline-button) and ``_on_message`` handlers registered on the
+PTB Application, and the ``_telegram_factory`` builder. The PTB ``Application``
+and the shared-connection registry are faked; adapter methods are mocked so no
+real bot / getUpdates poll is used.
+"""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+pytest.importorskip("telegram")
+
+from pydantic import SecretStr
+
+from primer.channel.telegram import factory as tg_factory
+from primer.model.channel import (
+    Channel,
+    ChannelProvider,
+    ChannelProviderType,
+    TelegramChannelProviderConfig,
+)
+
+
+# --------------------------------------------------------------------------- #
+# Fakes / helpers
+# --------------------------------------------------------------------------- #
+def _provider(pid: str = "cp-tg") -> ChannelProvider:
+    return ChannelProvider(
+        id=pid,
+        provider=ChannelProviderType.TELEGRAM,
+        config=TelegramChannelProviderConfig(
+            bot_token=SecretStr("123456:ABCDEF_this_is_long_enough")),
+    )
+
+
+def _channel(cid: str = "ch-1", ext: str = "100") -> Channel:
+    return Channel(
+        id=cid, provider_id="cp-tg",
+        provider=ChannelProviderType.TELEGRAM, external_id=ext,
+    )
+
+
+class _FakeEntry:
+    def __init__(self, adapters: dict | None = None) -> None:
+        self.adapters_by_chat_id = adapters or {}
+
+
+class _FakeRegistry:
+    def __init__(self, entry) -> None:
+        self._entry = entry
+
+    def entry(self, provider_id):
+        return self._entry
+
+
+class _FakeApp:
+    """Captures the PTB handlers registered by ``_install_handlers``."""
+
+    def __init__(self) -> None:
+        self.handlers: list = []
+
+    def add_handler(self, handler) -> None:
+        self.handlers.append(handler)
+
+
+_UID = [0]
+
+
+def _uid() -> str:
+    _UID[0] += 1
+    return f"telegram-prov-{_UID[0]}"
+
+
+def _mock_adapter(sp: bool = True) -> SimpleNamespace:
+    return SimpleNamespace(
+        _sp=object() if sp else None,
+        _channel=_channel(),
+        _reply_targets={},
+        _resolve_tag=AsyncMock(),
+        _handle_decision=AsyncMock(),
+        _handle_text_reply=AsyncMock(),
+        remember_reply_target=MagicMock(),
+        resolve_reply_target=MagicMock(),
+        apply_agent_pick=AsyncMock(),
+        build_agent_picker_keyboard=AsyncMock(),
+        apply_chat_decision_button=AsyncMock(),
+        handle_inbound_chat_media=AsyncMock(),
+        handle_inbound_chat_text=AsyncMock(),
+    )
+
+
+def _install(monkeypatch, entry):
+    """Install handlers on a FakeApp; return (on_callback, on_message)."""
+    pid = _uid()
+    monkeypatch.setattr(
+        tg_factory, "TELEGRAM_CONNECTIONS", _FakeRegistry(entry))
+    app = _FakeApp()
+    tg_factory._install_handlers(pid, app)
+    on_callback = app.handlers[0].callback
+    on_message = app.handlers[1].callback
+    return on_callback, on_message
+
+
+def _context():
+    return SimpleNamespace(bot=SimpleNamespace(
+        send_message=AsyncMock(return_value=SimpleNamespace(message_id=999)),
+        edit_message_text=AsyncMock()))
+
+
+def _cq(data, chat_id=100, msg_text="orig", mid=5):
+    message = SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id), text=msg_text, message_id=mid)
+    return SimpleNamespace(
+        data=data, message=message,
+        answer=AsyncMock(),
+        edit_message_reply_markup=AsyncMock(),
+        from_user=SimpleNamespace(id=7))
+
+
+def _msg(text="hi", reply_to=None, chat_id=100, from_id=7, media=None):
+    m = SimpleNamespace(
+        chat=SimpleNamespace(id=chat_id),
+        from_user=SimpleNamespace(id=from_id, full_name="Full Name"),
+        text=text, reply_to_message=reply_to,
+        photo=None, document=None, audio=None, voice=None, video=None,
+        message_id=5)
+    if media:
+        setattr(m, media, [object()])
+    return m
+
+
+# --------------------------------------------------------------------------- #
+# _route_channel_event
+# --------------------------------------------------------------------------- #
+def _route_msg():
+    entity = SimpleNamespace(type="bot_command", offset=0, length=4)
+    return SimpleNamespace(
+        chat=SimpleNamespace(id=100, type="group"),
+        from_user=SimpleNamespace(id=7, full_name="Full Name"),
+        entities=[entity], text="/cmd hi", caption=None, message_id=5)
+
+
+def _patch_normalizer(monkeypatch, result):
+    class _N:
+        def __init__(self, provider_id):
+            pass
+
+        async def normalize(self, envelope):
+            return result
+
+    monkeypatch.setattr(
+        "primer.channel.telegram.normalizer.TelegramEventNormalizer", _N)
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_no_router_returns_false():
+    adapter = SimpleNamespace(_event_router=lambda: None, _channel=_channel())
+    assert await tg_factory._route_channel_event(adapter, "p", _route_msg()) is False
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_normalized_none(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=True), route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, None)
+    assert await tg_factory._route_channel_event(adapter, "p", _route_msg()) is False
+    router.has_matching_rule.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_no_match(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=False), route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, {"norm": True})
+    assert await tg_factory._route_channel_event(adapter, "p", _route_msg()) is False
+    router.route_event.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_match_dispatches(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(return_value=True), route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, {"norm": True})
+    assert await tg_factory._route_channel_event(adapter, "p", _route_msg()) is True
+    router.route_event.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_route_channel_event_swallows_exception(monkeypatch):
+    router = SimpleNamespace(
+        has_matching_rule=AsyncMock(side_effect=RuntimeError("boom")),
+        route_event=AsyncMock())
+    adapter = SimpleNamespace(_event_router=lambda: router, _channel=_channel())
+    _patch_normalizer(monkeypatch, {"norm": True})
+    assert await tg_factory._route_channel_event(adapter, "p", _route_msg()) is False
+
+
+# --------------------------------------------------------------------------- #
+# _on_callback (inline buttons)
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_callback_none_is_noop(monkeypatch):
+    on_callback, _ = _install(monkeypatch, _FakeEntry())
+    # update.callback_query is None -> return without touching the bot.
+    await on_callback(SimpleNamespace(callback_query=None), _context())
+
+
+@pytest.mark.asyncio
+async def test_callback_no_entry_is_noop(monkeypatch):
+    on_callback, _ = _install(monkeypatch, None)
+    cq = _cq("a:TAG")
+    await on_callback(SimpleNamespace(callback_query=cq), _context())
+    cq.answer.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_unknown_chat_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    on_callback, _ = _install(monkeypatch, _FakeEntry({"999": adapter}))
+    cq = _cq("a:TAG", chat_id=100)  # chat 100 not registered
+    await on_callback(SimpleNamespace(callback_query=cq), _context())
+    adapter._handle_decision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_callback_approve(monkeypatch):
+    adapter = _mock_adapter()
+    adapter._resolve_tag = AsyncMock(return_value={
+        "workspace_id": "w", "session_id": "s", "tool_call_id": "t"})
+    on_callback, _ = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    ctx = _context()
+    cq = _cq("a:TAG")
+    await on_callback(SimpleNamespace(callback_query=cq), ctx)
+    adapter._handle_decision.assert_awaited_once()
+    kw = adapter._handle_decision.await_args.kwargs
+    assert kw["decision"] == "approved"
+    assert kw["workspace_id"] == "w"
+    assert kw["user_id"] == 7
+    ctx.bot.edit_message_text.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_approve_unresolvable_tag_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    adapter._resolve_tag = AsyncMock(return_value=None)
+    on_callback, _ = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    ctx = _context()
+    await on_callback(SimpleNamespace(callback_query=_cq("a:TAG")), ctx)
+    adapter._handle_decision.assert_not_awaited()
+    ctx.bot.edit_message_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_callback_reject_sends_reason_prompt(monkeypatch):
+    adapter = _mock_adapter()
+    ids = {"workspace_id": "w", "session_id": "s", "tool_call_id": "t"}
+    adapter._resolve_tag = AsyncMock(return_value=ids)
+    on_callback, _ = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    ctx = _context()
+    await on_callback(SimpleNamespace(callback_query=_cq("r:TAG")), ctx)
+    ctx.bot.send_message.assert_awaited_once()
+    adapter.remember_reply_target.assert_called_once()
+    kw = adapter.remember_reply_target.call_args.kwargs
+    assert kw["message_id"] == 999
+    assert kw["kind"] == "reject"
+    assert kw["ids"] == ids
+
+
+@pytest.mark.asyncio
+async def test_callback_reject_unresolvable_tag_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    adapter._resolve_tag = AsyncMock(return_value=None)
+    on_callback, _ = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    ctx = _context()
+    await on_callback(SimpleNamespace(callback_query=_cq("r:TAG")), ctx)
+    ctx.bot.send_message.assert_not_awaited()
+    adapter.remember_reply_target.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_callback_pick_agent_posts_notice(monkeypatch):
+    adapter = _mock_adapter()
+    adapter.apply_agent_pick = AsyncMock(return_value="Agent switched.")
+    on_callback, _ = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    ctx = _context()
+    await on_callback(
+        SimpleNamespace(callback_query=_cq("pick_agent:c1:a1")), ctx)
+    adapter.apply_agent_pick.assert_awaited_once()
+    ctx.bot.send_message.assert_awaited_once()
+    assert ctx.bot.send_message.await_args.kwargs["text"] == "Agent switched."
+
+
+@pytest.mark.asyncio
+async def test_callback_agentpage_navigates(monkeypatch):
+    adapter = _mock_adapter()
+    adapter.build_agent_picker_keyboard = AsyncMock(
+        return_value=[[{"text": "A", "callback_data": "pick_agent:c1:a1"}]])
+    on_callback, _ = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    cq = _cq("agentpage:c1:2")
+    await on_callback(SimpleNamespace(callback_query=cq), _context())
+    adapter.build_agent_picker_keyboard.assert_awaited_once()
+    assert adapter.build_agent_picker_keyboard.await_args.kwargs["page"] == 2
+    cq.edit_message_reply_markup.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_callback_chat_decision(monkeypatch):
+    adapter = _mock_adapter()
+    on_callback, _ = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    await on_callback(
+        SimpleNamespace(callback_query=_cq("chat_ok:c1")), _context())
+    adapter.apply_chat_decision_button.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# _on_message
+# --------------------------------------------------------------------------- #
+@pytest.mark.asyncio
+async def test_message_none_is_noop(monkeypatch):
+    _, on_message = _install(monkeypatch, _FakeEntry())
+    await on_message(SimpleNamespace(message=None), _context())
+
+
+@pytest.mark.asyncio
+async def test_message_no_entry_is_noop(monkeypatch):
+    _, on_message = _install(monkeypatch, None)
+    await on_message(SimpleNamespace(message=_msg()), _context())
+
+
+@pytest.mark.asyncio
+async def test_message_unknown_chat_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    _, on_message = _install(monkeypatch, _FakeEntry({"999": adapter}))
+    await on_message(SimpleNamespace(message=_msg(chat_id=100)), _context())
+    adapter.handle_inbound_chat_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_message_chat_text_dispatch(monkeypatch):
+    adapter = _mock_adapter()
+    adapter.handle_inbound_chat_text = AsyncMock(return_value="Chat started.")
+    _, on_message = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    monkeypatch.setattr(
+        tg_factory, "_route_channel_event", AsyncMock(return_value=False))
+    ctx = _context()
+    await on_message(SimpleNamespace(message=_msg(text="hello")), ctx)
+    adapter.handle_inbound_chat_text.assert_awaited_once()
+    assert adapter.handle_inbound_chat_text.await_args.kwargs["text"] == "hello"
+    ctx.bot.send_message.assert_awaited_once()
+    assert ctx.bot.send_message.await_args.kwargs["text"] == "Chat started."
+
+
+@pytest.mark.asyncio
+async def test_message_chat_media_dispatch(monkeypatch):
+    adapter = _mock_adapter()
+    adapter.handle_inbound_chat_media = AsyncMock(return_value=None)
+    _, on_message = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    monkeypatch.setattr(
+        tg_factory, "_route_channel_event", AsyncMock(return_value=False))
+    await on_message(
+        SimpleNamespace(message=_msg(text=None, media="photo")), _context())
+    adapter.handle_inbound_chat_media.assert_awaited_once()
+    adapter.handle_inbound_chat_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_message_rule_match_skips_chat_dispatch(monkeypatch):
+    adapter = _mock_adapter()
+    _, on_message = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    monkeypatch.setattr(
+        tg_factory, "_route_channel_event", AsyncMock(return_value=True))
+    await on_message(SimpleNamespace(message=_msg(text="trigger")), _context())
+    adapter.handle_inbound_chat_text.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_message_no_reply_without_storage_is_noop(monkeypatch):
+    adapter = _mock_adapter(sp=False)
+    _, on_message = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    await on_message(SimpleNamespace(message=_msg()), _context())
+    adapter.handle_inbound_chat_text.assert_not_awaited()
+    adapter._handle_text_reply.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_message_reply_session(monkeypatch):
+    adapter = _mock_adapter()
+    adapter._reply_targets = {33: {"kind": "reject"}}
+    _, on_message = _install(monkeypatch, _FakeEntry({"100": adapter}))
+    rec = SimpleNamespace(
+        kind="session", workspace_id="w", session_id="s", tool_call_id="t")
+    cleared: list = []
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            return rec
+
+        async def clear(self, cid, key):
+            cleared.append(key)
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    reply = SimpleNamespace(message_id=33)
+    msg = _msg(text="my answer", reply_to=reply)
+    await on_message(SimpleNamespace(message=msg), _context())
+    adapter._handle_text_reply.assert_awaited_once()
+    assert adapter._handle_text_reply.await_args.kwargs["text"] == "my answer"
+    assert cleared == ["33"]
+    assert 33 not in adapter._reply_targets  # popped from in-memory cache
+
+
+@pytest.mark.asyncio
+async def test_message_reply_reject_fallback(monkeypatch):
+    adapter = _mock_adapter()
+    adapter.resolve_reply_target = MagicMock(return_value={
+        "kind": "reject", "workspace_id": "w",
+        "session_id": "s", "tool_call_id": "t"})
+    _, on_message = _install(monkeypatch, _FakeEntry({"100": adapter}))
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            return None
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    reply = SimpleNamespace(message_id=44)
+    msg = _msg(text="because reasons", reply_to=reply)
+    await on_message(SimpleNamespace(message=msg), _context())
+    adapter._handle_decision.assert_awaited_once()
+    kw = adapter._handle_decision.await_args.kwargs
+    assert kw["decision"] == "rejected"
+    assert kw["reason"] == "because reasons"
+
+
+@pytest.mark.asyncio
+async def test_message_reply_lookup_error_falls_through(monkeypatch):
+    adapter = _mock_adapter()
+    adapter.resolve_reply_target = MagicMock(return_value=None)
+    _, on_message = _install(monkeypatch, _FakeEntry({"100": adapter}))
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            raise RuntimeError("store down")
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    reply = SimpleNamespace(message_id=66)
+    await on_message(
+        SimpleNamespace(message=_msg(reply_to=reply)), _context())
+    # lookup failed -> rec None -> in-memory fallback consulted (also None).
+    adapter.resolve_reply_target.assert_called_once_with(66)
+    adapter._handle_decision.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_message_reply_no_target_is_noop(monkeypatch):
+    adapter = _mock_adapter()
+    adapter.resolve_reply_target = MagicMock(return_value=None)
+    _, on_message = _install(monkeypatch, _FakeEntry({"100": adapter}))
+
+    class Corr:
+        def __init__(self, sp):
+            pass
+
+        async def lookup(self, cid, key):
+            return None
+
+    monkeypatch.setattr("primer.channel.correlation.CorrelationStore", Corr)
+    reply = SimpleNamespace(message_id=55)
+    await on_message(
+        SimpleNamespace(message=_msg(reply_to=reply)), _context())
+    adapter._handle_decision.assert_not_awaited()
+
+
+# --------------------------------------------------------------------------- #
+# idempotent install + _telegram_factory
+# --------------------------------------------------------------------------- #
+def test_install_handlers_is_idempotent(monkeypatch):
+    pid = _uid()
+    monkeypatch.setattr(
+        tg_factory, "TELEGRAM_CONNECTIONS", _FakeRegistry(_FakeEntry()))
+    app1 = _FakeApp()
+    tg_factory._install_handlers(pid, app1)
+    assert len(app1.handlers) == 2
+    app2 = _FakeApp()
+    tg_factory._install_handlers(pid, app2)  # same pid -> early return
+    assert app2.handlers == []
+
+
+@pytest.mark.asyncio
+async def test_telegram_factory_builds_and_installs(monkeypatch):
+    created: dict = {}
+
+    class _FakeAdapter:
+        def __init__(self, **kw):
+            created.update(kw)
+            self.initialized = False
+
+        async def initialize(self):
+            self.initialized = True
+
+    installed: list = []
+    monkeypatch.setattr(tg_factory, "TelegramChannelAdapter", _FakeAdapter)
+    monkeypatch.setattr(
+        tg_factory, "_install_handlers",
+        lambda pid, app: installed.append((pid, app)))
+    app_obj = object()
+    entry = SimpleNamespace(app=app_obj)
+    monkeypatch.setattr(
+        tg_factory, "TELEGRAM_CONNECTIONS", _FakeRegistry(entry))
+
+    provider = _provider("cp-x")
+    channel = _channel()
+    adapter = await tg_factory._telegram_factory(
+        provider, channel, object(), storage_provider="SP",
+        event_bus="EB", claim_engine="CE", artifact_registry="AR")
+
+    assert isinstance(adapter, _FakeAdapter)
+    assert adapter.initialized is True
+    assert created["provider"] is provider
+    assert created["storage_provider"] == "SP"
+    assert installed == [(provider.id, app_obj)]
+
+
+@pytest.mark.asyncio
+async def test_telegram_factory_without_connection_skips_handlers(monkeypatch):
+    class _FakeAdapter:
+        def __init__(self, **kw):
+            pass
+
+        async def initialize(self):
+            pass
+
+    installed: list = []
+    monkeypatch.setattr(tg_factory, "TelegramChannelAdapter", _FakeAdapter)
+    monkeypatch.setattr(
+        tg_factory, "_install_handlers", lambda *a: installed.append(a))
+    monkeypatch.setattr(
+        tg_factory, "TELEGRAM_CONNECTIONS", _FakeRegistry(None))
+    await tg_factory._telegram_factory(_provider("cp-y"), _channel(), object())
+    assert installed == []

--- a/tests/llm_adapters/test_ollama_adapter_cov.py
+++ b/tests/llm_adapters/test_ollama_adapter_cov.py
@@ -1,0 +1,805 @@
+"""Coverage tests for the OllamaLLM adapter.
+
+Placed outside ``tests/llm/`` so ``primer.llm.ollama`` counts in the CI
+unit sweep. Pure helpers are tested directly; the streaming surface is
+driven through a patched ``ollama.AsyncClient`` returning fake chunks.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+from types import SimpleNamespace as NS
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import ollama
+import pytest
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import HttpUrl, SecretStr
+
+from primer.llm.ollama import (
+    OllamaLLM,
+    _OPTIONS_KEYS,
+    _StreamState,
+    _TOP_LEVEL_KEYS,
+    _build_options_and_kwargs,
+    _classify_ollama_exception,
+    _map_stop_reason,
+    _maybe_log_unsupported_tool_choice,
+    _messages_to_ollama,
+    _next_index,
+    _response_format_to_ollama,
+    _tools_to_ollama,
+    _translate_chunk,
+)
+from primer.model.chat import (
+    AudioPart,
+    DocumentPart,
+    Done,
+    Error as ChatError,
+    ExtendedPart,
+    ImagePart,
+    Message,
+    ReasoningDelta,
+    StreamStart,
+    TextDelta,
+    TextPart,
+    Tool,
+    ToolCallEnd,
+    ToolCallPart,
+    ToolCallStart,
+    ToolResultPart,
+    Usage,
+    VideoPart,
+)
+from primer.model.except_ import (
+    AuthenticationError,
+    BadRequestError,
+    ConfigError,
+    ModelNotFoundError,
+    NetworkError,
+    ProviderError,
+    ProviderTimeoutError,
+    RateLimitError,
+    ServerError,
+    UnsupportedContentError,
+)
+from primer.model.provider import (
+    Limits,
+    LLMModel,
+    LLMProvider,
+    LLMProviderType,
+    OllamaConfig,
+)
+
+
+def _make_provider(
+    *,
+    url: str = "http://localhost:11434",
+    api_key: str | None = None,
+    models: list[str] | None = None,
+    max_concurrency: int = 4,
+    total_timeout_seconds: float | None = None,
+) -> LLMProvider:
+    return LLMProvider(
+        id="ollama-cov",
+        provider=LLMProviderType.OLLAMA,
+        models=[
+            LLMModel(name=name, context_length=8192) for name in (models or ["llama3"])
+        ],
+        config=OllamaConfig(
+            url=HttpUrl(url),
+            api_key=SecretStr(api_key) if api_key is not None else None,
+        ),
+        limits=Limits(
+            max_concurrency=max_concurrency,
+            total_timeout_seconds=total_timeout_seconds,
+        ),
+    )
+
+
+async def _aiter(items: list) -> AsyncIterator:
+    for item in items:
+        yield item
+
+
+def _patched_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_instance = MagicMock()
+    mock_instance.chat = AsyncMock()
+    cls_mock = MagicMock(return_value=mock_instance)
+    monkeypatch.setattr("primer.llm.ollama.ollama.AsyncClient", cls_mock)
+    return mock_instance
+
+
+def _ok_chunks() -> list[Any]:
+    return [
+        NS(model="llama3", done=False, message=NS(content="hi", thinking=None, tool_calls=None)),
+        NS(
+            model="llama3",
+            done=True,
+            done_reason="stop",
+            prompt_eval_count=5,
+            eval_count=3,
+            message=NS(content="", thinking=None, tool_calls=None),
+        ),
+    ]
+
+
+def _response_error(status_code: int | None, msg: str = "boom") -> ollama.ResponseError:
+    exc = ollama.ResponseError(msg)
+    exc.status_code = status_code  # type: ignore[assignment]
+    return exc
+
+
+# --------------------------------------------------------------------------- #
+# _classify_ollama_exception                                                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestClassify:
+    @pytest.mark.parametrize("status", [401, 403])
+    def test_auth(self, status: int) -> None:
+        exc = _response_error(status)
+        out = _classify_ollama_exception(exc)
+        assert isinstance(out, AuthenticationError)
+        assert out.status_code == status
+        assert out.cause is exc
+
+    def test_rate_limit(self) -> None:
+        assert isinstance(_classify_ollama_exception(_response_error(429)), RateLimitError)
+
+    def test_bad_request(self) -> None:
+        assert isinstance(_classify_ollama_exception(_response_error(400)), BadRequestError)
+
+    def test_server_error(self) -> None:
+        out = _classify_ollama_exception(_response_error(503))
+        assert isinstance(out, ServerError)
+        assert out.status_code == 503
+
+    def test_no_status_provider_error(self) -> None:
+        assert isinstance(_classify_ollama_exception(_response_error(None)), ProviderError)
+
+    def test_request_error_network(self) -> None:
+        out = _classify_ollama_exception(ollama.RequestError("conn refused"))
+        assert isinstance(out, NetworkError)
+
+    def test_httpx_timeout_network(self) -> None:
+        assert isinstance(
+            _classify_ollama_exception(httpx.TimeoutException("t")), NetworkError
+        )
+
+    def test_httpx_network_error_network(self) -> None:
+        assert isinstance(_classify_ollama_exception(httpx.NetworkError("down")), NetworkError)
+
+    def test_unknown_provider_error(self) -> None:
+        exc = RuntimeError("mystery")
+        out = _classify_ollama_exception(exc)
+        assert isinstance(out, ProviderError)
+        assert out.cause is exc
+
+
+# --------------------------------------------------------------------------- #
+# _messages_to_ollama                                                         #
+# --------------------------------------------------------------------------- #
+
+
+class TestMessagesToOllama:
+    def test_simple_text(self) -> None:
+        assert _messages_to_ollama(
+            [Message(role="user", parts=[TextPart(text="hi")])]
+        ) == [{"role": "user", "content": "hi"}]
+
+    def test_multiple_text_joined_newline(self) -> None:
+        assert _messages_to_ollama(
+            [Message(role="user", parts=[TextPart(text="a"), TextPart(text="b")])]
+        ) == [{"role": "user", "content": "a\nb"}]
+
+    def test_image_data_appended(self) -> None:
+        out = _messages_to_ollama(
+            [
+                Message(
+                    role="user",
+                    parts=[TextPart(text="d"), ImagePart(data=b"\x89PNG", mime_type="image/png")],
+                )
+            ]
+        )
+        assert out == [{"role": "user", "content": "d", "images": [b"\x89PNG"]}]
+
+    def test_image_url_without_data_raises(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="inline image data"):
+            _messages_to_ollama(
+                [Message(role="user", parts=[ImagePart(url="https://e/i.png")])]
+            )
+
+    def test_document_raises(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="documents"):
+            _messages_to_ollama(
+                [Message(role="user", parts=[DocumentPart(data=b"%PDF", mime_type="application/pdf")])]
+            )
+
+    def test_audio_raises(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="audio"):
+            _messages_to_ollama(
+                [Message(role="user", parts=[ExtendedPart(extended=AudioPart(data=b"x", mime_type="audio/mp3"))])]
+            )
+
+    def test_video_raises(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="video"):
+            _messages_to_ollama(
+                [Message(role="user", parts=[ExtendedPart(extended=VideoPart(url="https://e/v.mp4"))])]
+            )
+
+    def test_assistant_tool_call_nested(self) -> None:
+        out = _messages_to_ollama(
+            [
+                Message(
+                    role="assistant",
+                    parts=[
+                        TextPart(text="check"),
+                        ToolCallPart(id="c1", name="search", arguments={"q": "w"}),
+                    ],
+                )
+            ]
+        )
+        assert out == [
+            {
+                "role": "assistant",
+                "content": "check",
+                "tool_calls": [{"function": {"name": "search", "arguments": {"q": "w"}}}],
+            }
+        ]
+
+    def test_tool_role_id_to_name_lookup(self) -> None:
+        out = _messages_to_ollama(
+            [
+                Message(role="assistant", parts=[ToolCallPart(id="c1", name="search", arguments={})]),
+                Message(role="tool", parts=[ToolResultPart(id="c1", output="42")]),
+            ]
+        )
+        assert out[-1] == {"role": "tool", "content": "42", "tool_name": "search"}
+
+    def test_tool_role_unknown_id_empty_name(self) -> None:
+        out = _messages_to_ollama(
+            [Message(role="tool", parts=[ToolResultPart(id="unknown", output="42")])]
+        )
+        assert out == [{"role": "tool", "content": "42", "tool_name": ""}]
+
+    def test_tool_role_non_result_raises(self) -> None:
+        msg = Message.model_construct(role="tool", parts=[TextPart(text="oops")])
+        with pytest.raises(UnsupportedContentError, match="tool-role messages"):
+            _messages_to_ollama([msg])
+
+
+# --------------------------------------------------------------------------- #
+# tools / tool_choice / response_format / options                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestTools:
+    def test_none(self) -> None:
+        assert _tools_to_ollama(None) is None
+
+    def test_empty(self) -> None:
+        assert _tools_to_ollama([]) is None
+
+    def test_single_nested(self) -> None:
+        tool = Tool(
+            id="w",
+            description="weather",
+            toolset_id="kit",
+            args_schema={"type": "object", "properties": {"c": {"type": "string"}}},
+        )
+        out = _tools_to_ollama([tool])
+        assert out[0]["function"]["name"] == "w"
+        assert out[0]["type"] == "function"
+
+
+class TestToolChoice:
+    def test_none_silent(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.DEBUG, logger="primer.llm.ollama")
+        _maybe_log_unsupported_tool_choice(None)
+        assert all("tool_choice" not in r.message for r in caplog.records)
+
+    def test_non_none_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.DEBUG, logger="primer.llm.ollama")
+        _maybe_log_unsupported_tool_choice("auto")
+        assert any("tool_choice" in r.message for r in caplog.records)
+
+
+class TestResponseFormat:
+    def test_none(self) -> None:
+        assert _response_format_to_ollama(None) is None
+
+    def test_dict(self) -> None:
+        schema = {"type": "object"}
+        assert _response_format_to_ollama(schema) == schema
+
+    def test_pydantic(self) -> None:
+        class A(PydanticBaseModel):
+            value: int
+
+        out = _response_format_to_ollama(A)
+        assert "value" in out["properties"]
+
+    def test_invalid_raises(self) -> None:
+        with pytest.raises(ConfigError, match="response_format"):
+            _response_format_to_ollama(42)  # type: ignore[arg-type]
+
+
+class TestOptions:
+    def test_all_none(self) -> None:
+        options, top = _build_options_and_kwargs(
+            temperature=None, top_p=None, max_output_tokens=None, stop=None, extended=None
+        )
+        assert options == {} and top == {}
+
+    def test_sampling_to_options(self) -> None:
+        options, top = _build_options_and_kwargs(
+            temperature=0.7, top_p=0.9, max_output_tokens=128, stop=["END"], extended=None
+        )
+        assert options == {"temperature": 0.7, "top_p": 0.9, "num_predict": 128, "stop": ["END"]}
+        assert top == {}
+
+    @pytest.mark.parametrize("key", sorted(_OPTIONS_KEYS))
+    def test_options_keys_route(self, key: str) -> None:
+        options, top = _build_options_and_kwargs(
+            temperature=None, top_p=None, max_output_tokens=None, stop=None, extended={key: 1}
+        )
+        assert options == {key: 1} and top == {}
+
+    @pytest.mark.parametrize("key", sorted(_TOP_LEVEL_KEYS))
+    def test_top_level_keys_route(self, key: str) -> None:
+        options, top = _build_options_and_kwargs(
+            temperature=None, top_p=None, max_output_tokens=None, stop=None, extended={key: "v"}
+        )
+        assert options == {} and top == {key: "v"}
+
+    def test_unknown_dropped(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.DEBUG, logger="primer.llm.ollama")
+        options, top = _build_options_and_kwargs(
+            temperature=None,
+            top_p=None,
+            max_output_tokens=None,
+            stop=None,
+            extended={"frobnicate": True, "wibble": 42},
+        )
+        assert options == {} and top == {}
+        assert any("frobnicate" in r.message and "wibble" in r.message for r in caplog.records)
+
+
+# --------------------------------------------------------------------------- #
+# stop-reason / index / translate                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestStopReason:
+    def test_stop_no_tool(self) -> None:
+        assert _map_stop_reason("stop", _StreamState()) == "stop"
+
+    def test_stop_with_tool(self) -> None:
+        state = _StreamState()
+        state.saw_tool_call = True
+        assert _map_stop_reason("stop", state) == "tool_use"
+
+    @pytest.mark.parametrize("raw, mapped", [("length", "max_tokens"), ("load", "other"), ("x", "other"), (None, "other")])
+    def test_others(self, raw: str | None, mapped: str) -> None:
+        assert _map_stop_reason(raw, _StreamState()) == mapped
+
+
+class TestNextIndex:
+    def test_increments(self) -> None:
+        state = _StreamState()
+        assert (_next_index(state), _next_index(state), _next_index(state)) == (0, 1, 2)
+        assert state.next_index == 3
+
+
+class TestTranslate:
+    def test_first_chunk_stream_start(self) -> None:
+        state = _StreamState()
+        chunk = NS(model="llama3", done=False, message=NS(content="", thinking=None, tool_calls=None))
+        out = _translate_chunk(chunk, state, model_name="llama3")
+        assert any(isinstance(e, StreamStart) for e in out)
+        assert state.emitted_stream_start is True
+
+    def test_stream_start_falls_back_to_caller_model(self) -> None:
+        state = _StreamState()
+        chunk = NS(model=None, done=False, message=NS(content="", thinking=None, tool_calls=None))
+        out = _translate_chunk(chunk, state, model_name="caller")
+        start = next(e for e in out if isinstance(e, StreamStart))
+        assert start.model == "caller"
+
+    def test_text_delta(self) -> None:
+        state = _StreamState()
+        chunk = NS(model="m", done=False, message=NS(content="hi", thinking=None, tool_calls=None))
+        out = _translate_chunk(chunk, state, model_name="m")
+        deltas = [e for e in out if isinstance(e, TextDelta)]
+        assert deltas[0].text == "hi"
+
+    def test_reasoning_delta(self) -> None:
+        state = _StreamState()
+        chunk = NS(model="m", done=False, message=NS(content=None, thinking="hmm", tool_calls=None))
+        out = _translate_chunk(chunk, state, model_name="m")
+        assert any(isinstance(e, ReasoningDelta) and e.text == "hmm" for e in out)
+
+    def test_tool_calls_atomic(self) -> None:
+        state = _StreamState()
+        chunk = NS(
+            model="m",
+            done=False,
+            message=NS(
+                content=None,
+                thinking=None,
+                tool_calls=[NS(function=NS(name="search", arguments={"q": "w"}))],
+            ),
+        )
+        out = _translate_chunk(chunk, state, model_name="m")
+        assert [type(e).__name__ for e in out] == [
+            "StreamStart",
+            "ToolCallStart",
+            "ToolCallDelta",
+            "ToolCallEnd",
+        ]
+        start = next(e for e in out if isinstance(e, ToolCallStart))
+        end = next(e for e in out if isinstance(e, ToolCallEnd))
+        assert start.id == "call_0" and start.name == "search"
+        assert end.arguments == {"q": "w"}
+        assert state.saw_tool_call is True
+
+    def test_tool_call_missing_function_defaults(self) -> None:
+        state = _StreamState()
+        state.emitted_stream_start = True
+        chunk = NS(
+            model="m",
+            done=False,
+            message=NS(content=None, thinking=None, tool_calls=[NS(function=None)]),
+        )
+        out = _translate_chunk(chunk, state, model_name="m")
+        end = next(e for e in out if isinstance(e, ToolCallEnd))
+        assert end.arguments == {}
+        start = next(e for e in out if isinstance(e, ToolCallStart))
+        assert start.name == ""
+
+    def test_done_usage_then_done(self) -> None:
+        state = _StreamState()
+        state.emitted_stream_start = True
+        chunk = NS(
+            model="m",
+            done=True,
+            done_reason="stop",
+            prompt_eval_count=5,
+            eval_count=3,
+            message=NS(content="", thinking=None, tool_calls=None),
+        )
+        out = _translate_chunk(chunk, state, model_name="m")
+        assert [type(e).__name__ for e in out] == ["Usage", "Done"]
+        assert out[0].input_tokens == 5 and out[0].output_tokens == 3
+        assert out[1].raw_reason == "stop"
+
+    def test_done_without_tokens_omits_usage(self) -> None:
+        state = _StreamState()
+        state.emitted_stream_start = True
+        chunk = NS(
+            model="m",
+            done=True,
+            done_reason="stop",
+            prompt_eval_count=None,
+            eval_count=None,
+            message=NS(content="", thinking=None, tool_calls=None),
+        )
+        out = _translate_chunk(chunk, state, model_name="m")
+        assert [type(e).__name__ for e in out] == ["Done"]
+
+    def test_done_no_reason_uses_unknown(self) -> None:
+        state = _StreamState()
+        state.emitted_stream_start = True
+        chunk = NS(
+            model="m",
+            done=True,
+            done_reason=None,
+            prompt_eval_count=None,
+            eval_count=None,
+            message=NS(content="", thinking=None, tool_calls=None),
+        )
+        out = _translate_chunk(chunk, state, model_name="m")
+        assert isinstance(out[0], Done) and out[0].raw_reason == "unknown"
+
+    def test_none_message_chunk(self) -> None:
+        state = _StreamState()
+        chunk = NS(model="m", done=False, message=None)
+        out = _translate_chunk(chunk, state, model_name="m")
+        assert [type(e).__name__ for e in out] == ["StreamStart"]
+
+
+# --------------------------------------------------------------------------- #
+# Adapter surface                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestConstructor:
+    def test_valid(self) -> None:
+        assert OllamaLLM(_make_provider())._client is None
+
+    def test_with_api_key(self) -> None:
+        llm = OllamaLLM(_make_provider(api_key="tok"))
+        assert llm._config.api_key.get_secret_value() == "tok"
+
+    def test_wrong_provider_type_raises(self) -> None:
+        provider = _make_provider()
+        object.__setattr__(provider, "provider", LLMProviderType.OPENCHAT)
+        with pytest.raises(ConfigError, match="OLLAMA"):
+            OllamaLLM(provider)
+
+    def test_wrong_config_type_raises(self) -> None:
+        from primer.model.provider import OpenResponsesConfig
+
+        provider = LLMProvider(
+            id="x",
+            provider=LLMProviderType.OLLAMA,
+            models=[LLMModel(name="llama3", context_length=8192)],
+            config=OpenResponsesConfig(url=HttpUrl("https://x/v1/"), api_key=SecretStr("sk-x")),
+            limits=Limits(max_concurrency=1),
+        )
+        with pytest.raises(ConfigError, match="OllamaConfig"):
+            OllamaLLM(provider)
+
+    def test_logs_init(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO, logger="primer.llm.ollama")
+        OllamaLLM(_make_provider(models=["llama3", "mistral"]))
+        assert any("Ollama adapter initialized" in r.message for r in caplog.records)
+
+
+class TestGetClient:
+    def test_no_key_no_headers(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("primer.llm.ollama.ollama.AsyncClient", cls_mock)
+        OllamaLLM(_make_provider())._get_client()
+        kwargs = cls_mock.call_args.kwargs
+        assert kwargs["headers"] is None
+        assert "localhost:11434" in kwargs["host"]
+
+    def test_api_key_sets_bearer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("primer.llm.ollama.ollama.AsyncClient", cls_mock)
+        OllamaLLM(_make_provider(api_key="tok"))._get_client()
+        assert cls_mock.call_args.kwargs["headers"] == {"Authorization": "Bearer tok"}
+
+    def test_empty_key_no_header(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("primer.llm.ollama.ollama.AsyncClient", cls_mock)
+        OllamaLLM(_make_provider(api_key=""))._get_client()
+        assert cls_mock.call_args.kwargs["headers"] is None
+
+    def test_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("primer.llm.ollama.ollama.AsyncClient", cls_mock)
+        llm = OllamaLLM(_make_provider())
+        assert llm._get_client() is llm._get_client()
+        assert cls_mock.call_count == 1
+
+
+class TestListModelsAndTokens:
+    async def test_list_models(self) -> None:
+        llm = OllamaLLM(_make_provider(models=["llama3", "mistral"]))
+        assert list(await llm.list_models()) == ["llama3", "mistral"]
+
+    async def test_count_tokens_delegates(self) -> None:
+        llm = OllamaLLM(_make_provider())
+        with patch("primer.llm.ollama.count_tokens_hf", return_value=17) as mock:
+            n = await llm.count_tokens(
+                model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])], tools=None
+            )
+        assert n == 17
+        mock.assert_called_once()
+
+
+class TestAclose:
+    async def test_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _patched_client(monkeypatch)
+        client.close = AsyncMock()
+        llm = OllamaLLM(_make_provider())
+        llm._get_client()
+        await llm.aclose()
+        await llm.aclose()
+        assert client.close.await_count == 1
+
+
+class TestStream:
+    async def test_unknown_model_raises(self) -> None:
+        llm = OllamaLLM(_make_provider(models=["llama3"]))
+        with pytest.raises(ModelNotFoundError, match="not-real"):
+            async for _ in llm.stream(
+                model="not-real", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+            ):
+                pass
+
+    async def test_happy_path_events(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OllamaLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.return_value = _aiter(_ok_chunks())
+        kinds = [
+            type(e).__name__
+            async for e in llm.stream(
+                model="llama3",
+                messages=[Message(role="user", parts=[TextPart(text="hello")])],
+                max_output_tokens=64,
+            )
+        ]
+        assert kinds == ["StreamStart", "TextDelta", "Usage", "Done"]
+
+    async def test_request_payload_defaults(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OllamaLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.return_value = _aiter(_ok_chunks())
+        async for _ in llm.stream(
+            model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+        ):
+            pass
+        kwargs = client.chat.call_args.kwargs
+        assert kwargs["model"] == "llama3" and kwargs["stream"] is True
+        assert "tools" not in kwargs and "format" not in kwargs and "options" not in kwargs
+
+    async def test_request_payload_full(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OllamaLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.return_value = _aiter(_ok_chunks())
+        tool = Tool(
+            id="search",
+            description="Search",
+            toolset_id="default",
+            args_schema={"type": "object", "properties": {}, "required": []},
+        )
+        async for _ in llm.stream(
+            model="llama3",
+            messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            tools=[tool],
+            tool_choice="auto",
+            temperature=0.5,
+            max_output_tokens=64,
+            stop=["END"],
+            response_format={"type": "object"},
+            extended={"keep_alive": "10m", "top_k": 40},
+        ):
+            pass
+        kwargs = client.chat.call_args.kwargs
+        assert kwargs["tools"][0]["function"]["name"] == "search"
+        assert kwargs["options"]["num_predict"] == 64
+        assert kwargs["options"]["stop"] == ["END"]
+        assert kwargs["options"]["top_k"] == 40
+        assert kwargs["format"] == {"type": "object"}
+        assert kwargs["keep_alive"] == "10m"
+        assert "tool_choice" not in kwargs
+
+    async def test_trace_llm_io_records_messages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OllamaLLM(_make_provider(), trace_llm_io=True)
+        client = _patched_client(monkeypatch)
+        client.chat.return_value = _aiter(_ok_chunks())
+        kinds = [
+            type(e).__name__
+            async for e in llm.stream(
+                model="llama3",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                max_output_tokens=32,
+            )
+        ]
+        assert kinds[-1] == "Done"
+
+    async def test_pre_stream_error_reraised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OllamaLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.side_effect = _response_error(401)
+        with pytest.raises(AuthenticationError):
+            async for _ in llm.stream(
+                model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+            ):
+                pass
+
+    async def test_mid_stream_error_yields_chat_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OllamaLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+
+        async def failing() -> AsyncIterator:
+            yield NS(model="llama3", done=False, message=NS(content="hi", thinking=None, tool_calls=None))
+            raise _response_error(429)
+
+        client.chat.return_value = failing()
+        events = [
+            e
+            async for e in llm.stream(
+                model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+            )
+        ]
+        assert isinstance(events[0], StreamStart)
+        assert isinstance(events[-1], ChatError) and events[-1].fatal is True
+
+    async def test_connect_timeout_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OllamaLLM(_make_provider())
+        _patched_client(monkeypatch)
+
+        async def raise_connect_timeout(*_a, **_k):
+            raise ProviderTimeoutError("connect stalled", code="connect_timeout")
+
+        monkeypatch.setattr(
+            "primer.llm.ollama._open_with_connect_timeout", raise_connect_timeout
+        )
+        with pytest.raises(ProviderTimeoutError) as info:
+            async for _ in llm.stream(
+                model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+            ):
+                pass
+        assert info.value.code == "connect_timeout"
+
+    async def test_generation_budget_maps_to_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from primer.llm._timeout import GenerationBudgetExceeded
+
+        llm = OllamaLLM(_make_provider(total_timeout_seconds=30.0))
+        client = _patched_client(monkeypatch)
+        client.chat.return_value = _aiter(_ok_chunks())
+
+        async def budget_iter(*_a, **_k):
+            raise GenerationBudgetExceeded("over")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr("primer.llm.ollama._iter_with_timeout", budget_iter)
+        with pytest.raises(ProviderTimeoutError) as info:
+            async for _ in llm.stream(
+                model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+            ):
+                pass
+        assert info.value.code == "generation_timeout"
+
+    async def test_stall_timeout_maps_to_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OllamaLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.return_value = _aiter(_ok_chunks())
+
+        async def stall_iter(*_a, **_k):
+            raise TimeoutError("stall")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr("primer.llm.ollama._iter_with_timeout", stall_iter)
+        with pytest.raises(ProviderTimeoutError) as info:
+            async for _ in llm.stream(
+                model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+            ):
+                pass
+        assert info.value.code == "stream_timeout"
+
+
+class TestConcurrency:
+    async def test_semaphore_serialises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OllamaLLM(_make_provider(max_concurrency=1))
+        client = _patched_client(monkeypatch)
+        in_flight = 0
+        peak = 0
+
+        async def slow() -> AsyncIterator:
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)
+            for ch in _ok_chunks():
+                yield ch
+            in_flight -= 1
+
+        client.chat.side_effect = lambda **_: slow()
+
+        async def consume() -> None:
+            async for _ in llm.stream(
+                model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+            ):
+                pass
+
+        await asyncio.gather(consume(), consume(), consume())
+        assert peak == 1
+
+
+class TestPackageReexport:
+    def test_reexported(self) -> None:
+        import primer.llm as pkg
+
+        assert "OllamaLLM" in pkg.__all__
+        assert pkg.OllamaLLM is OllamaLLM

--- a/tests/llm_adapters/test_openai_compat_cov.py
+++ b/tests/llm_adapters/test_openai_compat_cov.py
@@ -1,0 +1,607 @@
+"""Coverage tests for the shared OpenAI-compatible helpers.
+
+Lives outside ``tests/llm/`` (which the CI coverage sweep ignores) so
+that ``primer.llm._openai_compat`` — the pure request-shaping and
+SSE-translation base shared by ``OpenChatLLM`` and ``OpenRouterLLM`` —
+is exercised by the *included* unit sweep.
+
+Every helper here is a pure function: no network, no mocking. Chunks are
+faked with ``SimpleNamespace`` so the ``getattr``-based translator sees
+duck-typed openai SDK objects.
+"""
+
+from __future__ import annotations
+
+import base64
+from types import SimpleNamespace as NS
+from typing import Any
+
+import pytest
+from pydantic import BaseModel as PydanticBaseModel
+
+from primer.llm._openai_compat import (
+    _ToolCallInProgress,
+    _StreamState,
+    _build_sampling_params,
+    _build_usage,
+    _extract_extended_kwargs,
+    _map_finish_reason,
+    _messages_to_chat,
+    _part_to_content,
+    _response_format_to_param,
+    _tool_choice_to_chat,
+    _tool_to_chat,
+    _translate_chunk,
+)
+from primer.model.chat import (
+    AudioPart,
+    DocumentPart,
+    Done,
+    ExtendedPart,
+    ImagePart,
+    Message,
+    StreamStart,
+    TextDelta,
+    TextPart,
+    Tool,
+    ToolCallDelta,
+    ToolCallEnd,
+    ToolCallPart,
+    ToolCallStart,
+    ToolResultPart,
+    Usage,
+    VideoPart,
+)
+from primer.model.except_ import ConfigError, UnsupportedContentError
+
+
+# --------------------------------------------------------------------------- #
+# _part_to_content                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestPartToContent:
+    def test_text_part(self) -> None:
+        assert _part_to_content(TextPart(text="hi")) == {"type": "text", "text": "hi"}
+
+    def test_image_url_plain(self) -> None:
+        out = _part_to_content(ImagePart(url="https://example.com/x.png"))
+        assert out == {
+            "type": "image_url",
+            "image_url": {"url": "https://example.com/x.png"},
+        }
+
+    def test_image_url_with_detail(self) -> None:
+        out = _part_to_content(ImagePart(url="https://example.com/x.png", detail="low"))
+        assert out["image_url"] == {"url": "https://example.com/x.png", "detail": "low"}
+
+    def test_image_data_becomes_data_uri(self) -> None:
+        out = _part_to_content(ImagePart(data=b"\x89PNG", mime_type="image/png"))
+        url = out["image_url"]["url"]
+        assert url.startswith("data:image/png;base64,")
+        assert base64.b64decode(url.split(",", 1)[1]) == b"\x89PNG"
+
+    def test_image_data_defaults_mime(self) -> None:
+        out = _part_to_content(ImagePart(data=b"raw"))
+        assert out["image_url"]["url"].startswith(
+            "data:application/octet-stream;base64,"
+        )
+
+    def test_image_file_id_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="file_id"):
+            _part_to_content(ImagePart(file_id="file-abc"))
+
+    def test_document_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="document"):
+            _part_to_content(DocumentPart(data=b"%PDF", mime_type="application/pdf"))
+
+    def test_audio_extended_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="audio"):
+            _part_to_content(
+                ExtendedPart(extended=AudioPart(data=b"x", mime_type="audio/mp3"))
+            )
+
+    def test_video_extended_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="video"):
+            _part_to_content(
+                ExtendedPart(extended=VideoPart(url="https://example.com/v.mp4"))
+            )
+
+
+# --------------------------------------------------------------------------- #
+# _messages_to_chat                                                            #
+# --------------------------------------------------------------------------- #
+
+
+class TestMessagesToChat:
+    def test_user_text_only_string_content(self) -> None:
+        assert _messages_to_chat(
+            [Message(role="user", parts=[TextPart(text="hello")])]
+        ) == [{"role": "user", "content": "hello"}]
+
+    def test_system_message(self) -> None:
+        assert _messages_to_chat(
+            [Message(role="system", parts=[TextPart(text="be terse")])]
+        ) == [{"role": "system", "content": "be terse"}]
+
+    def test_user_image_becomes_content_array_with_leading_text(self) -> None:
+        rows = _messages_to_chat(
+            [
+                Message(
+                    role="user",
+                    parts=[
+                        TextPart(text="describe"),
+                        ImagePart(url="https://example.com/cat.png"),
+                    ],
+                )
+            ]
+        )
+        assert rows == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": "describe"},
+                    {
+                        "type": "image_url",
+                        "image_url": {"url": "https://example.com/cat.png"},
+                    },
+                ],
+            }
+        ]
+
+    def test_image_only_content_array_no_text_prefix(self) -> None:
+        rows = _messages_to_chat(
+            [Message(role="user", parts=[ImagePart(url="https://x/y.png")])]
+        )
+        assert rows == [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "image_url", "image_url": {"url": "https://x/y.png"}}
+                ],
+            }
+        ]
+
+    def test_empty_message_yields_none_content(self) -> None:
+        rows = _messages_to_chat([Message.model_construct(role="assistant", parts=[])])
+        assert rows == [{"role": "assistant", "content": None}]
+
+    def test_assistant_tool_call_only_null_content(self) -> None:
+        rows = _messages_to_chat(
+            [
+                Message(
+                    role="assistant",
+                    parts=[ToolCallPart(id="c1", name="lookup", arguments={"q": "abc"})],
+                )
+            ]
+        )
+        assert rows == [
+            {
+                "role": "assistant",
+                "content": None,
+                "tool_calls": [
+                    {
+                        "id": "c1",
+                        "type": "function",
+                        "function": {"name": "lookup", "arguments": '{"q": "abc"}'},
+                    }
+                ],
+            }
+        ]
+
+    def test_assistant_text_plus_tool_call(self) -> None:
+        rows = _messages_to_chat(
+            [
+                Message(
+                    role="assistant",
+                    parts=[
+                        TextPart(text="checking"),
+                        ToolCallPart(id="c1", name="search", arguments={}),
+                    ],
+                )
+            ]
+        )
+        assert rows[0]["content"] == "checking"
+        assert rows[0]["tool_calls"][0]["function"]["arguments"] == "{}"
+
+    def test_tool_role_one_row_per_result(self) -> None:
+        rows = _messages_to_chat(
+            [
+                Message(
+                    role="tool",
+                    parts=[
+                        ToolResultPart(id="c1", output="a"),
+                        ToolResultPart(id="c2", output="b"),
+                    ],
+                )
+            ]
+        )
+        assert rows == [
+            {"role": "tool", "tool_call_id": "c1", "content": "a"},
+            {"role": "tool", "tool_call_id": "c2", "content": "b"},
+        ]
+
+    def test_tool_role_with_non_result_raises(self) -> None:
+        msg = Message.model_construct(role="tool", parts=[TextPart(text="nope")])
+        with pytest.raises(UnsupportedContentError, match="ToolResultPart"):
+            _messages_to_chat([msg])
+
+    def test_tool_result_in_non_tool_message_raises(self) -> None:
+        msg = Message.model_construct(
+            role="assistant", parts=[ToolResultPart(id="c1", output="x")]
+        )
+        with pytest.raises(UnsupportedContentError, match="only valid inside a tool"):
+            _messages_to_chat([msg])
+
+    def test_full_conversation_roles_order(self) -> None:
+        rows = _messages_to_chat(
+            [
+                Message(role="system", parts=[TextPart(text="sys")]),
+                Message(role="user", parts=[TextPart(text="q")]),
+                Message(
+                    role="assistant",
+                    parts=[ToolCallPart(id="c1", name="w", arguments={"c": "NYC"})],
+                ),
+                Message(role="tool", parts=[ToolResultPart(id="c1", output="sunny")]),
+                Message(role="assistant", parts=[TextPart(text="done")]),
+            ]
+        )
+        assert [r["role"] for r in rows] == [
+            "system",
+            "user",
+            "assistant",
+            "tool",
+            "assistant",
+        ]
+
+
+# --------------------------------------------------------------------------- #
+# tools / tool_choice / response_format                                        #
+# --------------------------------------------------------------------------- #
+
+
+class TestTools:
+    def test_tool_to_chat_wraps_function_and_drops_toolset(self) -> None:
+        tool = Tool(
+            id="add",
+            description="Add",
+            toolset_id="math",
+            args_schema={"type": "object", "properties": {}},
+        )
+        out = _tool_to_chat(tool)
+        assert out["type"] == "function"
+        assert out["function"]["name"] == "add"
+        assert "toolset_id" not in out["function"]
+
+
+class TestToolChoice:
+    def test_none(self) -> None:
+        assert _tool_choice_to_chat(None) is None
+
+    @pytest.mark.parametrize("mode", ["auto", "required", "none"])
+    def test_modes_pass_through(self, mode: str) -> None:
+        assert _tool_choice_to_chat(mode) == mode
+
+    def test_named_tool_wraps(self) -> None:
+        assert _tool_choice_to_chat("add") == {
+            "type": "function",
+            "function": {"name": "add"},
+        }
+
+
+class TestResponseFormat:
+    def test_none(self) -> None:
+        assert _response_format_to_param(None) is None
+
+    def test_dict_schema(self) -> None:
+        schema = {"type": "object", "properties": {"x": {"type": "integer"}}}
+        assert _response_format_to_param(schema) == {
+            "type": "json_schema",
+            "json_schema": {"name": "schema", "schema": schema, "strict": True},
+        }
+
+    def test_pydantic_class(self) -> None:
+        class Reply(PydanticBaseModel):
+            value: int
+
+        out = _response_format_to_param(Reply)
+        assert out is not None
+        assert out["json_schema"]["name"] == "Reply"
+        assert out["json_schema"]["strict"] is True
+        assert "value" in out["json_schema"]["schema"]["properties"]
+
+    def test_invalid_type_raises(self) -> None:
+        with pytest.raises(ConfigError, match="response_format"):
+            _response_format_to_param(123)  # type: ignore[arg-type]
+
+
+# --------------------------------------------------------------------------- #
+# sampling / extended                                                          #
+# --------------------------------------------------------------------------- #
+
+
+class TestSampling:
+    def test_all_none_empty(self) -> None:
+        assert (
+            _build_sampling_params(
+                temperature=None, top_p=None, max_output_tokens=None, stop=None
+            )
+            == {}
+        )
+
+    def test_temp_top_p(self) -> None:
+        out = _build_sampling_params(
+            temperature=0.7, top_p=0.9, max_output_tokens=None, stop=None
+        )
+        assert out["temperature"] == 0.7
+        assert out["top_p"] == 0.9
+
+    def test_max_tokens_key(self) -> None:
+        assert _build_sampling_params(
+            temperature=None, top_p=None, max_output_tokens=512, stop=None
+        ) == {"max_tokens": 512}
+
+    def test_stop_native(self) -> None:
+        assert _build_sampling_params(
+            temperature=None, top_p=None, max_output_tokens=None, stop=["E", "\n"]
+        ) == {"stop": ["E", "\n"]}
+
+
+class TestExtendedKwargs:
+    def test_none(self) -> None:
+        assert _extract_extended_kwargs(None) == {}
+
+    def test_empty(self) -> None:
+        assert _extract_extended_kwargs({}) == {}
+
+    @pytest.mark.parametrize(
+        "key, value",
+        [
+            ("parallel_tool_calls", False),
+            ("presence_penalty", 0.5),
+            ("frequency_penalty", -0.25),
+            ("logprobs", True),
+            ("top_logprobs", 3),
+            ("seed", 7),
+            ("user", "u-123"),
+        ],
+    )
+    def test_recognised_pass_through(self, key: str, value: Any) -> None:
+        assert _extract_extended_kwargs({key: value}) == {key: value}
+
+    def test_unknown_dropped(self) -> None:
+        assert _extract_extended_kwargs({"frobnicate": True, "foobar": 1}) == {}
+
+    def test_reasoning_keys_dropped(self) -> None:
+        assert (
+            _extract_extended_kwargs(
+                {"reasoning_effort": "high", "reasoning_summary": "brief"}
+            )
+            == {}
+        )
+
+    def test_mixed_keeps_only_recognised(self) -> None:
+        assert _extract_extended_kwargs({"seed": 1, "junk": 2}) == {"seed": 1}
+
+
+# --------------------------------------------------------------------------- #
+# finish-reason / usage helpers                                               #
+# --------------------------------------------------------------------------- #
+
+
+class TestFinishReason:
+    @pytest.mark.parametrize(
+        "raw, mapped",
+        [
+            ("stop", "stop"),
+            ("length", "max_tokens"),
+            ("tool_calls", "tool_use"),
+            ("content_filter", "content_filter"),
+            ("weird", "other"),
+            (None, "other"),
+        ],
+    )
+    def test_map(self, raw: str | None, mapped: str) -> None:
+        assert _map_finish_reason(raw) == mapped
+
+
+class TestBuildUsage:
+    def test_none(self) -> None:
+        assert _build_usage(None) is None
+
+    def test_partial_none(self) -> None:
+        assert _build_usage(NS(prompt_tokens=None, completion_tokens=4)) is None
+        assert _build_usage(NS(prompt_tokens=4, completion_tokens=None)) is None
+
+    def test_full(self) -> None:
+        out = _build_usage(NS(prompt_tokens=11, completion_tokens=7))
+        assert isinstance(out, Usage)
+        assert (out.input_tokens, out.output_tokens, out.cumulative) == (11, 7, False)
+
+
+# --------------------------------------------------------------------------- #
+# dataclass state                                                             #
+# --------------------------------------------------------------------------- #
+
+
+class TestState:
+    def test_stream_state_defaults(self) -> None:
+        state = _StreamState()
+        assert state.stream_started is False
+        assert state.saw_function_call is False
+        assert state.tool_calls == {}
+        assert state.request_id is None
+        assert state.model == ""
+
+    def test_tool_call_in_progress_defaults(self) -> None:
+        tc = _ToolCallInProgress(call_id="c1", name="search")
+        assert tc.arguments_buffer == ""
+        assert tc.index == 0
+
+
+# --------------------------------------------------------------------------- #
+# _translate_chunk                                                            #
+# --------------------------------------------------------------------------- #
+
+
+def _delta_chunk(
+    *, role=None, content=None, tool_calls=None, finish_reason=None, usage=None
+) -> NS:
+    return NS(
+        id="chatcmpl-1",
+        model="gpt-test",
+        choices=[
+            NS(
+                index=0,
+                delta=NS(role=role, content=content, tool_calls=tool_calls),
+                finish_reason=finish_reason,
+            )
+        ],
+        usage=usage,
+    )
+
+
+class TestTranslateChunk:
+    def test_role_chunk_emits_stream_start(self) -> None:
+        state = _StreamState()
+        out = _translate_chunk(_delta_chunk(role="assistant"), state)
+        assert len(out) == 1 and isinstance(out[0], StreamStart)
+        assert out[0].request_id == "chatcmpl-1"
+        assert out[0].model == "gpt-test"
+        assert state.stream_started is True
+
+    def test_role_and_content_same_chunk(self) -> None:
+        state = _StreamState()
+        out = _translate_chunk(_delta_chunk(role="assistant", content="hi"), state)
+        assert [type(e).__name__ for e in out] == ["StreamStart", "TextDelta"]
+
+    def test_text_delta_after_start(self) -> None:
+        state = _StreamState()
+        _translate_chunk(_delta_chunk(role="assistant"), state)
+        out = _translate_chunk(_delta_chunk(content="hello"), state)
+        assert isinstance(out[0], TextDelta) and out[0].text == "hello"
+
+    def test_tool_call_start_then_delta_append(self) -> None:
+        state = _StreamState()
+        _translate_chunk(_delta_chunk(role="assistant"), state)
+        start = _translate_chunk(
+            _delta_chunk(
+                tool_calls=[
+                    NS(index=0, id="call_z", function=NS(name="search", arguments=""))
+                ]
+            ),
+            state,
+        )
+        assert isinstance(start[0], ToolCallStart)
+        assert start[0].id == "call_z" and start[0].name == "search"
+        assert state.saw_function_call is True
+        # append onto existing tracked call
+        more = _translate_chunk(
+            _delta_chunk(
+                tool_calls=[
+                    NS(index=0, id=None, function=NS(name=None, arguments='{"q":1}'))
+                ]
+            ),
+            state,
+        )
+        assert isinstance(more[0], ToolCallDelta)
+        assert more[0].arguments_delta == '{"q":1}' and more[0].id == "call_z"
+
+    def test_tool_call_start_with_initial_args_emits_start_and_delta(self) -> None:
+        state = _StreamState()
+        _translate_chunk(_delta_chunk(role="assistant"), state)
+        out = _translate_chunk(
+            _delta_chunk(
+                tool_calls=[
+                    NS(index=0, id="call_a", function=NS(name="f", arguments='{"a":'))
+                ]
+            ),
+            state,
+        )
+        kinds = [type(e).__name__ for e in out]
+        assert kinds == ["ToolCallStart", "ToolCallDelta"]
+        assert out[1].arguments_delta == '{"a":'
+
+    def test_finish_tool_calls_flushes_end_then_done(self) -> None:
+        state = _StreamState()
+        _translate_chunk(_delta_chunk(role="assistant"), state)
+        _translate_chunk(
+            _delta_chunk(
+                tool_calls=[
+                    NS(
+                        index=0,
+                        id="call_q",
+                        function=NS(name="lookup", arguments='{"q":"v"}'),
+                    )
+                ]
+            ),
+            state,
+        )
+        out = _translate_chunk(_delta_chunk(finish_reason="tool_calls"), state)
+        assert [type(e).__name__ for e in out] == ["ToolCallEnd", "Done"]
+        end = out[0]
+        assert isinstance(end, ToolCallEnd)
+        assert end.id == "call_q" and end.arguments == {"q": "v"}
+        assert out[1].stop_reason == "tool_use" and out[1].raw_reason == "tool_calls"
+
+    def test_finish_tool_calls_invalid_json_defaults_empty(self) -> None:
+        state = _StreamState()
+        _translate_chunk(_delta_chunk(role="assistant"), state)
+        _translate_chunk(
+            _delta_chunk(
+                tool_calls=[
+                    NS(index=0, id="c", function=NS(name="f", arguments="{not-json"))
+                ]
+            ),
+            state,
+        )
+        out = _translate_chunk(_delta_chunk(finish_reason="tool_calls"), state)
+        end = out[0]
+        assert isinstance(end, ToolCallEnd) and end.arguments == {}
+
+    def test_finish_stop_with_usage(self) -> None:
+        state = _StreamState()
+        _translate_chunk(_delta_chunk(role="assistant", content="ok"), state)
+        out = _translate_chunk(
+            _delta_chunk(finish_reason="stop", usage=NS(prompt_tokens=12, completion_tokens=6)),
+            state,
+        )
+        assert [type(e).__name__ for e in out] == ["Usage", "Done"]
+        assert out[0].input_tokens == 12 and out[0].output_tokens == 6
+        assert out[1].stop_reason == "stop"
+
+    def test_finish_length_maps_max_tokens(self) -> None:
+        state = _StreamState()
+        state.stream_started = True
+        out = _translate_chunk(_delta_chunk(finish_reason="length"), state)
+        assert isinstance(out[-1], Done) and out[-1].stop_reason == "max_tokens"
+
+    def test_finish_content_filter(self) -> None:
+        state = _StreamState()
+        state.stream_started = True
+        out = _translate_chunk(_delta_chunk(finish_reason="content_filter"), state)
+        assert isinstance(out[-1], Done) and out[-1].stop_reason == "content_filter"
+
+    def test_trailing_usage_only_no_choices(self) -> None:
+        state = _StreamState()
+        state.stream_started = True
+        chunk = NS(id="x", model="m", choices=[], usage=NS(prompt_tokens=3, completion_tokens=4))
+        out = _translate_chunk(chunk, state)
+        assert len(out) == 1 and isinstance(out[0], Usage)
+        assert out[0].input_tokens == 3
+
+    def test_no_choices_no_usage_empty(self) -> None:
+        state = _StreamState()
+        state.stream_started = True
+        chunk = NS(id="x", model="m", choices=[], usage=None)
+        assert _translate_chunk(chunk, state) == []
+
+    def test_delta_none_produces_nothing(self) -> None:
+        state = _StreamState()
+        chunk = NS(
+            id="x",
+            model="m",
+            choices=[NS(index=0, delta=None, finish_reason=None)],
+            usage=None,
+        )
+        assert _translate_chunk(chunk, state) == []

--- a/tests/llm_adapters/test_openchat_adapter_cov.py
+++ b/tests/llm_adapters/test_openchat_adapter_cov.py
@@ -1,0 +1,447 @@
+"""Coverage tests for the OpenChatLLM adapter (Chat Completions).
+
+Placed outside ``tests/llm/`` so ``primer.llm.openchat`` counts in the
+CI unit sweep. The openai SDK client is patched with a MagicMock whose
+``chat.completions.create`` returns an async iterator of fake chunks, so
+these tests are pure in-process — no network IO.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator
+from types import SimpleNamespace as NS
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import openai
+import pytest
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import HttpUrl, SecretStr
+
+from primer.llm.openchat import OpenChatLLM, _POLICY_BY_FLAVOR
+from primer.model.chat import (
+    Error as ChatError,
+    Message,
+    StreamStart,
+    TextPart,
+    Tool,
+)
+from primer.model.except_ import (
+    AuthenticationError,
+    ConfigError,
+    ModelNotFoundError,
+    ProviderTimeoutError,
+    RateLimitError,
+)
+from primer.model.provider import (
+    Limits,
+    LLMModel,
+    LLMProvider,
+    LLMProviderType,
+    OpenChatConfig,
+    OpenChatFlavor,
+)
+
+
+def _make_provider(
+    *,
+    flavor: OpenChatFlavor = OpenChatFlavor.OPENAI,
+    api_key: str | None = "sk-test",
+    models: list[str] | None = None,
+    max_concurrency: int = 4,
+    url: str = "https://api.openai.com/v1/",
+    total_timeout_seconds: float | None = None,
+) -> LLMProvider:
+    return LLMProvider(
+        id="openchat-cov",
+        provider=LLMProviderType.OPENCHAT,
+        models=[
+            LLMModel(name=name, context_length=8192)
+            for name in (models or ["gpt-4o-mini"])
+        ],
+        config=OpenChatConfig(
+            url=HttpUrl(url),
+            api_key=SecretStr(api_key) if api_key is not None else None,
+            flavor=flavor,
+        ),
+        limits=Limits(
+            max_concurrency=max_concurrency,
+            total_timeout_seconds=total_timeout_seconds,
+        ),
+    )
+
+
+async def _aiter(items: list) -> AsyncIterator:
+    for item in items:
+        yield item
+
+
+def _patched_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    mock_instance = MagicMock()
+    mock_instance.chat = MagicMock()
+    mock_instance.chat.completions = MagicMock()
+    mock_instance.chat.completions.create = AsyncMock()
+    cls_mock = MagicMock(return_value=mock_instance)
+    monkeypatch.setattr("primer.llm.openchat.AsyncOpenAI", cls_mock)
+    return mock_instance
+
+
+def _make_openai_error(cls: type, *, status_code: int = 400, code: str | None = None):
+    exc = cls.__new__(cls)
+    exc.status_code = status_code
+    exc.code = code
+    exc.message = f"test {cls.__name__}"
+    Exception.__init__(exc, exc.message)
+    return exc
+
+
+def _simple_seq(model: str = "gpt-4o-mini") -> list[Any]:
+    return [
+        NS(
+            id="chatcmpl-1",
+            model=model,
+            choices=[NS(index=0, delta=NS(role="assistant", content=None, tool_calls=None), finish_reason=None)],
+            usage=None,
+        ),
+        NS(
+            id="chatcmpl-1",
+            model=model,
+            choices=[NS(index=0, delta=NS(role=None, content="hello", tool_calls=None), finish_reason=None)],
+            usage=None,
+        ),
+        NS(
+            id="chatcmpl-1",
+            model=model,
+            choices=[NS(index=0, delta=NS(role=None, content=None, tool_calls=None), finish_reason="stop")],
+            usage=NS(prompt_tokens=4, completion_tokens=2),
+        ),
+    ]
+
+
+class TestFlavorPolicy:
+    @pytest.mark.parametrize(
+        "flavor, requires",
+        [
+            (OpenChatFlavor.OPENAI, True),
+            (OpenChatFlavor.LMSTUDIO, False),
+            (OpenChatFlavor.OLLAMA, False),
+            (OpenChatFlavor.VLLM, False),
+            (OpenChatFlavor.OTHER, True),
+        ],
+    )
+    def test_policy_table(self, flavor: OpenChatFlavor, requires: bool) -> None:
+        assert _POLICY_BY_FLAVOR[flavor].require_api_key is requires
+
+    def test_policy_frozen(self) -> None:
+        with pytest.raises(Exception):
+            _POLICY_BY_FLAVOR[OpenChatFlavor.OPENAI].require_api_key = False  # type: ignore[misc]
+
+
+class TestConstructor:
+    def test_valid_openai(self) -> None:
+        llm = OpenChatLLM(_make_provider())
+        assert llm._policy is _POLICY_BY_FLAVOR[OpenChatFlavor.OPENAI]
+        assert llm._client is None
+
+    def test_lmstudio_no_key_ok(self) -> None:
+        llm = OpenChatLLM(
+            _make_provider(flavor=OpenChatFlavor.LMSTUDIO, api_key=None, url="http://localhost:1234/v1/")
+        )
+        assert llm._policy.require_api_key is False
+
+    def test_empty_key_openai_raises(self) -> None:
+        with pytest.raises(ConfigError, match="api_key is required"):
+            OpenChatLLM(_make_provider(api_key=""))
+
+    def test_missing_key_other_flavor_raises(self) -> None:
+        with pytest.raises(ConfigError, match="api_key is required"):
+            OpenChatLLM(
+                _make_provider(flavor=OpenChatFlavor.OTHER, api_key=None, url="https://api.example.com/v1/")
+            )
+
+    def test_wrong_provider_type_raises(self) -> None:
+        provider = _make_provider()
+        object.__setattr__(provider, "provider", LLMProviderType.OPENRESPONSES)
+        with pytest.raises(ConfigError, match="OPENCHAT"):
+            OpenChatLLM(provider)
+
+    def test_wrong_config_type_raises(self) -> None:
+        from primer.model.provider import OpenResponsesConfig
+
+        provider = LLMProvider(
+            id="x",
+            provider=LLMProviderType.OPENCHAT,
+            models=[LLMModel(name="gpt-4o-mini", context_length=8192)],
+            config=OpenResponsesConfig(url=HttpUrl("https://x/v1/"), api_key=SecretStr("sk-x")),
+            limits=Limits(max_concurrency=1),
+        )
+        with pytest.raises(ConfigError, match="OpenChatConfig"):
+            OpenChatLLM(provider)
+
+    def test_logs_init(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO, logger="primer.llm.openchat")
+        OpenChatLLM(_make_provider(models=["gpt-4o-mini", "gpt-4o"], max_concurrency=2))
+        records = [r for r in caplog.records if "OpenChat adapter" in r.message]
+        assert len(records) == 1
+        assert records[0].flavor == "openai"  # type: ignore[attr-defined]
+
+
+class TestGetClient:
+    def test_client_uses_config_key(self) -> None:
+        llm = OpenChatLLM(_make_provider(api_key="sk-xyz"))
+        client = llm._get_client()
+        assert client.api_key == "sk-xyz"
+        assert str(client.base_url).rstrip("/").endswith("openai.com/v1")
+
+    def test_client_no_key_uses_placeholder(self) -> None:
+        llm = OpenChatLLM(
+            _make_provider(flavor=OpenChatFlavor.LMSTUDIO, api_key=None, url="http://localhost:1234/v1/")
+        )
+        client = llm._get_client()
+        assert client.api_key == "no-key-required"
+
+    def test_client_cached(self) -> None:
+        llm = OpenChatLLM(_make_provider())
+        assert llm._get_client() is llm._get_client()
+
+
+class TestListModelsAndTokens:
+    async def test_list_models_configured(self) -> None:
+        llm = OpenChatLLM(_make_provider(models=["gpt-4o-mini", "gpt-4o"]))
+        assert list(await llm.list_models()) == ["gpt-4o-mini", "gpt-4o"]
+
+    async def test_list_models_no_upstream_call(self) -> None:
+        llm = OpenChatLLM(_make_provider())
+        with patch.object(OpenChatLLM, "_get_client") as mock:
+            await llm.list_models()
+            mock.assert_not_called()
+
+    async def test_count_tokens_positive(self) -> None:
+        llm = OpenChatLLM(_make_provider(models=["gpt-4o"]))
+        n = await llm.count_tokens(
+            model="gpt-4o",
+            messages=[Message(role="user", parts=[TextPart(text="hello world")])],
+            tools=None,
+        )
+        assert isinstance(n, int) and n > 0
+
+
+class TestAclose:
+    async def test_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        client = _patched_client(monkeypatch)
+        client.close = AsyncMock()
+        llm = OpenChatLLM(_make_provider())
+        llm._get_client()
+        await llm.aclose()
+        await llm.aclose()
+        assert client.close.await_count == 1
+
+
+class TestStream:
+    async def test_unknown_model_raises(self) -> None:
+        llm = OpenChatLLM(_make_provider(models=["gpt-4o-mini"]))
+        with pytest.raises(ModelNotFoundError, match="not-a-real-model"):
+            async for _ in llm.stream(
+                model="not-a-real-model",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+    async def test_happy_path_event_sequence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenChatLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.completions.create.return_value = _aiter(_simple_seq())
+        kinds = [
+            type(e).__name__
+            async for e in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            )
+        ]
+        assert kinds == ["StreamStart", "TextDelta", "Usage", "Done"]
+
+    async def test_request_payload_full(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenChatLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.completions.create.return_value = _aiter(_simple_seq())
+
+        class Out(PydanticBaseModel):
+            value: int
+
+        tool = Tool(
+            id="search",
+            description="Search",
+            toolset_id="default",
+            args_schema={"type": "object", "properties": {}, "required": []},
+        )
+        async for _ in llm.stream(
+            model="gpt-4o-mini",
+            messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            temperature=0.5,
+            top_p=0.9,
+            max_output_tokens=64,
+            stop=["END"],
+            tools=[tool],
+            tool_choice="auto",
+            response_format=Out,
+            extended={"seed": 42, "frobnicate": True},
+        ):
+            pass
+        kwargs = client.chat.completions.create.call_args.kwargs
+        assert kwargs["stream"] is True
+        assert kwargs["stream_options"] == {"include_usage": True}
+        assert kwargs["temperature"] == 0.5
+        assert kwargs["top_p"] == 0.9
+        assert kwargs["max_tokens"] == 64
+        assert kwargs["stop"] == ["END"]
+        assert kwargs["tools"][0]["function"]["name"] == "search"
+        assert kwargs["tool_choice"] == "auto"
+        assert kwargs["response_format"]["json_schema"]["name"] == "Out"
+        assert kwargs["seed"] == 42
+        assert "frobnicate" not in kwargs
+
+    async def test_request_payload_omits_optionals(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenChatLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.completions.create.return_value = _aiter(_simple_seq())
+        async for _ in llm.stream(
+            model="gpt-4o-mini",
+            messages=[Message(role="user", parts=[TextPart(text="hi")])],
+        ):
+            pass
+        kwargs = client.chat.completions.create.call_args.kwargs
+        for omitted in ("temperature", "top_p", "max_tokens", "stop", "tools", "tool_choice", "response_format"):
+            assert omitted not in kwargs
+
+    async def test_trace_llm_io_records_messages(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenChatLLM(_make_provider(), trace_llm_io=True)
+        client = _patched_client(monkeypatch)
+        client.chat.completions.create.return_value = _aiter(_simple_seq())
+        kinds = [
+            type(e).__name__
+            async for e in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                max_output_tokens=32,
+            )
+        ]
+        assert kinds[-1] == "Done"
+
+    async def test_pre_stream_auth_error_reraised(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenChatLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.completions.create.side_effect = _make_openai_error(
+            openai.AuthenticationError, status_code=401
+        )
+        with pytest.raises(AuthenticationError):
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+    async def test_mid_stream_error_yields_chat_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenChatLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+
+        async def failing() -> AsyncIterator:
+            yield NS(
+                id="x",
+                model="gpt-4o-mini",
+                choices=[NS(index=0, delta=NS(role="assistant", content=None, tool_calls=None), finish_reason=None)],
+                usage=None,
+            )
+            raise _make_openai_error(openai.RateLimitError, status_code=429)
+
+        client.chat.completions.create.return_value = failing()
+        events = [
+            e
+            async for e in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            )
+        ]
+        assert isinstance(events[0], StreamStart)
+        assert isinstance(events[-1], ChatError)
+        assert events[-1].fatal is True
+
+    async def test_generation_budget_maps_to_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from primer.llm._timeout import GenerationBudgetExceeded
+
+        llm = OpenChatLLM(_make_provider(total_timeout_seconds=30.0))
+        client = _patched_client(monkeypatch)
+        client.chat.completions.create.return_value = _aiter(_simple_seq())
+
+        async def budget_iter(*_a, **_k):
+            raise GenerationBudgetExceeded("over budget")
+            yield  # pragma: no cover - marks this an async generator
+
+        monkeypatch.setattr("primer.llm.openchat._iter_with_timeout", budget_iter)
+        with pytest.raises(ProviderTimeoutError) as info:
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+        assert info.value.code == "generation_timeout"
+
+    async def test_stall_timeout_maps_to_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenChatLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.chat.completions.create.return_value = _aiter(_simple_seq())
+
+        async def stall_iter(*_a, **_k):
+            raise TimeoutError("stall")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr("primer.llm.openchat._iter_with_timeout", stall_iter)
+        with pytest.raises(ProviderTimeoutError) as info:
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+        assert info.value.code == "stream_timeout"
+
+
+class TestConcurrency:
+    async def test_semaphore_serialises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenChatLLM(_make_provider(max_concurrency=1))
+        client = _patched_client(monkeypatch)
+        in_flight = 0
+        peak = 0
+
+        async def slow() -> AsyncIterator:
+            nonlocal in_flight, peak
+            in_flight += 1
+            peak = max(peak, in_flight)
+            await asyncio.sleep(0.01)
+            yield NS(
+                id="x",
+                model="gpt-4o-mini",
+                choices=[NS(index=0, delta=NS(role="assistant", content="hi", tool_calls=None), finish_reason="stop")],
+                usage=NS(prompt_tokens=1, completion_tokens=1),
+            )
+            in_flight -= 1
+
+        client.chat.completions.create.side_effect = lambda **_: slow()
+
+        async def consume() -> None:
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+        await asyncio.gather(consume(), consume(), consume())
+        assert peak == 1
+
+
+class TestPackageReexport:
+    def test_reexported(self) -> None:
+        import primer.llm as pkg
+
+        assert "OpenChatLLM" in pkg.__all__
+        assert pkg.OpenChatLLM is OpenChatLLM

--- a/tests/llm_adapters/test_openrouter_adapter_cov.py
+++ b/tests/llm_adapters/test_openrouter_adapter_cov.py
@@ -1,0 +1,491 @@
+"""Coverage tests for the OpenRouterLLM adapter.
+
+Placed outside ``tests/llm/`` so ``primer.llm.openrouter`` counts in the
+CI unit sweep. The openai SDK transport is mocked with respx, so the
+stream/discover paths run in-process with no network IO.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import httpx
+import pytest
+import respx
+from pydantic import BaseModel as PydanticBaseModel
+from pydantic import SecretStr
+
+from primer.llm.openrouter import (
+    OPENROUTER_BASE_URL,
+    OpenRouterLLM,
+    _attribution_headers,
+    _discover_openrouter_models,
+)
+from primer.model.chat import (
+    Done,
+    Error as ChatError,
+    Message,
+    StreamStart,
+    TextDelta,
+    TextPart,
+    Tool,
+    Usage,
+)
+from primer.model.except_ import (
+    BadRequestError,
+    ConfigError,
+    ModelNotFoundError,
+    ProviderTimeoutError,
+)
+from primer.model.provider import (
+    Limits,
+    LLMModel,
+    LLMProvider,
+    LLMProviderType,
+    OpenRouterConfig,
+)
+
+
+def _make_provider(
+    *,
+    api_key: str = "sk-or-v1-abc",
+    app_name: str | None = None,
+    app_url: str | None = None,
+    models: list[str] | None = None,
+    total_timeout_seconds: float | None = None,
+) -> LLMProvider:
+    return LLMProvider(
+        id="or-cov",
+        provider=LLMProviderType.OPENROUTER,
+        config=OpenRouterConfig(
+            api_key=SecretStr(api_key),
+            app_name=app_name,
+            app_url=app_url,
+        ),
+        models=[
+            LLMModel(name=n, context_length=200000)
+            for n in (models or ["anthropic/claude-3.5-sonnet"])
+        ],
+        limits=Limits(
+            max_concurrency=4,
+            total_timeout_seconds=total_timeout_seconds,
+        ),
+    )
+
+
+_SSE = (
+    b'data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"role":"assistant"},"finish_reason":null}]}\n\n'
+    b'data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{"content":"hello"},"finish_reason":null}]}\n\n'
+    b'data: {"id":"x","object":"chat.completion.chunk","choices":[{"index":0,"delta":{},"finish_reason":"stop"}],"usage":{"prompt_tokens":1,"completion_tokens":2,"total_tokens":3}}\n\n'
+    b"data: [DONE]\n\n"
+)
+
+
+def _mock_stream() -> None:
+    respx.post(f"{OPENROUTER_BASE_URL}/chat/completions").mock(
+        return_value=httpx.Response(
+            200, content=_SSE, headers={"content-type": "text/event-stream"}
+        )
+    )
+
+
+class TestAttributionHeaders:
+    def test_both_fields(self) -> None:
+        h = _attribution_headers(
+            OpenRouterConfig(
+                api_key=SecretStr("k"), app_name="primer", app_url="https://p.example"
+            )
+        )
+        assert h["X-Title"] == "primer"
+        assert h["HTTP-Referer"] == "https://p.example/"
+
+    def test_only_name(self) -> None:
+        h = _attribution_headers(OpenRouterConfig(api_key=SecretStr("k"), app_name="primer"))
+        assert h == {"X-Title": "primer"}
+
+    def test_neither(self) -> None:
+        assert _attribution_headers(OpenRouterConfig(api_key=SecretStr("k"))) == {}
+
+
+class TestConstructor:
+    def test_valid(self) -> None:
+        llm = OpenRouterLLM(_make_provider())
+        assert llm._client is None
+
+    def test_wrong_provider_type_raises(self) -> None:
+        provider = _make_provider()
+        object.__setattr__(provider, "provider", LLMProviderType.OPENCHAT)
+        with pytest.raises(ConfigError, match="OPENROUTER"):
+            OpenRouterLLM(provider)
+
+    def test_wrong_config_type_raises(self) -> None:
+        from pydantic import HttpUrl
+        from primer.model.provider import OpenChatConfig, OpenChatFlavor
+
+        provider = LLMProvider(
+            id="x",
+            provider=LLMProviderType.OPENROUTER,
+            models=[LLMModel(name="anthropic/claude-3.5-sonnet", context_length=1000)],
+            config=OpenChatConfig(
+                url=HttpUrl("https://x/v1/"),
+                api_key=SecretStr("sk-x"),
+                flavor=OpenChatFlavor.OPENAI,
+            ),
+            limits=Limits(max_concurrency=1),
+        )
+        with pytest.raises(ConfigError, match="OpenRouterConfig"):
+            OpenRouterLLM(provider)
+
+    def test_logs_init(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO, logger="primer.llm.openrouter")
+        OpenRouterLLM(_make_provider(app_name="p"))
+        records = [r for r in caplog.records if "OpenRouter adapter initialized" in r.message]
+        assert len(records) == 1
+        assert records[0].app_name_set is True  # type: ignore[attr-defined]
+
+
+class TestGetClient:
+    async def test_base_url_pinned(self) -> None:
+        llm = OpenRouterLLM(_make_provider())
+        try:
+            client = llm._get_client()
+            assert str(client.base_url).rstrip("/") == OPENROUTER_BASE_URL.rstrip("/")
+        finally:
+            await llm.aclose()
+
+    async def test_client_cached(self) -> None:
+        llm = OpenRouterLLM(_make_provider())
+        try:
+            assert llm._get_client() is llm._get_client()
+        finally:
+            await llm.aclose()
+
+
+class TestListModels:
+    async def test_sorted_dedup(self) -> None:
+        llm = OpenRouterLLM(_make_provider(models=["openai/gpt-4o", "anthropic/claude-3.5-sonnet"]))
+        try:
+            assert list(await llm.list_models()) == [
+                "anthropic/claude-3.5-sonnet",
+                "openai/gpt-4o",
+            ]
+        finally:
+            await llm.aclose()
+
+    async def test_no_upstream_call(self) -> None:
+        llm = OpenRouterLLM(_make_provider())
+        try:
+            with respx.mock(assert_all_called=False) as router:
+                router.get(f"{OPENROUTER_BASE_URL}/models").mock(
+                    return_value=httpx.Response(500)
+                )
+                assert list(await llm.list_models()) == ["anthropic/claude-3.5-sonnet"]
+        finally:
+            await llm.aclose()
+
+
+class TestCountTokens:
+    async def test_positive(self) -> None:
+        llm = OpenRouterLLM(_make_provider())
+        try:
+            n = await llm.count_tokens(
+                model="anthropic/claude-3.5-sonnet",
+                messages=[Message(role="user", parts=[TextPart(text="hi there")])],
+                tools=None,
+            )
+            assert isinstance(n, int) and n > 0
+        finally:
+            await llm.aclose()
+
+
+class TestStream:
+    async def test_unknown_model_raises(self) -> None:
+        llm = OpenRouterLLM(_make_provider(models=["anthropic/claude-3.5-sonnet"]))
+        try:
+            with pytest.raises(ModelNotFoundError, match="nope"):
+                async for _ in llm.stream(
+                    model="nope",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                ):
+                    pass
+        finally:
+            await llm.aclose()
+
+    @respx.mock
+    async def test_happy_path_events(self) -> None:
+        _mock_stream()
+        llm = OpenRouterLLM(_make_provider())
+        try:
+            events = [
+                ev
+                async for ev in llm.stream(
+                    model="anthropic/claude-3.5-sonnet",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                )
+            ]
+        finally:
+            await llm.aclose()
+        assert any(isinstance(e, StreamStart) for e in events)
+        assert any(isinstance(e, TextDelta) and e.text == "hello" for e in events)
+        assert any(isinstance(e, Usage) for e in events)
+        assert isinstance(events[-1], Done) and events[-1].stop_reason == "stop"
+
+    @respx.mock
+    async def test_attribution_and_auth_headers_sent(self) -> None:
+        _mock_stream()
+        llm = OpenRouterLLM(
+            _make_provider(api_key="sk-or-v1-zzz", app_name="primer", app_url="https://p.example")
+        )
+        try:
+            async for _ in llm.stream(
+                model="anthropic/claude-3.5-sonnet",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+            req = respx.calls.last.request
+            assert req.headers["Authorization"] == "Bearer sk-or-v1-zzz"
+            assert req.headers["X-Title"] == "primer"
+            assert req.headers["HTTP-Referer"] == "https://p.example/"
+        finally:
+            await llm.aclose()
+
+    @respx.mock
+    async def test_4xx_surfaces_as_bad_request(self) -> None:
+        respx.post(f"{OPENROUTER_BASE_URL}/chat/completions").mock(
+            return_value=httpx.Response(
+                400,
+                json={"error": {"message": "bad model id", "code": "invalid_request_error"}},
+            )
+        )
+        llm = OpenRouterLLM(_make_provider())
+        try:
+            with pytest.raises(BadRequestError):
+                async for _ in llm.stream(
+                    model="anthropic/claude-3.5-sonnet",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                ):
+                    pass
+        finally:
+            await llm.aclose()
+
+    @respx.mock
+    async def test_request_body_includes_tools_and_response_format(self) -> None:
+        _mock_stream()
+
+        class Out(PydanticBaseModel):
+            value: int
+
+        tool = Tool(
+            id="search",
+            description="Search",
+            toolset_id="default",
+            args_schema={"type": "object", "properties": {}, "required": []},
+        )
+        llm = OpenRouterLLM(_make_provider())
+        try:
+            async for _ in llm.stream(
+                model="anthropic/claude-3.5-sonnet",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                temperature=0.3,
+                max_output_tokens=64,
+                stop=["END"],
+                tools=[tool],
+                tool_choice="required",
+                response_format=Out,
+                extended={"seed": 5, "junk": 1},
+            ):
+                pass
+        finally:
+            await llm.aclose()
+        body = json.loads(respx.calls.last.request.content)
+        assert body["stream"] is True
+        assert body["stream_options"] == {"include_usage": True}
+        assert body["max_tokens"] == 64
+        assert body["stop"] == ["END"]
+        assert body["tools"][0]["function"]["name"] == "search"
+        assert body["tool_choice"] == "required"
+        assert body["response_format"]["json_schema"]["name"] == "Out"
+        assert body["seed"] == 5
+        assert "junk" not in body
+
+    @respx.mock
+    async def test_trace_llm_io_records_messages(self) -> None:
+        _mock_stream()
+        llm = OpenRouterLLM(_make_provider(), trace_llm_io=True)
+        try:
+            events = [
+                ev
+                async for ev in llm.stream(
+                    model="anthropic/claude-3.5-sonnet",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                    max_output_tokens=32,
+                )
+            ]
+        finally:
+            await llm.aclose()
+        assert any(isinstance(e, Done) for e in events)
+
+    @respx.mock
+    async def test_generation_budget_maps_to_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from primer.llm._timeout import GenerationBudgetExceeded
+
+        _mock_stream()
+
+        async def budget_iter(*_a, **_k):
+            raise GenerationBudgetExceeded("over")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr("primer.llm.openrouter._iter_with_timeout", budget_iter)
+        llm = OpenRouterLLM(_make_provider(total_timeout_seconds=30.0))
+        try:
+            with pytest.raises(ProviderTimeoutError) as info:
+                async for _ in llm.stream(
+                    model="anthropic/claude-3.5-sonnet",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                ):
+                    pass
+            assert info.value.code == "generation_timeout"
+        finally:
+            await llm.aclose()
+
+    @respx.mock
+    async def test_stall_timeout_maps_to_timeout(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        _mock_stream()
+
+        async def stall_iter(*_a, **_k):
+            raise TimeoutError("stall")
+            yield  # pragma: no cover
+
+        monkeypatch.setattr("primer.llm.openrouter._iter_with_timeout", stall_iter)
+        llm = OpenRouterLLM(_make_provider())
+        try:
+            with pytest.raises(ProviderTimeoutError) as info:
+                async for _ in llm.stream(
+                    model="anthropic/claude-3.5-sonnet",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                ):
+                    pass
+            assert info.value.code == "stream_timeout"
+        finally:
+            await llm.aclose()
+
+    @respx.mock
+    async def test_mid_stream_error_yields_chat_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from types import SimpleNamespace as NS
+
+        _mock_stream()
+
+        async def failing_iter(*_a, **_k):
+            yield NS(
+                id="x",
+                model="m",
+                choices=[
+                    NS(
+                        index=0,
+                        delta=NS(role="assistant", content=None, tool_calls=None),
+                        finish_reason=None,
+                    )
+                ],
+                usage=None,
+            )
+            raise RuntimeError("boom mid-stream")
+
+        monkeypatch.setattr("primer.llm.openrouter._iter_with_timeout", failing_iter)
+        llm = OpenRouterLLM(_make_provider())
+        try:
+            events = [
+                ev
+                async for ev in llm.stream(
+                    model="anthropic/claude-3.5-sonnet",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                )
+            ]
+        finally:
+            await llm.aclose()
+        assert isinstance(events[0], StreamStart)
+        assert isinstance(events[-1], ChatError) and events[-1].fatal is True
+
+
+class TestAclose:
+    async def test_idempotent(self) -> None:
+        llm = OpenRouterLLM(_make_provider())
+        llm._get_client()
+        await llm.aclose()
+        await llm.aclose()
+        assert llm._client is None
+
+
+class TestDiscover:
+    @respx.mock
+    async def test_rich_catalogue(self) -> None:
+        respx.get(f"{OPENROUTER_BASE_URL}/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "data": [
+                        {
+                            "id": "anthropic/claude-3.5-sonnet",
+                            "name": "Claude 3.5 Sonnet",
+                            "context_length": 200000,
+                            "pricing": {"prompt": "3", "completion": "15"},
+                            "architecture": {"modality": "text"},
+                        },
+                        "not-a-dict",
+                        {"name": "no id here"},
+                    ]
+                },
+            )
+        )
+        out = await _discover_openrouter_models(OpenRouterConfig(api_key=SecretStr("sk-or-v1-abc")))
+        assert len(out) == 1
+        row = out[0]
+        assert row["id"] == "anthropic/claude-3.5-sonnet"
+        assert row["input_price_per_million"] == "3"
+        assert row["output_price_per_million"] == "15"
+        assert row["modality"] == "text"
+
+    @respx.mock
+    async def test_missing_fields_default(self) -> None:
+        respx.get(f"{OPENROUTER_BASE_URL}/models").mock(
+            return_value=httpx.Response(200, json={"data": [{"id": "some/model"}]})
+        )
+        out = await _discover_openrouter_models(OpenRouterConfig(api_key=SecretStr("sk-or-v1-abc")))
+        row = out[0]
+        assert row["name"] == "some/model"
+        assert row["context_length"] is None
+        assert row["input_price_per_million"] is None
+        assert row["modality"] == "text"
+
+    @respx.mock
+    async def test_empty_data(self) -> None:
+        respx.get(f"{OPENROUTER_BASE_URL}/models").mock(
+            return_value=httpx.Response(200, json={})
+        )
+        assert await _discover_openrouter_models(OpenRouterConfig(api_key=SecretStr("k"))) == []
+
+    @respx.mock
+    async def test_4xx_raises_http_status_error(self) -> None:
+        respx.get(f"{OPENROUTER_BASE_URL}/models").mock(
+            return_value=httpx.Response(401, json={"error": {"message": "bad key"}})
+        )
+        with pytest.raises(httpx.HTTPStatusError) as info:
+            await _discover_openrouter_models(OpenRouterConfig(api_key=SecretStr("sk-or-v1-bad")))
+        assert info.value.response.status_code == 401
+
+    @respx.mock
+    async def test_discover_sends_attribution(self) -> None:
+        route = respx.get(f"{OPENROUTER_BASE_URL}/models").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+        await _discover_openrouter_models(
+            OpenRouterConfig(api_key=SecretStr("k"), app_name="primer")
+        )
+        assert route.calls.last.request.headers["X-Title"] == "primer"
+        assert route.calls.last.request.headers["Authorization"] == "Bearer k"

--- a/tests/observability/test_anthropic_adapter_unit.py
+++ b/tests/observability/test_anthropic_adapter_unit.py
@@ -1,0 +1,977 @@
+"""Unit tests for the Anthropic LLM adapter (:mod:`primer.llm.anthropic`).
+
+These live under ``tests/observability`` alongside
+``test_llm_instrumentation.py`` — the CI coverage sweep ignores
+``tests/llm`` (see ``pyproject`` note / the sweep's ``--ignore`` list),
+so adapter unit tests placed there do not count toward coverage. This
+file mirrors the mocking shapes used by the existing ``tests/llm``
+adapter tests (SimpleNamespace fake events, patched SDK client) but
+lives in an included directory.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import json
+import logging
+from collections.abc import AsyncIterator
+from types import SimpleNamespace as NS
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import respx
+from pydantic import BaseModel, HttpUrl, SecretStr
+
+from primer.llm.anthropic import (
+    ANTHROPIC_BASE_URL,
+    ANTHROPIC_VERSION,
+    AnthropicLLM,
+    _DEFAULT_MAX_TOKENS,
+    _build_sampling_kwargs,
+    _citation_to_universal,
+    _discover_anthropic_models,
+    _extract_extended_kwargs,
+    _map_stop_reason,
+    _messages_to_anthropic,
+    _part_to_anthropic_block,
+    _response_format_to_emulation,
+    _StreamState,
+    _tool_choice_to_anthropic,
+    _tools_to_anthropic,
+    _translate_event,
+)
+from primer.model.chat import (
+    AudioPart,
+    Citation,
+    DocumentPart,
+    Done,
+    Error as ChatError,
+    ExtendedEvent,
+    ExtendedPart,
+    ImagePart,
+    Message,
+    ReasoningDelta,
+    ServerToolCallStart,
+    TextDelta,
+    TextPart,
+    Tool,
+    ToolCallDelta,
+    ToolCallEnd,
+    ToolCallPart,
+    ToolCallStart,
+    ToolResultPart,
+    Usage,
+    VideoPart,
+)
+from primer.model.except_ import (
+    AuthenticationError,
+    ConfigError,
+    ModelNotFoundError,
+    PrimerError,
+    UnsupportedContentError,
+)
+from primer.model.provider import (
+    AnthropicConfig,
+    Limits,
+    LLMModel,
+    LLMProvider,
+    LLMProviderType,
+    OpenResponsesConfig,
+)
+
+
+def _make_provider(
+    *,
+    api_key: str = "sk-ant-test",
+    models: list[str] | None = None,
+    max_concurrency: int = 4,
+) -> LLMProvider:
+    return LLMProvider(
+        id="anthropic-default",
+        provider=LLMProviderType.ANTHROPIC,
+        models=[
+            LLMModel(name=name, context_length=200_000)
+            for name in (models or ["claude-sonnet-4-5"])
+        ],
+        config=AnthropicConfig(api_key=SecretStr(api_key)),
+        limits=Limits(max_concurrency=max_concurrency),
+    )
+
+
+async def _aiter(items: list) -> AsyncIterator:
+    for item in items:
+        yield item
+
+
+def _ok_events() -> list[Any]:
+    return [
+        NS(
+            type="message_start",
+            message=NS(id="msg_1", model="claude-sonnet-4-5", usage=NS(input_tokens=5)),
+        ),
+        NS(type="content_block_start", index=0, content_block=NS(type="text")),
+        NS(type="content_block_delta", index=0, delta=NS(type="text_delta", text="hi")),
+        NS(type="content_block_stop", index=0),
+        NS(type="message_delta", delta=NS(stop_reason="end_turn"), usage=NS(output_tokens=3)),
+        NS(type="message_stop"),
+    ]
+
+
+# --------------------------------------------------------------------------- #
+# Part -> content-block mapping                                                #
+# --------------------------------------------------------------------------- #
+
+
+class TestPartMapping:
+    def test_text(self) -> None:
+        assert _part_to_anthropic_block(TextPart(text="hello")) == {
+            "type": "text",
+            "text": "hello",
+        }
+
+    def test_image_data_base64(self) -> None:
+        block = _part_to_anthropic_block(ImagePart(data=b"\x89PNG", mime_type="image/png"))
+        assert block["type"] == "image"
+        assert block["source"]["type"] == "base64"
+        assert block["source"]["media_type"] == "image/png"
+        assert base64.b64decode(block["source"]["data"]) == b"\x89PNG"
+
+    def test_image_data_default_mime(self) -> None:
+        block = _part_to_anthropic_block(ImagePart(data=b"raw"))
+        assert block["source"]["media_type"] == "image/png"
+
+    def test_image_url(self) -> None:
+        block = _part_to_anthropic_block(ImagePart(url="https://x/y.png"))
+        assert block["source"] == {"type": "url", "url": "https://x/y.png"}
+
+    def test_image_file_id_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="file_id images"):
+            _part_to_anthropic_block(ImagePart(file_id="file_123"))
+
+    def test_document_data_base64(self) -> None:
+        block = _part_to_anthropic_block(
+            DocumentPart(data=b"%PDF", mime_type="application/pdf")
+        )
+        assert block["type"] == "document"
+        assert block["source"]["media_type"] == "application/pdf"
+        assert base64.b64decode(block["source"]["data"]) == b"%PDF"
+
+    def test_document_default_mime(self) -> None:
+        block = _part_to_anthropic_block(DocumentPart(data=b"%PDF"))
+        assert block["source"]["media_type"] == "application/pdf"
+
+    def test_document_url(self) -> None:
+        block = _part_to_anthropic_block(DocumentPart(url="https://x/y.pdf"))
+        assert block["source"] == {"type": "url", "url": "https://x/y.pdf"}
+
+    def test_document_file_id_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="file_id documents"):
+            _part_to_anthropic_block(DocumentPart(file_id="file_9"))
+
+    def test_tool_call(self) -> None:
+        block = _part_to_anthropic_block(
+            ToolCallPart(id="call_1", name="search", arguments={"q": "x"})
+        )
+        assert block == {
+            "type": "tool_use",
+            "id": "call_1",
+            "name": "search",
+            "input": {"q": "x"},
+        }
+
+    def test_audio_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="audio"):
+            _part_to_anthropic_block(ExtendedPart(extended=AudioPart(data=b"a")))
+
+    def test_video_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="video"):
+            _part_to_anthropic_block(ExtendedPart(extended=VideoPart(data=b"v")))
+
+
+class TestMessagesToAnthropic:
+    def test_system_lifted_and_concatenated(self) -> None:
+        system, msgs = _messages_to_anthropic(
+            [
+                Message(role="system", parts=[TextPart(text="a")]),
+                Message(role="system", parts=[TextPart(text="b")]),
+                Message(role="user", parts=[TextPart(text="hi")]),
+            ]
+        )
+        assert system == "a\n\nb"
+        assert [m["role"] for m in msgs] == ["user"]
+
+    def test_no_system_returns_none(self) -> None:
+        system, msgs = _messages_to_anthropic(
+            [Message(role="user", parts=[TextPart(text="hi")])]
+        )
+        assert system is None
+        assert msgs[0]["content"][0]["type"] == "text"
+
+    def test_system_non_text_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="system messages"):
+            _messages_to_anthropic(
+                [Message(role="system", parts=[ImagePart(data=b"x")])]
+            )
+
+    def test_tool_role_flattened_to_user_tool_result(self) -> None:
+        _, msgs = _messages_to_anthropic(
+            [
+                Message(
+                    role="tool",
+                    parts=[
+                        ToolResultPart(id="call_1", output="42", error=False),
+                        ToolResultPart(id="call_2", output="boom", error=True),
+                    ],
+                )
+            ]
+        )
+        assert msgs[0]["role"] == "user"
+        blocks = msgs[0]["content"]
+        assert blocks[0] == {
+            "type": "tool_result",
+            "tool_use_id": "call_1",
+            "content": "42",
+            "is_error": False,
+        }
+        assert blocks[1]["is_error"] is True
+
+    def test_tool_role_non_tool_result_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="tool-role"):
+            _messages_to_anthropic(
+                [Message(role="tool", parts=[TextPart(text="nope")])]
+            )
+
+    def test_assistant_role_preserved(self) -> None:
+        _, msgs = _messages_to_anthropic(
+            [Message(role="assistant", parts=[TextPart(text="ok")])]
+        )
+        assert msgs[0]["role"] == "assistant"
+
+
+class TestToolTranslation:
+    def _tool(self) -> Tool:
+        return Tool(
+            id="search",
+            description="Search",
+            toolset_id="ts",
+            args_schema={"type": "object", "properties": {}},
+        )
+
+    def test_tools_none_and_empty(self) -> None:
+        assert _tools_to_anthropic(None) is None
+        assert _tools_to_anthropic([]) is None
+
+    def test_tools_mapped(self) -> None:
+        out = _tools_to_anthropic([self._tool()])
+        assert out == [
+            {
+                "name": "search",
+                "description": "Search",
+                "input_schema": {"type": "object", "properties": {}},
+            }
+        ]
+
+    def test_tool_choice_variants(self) -> None:
+        assert _tool_choice_to_anthropic(None) is None
+        assert _tool_choice_to_anthropic("auto") == {"type": "auto"}
+        assert _tool_choice_to_anthropic("required") == {"type": "any"}
+        assert _tool_choice_to_anthropic("none") == {"type": "none"}
+        assert _tool_choice_to_anthropic("search") == {"type": "tool", "name": "search"}
+
+
+class _Schema(BaseModel):
+    answer: str
+
+
+class TestResponseFormatEmulation:
+    def test_none(self) -> None:
+        assert (
+            _response_format_to_emulation(None, has_tools=False, has_tool_choice=False)
+            is None
+        )
+
+    def test_with_tools_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="cannot be combined with tools"):
+            _response_format_to_emulation(_Schema, has_tools=True, has_tool_choice=False)
+
+    def test_with_tool_choice_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="explicit tool_choice"):
+            _response_format_to_emulation(_Schema, has_tools=False, has_tool_choice=True)
+
+    def test_pydantic_model(self) -> None:
+        tools, choice = _response_format_to_emulation(
+            _Schema, has_tools=False, has_tool_choice=False
+        )
+        assert tools[0]["name"] == "structured_output"
+        assert tools[0]["input_schema"]["properties"]["answer"]["type"] == "string"
+        assert choice == {"type": "tool", "name": "structured_output"}
+
+    def test_dict_schema(self) -> None:
+        tools, choice = _response_format_to_emulation(
+            {"type": "object"}, has_tools=False, has_tool_choice=False
+        )
+        assert tools[0]["input_schema"] == {"type": "object"}
+
+    def test_invalid_type_rejected(self) -> None:
+        with pytest.raises(ConfigError, match="Pydantic class or dict"):
+            _response_format_to_emulation(123, has_tools=False, has_tool_choice=False)  # type: ignore[arg-type]
+
+
+class TestSamplingAndExtended:
+    def test_default_max_tokens_logged(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.INFO, logger="primer.llm.anthropic")
+        out = _build_sampling_kwargs(
+            temperature=None, top_p=None, max_output_tokens=None, stop=None
+        )
+        assert out["max_tokens"] == _DEFAULT_MAX_TOKENS
+        assert any("max_output_tokens" in r.message for r in caplog.records)
+
+    def test_all_sampling_knobs(self) -> None:
+        out = _build_sampling_kwargs(
+            temperature=0.5, top_p=0.9, max_output_tokens=100, stop=["X"]
+        )
+        assert out == {
+            "temperature": 0.5,
+            "top_p": 0.9,
+            "max_tokens": 100,
+            "stop_sequences": ["X"],
+        }
+
+    def test_extended_passthrough_and_dropped(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="primer.llm.anthropic")
+        out = _extract_extended_kwargs(
+            {"top_k": 5, "thinking": {"type": "enabled"}, "bogus": 1}
+        )
+        assert out == {"top_k": 5, "thinking": {"type": "enabled"}}
+        assert any("dropped unknown" in r.message for r in caplog.records)
+
+    def test_extended_empty(self) -> None:
+        assert _extract_extended_kwargs(None) == {}
+        assert _extract_extended_kwargs({}) == {}
+
+
+class TestStopReasonMapping:
+    def test_none_is_other(self) -> None:
+        assert _map_stop_reason(None, _StreamState()) == "other"
+
+    def test_end_turn_without_tool_use(self) -> None:
+        assert _map_stop_reason("end_turn", _StreamState()) == "stop"
+
+    def test_end_turn_with_tool_use(self) -> None:
+        state = _StreamState(saw_tool_use=True)
+        assert _map_stop_reason("end_turn", state) == "tool_use"
+
+    def test_known_reasons(self) -> None:
+        st = _StreamState()
+        assert _map_stop_reason("max_tokens", st) == "max_tokens"
+        assert _map_stop_reason("stop_sequence", st) == "stop_sequence"
+        assert _map_stop_reason("tool_use", st) == "tool_use"
+        assert _map_stop_reason("pause_turn", st) == "stop"
+        assert _map_stop_reason("refusal", st) == "content_filter"
+
+    def test_unknown_reason_is_other(self) -> None:
+        assert _map_stop_reason("mystery", _StreamState()) == "other"
+
+
+class TestCitation:
+    def test_char_location_fields(self) -> None:
+        cit = _citation_to_universal(
+            NS(
+                url="https://x",
+                title="T",
+                cited_text="quote",
+                start_char_index=1,
+                end_char_index=9,
+                file_id="f1",
+            ),
+            index=2,
+        )
+        assert cit.source_url == "https://x"
+        assert cit.source_title == "T"
+        assert cit.source_id == "f1"
+        assert cit.quoted_text == "quote"
+        assert (cit.start_index, cit.end_index, cit.index) == (1, 9, 2)
+
+
+# --------------------------------------------------------------------------- #
+# Stream-event translation                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestTranslateEvent:
+    def test_message_start_emits_stream_start_and_captures_usage(self) -> None:
+        state = _StreamState()
+        out = _translate_event(
+            NS(type="message_start", message=NS(id="req_9", model="claude-x", usage=NS(input_tokens=7))),
+            state,
+            model_name="fallback",
+        )
+        assert isinstance(out[0], type(out[0]))
+        assert out[0].request_id == "req_9"
+        assert out[0].model == "claude-x"
+        assert state.input_tokens == 7
+
+    def test_message_start_falls_back_to_model_name(self) -> None:
+        state = _StreamState()
+        out = _translate_event(
+            NS(type="message_start", message=NS(id="r", model=None, usage=None)),
+            state,
+            model_name="fallback",
+        )
+        assert out[0].model == "fallback"
+
+    def test_text_block_start_and_delta(self) -> None:
+        state = _StreamState()
+        _translate_event(
+            NS(type="content_block_start", index=0, content_block=NS(type="text")),
+            state,
+            model_name="m",
+        )
+        out = _translate_event(
+            NS(type="content_block_delta", index=0, delta=NS(type="text_delta", text="hi")),
+            state,
+            model_name="m",
+        )
+        assert out == [TextDelta(text="hi", index=0)]
+
+    def test_tool_use_block_lifecycle(self) -> None:
+        state = _StreamState()
+        start = _translate_event(
+            NS(
+                type="content_block_start",
+                index=1,
+                content_block=NS(type="tool_use", id="call_1", name="search"),
+            ),
+            state,
+            model_name="m",
+        )
+        assert start == [ToolCallStart(id="call_1", name="search", index=1)]
+        assert state.saw_tool_use is True
+
+        delta = _translate_event(
+            NS(
+                type="content_block_delta",
+                index=1,
+                delta=NS(type="input_json_delta", partial_json='{"q":'),
+            ),
+            state,
+            model_name="m",
+        )
+        assert delta == [ToolCallDelta(id="call_1", arguments_delta='{"q":', index=1)]
+
+        _translate_event(
+            NS(
+                type="content_block_delta",
+                index=1,
+                delta=NS(type="input_json_delta", partial_json='"x"}'),
+            ),
+            state,
+            model_name="m",
+        )
+        stop = _translate_event(
+            NS(type="content_block_stop", index=1), state, model_name="m"
+        )
+        assert stop == [ToolCallEnd(id="call_1", arguments={"q": "x"}, index=1)]
+
+    def test_tool_use_stop_with_malformed_json(self) -> None:
+        state = _StreamState()
+        _translate_event(
+            NS(
+                type="content_block_start",
+                index=0,
+                content_block=NS(type="tool_use", id="c", name="n"),
+            ),
+            state,
+            model_name="m",
+        )
+        state.accumulated_args[0] = "{not json"
+        out = _translate_event(NS(type="content_block_stop", index=0), state, model_name="m")
+        assert out == [ToolCallEnd(id="c", arguments={}, index=0)]
+
+    def test_tool_use_stop_non_dict_json(self) -> None:
+        state = _StreamState()
+        _translate_event(
+            NS(
+                type="content_block_start",
+                index=0,
+                content_block=NS(type="tool_use", id="c", name="n"),
+            ),
+            state,
+            model_name="m",
+        )
+        state.accumulated_args[0] = "[1, 2]"
+        out = _translate_event(NS(type="content_block_stop", index=0), state, model_name="m")
+        assert out == [ToolCallEnd(id="c", arguments={}, index=0)]
+
+    def test_content_block_stop_non_tool_is_noop(self) -> None:
+        state = _StreamState()
+        state.block_kinds[0] = "text"
+        assert _translate_event(NS(type="content_block_stop", index=0), state, model_name="m") == []
+
+    def test_thinking_block_and_delta(self) -> None:
+        state = _StreamState()
+        assert _translate_event(
+            NS(type="content_block_start", index=0, content_block=NS(type="thinking")),
+            state,
+            model_name="m",
+        ) == []
+        out = _translate_event(
+            NS(type="content_block_delta", index=0, delta=NS(type="thinking_delta", thinking="ponder")),
+            state,
+            model_name="m",
+        )
+        assert out == [ReasoningDelta(text="ponder", index=0)]
+
+    def test_signature_delta(self) -> None:
+        out = _translate_event(
+            NS(type="content_block_delta", index=0, delta=NS(type="signature_delta", signature="sig")),
+            _StreamState(),
+            model_name="m",
+        )
+        assert out[0].text == ""
+        assert out[0].signature == "sig"
+
+    def test_citations_delta(self) -> None:
+        out = _translate_event(
+            NS(
+                type="content_block_delta",
+                index=2,
+                delta=NS(type="citations_delta", citation=NS(url="https://x", title="T")),
+            ),
+            _StreamState(),
+            model_name="m",
+        )
+        assert isinstance(out[0], ExtendedEvent)
+        assert isinstance(out[0].extended, Citation)
+        assert out[0].extended.source_url == "https://x"
+
+    def test_citations_delta_missing_citation(self) -> None:
+        out = _translate_event(
+            NS(type="content_block_delta", index=0, delta=NS(type="citations_delta", citation=None)),
+            _StreamState(),
+            model_name="m",
+        )
+        assert out == []
+
+    def test_unknown_delta_type_ignored(self) -> None:
+        out = _translate_event(
+            NS(type="content_block_delta", index=0, delta=NS(type="mystery_delta")),
+            _StreamState(),
+            model_name="m",
+        )
+        assert out == []
+
+    def test_server_tool_use_block(self) -> None:
+        out = _translate_event(
+            NS(
+                type="content_block_start",
+                index=0,
+                content_block=NS(type="server_tool_use", id="st_1", name="web_search"),
+            ),
+            _StreamState(),
+            model_name="m",
+        )
+        assert isinstance(out[0].extended, ServerToolCallStart)
+        assert out[0].extended.tool_name == "web_search"
+
+    def test_unknown_block_type_registered_silently(self) -> None:
+        state = _StreamState()
+        out = _translate_event(
+            NS(type="content_block_start", index=3, content_block=NS(type="wat")),
+            state,
+            model_name="m",
+        )
+        assert out == []
+        assert state.block_kinds[3] == "wat"
+
+    def test_message_delta_captures_stop_and_usage(self) -> None:
+        state = _StreamState()
+        _translate_event(
+            NS(type="message_delta", delta=NS(stop_reason="max_tokens"), usage=NS(output_tokens=11)),
+            state,
+            model_name="m",
+        )
+        assert state.final_stop_reason == "max_tokens"
+        assert state.output_tokens == 11
+
+    def test_message_stop_emits_usage_and_done(self) -> None:
+        state = _StreamState(input_tokens=5, output_tokens=3, final_stop_reason="end_turn")
+        out = _translate_event(NS(type="message_stop"), state, model_name="m")
+        assert out[0] == Usage(input_tokens=5, output_tokens=3, cumulative=False)
+        assert isinstance(out[1], Done)
+        assert out[1].stop_reason == "stop"
+
+    def test_message_stop_without_usage_only_done(self) -> None:
+        out = _translate_event(NS(type="message_stop"), _StreamState(), model_name="m")
+        assert len(out) == 1
+        assert isinstance(out[0], Done)
+
+    def test_unknown_event_ignored(self) -> None:
+        assert _translate_event(NS(type="ping"), _StreamState(), model_name="m") == []
+
+
+# --------------------------------------------------------------------------- #
+# stream() full-drive                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def _patched_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    inst = MagicMock()
+    inst.messages = MagicMock()
+    inst.messages.create = AsyncMock()
+    monkeypatch.setattr("primer.llm.anthropic.AsyncAnthropic", MagicMock(return_value=inst))
+    return inst
+
+
+class TestStream:
+    async def test_unknown_model_raises(self) -> None:
+        llm = AnthropicLLM(_make_provider(models=["claude-sonnet-4-5"]))
+        with pytest.raises(ModelNotFoundError, match="not-real"):
+            async for _ in llm.stream(
+                model="not-real",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+    async def test_full_stream_event_sequence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = AnthropicLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.messages.create.return_value = _aiter(_ok_events())
+        out = [
+            ev
+            async for ev in llm.stream(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                max_output_tokens=64,
+            )
+        ]
+        assert [type(e).__name__ for e in out] == ["StreamStart", "TextDelta", "Usage", "Done"]
+
+    async def test_request_construction(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = AnthropicLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.messages.create.return_value = _aiter(_ok_events())
+        tool = Tool(id="search", description="S", toolset_id="t", args_schema={"type": "object"})
+        async for _ in llm.stream(
+            model="claude-sonnet-4-5",
+            messages=[
+                Message(role="system", parts=[TextPart(text="be terse")]),
+                Message(role="user", parts=[TextPart(text="hi")]),
+            ],
+            temperature=0.3,
+            top_p=0.8,
+            max_output_tokens=32,
+            stop=["END"],
+            tools=[tool],
+            tool_choice="required",
+            extended={"top_k": 4, "junk": 1},
+        ):
+            pass
+        kwargs = client.messages.create.call_args.kwargs
+        assert kwargs["stream"] is True
+        assert kwargs["model"] == "claude-sonnet-4-5"
+        assert kwargs["system"] == "be terse"
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["top_p"] == 0.8
+        assert kwargs["max_tokens"] == 32
+        assert kwargs["stop_sequences"] == ["END"]
+        assert kwargs["tools"][0]["name"] == "search"
+        assert kwargs["tool_choice"] == {"type": "any"}
+        assert kwargs["top_k"] == 4
+        assert "junk" not in kwargs
+
+    async def test_response_format_emulation_in_request(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        llm = AnthropicLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.messages.create.return_value = _aiter(_ok_events())
+        async for _ in llm.stream(
+            model="claude-sonnet-4-5",
+            messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            response_format=_Schema,
+        ):
+            pass
+        kwargs = client.messages.create.call_args.kwargs
+        assert kwargs["tools"][0]["name"] == "structured_output"
+        assert kwargs["tool_choice"] == {"type": "tool", "name": "structured_output"}
+
+    async def test_error_before_stream_raises_classified(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        llm = AnthropicLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.messages.create = AsyncMock(side_effect=RuntimeError("boom"))
+        with pytest.raises(PrimerError):
+            async for _ in llm.stream(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+    async def test_auth_error_before_stream(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        import anthropic
+
+        llm = AnthropicLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        exc = anthropic.AuthenticationError.__new__(anthropic.AuthenticationError)
+        exc.status_code = 401
+        exc.code = None
+        exc.message = "bad key"
+        Exception.__init__(exc, "bad key")
+        client.messages.create = AsyncMock(side_effect=exc)
+        with pytest.raises(AuthenticationError):
+            async for _ in llm.stream(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+    async def test_mid_stream_error_yields_chat_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        llm = AnthropicLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+
+        async def _failing() -> AsyncIterator:
+            yield NS(
+                type="message_start",
+                message=NS(id="m", model="claude-sonnet-4-5", usage=NS(input_tokens=1)),
+            )
+            raise RuntimeError("mid-stream boom")
+
+        client.messages.create.return_value = _failing()
+        out = [
+            ev
+            async for ev in llm.stream(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            )
+        ]
+        assert isinstance(out[-1], ChatError)
+        assert out[-1].fatal is True
+
+
+# --------------------------------------------------------------------------- #
+# Adapter lifecycle + construction                                            #
+# --------------------------------------------------------------------------- #
+
+
+class _StallStream:
+    def __aiter__(self) -> "_StallStream":
+        return self
+
+    async def __anext__(self) -> Any:
+        await asyncio.sleep(3600)
+
+
+async def _slow_forever(event: Any) -> AsyncIterator:
+    while True:
+        await asyncio.sleep(0.005)
+        yield event
+
+
+class TestTimeouts:
+    async def test_connect_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        llm = AnthropicLLM(_make_provider())
+        llm._connect_timeout_seconds = 0.05
+        client = _patched_client(monkeypatch)
+
+        async def _stall(**_: Any) -> Any:
+            await asyncio.sleep(3600)
+
+        client.messages.create = _stall
+        with pytest.raises(ProviderTimeoutError):
+            async for _ in llm.stream(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+    async def test_stream_stall_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        llm = AnthropicLLM(_make_provider())
+        llm._connect_timeout_seconds = None
+        llm._request_timeout_seconds = 0.05
+        client = _patched_client(monkeypatch)
+        client.messages.create.return_value = _StallStream()
+        with pytest.raises(ProviderTimeoutError) as exc:
+            async for _ in llm.stream(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+        assert exc.value.code == "stream_timeout"
+
+    async def test_generation_budget_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        llm = AnthropicLLM(_make_provider())
+        llm._connect_timeout_seconds = None
+        llm._request_timeout_seconds = None
+        llm._total_timeout_seconds = 0.05
+        client = _patched_client(monkeypatch)
+        client.messages.create.return_value = _slow_forever(NS(type="ping"))
+        with pytest.raises(ProviderTimeoutError) as exc:
+            async for _ in llm.stream(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+        assert exc.value.code == "generation_timeout"
+
+    async def test_trace_llm_io_sets_span_attribute(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        provider = _make_provider()
+        llm = AnthropicLLM(provider, trace_llm_io=True)
+        client = _patched_client(monkeypatch)
+        client.messages.create.return_value = _aiter(_ok_events())
+        async for _ in llm.stream(
+            model="claude-sonnet-4-5",
+            messages=[Message(role="user", parts=[TextPart(text="hi")])],
+        ):
+            pass
+        # The request-messages attribute is serialised only when tracing IO.
+        assert client.messages.create.call_args is not None
+
+
+class TestAdapterLifecycle:
+    def test_rejects_wrong_provider_type(self) -> None:
+        provider = _make_provider()
+        object.__setattr__(provider, "provider", LLMProviderType.GEMINI)
+        with pytest.raises(ConfigError, match="ANTHROPIC"):
+            AnthropicLLM(provider)
+
+    def test_rejects_wrong_config_type(self) -> None:
+        provider = LLMProvider(
+            id="a",
+            provider=LLMProviderType.ANTHROPIC,
+            models=[LLMModel(name="claude-sonnet-4-5", context_length=1024)],
+            config=OpenResponsesConfig(  # type: ignore[arg-type]
+                url=HttpUrl("https://api.openai.com/v1/"),
+                api_key=SecretStr("sk-x"),
+            ),
+            limits=Limits(max_concurrency=1),
+        )
+        with pytest.raises(ConfigError, match="AnthropicConfig"):
+            AnthropicLLM(provider)
+
+    def test_accepts_empty_api_key(self) -> None:
+        llm = AnthropicLLM(_make_provider(api_key=""))
+        assert llm._client is None
+
+    async def test_list_models(self) -> None:
+        llm = AnthropicLLM(_make_provider(models=["a", "b"]))
+        assert list(await llm.list_models()) == ["a", "b"]
+
+    async def test_get_client_lazy_and_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        inst = _patched_client(monkeypatch)
+        llm = AnthropicLLM(_make_provider())
+        assert llm._client is None
+        c1 = llm._get_client()
+        c2 = llm._get_client()
+        assert c1 is c2 is inst
+
+    async def test_aclose_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        inst = _patched_client(monkeypatch)
+        inst.close = AsyncMock()
+        llm = AnthropicLLM(_make_provider())
+        llm._get_client()
+        await llm.aclose()
+        await llm.aclose()  # no error second time
+        inst.close.assert_awaited_once()
+
+    async def test_count_tokens_delegates(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        _patched_client(monkeypatch)
+        llm = AnthropicLLM(_make_provider())
+        with patch(
+            "primer.llm.anthropic.count_tokens_anthropic",
+            new=AsyncMock(return_value=123),
+        ) as mock_count:
+            n = await llm.count_tokens(
+                model="claude-sonnet-4-5",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            )
+        assert n == 123
+        mock_count.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# Model discovery (respx-mocked HTTP)                                          #
+# --------------------------------------------------------------------------- #
+
+
+class TestDiscover:
+    @respx.mock
+    async def test_maps_and_paginates(self) -> None:
+        respx.get(f"{ANTHROPIC_BASE_URL}/models").mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={
+                        "data": [
+                            {"id": "claude-opus-4-5", "display_name": "Opus"},
+                            {"id": "claude-opus-4-5", "display_name": "Dup"},
+                            "not-a-dict-entry",
+                            {"display_name": "no-id-ignored"},
+                        ],
+                        "has_more": True,
+                        "last_id": "claude-opus-4-5",
+                    },
+                ),
+                httpx.Response(
+                    200,
+                    json={"data": [{"id": "claude-haiku-4"}], "has_more": False},
+                ),
+            ]
+        )
+        out = await _discover_anthropic_models(AnthropicConfig(api_key=SecretStr("k")))
+        assert [m["name"] for m in out] == ["claude-opus-4-5", "claude-haiku-4"]
+        # display_name falls back to the id when absent.
+        assert out[1]["display_name"] == "claude-haiku-4"
+
+    @respx.mock
+    async def test_sends_version_header_and_key(self) -> None:
+        route = respx.get(f"{ANTHROPIC_BASE_URL}/models").mock(
+            return_value=httpx.Response(200, json={"data": [], "has_more": False})
+        )
+        await _discover_anthropic_models(AnthropicConfig(api_key=SecretStr("secret-key")))
+        req = route.calls.last.request
+        assert req.headers["x-api-key"] == "secret-key"
+        assert req.headers["anthropic-version"] == ANTHROPIC_VERSION
+
+    @respx.mock
+    async def test_has_more_without_cursor_stops(self) -> None:
+        respx.get(f"{ANTHROPIC_BASE_URL}/models").mock(
+            return_value=httpx.Response(
+                200, json={"data": [{"id": "m1"}], "has_more": True}
+            )
+        )
+        out = await _discover_anthropic_models(AnthropicConfig(api_key=SecretStr("k")))
+        assert [m["name"] for m in out] == ["m1"]
+
+    @respx.mock
+    async def test_401_raises(self) -> None:
+        respx.get(f"{ANTHROPIC_BASE_URL}/models").mock(
+            return_value=httpx.Response(401, json={"error": "nope"})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await _discover_anthropic_models(AnthropicConfig(api_key=SecretStr("bad")))
+
+    @respx.mock
+    async def test_no_api_key_sends_empty(self) -> None:
+        route = respx.get(f"{ANTHROPIC_BASE_URL}/models").mock(
+            return_value=httpx.Response(200, json={"data": [], "has_more": False})
+        )
+        out = await _discover_anthropic_models(AnthropicConfig())
+        assert out == []
+        assert route.calls.last.request.headers["x-api-key"] == ""

--- a/tests/observability/test_gemini_adapter_unit.py
+++ b/tests/observability/test_gemini_adapter_unit.py
@@ -1,0 +1,898 @@
+"""Unit tests for the Gemini LLM adapter (:mod:`primer.llm.gemini`).
+
+Placed under ``tests/observability`` (an included directory) rather than
+``tests/llm`` — which the CI coverage sweep ignores — so the coverage
+they exercise is counted. Mocking mirrors the existing ``tests/llm``
+adapter tests: pure translators are called directly, stream chunks are
+faked with ``SimpleNamespace``, and the google-genai client is mocked at
+the ``_get_client`` boundary.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+from collections.abc import AsyncIterator
+from types import SimpleNamespace as NS
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import httpx
+import pytest
+import respx
+from google.genai import types as gtypes
+from pydantic import BaseModel, HttpUrl, SecretStr
+
+from primer.llm.gemini import (
+    GEMINI_BASE_URL,
+    GeminiLLM,
+    _StreamState,
+    _build_usage,
+    _build_sampling_kwargs,
+    _discover_gemini_models,
+    _extract_extended_kwargs,
+    _grounding_to_citations,
+    _logprobs_to_event,
+    _map_finish_reason,
+    _messages_to_gemini,
+    _part_to_events,
+    _part_to_gemini,
+    _response_format_to_gemini,
+    _safety_ratings_to_event,
+    _translate_chunk,
+    _tool_choice_to_gemini,
+    _tools_to_gemini,
+)
+from primer.model.chat import (
+    AudioPart,
+    Citation,
+    DocumentPart,
+    Done,
+    ExtendedEvent,
+    ExtendedPart,
+    ImagePart,
+    Logprobs,
+    MediaDelta,
+    Message,
+    ReasoningDelta,
+    SafetyRatings,
+    ServerToolCallStart,
+    StreamStart,
+    TextDelta,
+    TextPart,
+    Tool,
+    ToolCallDelta,
+    ToolCallEnd,
+    ToolCallPart,
+    ToolCallStart,
+    ToolResultPart,
+    Usage,
+    VideoPart,
+)
+from primer.model.except_ import (
+    ConfigError,
+    ModelNotFoundError,
+    PrimerError,
+    UnsupportedContentError,
+)
+from primer.model.provider import (
+    GoogleConfig,
+    Limits,
+    LLMModel,
+    LLMProvider,
+    LLMProviderType,
+)
+
+
+def _make_provider(
+    *,
+    api_key: str = "AIza-test",
+    models: list[str] | None = None,
+    max_concurrency: int = 4,
+) -> LLMProvider:
+    return LLMProvider(
+        id="gemini-default",
+        provider=LLMProviderType.GEMINI,
+        models=[
+            LLMModel(name=name, context_length=1_000_000)
+            for name in (models or ["gemini-2.5-flash"])
+        ],
+        config=GoogleConfig(api_key=SecretStr(api_key)),
+        limits=Limits(max_concurrency=max_concurrency),
+    )
+
+
+async def _aiter(items: list) -> AsyncIterator:
+    for item in items:
+        yield item
+
+
+# --------------------------------------------------------------------------- #
+# Part -> gemini Part mapping                                                  #
+# --------------------------------------------------------------------------- #
+
+
+class TestPartMapping:
+    def test_text(self) -> None:
+        assert _part_to_gemini(TextPart(text="hi"), {}).text == "hi"
+
+    def test_image_data(self) -> None:
+        out = _part_to_gemini(ImagePart(data=b"\x89PNG", mime_type="image/png"), {})
+        assert out.inline_data.mime_type == "image/png"
+        assert out.inline_data.data == b"\x89PNG"
+
+    def test_image_data_default_mime(self) -> None:
+        assert _part_to_gemini(ImagePart(data=b"x"), {}).inline_data.mime_type == "image/png"
+
+    def test_image_url(self) -> None:
+        out = _part_to_gemini(ImagePart(url="https://x/i.png", mime_type="image/png"), {})
+        assert out.file_data.file_uri == "https://x/i.png"
+
+    def test_image_file_id(self) -> None:
+        out = _part_to_gemini(ImagePart(file_id="files/a"), {})
+        assert out.file_data.file_uri == "files/a"
+
+    def test_document_data_default_mime(self) -> None:
+        out = _part_to_gemini(DocumentPart(data=b"%PDF"), {})
+        assert out.inline_data.mime_type == "application/pdf"
+
+    def test_document_url(self) -> None:
+        out = _part_to_gemini(DocumentPart(url="https://x/d.pdf", mime_type="application/pdf"), {})
+        assert out.file_data.file_uri == "https://x/d.pdf"
+
+    def test_document_file_id(self) -> None:
+        out = _part_to_gemini(DocumentPart(file_id="files/doc"), {})
+        assert out.file_data.file_uri == "files/doc"
+
+    def test_tool_call(self) -> None:
+        out = _part_to_gemini(
+            ToolCallPart(id="c1", name="search", arguments={"q": "x"}), {}
+        )
+        assert out.function_call.name == "search"
+        assert out.function_call.args == {"q": "x"}
+
+    def test_tool_result_requires_name_lookup(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="no matching ToolCallPart"):
+            _part_to_gemini(ToolResultPart(id="c1", output="42"), {})
+
+    def test_tool_result_with_name_lookup(self) -> None:
+        out = _part_to_gemini(ToolResultPart(id="c1", output="42"), {"c1": "search"})
+        assert out.function_response.name == "search"
+        assert out.function_response.response == {"result": "42"}
+
+    def test_audio_data_default_mime(self) -> None:
+        out = _part_to_gemini(ExtendedPart(extended=AudioPart(data=b"a")), {})
+        assert out.inline_data.mime_type == "audio/mpeg"
+
+    def test_audio_url(self) -> None:
+        out = _part_to_gemini(
+            ExtendedPart(extended=AudioPart(url="https://x/a.mp3", mime_type="audio/mpeg")), {}
+        )
+        assert out.file_data.file_uri == "https://x/a.mp3"
+
+    def test_video_data_default_mime(self) -> None:
+        out = _part_to_gemini(ExtendedPart(extended=VideoPart(data=b"v")), {})
+        assert out.inline_data.mime_type == "video/mp4"
+
+    def test_video_url_with_metadata(self) -> None:
+        out = _part_to_gemini(
+            ExtendedPart(
+                extended=VideoPart(
+                    url="https://x/v.mp4",
+                    mime_type="video/mp4",
+                    start_offset="10s",
+                    end_offset="20s",
+                    fps=2.0,
+                )
+            ),
+            {},
+        )
+        assert out.file_data.file_uri == "https://x/v.mp4"
+        assert out.video_metadata.fps == 2.0
+
+
+class TestMessagesToGemini:
+    def test_system_concatenated_and_model_role(self) -> None:
+        system, contents = _messages_to_gemini(
+            [
+                Message(role="system", parts=[TextPart(text="a")]),
+                Message(role="system", parts=[TextPart(text="b")]),
+                Message(role="assistant", parts=[TextPart(text="hey")]),
+                Message(role="user", parts=[TextPart(text="hi")]),
+            ]
+        )
+        assert system == "a\n\nb"
+        assert [c.role for c in contents] == ["model", "user"]
+
+    def test_no_system(self) -> None:
+        system, contents = _messages_to_gemini(
+            [Message(role="user", parts=[TextPart(text="hi")])]
+        )
+        assert system is None
+        assert contents[0].role == "user"
+
+    def test_system_non_text_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="system messages"):
+            _messages_to_gemini([Message(role="system", parts=[ImagePart(data=b"x")])])
+
+    def test_tool_role_becomes_user_function_response(self) -> None:
+        _, contents = _messages_to_gemini(
+            [
+                Message(
+                    role="assistant",
+                    parts=[ToolCallPart(id="c1", name="search", arguments={})],
+                ),
+                Message(role="tool", parts=[ToolResultPart(id="c1", output="42")]),
+            ]
+        )
+        # assistant model content + synthesised user content with function_response
+        tool_content = contents[-1]
+        assert tool_content.role == "user"
+        assert tool_content.parts[0].function_response.name == "search"
+
+    def test_tool_role_non_tool_result_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="tool-role"):
+            _messages_to_gemini([Message(role="tool", parts=[TextPart(text="x")])])
+
+
+class TestToolTranslation:
+    def _tools(self) -> list[Tool]:
+        return [
+            Tool(id="a", description="A", toolset_id="t", args_schema={"type": "object"}),
+            Tool(id="b", description="B", toolset_id="t", args_schema={"type": "object"}),
+        ]
+
+    def test_empty(self) -> None:
+        assert _tools_to_gemini(None) == []
+        assert _tools_to_gemini([]) == []
+
+    def test_folds_into_single_tool(self) -> None:
+        out = _tools_to_gemini(self._tools())
+        assert len(out) == 1
+        decls = out[0].function_declarations
+        assert [d.name for d in decls] == ["a", "b"]
+
+    def test_tool_choice_none(self) -> None:
+        assert _tool_choice_to_gemini(None) is None
+
+    def test_tool_choice_auto(self) -> None:
+        cfg = _tool_choice_to_gemini("auto")
+        assert cfg.function_calling_config.mode == gtypes.FunctionCallingConfigMode.AUTO
+
+    def test_tool_choice_required(self) -> None:
+        cfg = _tool_choice_to_gemini("required")
+        assert cfg.function_calling_config.mode == gtypes.FunctionCallingConfigMode.ANY
+
+    def test_tool_choice_none_string(self) -> None:
+        cfg = _tool_choice_to_gemini("none")
+        assert cfg.function_calling_config.mode == gtypes.FunctionCallingConfigMode.NONE
+
+    def test_tool_choice_specific(self) -> None:
+        cfg = _tool_choice_to_gemini("search")
+        assert cfg.function_calling_config.mode == gtypes.FunctionCallingConfigMode.ANY
+        assert cfg.function_calling_config.allowed_function_names == ["search"]
+
+
+class _Schema(BaseModel):
+    answer: str
+
+
+class TestResponseFormatAndSampling:
+    def test_response_format_none(self) -> None:
+        assert _response_format_to_gemini(None) == {}
+
+    def test_response_format_dict(self) -> None:
+        out = _response_format_to_gemini({"type": "object"})
+        assert out["response_mime_type"] == "application/json"
+        assert out["response_schema"] == {"type": "object"}
+
+    def test_response_format_pydantic(self) -> None:
+        out = _response_format_to_gemini(_Schema)
+        assert out["response_schema"]["properties"]["answer"]["type"] == "string"
+
+    def test_response_format_invalid(self) -> None:
+        with pytest.raises(ConfigError, match="Pydantic class or dict"):
+            _response_format_to_gemini(123)  # type: ignore[arg-type]
+
+    def test_sampling_kwargs(self) -> None:
+        out = _build_sampling_kwargs(
+            temperature=0.4, top_p=0.9, max_output_tokens=50, stop=["Z"]
+        )
+        assert out == {
+            "temperature": 0.4,
+            "top_p": 0.9,
+            "max_output_tokens": 50,
+            "stop_sequences": ["Z"],
+        }
+
+    def test_sampling_kwargs_empty(self) -> None:
+        assert _build_sampling_kwargs(
+            temperature=None, top_p=None, max_output_tokens=None, stop=None
+        ) == {}
+
+    def test_extended_thinking_and_passthrough(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="primer.llm.gemini")
+        out = _extract_extended_kwargs(
+            {"thinking_budget": 128, "include_thoughts": True, "seed": 3, "junk": 1}
+        )
+        assert out["seed"] == 3
+        assert isinstance(out["thinking_config"], gtypes.ThinkingConfig)
+        assert out["thinking_config"].thinking_budget == 128
+        assert any("dropped unknown" in r.message for r in caplog.records)
+
+    def test_extended_empty(self) -> None:
+        assert _extract_extended_kwargs(None) == {}
+        assert _extract_extended_kwargs({}) == {}
+
+
+class TestFinishReasonAndUsage:
+    def test_stop_without_function_call(self) -> None:
+        assert _map_finish_reason("STOP", _StreamState()) == "stop"
+
+    def test_stop_with_function_call(self) -> None:
+        assert _map_finish_reason("STOP", _StreamState(saw_function_call=True)) == "tool_use"
+
+    def test_max_tokens(self) -> None:
+        assert _map_finish_reason("MAX_TOKENS", _StreamState()) == "max_tokens"
+
+    def test_stop_sequence(self) -> None:
+        assert _map_finish_reason("STOP_SEQUENCE", _StreamState()) == "stop_sequence"
+
+    def test_safety_family_is_content_filter(self) -> None:
+        for reason in ("SAFETY", "RECITATION", "PROHIBITED_CONTENT", "SPII", "IMAGE_SAFETY", "BLOCKLIST"):
+            assert _map_finish_reason(reason, _StreamState()) == "content_filter"
+
+    def test_malformed_function_call_is_error(self) -> None:
+        assert _map_finish_reason("MALFORMED_FUNCTION_CALL", _StreamState()) == "error"
+
+    def test_unknown_is_other(self) -> None:
+        assert _map_finish_reason("WHATEVER", _StreamState()) == "other"
+
+    def test_build_usage_none(self) -> None:
+        assert _build_usage(None) is None
+
+    def test_build_usage_missing_counts(self) -> None:
+        assert _build_usage(NS(prompt_token_count=None, candidates_token_count=5)) is None
+
+    def test_build_usage_full(self) -> None:
+        usage = _build_usage(
+            NS(
+                prompt_token_count=10,
+                candidates_token_count=20,
+                cached_content_token_count=4,
+                thoughts_token_count=7,
+            )
+        )
+        assert usage == Usage(
+            input_tokens=10,
+            output_tokens=20,
+            cached_input_tokens=4,
+            reasoning_tokens=7,
+            cumulative=True,
+        )
+
+
+class TestPartToEvents:
+    def test_text_delta(self) -> None:
+        out = _part_to_events(NS(text="hi", thought=None), _StreamState())
+        assert out == [TextDelta(text="hi", index=0)]
+
+    def test_reasoning_delta(self) -> None:
+        out = _part_to_events(NS(text="ponder", thought=True), _StreamState())
+        assert out == [ReasoningDelta(text="ponder", index=0)]
+
+    def test_function_call(self) -> None:
+        state = _StreamState()
+        out = _part_to_events(
+            NS(function_call=NS(id="call_1", name="search", args={"q": "x"})), state
+        )
+        assert isinstance(out[0], ToolCallStart)
+        assert isinstance(out[1], ToolCallDelta)
+        assert json.loads(out[1].arguments_delta) == {"q": "x"}
+        assert isinstance(out[2], ToolCallEnd)
+        assert state.saw_function_call is True
+
+    def test_function_call_synthesises_id(self) -> None:
+        out = _part_to_events(
+            NS(function_call=NS(id=None, name="fn", args=None)), _StreamState()
+        )
+        assert out[0].id == "call_0"
+        assert out[2].arguments == {}
+
+    def test_inline_audio(self) -> None:
+        out = _part_to_events(NS(inline_data=NS(mime_type="audio/mpeg", data=b"a")), _StreamState())
+        assert out == [MediaDelta(kind="audio", data=b"a", mime_type="audio/mpeg", index=0)]
+
+    def test_inline_image(self) -> None:
+        out = _part_to_events(NS(inline_data=NS(mime_type="image/png", data=b"i")), _StreamState())
+        assert out == [MediaDelta(kind="image", data=b"i", mime_type="image/png", index=0)]
+
+    def test_executable_code_and_result(self) -> None:
+        state = _StreamState()
+        start = _part_to_events(NS(executable_code=NS(code="print(1)")), state)
+        assert isinstance(start[0].extended, ServerToolCallStart)
+        assert start[0].extended.tool_name == "code_execution"
+        result = _part_to_events(
+            NS(code_execution_result=NS(outcome="OK", output="1")), state
+        )
+        assert result[0].extended.result == {"outcome": "OK", "output": "1"}
+
+    def test_unknown_part_ignored(self) -> None:
+        assert _part_to_events(NS(), _StreamState()) == []
+
+
+class TestMetadataEvents:
+    def test_grounding_none(self) -> None:
+        assert _grounding_to_citations(None, _StreamState()) == []
+
+    def test_grounding_chunks(self) -> None:
+        gm = NS(grounding_chunks=[NS(web=NS(uri="https://x", title="T"), retrieved_context=None)])
+        out = _grounding_to_citations(gm, _StreamState())
+        assert isinstance(out[0].extended, Citation)
+        assert out[0].extended.source_url == "https://x"
+
+    def test_safety_empty(self) -> None:
+        assert _safety_ratings_to_event(None) == []
+
+    def test_safety_ratings(self) -> None:
+        out = _safety_ratings_to_event([NS(category="HARM", probability="LOW")])
+        assert isinstance(out[0].extended, SafetyRatings)
+        assert out[0].extended.ratings == {"HARM": "LOW"}
+
+    def test_logprobs_none(self) -> None:
+        assert _logprobs_to_event(None, _StreamState()) == []
+
+    def test_logprobs_empty_chosen(self) -> None:
+        assert _logprobs_to_event(NS(chosen_candidates=[]), _StreamState()) == []
+
+    def test_logprobs_tokens(self) -> None:
+        out = _logprobs_to_event(
+            NS(chosen_candidates=[NS(token="hi", log_probability=-0.5)]), _StreamState()
+        )
+        assert isinstance(out[0].extended, Logprobs)
+        assert out[0].extended.tokens[0].token == "hi"
+
+
+class TestTranslateChunk:
+    def test_stream_start_emitted_first(self) -> None:
+        state = _StreamState()
+        chunk = NS(response_id="resp_1", candidates=[], usage_metadata=None)
+        out = _translate_chunk(chunk, state, model_name="gemini-x")
+        assert isinstance(out[0], StreamStart)
+        assert out[0].request_id == "resp_1"
+        assert out[0].model == "gemini-x"
+        assert state.emitted_stream_start is True
+
+    def test_text_chunk(self) -> None:
+        state = _StreamState()
+        state.emitted_stream_start = True
+        candidate = NS(
+            content=NS(parts=[NS(text="hi", thought=None)]),
+            grounding_metadata=None,
+            safety_ratings=None,
+            logprobs_result=None,
+            finish_reason=None,
+        )
+        chunk = NS(response_id="r", candidates=[candidate], usage_metadata=None)
+        out = _translate_chunk(chunk, state, model_name="m")
+        assert out == [TextDelta(text="hi", index=0)]
+
+    def test_final_chunk_emits_usage_and_done(self) -> None:
+        state = _StreamState()
+        state.emitted_stream_start = True
+        usage_meta = NS(
+            prompt_token_count=5,
+            candidates_token_count=9,
+            cached_content_token_count=None,
+            thoughts_token_count=None,
+        )
+        candidate = NS(
+            content=None,
+            grounding_metadata=None,
+            safety_ratings=None,
+            logprobs_result=None,
+            finish_reason="STOP",
+        )
+        chunk = NS(response_id="r", candidates=[candidate], usage_metadata=usage_meta)
+        out = _translate_chunk(chunk, state, model_name="m")
+        assert isinstance(out[-2], Usage)
+        assert isinstance(out[-1], Done)
+        assert out[-1].stop_reason == "stop"
+        assert out[-1].raw_reason == "STOP"
+
+    def test_final_chunk_enum_finish_reason(self) -> None:
+        state = _StreamState()
+        state.emitted_stream_start = True
+        candidate = NS(
+            content=None,
+            grounding_metadata=None,
+            safety_ratings=None,
+            logprobs_result=None,
+            finish_reason=NS(name="MAX_TOKENS"),
+        )
+        chunk = NS(response_id="r", candidates=[candidate], usage_metadata=None)
+        out = _translate_chunk(chunk, state, model_name="m")
+        assert out[-1].raw_reason == "MAX_TOKENS"
+        assert out[-1].stop_reason == "max_tokens"
+
+    def test_no_candidates(self) -> None:
+        state = _StreamState()
+        state.emitted_stream_start = True
+        out = _translate_chunk(NS(response_id="r", candidates=[], usage_metadata=None), state, model_name="m")
+        assert out == []
+
+
+# --------------------------------------------------------------------------- #
+# stream() full-drive                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def _text_stream_chunks() -> list:
+    first = NS(
+        response_id="resp_1",
+        candidates=[
+            NS(
+                content=NS(parts=[NS(text="hi", thought=None)]),
+                grounding_metadata=None,
+                safety_ratings=None,
+                logprobs_result=None,
+                finish_reason=None,
+            )
+        ],
+        usage_metadata=None,
+    )
+    final = NS(
+        response_id="resp_1",
+        candidates=[
+            NS(
+                content=None,
+                grounding_metadata=None,
+                safety_ratings=None,
+                logprobs_result=None,
+                finish_reason="STOP",
+            )
+        ],
+        usage_metadata=NS(
+            prompt_token_count=5,
+            candidates_token_count=7,
+            cached_content_token_count=None,
+            thoughts_token_count=None,
+        ),
+    )
+    return [first, final]
+
+
+class TestStream:
+    async def test_unknown_model_raises(self) -> None:
+        llm = GeminiLLM(_make_provider(models=["gemini-2.5-flash"]))
+        with pytest.raises(ModelNotFoundError, match="not-real"):
+            async for _ in llm.stream(
+                model="not-real",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+    async def test_full_stream_sequence(self) -> None:
+        llm = GeminiLLM(_make_provider())
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content_stream = AsyncMock(
+            return_value=_aiter(_text_stream_chunks())
+        )
+        with patch.object(llm, "_get_client", return_value=mock_client):
+            out = [
+                ev
+                async for ev in llm.stream(
+                    model="gemini-2.5-flash",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                )
+            ]
+        assert [type(e).__name__ for e in out] == ["StreamStart", "TextDelta", "Usage", "Done"]
+
+    async def test_request_construction(self) -> None:
+        llm = GeminiLLM(_make_provider())
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content_stream = AsyncMock(
+            return_value=_aiter(_text_stream_chunks())
+        )
+        tool = Tool(id="search", description="S", toolset_id="t", args_schema={"type": "object"})
+        with patch.object(llm, "_get_client", return_value=mock_client):
+            async for _ in llm.stream(
+                model="gemini-2.5-flash",
+                messages=[
+                    Message(role="system", parts=[TextPart(text="be terse")]),
+                    Message(role="user", parts=[TextPart(text="hi")]),
+                ],
+                temperature=0.2,
+                max_output_tokens=64,
+                stop=["END"],
+                tools=[tool],
+                tool_choice="required",
+                extended={"seed": 9},
+            ):
+                pass
+        kwargs = mock_client.aio.models.generate_content_stream.call_args.kwargs
+        assert kwargs["model"] == "gemini-2.5-flash"
+        config = kwargs["config"]
+        assert config.system_instruction == "be terse"
+        assert config.temperature == 0.2
+        assert config.max_output_tokens == 64
+        assert config.stop_sequences == ["END"]
+        assert config.seed == 9
+        assert config.tools[0].function_declarations[0].name == "search"
+
+    async def test_error_before_stream_raises(self) -> None:
+        llm = GeminiLLM(_make_provider())
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content_stream = AsyncMock(
+            side_effect=RuntimeError("boom")
+        )
+        with patch.object(llm, "_get_client", return_value=mock_client):
+            with pytest.raises(PrimerError):
+                async for _ in llm.stream(
+                    model="gemini-2.5-flash",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                ):
+                    pass
+
+    async def test_mid_stream_error_yields_chat_error(self) -> None:
+        from primer.model.chat import Error as ChatError
+
+        llm = GeminiLLM(_make_provider())
+
+        async def _failing() -> AsyncIterator:
+            yield NS(response_id="r", candidates=[], usage_metadata=None)
+            raise RuntimeError("mid boom")
+
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content_stream = AsyncMock(return_value=_failing())
+        with patch.object(llm, "_get_client", return_value=mock_client):
+            out = [
+                ev
+                async for ev in llm.stream(
+                    model="gemini-2.5-flash",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                )
+            ]
+        assert isinstance(out[-1], ChatError)
+        assert out[-1].fatal is True
+
+
+class _StallStream:
+    def __aiter__(self) -> "_StallStream":
+        return self
+
+    async def __anext__(self) -> Any:
+        await asyncio.sleep(3600)
+
+
+async def _slow_forever(event: Any) -> AsyncIterator:
+    while True:
+        await asyncio.sleep(0.005)
+        yield event
+
+
+def _benign_chunk() -> Any:
+    return NS(response_id="r", candidates=[], usage_metadata=None)
+
+
+class TestTimeouts:
+    async def test_connect_timeout(self) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        llm = GeminiLLM(_make_provider())
+        llm._connect_timeout_seconds = 0.05
+        mock_client = MagicMock()
+
+        async def _stall(**_: Any) -> Any:
+            await asyncio.sleep(3600)
+
+        mock_client.aio.models.generate_content_stream = _stall
+        with patch.object(llm, "_get_client", return_value=mock_client):
+            with pytest.raises(ProviderTimeoutError):
+                async for _ in llm.stream(
+                    model="gemini-2.5-flash",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                ):
+                    pass
+
+    async def test_stream_stall_timeout(self) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        llm = GeminiLLM(_make_provider())
+        llm._connect_timeout_seconds = None
+        llm._request_timeout_seconds = 0.05
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content_stream = AsyncMock(return_value=_StallStream())
+        with patch.object(llm, "_get_client", return_value=mock_client):
+            with pytest.raises(ProviderTimeoutError) as exc:
+                async for _ in llm.stream(
+                    model="gemini-2.5-flash",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                ):
+                    pass
+        assert exc.value.code == "stream_timeout"
+
+    async def test_generation_budget_timeout(self) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        llm = GeminiLLM(_make_provider())
+        llm._connect_timeout_seconds = None
+        llm._request_timeout_seconds = None
+        llm._total_timeout_seconds = 0.05
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content_stream = AsyncMock(
+            return_value=_slow_forever(_benign_chunk())
+        )
+        with patch.object(llm, "_get_client", return_value=mock_client):
+            with pytest.raises(ProviderTimeoutError) as exc:
+                async for _ in llm.stream(
+                    model="gemini-2.5-flash",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                ):
+                    pass
+        assert exc.value.code == "generation_timeout"
+
+    async def test_trace_llm_io(self) -> None:
+        llm = GeminiLLM(_make_provider(), trace_llm_io=True)
+        mock_client = MagicMock()
+        mock_client.aio.models.generate_content_stream = AsyncMock(
+            return_value=_aiter(_text_stream_chunks())
+        )
+        with patch.object(llm, "_get_client", return_value=mock_client):
+            out = [
+                ev
+                async for ev in llm.stream(
+                    model="gemini-2.5-flash",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                )
+            ]
+        assert any(type(e).__name__ == "Done" for e in out)
+
+
+class TestAdapterLifecycle:
+    def test_rejects_wrong_provider_type(self) -> None:
+        provider = _make_provider()
+        object.__setattr__(provider, "provider", LLMProviderType.ANTHROPIC)
+        with pytest.raises(ConfigError, match="GEMINI"):
+            GeminiLLM(provider)
+
+    def test_rejects_wrong_config_type(self) -> None:
+        from primer.model.provider import OpenResponsesConfig
+
+        provider = LLMProvider(
+            id="g",
+            provider=LLMProviderType.GEMINI,
+            models=[LLMModel(name="gemini-2.5-flash", context_length=1024)],
+            config=OpenResponsesConfig(  # type: ignore[arg-type]
+                url=HttpUrl("https://api.openai.com/v1/"),
+                api_key=SecretStr("sk-x"),
+            ),
+            limits=Limits(max_concurrency=1),
+        )
+        with pytest.raises(ConfigError, match="GoogleConfig"):
+            GeminiLLM(provider)
+
+    def test_accepts_empty_api_key(self) -> None:
+        assert GeminiLLM(_make_provider(api_key=""))._client is None
+
+    async def test_list_models(self) -> None:
+        llm = GeminiLLM(_make_provider(models=["x", "y"]))
+        assert list(await llm.list_models()) == ["x", "y"]
+
+    def test_get_client_lazy_and_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        inst = MagicMock()
+        monkeypatch.setattr("primer.llm.gemini.genai.Client", MagicMock(return_value=inst))
+        llm = GeminiLLM(_make_provider())
+        assert llm._client is None
+        assert llm._get_client() is inst
+        assert llm._get_client() is inst  # cached
+
+    async def test_aclose_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        inst = MagicMock()
+        inst.close = MagicMock()
+        monkeypatch.setattr("primer.llm.gemini.genai.Client", MagicMock(return_value=inst))
+        llm = GeminiLLM(_make_provider())
+        llm._get_client()
+        await llm.aclose()
+        await llm.aclose()
+        inst.close.assert_called_once()
+
+    async def test_count_tokens_delegates(self) -> None:
+        llm = GeminiLLM(_make_provider())
+        mock_client = MagicMock()
+        with patch.object(llm, "_get_client", return_value=mock_client):
+            with patch(
+                "primer.llm.gemini.count_tokens_gemini",
+                new=AsyncMock(return_value=55),
+            ) as mock_count:
+                n = await llm.count_tokens(
+                    model="gemini-2.5-flash",
+                    messages=[Message(role="user", parts=[TextPart(text="hi")])],
+                )
+        assert n == 55
+        mock_count.assert_awaited_once()
+
+
+# --------------------------------------------------------------------------- #
+# Model discovery (respx-mocked HTTP)                                          #
+# --------------------------------------------------------------------------- #
+
+
+class TestDiscover:
+    @respx.mock
+    async def test_filters_and_maps(self) -> None:
+        respx.get(f"{GEMINI_BASE_URL}/models").mock(
+            return_value=httpx.Response(
+                200,
+                json={
+                    "models": [
+                        {
+                            "name": "models/gemini-2.5-flash",
+                            "displayName": "Flash",
+                            "inputTokenLimit": 1048576,
+                            "supportedGenerationMethods": ["generateContent"],
+                        },
+                        {
+                            "name": "models/text-embedding-004",
+                            "supportedGenerationMethods": ["embedContent"],
+                        },
+                        "not-a-dict-entry",
+                        {
+                            # No name -> skipped.
+                            "supportedGenerationMethods": ["generateContent"],
+                        },
+                        {
+                            # Bare "models/" prefix -> empty id -> skipped.
+                            "name": "models/",
+                            "supportedGenerationMethods": ["generateContent"],
+                        },
+                        {
+                            "name": "models/gemini-2.5-pro",
+                            "supportedGenerationMethods": ["generateContent"],
+                        },
+                    ]
+                },
+            )
+        )
+        out = await _discover_gemini_models(GoogleConfig(api_key=SecretStr("k")))
+        assert [m["name"] for m in out] == ["gemini-2.5-flash", "gemini-2.5-pro"]
+        assert out[0]["context_length"] == 1048576
+        assert "context_length" not in out[1]
+
+    @respx.mock
+    async def test_paginates(self) -> None:
+        route = respx.get(f"{GEMINI_BASE_URL}/models").mock(
+            side_effect=[
+                httpx.Response(
+                    200,
+                    json={
+                        "models": [
+                            {"name": "models/a", "supportedGenerationMethods": ["generateContent"]}
+                        ],
+                        "nextPageToken": "P2",
+                    },
+                ),
+                httpx.Response(
+                    200,
+                    json={
+                        "models": [
+                            {"name": "models/b", "supportedGenerationMethods": ["generateContent"]}
+                        ]
+                    },
+                ),
+            ]
+        )
+        out = await _discover_gemini_models(GoogleConfig(api_key=SecretStr("k")))
+        assert [m["name"] for m in out] == ["a", "b"]
+        assert len(route.calls) == 2
+
+    @respx.mock
+    async def test_401_raises(self) -> None:
+        respx.get(f"{GEMINI_BASE_URL}/models").mock(
+            return_value=httpx.Response(401, json={"error": "bad"})
+        )
+        with pytest.raises(httpx.HTTPStatusError):
+            await _discover_gemini_models(GoogleConfig(api_key=SecretStr("bad")))

--- a/tests/observability/test_openresponses_adapter_unit.py
+++ b/tests/observability/test_openresponses_adapter_unit.py
@@ -1,0 +1,927 @@
+"""Unit tests for the OpenResponses LLM adapter
+(:mod:`primer.llm.openresponses`).
+
+Placed under ``tests/observability`` (an included directory) because the
+CI coverage sweep ignores ``tests/llm``. Pure translators are called
+directly; streaming events are faked with ``SimpleNamespace``; the
+``AsyncOpenAI`` client is patched at the module symbol so ``stream()``
+can be driven end-to-end.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import base64
+import logging
+from collections.abc import AsyncIterator
+from types import SimpleNamespace as NS
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from pydantic import BaseModel, HttpUrl, SecretStr
+
+from primer.llm.openresponses import (
+    OpenResponsesLLM,
+    _FlavorPolicy,
+    _POLICY_BY_FLAVOR,
+    _StreamState,
+    _annotation_to_citation,
+    _build_sampling_params,
+    _build_usage,
+    _extract_extended_kwargs,
+    _map_incomplete_reason,
+    _map_stop_reason,
+    _messages_to_input_items,
+    _part_to_input_content,
+    _response_format_to_text_param,
+    _tool_choice_to_openai,
+    _tool_to_openai,
+    _translate_event,
+)
+from primer.model.chat import (
+    AudioPart,
+    Citation,
+    DocumentPart,
+    Done,
+    Error as ChatError,
+    ExtendedEvent,
+    ExtendedPart,
+    ImagePart,
+    MediaDelta,
+    Message,
+    RawReasoningDelta,
+    ReasoningDelta,
+    RefusalDelta,
+    ServerToolCallDelta,
+    ServerToolCallEnd,
+    ServerToolCallStart,
+    StreamStart,
+    TextDelta,
+    TextPart,
+    Tool,
+    ToolCallDelta,
+    ToolCallEnd,
+    ToolCallPart,
+    ToolResultPart,
+    Usage,
+    VideoPart,
+)
+from primer.model.except_ import (
+    ConfigError,
+    ModelNotFoundError,
+    PrimerError,
+    UnsupportedContentError,
+)
+from primer.model.provider import (
+    Limits,
+    LLMModel,
+    LLMProvider,
+    LLMProviderType,
+    OpenResponsesConfig,
+    OpenResponsesFlavor,
+)
+
+
+def _make_provider(
+    *,
+    flavor: OpenResponsesFlavor = OpenResponsesFlavor.OPENAI,
+    api_key: str = "sk-test",
+    models: list[str] | None = None,
+    max_concurrency: int = 4,
+) -> LLMProvider:
+    return LLMProvider(
+        id="openai-default",
+        provider=LLMProviderType.OPENRESPONSES,
+        models=[
+            LLMModel(name=name, context_length=128_000)
+            for name in (models or ["gpt-4o-mini"])
+        ],
+        config=OpenResponsesConfig(
+            url=HttpUrl("https://api.openai.com/v1/"),
+            api_key=SecretStr(api_key),
+            flavor=flavor,
+        ),
+        limits=Limits(max_concurrency=max_concurrency),
+    )
+
+
+async def _aiter(items: list) -> AsyncIterator:
+    for item in items:
+        yield item
+
+
+# --------------------------------------------------------------------------- #
+# Part -> input content mapping                                               #
+# --------------------------------------------------------------------------- #
+
+
+class TestPartToInputContent:
+    def test_text_user_input_text(self) -> None:
+        assert _part_to_input_content(TextPart(text="hi"), role="user") == {
+            "type": "input_text",
+            "text": "hi",
+        }
+
+    def test_text_assistant_output_text(self) -> None:
+        assert _part_to_input_content(TextPart(text="hi"), role="assistant") == {
+            "type": "output_text",
+            "text": "hi",
+        }
+
+    def test_image_data_becomes_data_uri(self) -> None:
+        out = _part_to_input_content(ImagePart(data=b"img", mime_type="image/png"))
+        assert out["type"] == "input_image"
+        assert out["image_url"].startswith("data:image/png;base64,")
+
+    def test_image_data_default_mime(self) -> None:
+        out = _part_to_input_content(ImagePart(data=b"img"))
+        assert out["image_url"].startswith("data:application/octet-stream;base64,")
+
+    def test_image_url_and_detail(self) -> None:
+        out = _part_to_input_content(ImagePart(url="https://x/i.png", detail="high"))
+        assert out["image_url"] == "https://x/i.png"
+        assert out["detail"] == "high"
+
+    def test_image_file_id(self) -> None:
+        out = _part_to_input_content(ImagePart(file_id="file_1"))
+        assert out["file_id"] == "file_1"
+
+    def test_document_data_uri_and_filename(self) -> None:
+        out = _part_to_input_content(
+            DocumentPart(data=b"%PDF", mime_type="application/pdf", filename="r.pdf")
+        )
+        assert out["type"] == "input_file"
+        assert out["file_data"].startswith("data:application/pdf;base64,")
+        assert out["filename"] == "r.pdf"
+
+    def test_document_data_default_filename(self) -> None:
+        out = _part_to_input_content(DocumentPart(data=b"%PDF"))
+        assert out["filename"] == "file"
+
+    def test_document_url(self) -> None:
+        out = _part_to_input_content(DocumentPart(url="https://x/d.pdf", filename="d.pdf"))
+        assert out["file_url"] == "https://x/d.pdf"
+        assert out["filename"] == "d.pdf"
+
+    def test_document_file_id(self) -> None:
+        out = _part_to_input_content(DocumentPart(file_id="file_9", filename="n"))
+        assert out["file_id"] == "file_9"
+        assert out["filename"] == "n"
+
+    def test_audio_mp3(self) -> None:
+        out = _part_to_input_content(
+            ExtendedPart(extended=AudioPart(data=b"a", mime_type="audio/mpeg"))
+        )
+        assert out["type"] == "input_audio"
+        assert out["input_audio"]["format"] == "mp3"
+        assert base64.b64decode(out["input_audio"]["data"]) == b"a"
+
+    def test_audio_wav(self) -> None:
+        out = _part_to_input_content(
+            ExtendedPart(extended=AudioPart(data=b"a", mime_type="audio/wav"))
+        )
+        assert out["input_audio"]["format"] == "wav"
+
+    def test_audio_without_data_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="inline base64 audio"):
+            _part_to_input_content(
+                ExtendedPart(extended=AudioPart(url="https://x/a.mp3", mime_type="audio/mpeg"))
+            )
+
+    def test_audio_bad_mime_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="audio/mp3"):
+            _part_to_input_content(
+                ExtendedPart(extended=AudioPart(data=b"a", mime_type="audio/ogg"))
+            )
+
+    def test_video_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="does not accept video"):
+            _part_to_input_content(ExtendedPart(extended=VideoPart(data=b"v")))
+
+
+class TestMessagesToInputItems:
+    def test_system_and_user_inline(self) -> None:
+        items = _messages_to_input_items(
+            [
+                Message(role="system", parts=[TextPart(text="be terse")]),
+                Message(role="user", parts=[TextPart(text="hi")]),
+            ]
+        )
+        assert items[0]["role"] == "system"
+        assert items[0]["content"][0] == {"type": "input_text", "text": "be terse"}
+        assert items[1]["role"] == "user"
+
+    def test_tool_role_becomes_function_call_output(self) -> None:
+        items = _messages_to_input_items(
+            [Message(role="tool", parts=[ToolResultPart(id="call_1", output="42")])]
+        )
+        assert items == [
+            {"type": "function_call_output", "call_id": "call_1", "output": "42"}
+        ]
+
+    def test_tool_role_non_tool_result_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="tool-role"):
+            _messages_to_input_items(
+                [Message(role="tool", parts=[TextPart(text="x")])]
+            )
+
+    def test_assistant_tool_call_splits_out(self) -> None:
+        items = _messages_to_input_items(
+            [
+                Message(
+                    role="assistant",
+                    parts=[
+                        TextPart(text="calling"),
+                        ToolCallPart(id="call_1", name="search", arguments={"q": "x"}),
+                    ],
+                )
+            ]
+        )
+        # First a message item flushed, then the function_call item.
+        assert items[0]["role"] == "assistant"
+        assert items[0]["content"][0]["type"] == "output_text"
+        assert items[1]["type"] == "function_call"
+        assert items[1]["call_id"] == "call_1"
+        assert items[1]["name"] == "search"
+
+    def test_tool_result_outside_tool_role_rejected(self) -> None:
+        with pytest.raises(UnsupportedContentError, match="only valid inside a tool-role"):
+            _messages_to_input_items(
+                [Message(role="user", parts=[ToolResultPart(id="c", output="o")])]
+            )
+
+
+class _Schema(BaseModel):
+    answer: str
+
+
+class TestToolAndFormatTranslation:
+    def test_tool_to_openai(self) -> None:
+        tool = Tool(id="search", description="S", toolset_id="t", args_schema={"type": "object"})
+        assert _tool_to_openai(tool) == {
+            "type": "function",
+            "name": "search",
+            "description": "S",
+            "parameters": {"type": "object"},
+        }
+
+    def test_tool_choice_variants(self) -> None:
+        assert _tool_choice_to_openai(None) is None
+        assert _tool_choice_to_openai("auto") == "auto"
+        assert _tool_choice_to_openai("required") == "required"
+        assert _tool_choice_to_openai("none") == "none"
+        assert _tool_choice_to_openai("search") == {"type": "function", "name": "search"}
+
+    def test_response_format_none(self) -> None:
+        assert _response_format_to_text_param(None) is None
+
+    def test_response_format_dict(self) -> None:
+        out = _response_format_to_text_param({"type": "object"})
+        assert out["format"]["name"] == "schema"
+        assert out["format"]["schema"] == {"type": "object"}
+        assert out["format"]["strict"] is True
+
+    def test_response_format_pydantic(self) -> None:
+        out = _response_format_to_text_param(_Schema)
+        assert out["format"]["name"] == "_Schema"
+        assert out["format"]["schema"]["properties"]["answer"]["type"] == "string"
+
+    def test_response_format_invalid(self) -> None:
+        with pytest.raises(ConfigError, match="Pydantic class or dict"):
+            _response_format_to_text_param(123)  # type: ignore[arg-type]
+
+
+class TestSamplingAndExtended:
+    def test_max_output_tokens_key(self) -> None:
+        out = _build_sampling_params(
+            temperature=0.5, top_p=0.9, max_output_tokens=64, stop=None
+        )
+        assert out["temperature"] == 0.5
+        assert out["top_p"] == 0.9
+        assert out["max_output_tokens"] == 64
+
+    def test_stop_is_dropped_with_warning(self, caplog: pytest.LogCaptureFixture) -> None:
+        caplog.set_level(logging.WARNING)
+        out = _build_sampling_params(
+            temperature=None, top_p=None, max_output_tokens=None, stop=["END"]
+        )
+        assert "stop" not in out
+        assert any("stop" in r.message.lower() for r in caplog.records)
+
+    def test_extended_reasoning_and_passthrough(
+        self, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        caplog.set_level(logging.DEBUG, logger="primer.llm.openresponses")
+        out = _extract_extended_kwargs(
+            {
+                "reasoning_effort": "high",
+                "reasoning_summary": "auto",
+                "parallel_tool_calls": True,
+                "bogus": 1,
+            }
+        )
+        assert out["reasoning"] == {"effort": "high", "summary": "auto"}
+        assert out["parallel_tool_calls"] is True
+        assert any("dropped unknown" in r.message for r in caplog.records)
+
+    def test_extended_empty(self) -> None:
+        assert _extract_extended_kwargs(None) == {}
+        assert _extract_extended_kwargs({}) == {}
+
+
+class TestStopAndUsage:
+    def test_map_stop_reason_completed_stop(self) -> None:
+        assert _map_stop_reason("completed", _StreamState()) == "stop"
+
+    def test_map_stop_reason_completed_tool_use(self) -> None:
+        assert _map_stop_reason("completed", _StreamState(saw_function_call=True)) == "tool_use"
+
+    def test_map_stop_reason_failed(self) -> None:
+        assert _map_stop_reason("failed", _StreamState()) == "error"
+
+    def test_map_stop_reason_other(self) -> None:
+        assert _map_stop_reason("weird", _StreamState()) == "other"
+
+    def test_map_incomplete_reason(self) -> None:
+        assert _map_incomplete_reason("max_output_tokens") == "max_tokens"
+        assert _map_incomplete_reason("content_filter") == "content_filter"
+        assert _map_incomplete_reason(None) == "other"
+
+    def test_build_usage_none(self) -> None:
+        assert _build_usage(None) is None
+
+    def test_build_usage_missing_counts(self) -> None:
+        assert _build_usage(NS(input_tokens=None, output_tokens=5)) is None
+
+    def test_build_usage_full_with_details(self) -> None:
+        usage = _build_usage(
+            NS(
+                input_tokens=10,
+                output_tokens=20,
+                input_tokens_details=NS(cached_tokens=3),
+                output_tokens_details=NS(reasoning_tokens=6),
+            )
+        )
+        assert usage == Usage(
+            input_tokens=10,
+            output_tokens=20,
+            cached_input_tokens=3,
+            reasoning_tokens=6,
+            cumulative=False,
+        )
+
+    def test_annotation_to_citation(self) -> None:
+        cit = _annotation_to_citation(
+            NS(url="https://x", title="T", start_index=1, end_index=9), index=2
+        )
+        assert cit.source_url == "https://x"
+        assert cit.index == 2
+
+
+class TestFlavorPolicy:
+    def test_openai_requires_key(self) -> None:
+        assert _POLICY_BY_FLAVOR[OpenResponsesFlavor.OPENAI].require_api_key is True
+
+    def test_lmstudio_tolerates_no_key(self) -> None:
+        p = _POLICY_BY_FLAVOR[OpenResponsesFlavor.LMSTUDIO]
+        assert p.require_api_key is False
+        assert p.drop_encrypted_reasoning is True
+
+    def test_policy_frozen(self) -> None:
+        with pytest.raises(Exception):
+            _POLICY_BY_FLAVOR[OpenResponsesFlavor.OPENAI].require_api_key = False  # type: ignore[misc]
+
+
+# --------------------------------------------------------------------------- #
+# Stream-event translation                                                    #
+# --------------------------------------------------------------------------- #
+
+
+class TestTranslateEvent:
+    def test_response_created(self) -> None:
+        out = _translate_event(
+            NS(type="response.created", response=NS(id="resp_1", model="gpt-4o-mini")),
+            _StreamState(),
+        )
+        assert out == [StreamStart(request_id="resp_1", model="gpt-4o-mini")]
+
+    def test_output_item_added_message(self) -> None:
+        state = _StreamState()
+        out = _translate_event(
+            NS(type="response.output_item.added", item=NS(type="message", id="m1")),
+            state,
+        )
+        assert out == []
+        assert state.item_kind["m1"] == "message"
+
+    def test_output_item_added_function_call(self) -> None:
+        state = _StreamState()
+        out = _translate_event(
+            NS(
+                type="response.output_item.added",
+                item=NS(type="function_call", id="i1", call_id="call_1", name="search"),
+            ),
+            state,
+        )
+        assert out[0].id == "call_1"
+        assert out[0].name == "search"
+        assert state.saw_function_call is True
+        assert state.item_call_id["i1"] == "call_1"
+
+    def test_output_item_added_server_tool(self) -> None:
+        state = _StreamState()
+        out = _translate_event(
+            NS(type="response.output_item.added", item=NS(type="web_search_call", id="w1")),
+            state,
+        )
+        assert isinstance(out[0].extended, ServerToolCallStart)
+        assert out[0].extended.tool_name == "web_search"
+
+    def test_output_item_added_unknown(self) -> None:
+        state = _StreamState()
+        out = _translate_event(
+            NS(type="response.output_item.added", item=NS(type="mystery", id="x1")),
+            state,
+        )
+        assert out == []
+        assert state.item_kind["x1"] == "mystery"
+
+    def test_content_part_added(self) -> None:
+        out = _translate_event(
+            NS(type="response.content_part.added", item_id="m1", content_index=0),
+            _StreamState(),
+        )
+        assert out == []
+
+    def test_output_text_delta(self) -> None:
+        out = _translate_event(
+            NS(type="response.output_text.delta", item_id="m1", content_index=0, delta="hi"),
+            _StreamState(),
+        )
+        assert out == [TextDelta(text="hi", index=0)]
+
+    def test_reasoning_summary_delta(self) -> None:
+        out = _translate_event(
+            NS(
+                type="response.reasoning_summary_text.delta",
+                item_id="m1",
+                summary_index=0,
+                delta="thinking",
+            ),
+            _StreamState(),
+        )
+        assert out == [ReasoningDelta(text="thinking", index=0)]
+
+    def test_reasoning_text_delta(self) -> None:
+        out = _translate_event(
+            NS(type="response.reasoning_text.delta", item_id="m1", content_index=0, delta="raw"),
+            _StreamState(),
+        )
+        assert isinstance(out[0].extended, RawReasoningDelta)
+        assert out[0].extended.text == "raw"
+
+    def test_refusal_delta(self) -> None:
+        out = _translate_event(
+            NS(type="response.refusal.delta", item_id="m1", content_index=0, delta="no"),
+            _StreamState(),
+        )
+        assert isinstance(out[0].extended, RefusalDelta)
+        assert out[0].extended.text == "no"
+
+    def test_function_call_arguments_delta_and_done(self) -> None:
+        state = _StreamState()
+        _translate_event(
+            NS(
+                type="response.output_item.added",
+                item=NS(type="function_call", id="i1", call_id="call_1", name="search"),
+            ),
+            state,
+        )
+        delta = _translate_event(
+            NS(type="response.function_call_arguments.delta", item_id="i1", delta='{"q":'),
+            state,
+        )
+        assert isinstance(delta[0], ToolCallDelta)
+        assert delta[0].id == "call_1"
+        done = _translate_event(
+            NS(type="response.function_call_arguments.done", item_id="i1", arguments='{"q": "x"}'),
+            state,
+        )
+        assert done == [ToolCallEnd(id="call_1", arguments={"q": "x"}, index=done[0].index)]
+
+    def test_function_call_arguments_done_bad_json(self) -> None:
+        state = _StreamState()
+        out = _translate_event(
+            NS(type="response.function_call_arguments.done", item_id="i9", arguments="{bad"),
+            state,
+        )
+        assert out[0].arguments == {}
+
+    def test_audio_delta(self) -> None:
+        raw = base64.b64encode(b"snd").decode()
+        out = _translate_event(
+            NS(type="response.audio.delta", item_id="m1", content_index=0, delta=raw),
+            _StreamState(),
+        )
+        assert isinstance(out[0], MediaDelta)
+        assert out[0].kind == "audio"
+        assert out[0].data == b"snd"
+
+    def test_image_partial(self) -> None:
+        raw = base64.b64encode(b"img").decode()
+        out = _translate_event(
+            NS(type="response.image_generation_call.partial_image", item_id="m1", partial_image_b64=raw),
+            _StreamState(),
+        )
+        assert out[0].kind == "image"
+        assert out[0].data == b"img"
+
+    def test_code_interpreter_delta(self) -> None:
+        out = _translate_event(
+            NS(type="response.code_interpreter_call.code.delta", item_id="c1", delta="print(1)"),
+            _StreamState(),
+        )
+        assert isinstance(out[0].extended, ServerToolCallDelta)
+        assert out[0].extended.text == "print(1)"
+
+    def test_annotation_added(self) -> None:
+        out = _translate_event(
+            NS(
+                type="response.output_text_annotation.added",
+                item_id="m1",
+                content_index=0,
+                annotation=NS(url="https://x", title="T"),
+            ),
+            _StreamState(),
+        )
+        assert isinstance(out[0].extended, Citation)
+
+    def test_annotation_added_missing(self) -> None:
+        out = _translate_event(
+            NS(type="response.output_text_annotation.added", item_id="m1", content_index=0, annotation=None),
+            _StreamState(),
+        )
+        assert out == []
+
+    def test_response_completed_with_usage(self) -> None:
+        out = _translate_event(
+            NS(
+                type="response.completed",
+                response=NS(
+                    usage=NS(
+                        input_tokens=5,
+                        output_tokens=7,
+                        input_tokens_details=None,
+                        output_tokens_details=None,
+                    )
+                ),
+            ),
+            _StreamState(),
+        )
+        assert isinstance(out[0], Usage)
+        assert isinstance(out[1], Done)
+        assert out[1].stop_reason == "stop"
+
+    def test_response_completed_without_usage(self) -> None:
+        out = _translate_event(
+            NS(type="response.completed", response=NS(usage=None)), _StreamState()
+        )
+        assert len(out) == 1
+        assert isinstance(out[0], Done)
+
+    def test_response_failed(self) -> None:
+        out = _translate_event(NS(type="response.failed"), _StreamState())
+        assert out == [Done(stop_reason="error", raw_reason="failed")]
+
+    def test_response_incomplete_max_tokens(self) -> None:
+        out = _translate_event(
+            NS(
+                type="response.incomplete",
+                response=NS(incomplete_details=NS(reason="max_output_tokens")),
+            ),
+            _StreamState(),
+        )
+        assert out[0].stop_reason == "max_tokens"
+        assert out[0].raw_reason == "incomplete:max_output_tokens"
+
+    def test_response_incomplete_no_reason(self) -> None:
+        out = _translate_event(
+            NS(type="response.incomplete", response=NS(incomplete_details=NS(reason=None))),
+            _StreamState(),
+        )
+        assert out[0].raw_reason == "incomplete"
+
+    def test_error_event(self) -> None:
+        out = _translate_event(
+            NS(type="error", code="rate_limit", message="slow down"), _StreamState()
+        )
+        assert isinstance(out[0], ChatError)
+        assert out[0].fatal is False
+        assert out[0].code == "rate_limit"
+
+    def test_generic_server_tool_completed_ends_call(self) -> None:
+        state = _StreamState()
+        _translate_event(
+            NS(type="response.output_item.added", item=NS(type="web_search_call", id="w1")),
+            state,
+        )
+        out = _translate_event(
+            NS(type="response.web_search_call.completed", item_id="w1"), state
+        )
+        assert isinstance(out[0].extended, ServerToolCallEnd)
+
+    def test_generic_done_in_skip_list(self) -> None:
+        assert _translate_event(
+            NS(type="response.output_text.done", item_id="m1"), _StreamState()
+        ) == []
+
+    def test_generic_completed_non_server_tool_is_noop(self) -> None:
+        # An item that is not a tracked server-tool call yields nothing.
+        assert _translate_event(
+            NS(type="response.custom_thing.completed", item_id="unknown"),
+            _StreamState(),
+        ) == []
+
+    def test_unhandled_event(self) -> None:
+        assert _translate_event(NS(type="response.mystery.thing"), _StreamState()) == []
+
+
+# --------------------------------------------------------------------------- #
+# stream() full-drive                                                         #
+# --------------------------------------------------------------------------- #
+
+
+def _patched_client(monkeypatch: pytest.MonkeyPatch) -> MagicMock:
+    inst = MagicMock()
+    inst.responses = MagicMock()
+    inst.responses.create = AsyncMock()
+    monkeypatch.setattr("primer.llm.openresponses.AsyncOpenAI", MagicMock(return_value=inst))
+    return inst
+
+
+def _ok_events() -> list[Any]:
+    return [
+        NS(type="response.created", response=NS(id="resp_1", model="gpt-4o-mini")),
+        NS(type="response.output_item.added", item=NS(type="message", id="m1")),
+        NS(type="response.output_text.delta", item_id="m1", content_index=0, delta="hi"),
+        NS(
+            type="response.completed",
+            response=NS(
+                usage=NS(
+                    input_tokens=5,
+                    output_tokens=7,
+                    input_tokens_details=None,
+                    output_tokens_details=None,
+                )
+            ),
+        ),
+    ]
+
+
+class TestStream:
+    async def test_unknown_model_raises(self) -> None:
+        llm = OpenResponsesLLM(_make_provider(models=["gpt-4o-mini"]))
+        with pytest.raises(ModelNotFoundError, match="not-real"):
+            async for _ in llm.stream(
+                model="not-real",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+    async def test_full_stream_sequence(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenResponsesLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.responses.create.return_value = _aiter(_ok_events())
+        out = [
+            ev
+            async for ev in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            )
+        ]
+        assert [type(e).__name__ for e in out] == ["StreamStart", "TextDelta", "Usage", "Done"]
+
+    async def test_request_construction(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenResponsesLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.responses.create.return_value = _aiter(_ok_events())
+        tool = Tool(id="search", description="S", toolset_id="t", args_schema={"type": "object"})
+        async for _ in llm.stream(
+            model="gpt-4o-mini",
+            messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            temperature=0.3,
+            max_output_tokens=64,
+            tools=[tool],
+            tool_choice="required",
+            extended={"parallel_tool_calls": True, "junk": 1},
+        ):
+            pass
+        kwargs = client.responses.create.call_args.kwargs
+        assert kwargs["model"] == "gpt-4o-mini"
+        assert kwargs["store"] is False
+        assert kwargs["stream"] is True
+        assert kwargs["temperature"] == 0.3
+        assert kwargs["max_output_tokens"] == 64
+        assert kwargs["tools"][0]["name"] == "search"
+        assert kwargs["tool_choice"] == "required"
+        assert kwargs["parallel_tool_calls"] is True
+        assert "junk" not in kwargs
+
+    async def test_response_format_in_request(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenResponsesLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.responses.create.return_value = _aiter(_ok_events())
+        async for _ in llm.stream(
+            model="gpt-4o-mini",
+            messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            response_format=_Schema,
+        ):
+            pass
+        kwargs = client.responses.create.call_args.kwargs
+        assert kwargs["text"]["format"]["name"] == "_Schema"
+
+    async def test_error_before_stream_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenResponsesLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+        client.responses.create = AsyncMock(side_effect=RuntimeError("boom"))
+        with pytest.raises(PrimerError):
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+
+    async def test_mid_stream_error_yields_chat_error(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        llm = OpenResponsesLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+
+        async def _failing() -> AsyncIterator:
+            yield NS(type="response.created", response=NS(id="r", model="gpt-4o-mini"))
+            raise RuntimeError("mid boom")
+
+        client.responses.create.return_value = _failing()
+        out = [
+            ev
+            async for ev in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            )
+        ]
+        assert isinstance(out[-1], ChatError)
+        assert out[-1].fatal is True
+
+
+class _StallStream:
+    def __aiter__(self) -> "_StallStream":
+        return self
+
+    async def __anext__(self) -> Any:
+        await asyncio.sleep(3600)
+
+    async def aclose(self) -> None:
+        return None
+
+
+async def _slow_forever(event: Any) -> AsyncIterator:
+    while True:
+        await asyncio.sleep(0.005)
+        yield event
+
+
+class TestTimeouts:
+    async def test_connect_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        llm = OpenResponsesLLM(_make_provider())
+        llm._connect_timeout_seconds = 0.05
+        client = _patched_client(monkeypatch)
+
+        async def _stall(**_: Any) -> Any:
+            await asyncio.sleep(3600)
+
+        client.responses.create = _stall
+        with pytest.raises(ProviderTimeoutError) as exc:
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+        assert exc.value.code == "connect_timeout"
+
+    async def test_stream_stall_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        llm = OpenResponsesLLM(_make_provider())
+        llm._connect_timeout_seconds = None
+        llm._request_timeout_seconds = 0.05
+        client = _patched_client(monkeypatch)
+        client.responses.create.return_value = _StallStream()
+        with pytest.raises(ProviderTimeoutError) as exc:
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+        assert exc.value.code == "stream_timeout"
+
+    async def test_generation_budget_timeout(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from primer.model.except_ import ProviderTimeoutError
+
+        llm = OpenResponsesLLM(_make_provider())
+        llm._connect_timeout_seconds = None
+        llm._request_timeout_seconds = None
+        llm._total_timeout_seconds = 0.05
+        client = _patched_client(monkeypatch)
+        client.responses.create.return_value = _slow_forever(NS(type="response.in_progress"))
+        with pytest.raises(ProviderTimeoutError) as exc:
+            async for _ in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            ):
+                pass
+        assert exc.value.code == "generation_timeout"
+
+    async def test_trace_llm_io(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        llm = OpenResponsesLLM(_make_provider(), trace_llm_io=True)
+        client = _patched_client(monkeypatch)
+        client.responses.create.return_value = _aiter(_ok_events())
+        out = [
+            ev
+            async for ev in llm.stream(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            )
+        ]
+        assert any(type(e).__name__ == "Done" for e in out)
+
+
+class TestAdapterLifecycle:
+    def test_rejects_wrong_provider_type(self) -> None:
+        provider = _make_provider()
+        object.__setattr__(provider, "provider", LLMProviderType.ANTHROPIC)
+        with pytest.raises(ConfigError, match="OPENRESPONSES"):
+            OpenResponsesLLM(provider)
+
+    def test_rejects_wrong_config_type(self) -> None:
+        from primer.model.provider import AnthropicConfig
+
+        provider = LLMProvider(
+            id="o",
+            provider=LLMProviderType.OPENRESPONSES,
+            models=[LLMModel(name="gpt-4o-mini", context_length=1024)],
+            config=AnthropicConfig(api_key=SecretStr("sk-x")),  # type: ignore[arg-type]
+            limits=Limits(max_concurrency=1),
+        )
+        with pytest.raises(ConfigError, match="OpenResponsesConfig"):
+            OpenResponsesLLM(provider)
+
+    def test_openai_flavor_requires_key(self) -> None:
+        with pytest.raises(ConfigError, match="api_key is required"):
+            OpenResponsesLLM(_make_provider(flavor=OpenResponsesFlavor.OPENAI, api_key=""))
+
+    def test_lmstudio_flavor_allows_empty_key(self) -> None:
+        llm = OpenResponsesLLM(_make_provider(flavor=OpenResponsesFlavor.LMSTUDIO, api_key=""))
+        assert llm._policy.require_api_key is False
+
+    async def test_list_models(self) -> None:
+        llm = OpenResponsesLLM(_make_provider(models=["a", "b"]))
+        assert list(await llm.list_models()) == ["a", "b"]
+
+    def test_get_client_lazy_and_cached(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        inst = _patched_client(monkeypatch)
+        llm = OpenResponsesLLM(_make_provider())
+        assert llm._client is None
+        assert llm._get_client() is inst
+        assert llm._get_client() is inst
+
+    def test_get_client_empty_key_uses_sentinel(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        cls_mock = MagicMock(return_value=MagicMock())
+        monkeypatch.setattr("primer.llm.openresponses.AsyncOpenAI", cls_mock)
+        llm = OpenResponsesLLM(_make_provider(flavor=OpenResponsesFlavor.LMSTUDIO, api_key=""))
+        llm._get_client()
+        assert cls_mock.call_args.kwargs["api_key"] == "no-key-required"
+
+    async def test_aclose_idempotent(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        inst = _patched_client(monkeypatch)
+        inst.close = AsyncMock()
+        llm = OpenResponsesLLM(_make_provider())
+        llm._get_client()
+        await llm.aclose()
+        await llm.aclose()
+        inst.close.assert_awaited_once()
+
+    async def test_count_tokens_delegates(self) -> None:
+        llm = OpenResponsesLLM(_make_provider())
+        with patch(
+            "primer.llm._tokenizer.openai.count_tokens_openai",
+            return_value=42,
+        ) as mock_count:
+            n = await llm.count_tokens(
+                model="gpt-4o-mini",
+                messages=[Message(role="user", parts=[TextPart(text="hi")])],
+            )
+        assert n == 42
+        mock_count.assert_called_once()


### PR DESCRIPTION
Adds **583 unit tests** for the biggest untested code paths, so overall coverage clears the 80% gate (now on main) with healthy margin.

## Root cause
The LLM adapters read as 19-58% covered because their **existing tests live under `tests/llm/`, which the CI coverage sweep `--ignore`s**. These new tests go in *included* dirs so they count.

## Coverage lift (per module, before -> after)
| Module | | Module | |
|---|---|---|---|
| `llm/_openai_compat` | 19->99% | `llm/gemini` | 42->100% |
| `llm/openchat` | 28->100% | `llm/openresponses` | 44->99% |
| `llm/openrouter` | 37->100% | `llm/anthropic` | 56->100% |
| `llm/ollama` | 58->100% | `channel/slack/factory` | 6->90% |
| `channel/discord/factory` | 11->88% | `channel/telegram/factory` | 10->95% |

~1,600 previously-missed statements now covered (≈ +4.4% overall).

## Notes
- Mocked only (respx / SDK-boundary patches) — no live Slack/Discord/Telegram/LLM calls, no source changes.
- Follow-up worth considering: split the mocked adapter tests out of the `tests/llm/` ignore so they count without parallel files.