### PR TITLE
feat(runtime): implement health op for liveness probe

### DIFF
--- a/runtime/primer_runtime/server.py
+++ b/runtime/primer_runtime/server.py
@@ -160,6 +160,22 @@ async def _ws_handler(request: web.Request) -> web.WebSocketResponse:
             op_name: str = frame.get("op", "")
             args: dict = frame.get("args") or {}
 
+            # --- Liveness -------------------------------------------------
+            # Cheap health probe used by the platform's workspace probe task
+            # and RuntimeClient.ping(). Connection-level (not a filesystem
+            # op), so it is answered here rather than via the HANDLERS table.
+            if op_name == OpName.HEALTH:
+                await ws.send_str(serialize(Response(
+                    req_id=frame_req_id,
+                    ok=True,
+                    result={
+                        "ok": True,
+                        "version": RUNTIME_VERSION,
+                        "protocol": PROTOCOL_VERSION,
+                    },
+                )))
+                continue
+
             # --- Watch ops -----------------------------------------------
             if op_name == OpName.WATCH_START:
                 start_watch(

--- a/runtime/tests/test_server.py
+++ b/runtime/tests/test_server.py
@@ -13,7 +13,7 @@ import aiohttp
 from aiohttp import web
 from aiohttp.test_utils import TestServer
 
-from primer_runtime.server import build_app, PROTOCOL_VERSION
+from primer_runtime.server import build_app, PROTOCOL_VERSION, RUNTIME_VERSION
 
 
 class WSAuthError(Exception):
@@ -133,3 +133,27 @@ async def test_unknown_op_returns_eunsupported(server: ServerFixture) -> None:
         resp = await ws.receive_json()
         assert resp["ok"] is False
         assert resp["error"]["code"] == "EUNSUPPORTED"
+
+
+@pytest.mark.asyncio
+async def test_health_returns_ok(server: ServerFixture) -> None:
+    """The ``health`` op is a cheap liveness probe used by the platform's
+    workspace probe task and RuntimeClient.ping(); it must reply ok=True
+    with the runtime + protocol versions."""
+    async with server.client(token="abc123") as ws:
+        await ws.send_json(
+            {
+                "req_id": 0,
+                "op": "hello",
+                "args": {"protocol": PROTOCOL_VERSION, "client": "test/0"},
+            }
+        )
+        _ = await ws.receive_json()  # consume hello response
+
+        await ws.send_json({"req_id": 7, "op": "health", "args": {}})
+        resp = await ws.receive_json()
+        assert resp["req_id"] == 7
+        assert resp["ok"] is True
+        assert resp["result"]["ok"] is True
+        assert resp["result"]["version"] == RUNTIME_VERSION
+        assert resp["result"]["protocol"] == PROTOCOL_VERSION


### PR DESCRIPTION
## Problem

The workspace runtime never implemented the `health` op, yet the platform sends it constantly:

- `RuntimeClient.ping()` (`primer/workspace/runtime/runtime_client.py`) sends `OpName.HEALTH`.
- `WorkspaceProbeTask` (`primer/workspace/probe.py`) calls `handle.ping()` every ~30s and, on three consecutive misses, flips a workspace to `phase="failed"` — then reconciles every session on it to `ENDED/workspace_lost`.
- `WSSandbox.inspect()` reads `version`/`uptime_s`/… out of the `health` result.

The runtime's dispatch had no `health` handler (not in the `HANDLERS` table, not special-cased in the server loop), so it replied `EUNSUPPORTED: Op not implemented: 'health'`. Result: **every** k8s/container workspace fails its liveness probe and is marked `failed`, killing its sessions — regardless of reachability mode.

## Fix

Answer `health` at the connection level in `server.py`'s message loop (alongside `hello`/`watch`/`pty`/`exec` — it is a liveness concern, not a filesystem op, and this avoids an `ops -> server` import cycle for `RUNTIME_VERSION`). It returns `{ok, version, protocol}`, satisfying `RuntimeClient.ping()` and populating `WSSandbox.inspect()`'s `version`.

## Test

Added `test_health_returns_ok` in `runtime/tests/test_server.py` (handshake → `health` → assert `ok` + versions). Full runtime suite: **56 passed**; `ruff` clean.

Verified live: after deploying a runtime image carrying this change, a fresh k3s workspace reaches `phase=running` with `last_probe_ok=true`, and a `public-api-finder` graph session executes in it to completion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)