### PR TITLE
fix(model): unbreak main — finalize session forward-ref rebuild when graph loads first

### DIFF
--- a/primer/model/graph.py
+++ b/primer/model/graph.py
@@ -1179,3 +1179,30 @@ __all__ = [
     "NodeRuntimeState",
     "NodeRuntimeStatus",
 ]
+
+
+# ===========================================================================
+# Forward-reference finalisation (import-order-independent)
+# ===========================================================================
+#
+# ``primer.model.workspace_session`` imports ``SessionStatus`` from *this*
+# module at its top level (it is the ``GraphThread.status`` field annotation
+# above). So when ``primer.model.graph`` is the FIRST module in an import chain
+# to load -- e.g. ``primer.agent.base`` -> ``primer.agent.prompt_render`` ->
+# ``from primer.model.graph import ExecutionContext`` -- Python runs
+# ``workspace_session`` to completion *while ``Graph`` here is still undefined*.
+# ``workspace_session._rebuild_models()`` fires at that moment, cannot
+# ``from primer.model.graph import Graph`` (this module is mid-load), swallows
+# the ImportError, and leaves ``AgentSessionBinding`` / ``GraphSessionBinding``
+# / ``WorkspaceSession`` with unresolved ``Agent`` / ``Graph`` forward refs.
+# That in turn leaves ``_CreateSessionArgs`` (in ``primer.toolset.workspaces``,
+# which embeds the ``SessionBinding`` union) permanently un-buildable.
+#
+# Now that ``Graph`` is defined, finish the rebuild that workspace_session had
+# to abandon. ``_rebuild_models()`` is idempotent, so this is a no-op when
+# workspace_session already resolved the refs on its own (it loaded standalone
+# first). Together the two call sites make forward-ref resolution independent
+# of which module loads first.
+from primer.model import workspace_session as _workspace_session  # noqa: E402
+
+_workspace_session._rebuild_models()


### PR DESCRIPTION
**Main is currently red** (104 failed, 399 collection errors: `_CreateSessionArgs is not fully defined; ... define Agent, then model_rebuild()`). Regression from the agent-render merge (`0962f7c2`..`7e6a1df7`); the prior commit `c86e834b` was green.

## Mechanism
`primer/agent/base.py` now imports `primer.agent.prompt_render` -> `from primer.model.graph import ExecutionContext`, so `primer.model.graph` can be the **first** module loaded in a chain. `primer.model.workspace_session` imports `SessionStatus` from graph at top level, so Python finishes loading `workspace_session` **while `Graph` is still undefined** (graph.py mid-load). `workspace_session._rebuild_models()` then can't `import Graph`, swallows the ImportError, and leaves `AgentSessionBinding`/`GraphSessionBinding`/`WorkspaceSession` — and thus `_CreateSessionArgs` (embeds the `SessionBinding` union) — with unresolved forward refs.

## Fix
Re-run the **idempotent** `_rebuild_models()` at the end of `graph.py`, after `Graph` is defined. The two call sites make forward-ref resolution independent of load order. One file, +27 lines (mostly the explanation).

## Verified
- `import primer.model.graph / toolset.workspaces / agent.base / api._app_lifespan` all clean.
- The previously-erroring tests pass (`test_lifespan_teardown`, `test_lifespan_integration`, `test_web_fetch_bootstrap`) and the agent-render feature tests still pass (`test_prompt_render`, `test_agent_node_system_prompt_ctx`) — 16 passed.

Merging this unblocks main CI, coverage PR #92, and the 0.2.0 release.