### PR TITLE
fix(studio): quick-open hides internal files + drop graph_transition noise from run view

### DIFF
--- a/tests/ui/test_session_detail_node_inspector.py
+++ b/tests/ui/test_session_detail_node_inspector.py
@@ -41,6 +41,27 @@ def test_inspector_no_activity_neutral_state() -> None:
     assert "no activity yet" in DETAIL
 
 
+def test_inspector_filters_graph_transition_from_display() -> None:
+    # graph_transition frames render as a wall of bare "graph_transition"
+    # lines with no operator value, so they are dropped from the DISPLAYED
+    # stream. The filter runs BEFORE coalescing so every other kind
+    # (assistant_token, tool_call, tool_result, user_input, done, error)
+    # still renders.
+    assert 'cls !== "graph_transition"' in DETAIL
+    assert "_SLS_coalesceMessages(visibleFrames)" in DETAIL
+    # The unfiltered frame list must NOT be what gets coalesced/rendered.
+    assert "_SLS_coalesceMessages(frames)" not in DETAIL
+
+
+def test_inspector_keeps_graph_transition_refetch_listener() -> None:
+    # The live-refresh trigger must survive: the workspace tap listener still
+    # refetches on graph_transition / done / error. Only the DISPLAY is
+    # filtered, never the refetch trigger.
+    assert "useWorkspaceTapListener" in DETAIL
+    assert 'cls === "graph_transition" || cls === "done" || cls === "error"' in DETAIL
+    assert "states.refetch()" in DETAIL
+
+
 def test_bundle_transpiles_with_inspector() -> None:
     from primer.api._jsx_bundle import build_jsx_bundle
 

--- a/tests/ui/test_studio_quickopen_hidden_filter.py
+++ b/tests/ui/test_studio_quickopen_hidden_filter.py
@@ -1,0 +1,52 @@
+"""QuickOpen (⌘P "Go to file…") must not list internal/hidden junk.
+
+The finder fetches GET /workspaces/{wid}/files?recursive=true and used to list
+git internals (.state/.git/*), .tmp, __pycache__, and dotfiles — which crowd out
+real files and make the picker feel broken. The filter now skips any file whose
+relative path contains a SEGMENT that begins with "." or equals "__pycache__".
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+PALETTE = (UI / "components" / "studio-palette.jsx").read_text(encoding="utf-8")
+
+
+def _quickopen_src() -> str:
+    # Isolate QuickOpen's body so the guard is asserted on the ⌘P finder, not
+    # the sibling StudioCommandPalette (⌘K) which lists sessions/actions.
+    start = PALETTE.index("function QuickOpen(")
+    return PALETTE[start:]
+
+
+def test_quickopen_splits_path_into_segments() -> None:
+    src = _quickopen_src()
+    assert 'path.split("/")' in src
+
+
+def test_quickopen_skips_dot_and_pycache_segments() -> None:
+    # The exact exclusion predicate: any segment starting with "." (covers
+    # .state, .git, .tmp, .tenacious, dotfiles) OR equal to "__pycache__".
+    src = _quickopen_src()
+    assert 'seg.charAt(0) === "."' in src
+    assert 'seg === "__pycache__"' in src
+
+
+def test_quickopen_still_fuzzy_matches_and_skips_dirs() -> None:
+    # The junk-exclusion is additive: the directory skip + fuzzy match remain.
+    src = _quickopen_src()
+    assert "f.is_dir || f.isDir" in src
+    assert "STP_fuzzy(path, query)" in src
+
+
+def test_bundle_transpiles_with_quickopen_filter() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "window.QuickOpen = QuickOpen;" in text
+    assert 'seg === "__pycache__"' in text

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -666,7 +666,18 @@ function SD_NodeInspector({ gid, rid, wid, session, node, graph, pushToast }) {
     };
   }, [wid, rid, nodeId]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  const coalesced = window._SLS_coalesceMessages(frames);
+  // Drop graph_transition frames from the DISPLAYED stream — they render as
+  // a wall of bare "graph_transition" lines with no operator value. A frame's
+  // class/kind lives on kind (tap frames normalise tev.class -> kind; history
+  // records carry it.kind), or on class / payload.class; match the same way
+  // the refetch tap listener detects it (cls === "graph_transition"). NOTE:
+  // this only filters what is rendered — the useWorkspaceTapListener refetch
+  // trigger above is untouched.
+  const visibleFrames = frames.filter((f) => {
+    const cls = (f && f.kind) || (f && f.class) || (f && f.payload && f.payload.class);
+    return cls !== "graph_transition";
+  });
+  const coalesced = window._SLS_coalesceMessages(visibleFrames);
 
   // Empty state: no node selected -> the session-level live stream (the
   // run's End output), so the default view still shows the run's result.

--- a/ui/components/studio-palette.jsx
+++ b/ui/components/studio-palette.jsx
@@ -297,6 +297,17 @@ function QuickOpen({ wid, studio, open, onClose }) {
       // Skip directories
       if (f.is_dir || f.isDir) continue;
       var path = f.path || f.name || "";
+      // Skip internal/hidden files: any path SEGMENT that begins with "."
+      // (covers .state, .state/.git internals, .tmp, .tenacious, dotfiles)
+      // or is exactly "__pycache__". These crowd out real files and make the
+      // finder feel broken.
+      var segs = path.split("/");
+      var hidden = false;
+      for (var si = 0; si < segs.length; si++) {
+        var seg = segs[si];
+        if (seg.charAt(0) === "." || seg === "__pycache__") { hidden = true; break; }
+      }
+      if (hidden) continue;
       if (STP_fuzzy(path, query)) {
         results.push({ path: path, name: STP_basename(path) });
       }


### PR DESCRIPTION
Two Studio field-test fixes.

## Quick-open 'Go to file' listed internal/hidden junk
`QuickOpen` (⌘P) fetched `/files?recursive=true` and listed `.state`, `.state/.git/*` (git internals), `.tmp`, `__pycache__`, dotfiles — crowding out real files so the finder felt broken. Now the filter skips any path with a segment starting with `.` or equal to `__pycache__`; the `is_dir` skip + `STP_fuzzy(path, query)` matching are unchanged.

## Run view showed a wall of graph_transition lines
`SD_NodeInspector`'s per-node stream rendered `graph_transition` frames as bare noise lines. Now graph_transition frames are filtered out **before coalescing/rendering**; all other kinds (assistant_token, tool_call, tool_result, done, error, …) still render. The tap listener that refetches on graph_transition/done/error is untouched.

Structural tests added for both; full tests/ui: 690 passed.