### PR TITLE
feat(harness): download an outbound bundle as a tarball

### DIFF
--- a/primer/api/routers/harness.py
+++ b/primer/api/routers/harness.py
@@ -21,7 +21,7 @@ from datetime import datetime, timezone
 from typing import Annotated, Any
 from uuid import uuid4
 
-from fastapi import APIRouter, Depends, Path, Query, Request, status
+from fastapi import APIRouter, Depends, Path, Query, Request, Response, status
 from fastapi.responses import JSONResponse
 from pydantic import BaseModel, Field
 
@@ -29,6 +29,11 @@ from primer.api.deps import get_claim_engine, get_event_bus, get_storage_provide
 from primer.api.errors import common_responses
 from primer.api.pagination import parse_page
 from primer.harness.hashes import hash_overrides
+from primer.harness.outbound import (
+    OutboundBuildError,
+    build_bundle_targz,
+    build_outbound,
+)
 from primer.model.except_ import ConflictError, NotFoundError
 from primer.model.harness import (
     Harness,
@@ -698,6 +703,56 @@ async def build_harness(
     return JSONResponse(
         status_code=202,
         content=_harness_to_json(updated),
+    )
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/harnesses/{id}/bundle.tar.gz  — download the bundle (outbound only)
+# ---------------------------------------------------------------------------
+
+
+@harness_router.get(
+    "/{harness_id}/bundle.tar.gz",
+    summary="Download an outbound harness bundle as a gzipped tarball",
+    responses=common_responses(404, 409, 422, 500),
+)
+async def download_harness_bundle(
+    harness_id: str = Path(...),
+    sp=Depends(get_storage_provider),
+):
+    storage = _get_harness_storage(sp)
+    harness = await storage.get(harness_id)
+    if harness is None:
+        raise NotFoundError(f"Harness {harness_id!r} does not exist")
+
+    if harness.direction != HarnessDirection.OUTBOUND:
+        return JSONResponse(
+            status_code=409,
+            content={
+                "code": "direction_mismatch",
+                "detail": (
+                    f"Harness {harness_id!r} is inbound; "
+                    "bundle download is an outbound operation"
+                ),
+            },
+        )
+
+    # Build fresh from the live DB (the source of truth for an outbound
+    # harness) and stream it — no queue, no worker, no ephemeral pod fs.
+    try:
+        result = await build_outbound(harness, storage_provider=sp)
+    except OutboundBuildError as exc:
+        return JSONResponse(
+            status_code=422,
+            content={"code": exc.code, "detail": exc.message},
+        )
+
+    tar_gz = build_bundle_targz(result)
+    filename = f"{harness.slug}-{result.bundle_hash[:12]}.tar.gz"
+    return Response(
+        content=tar_gz,
+        media_type="application/gzip",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
     )
 
 

--- a/primer/harness/outbound.py
+++ b/primer/harness/outbound.py
@@ -17,7 +17,9 @@ The result is a :class:`BuildResult` that the dispatch layer hands to
 from __future__ import annotations
 
 import hashlib
+import io
 import json
+import tarfile
 from dataclasses import dataclass
 from typing import Any
 
@@ -235,9 +237,30 @@ async def build_outbound(
     )
 
 
+def build_bundle_targz(result: BuildResult) -> bytes:
+    """Package a built bundle as a deterministic gzipped tarball.
+
+    Members are the same ``(template_path, source_bytes)`` pairs that
+    :func:`primer.harness.git.push_bundle` writes to the git tree, so a
+    downloaded tarball is byte-identical in layout to what ``push``
+    publishes. Members are emitted in sorted path order with zeroed
+    mtime/uid/gid for a stable archive.
+    """
+    buf = io.BytesIO()
+    with tarfile.open(fileobj=buf, mode="w:gz", format=tarfile.PAX_FORMAT) as tar:
+        for f in sorted(result.files, key=lambda x: x.template_path):
+            data = f.source_bytes
+            info = tarfile.TarInfo(name=f.template_path)
+            info.size = len(data)
+            info.mtime = 0
+            tar.addfile(info, io.BytesIO(data))
+    return buf.getvalue()
+
+
 __all__ = [
     "BuildResult",
     "OutboundBuildError",
     "OutboundFile",
+    "build_bundle_targz",
     "build_outbound",
 ]

--- a/tests/api/test_harness_outbound_router.py
+++ b/tests/api/test_harness_outbound_router.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import io
+import tarfile
 from datetime import datetime, timezone
 
 import pytest
 
+from primer.model.agent import Agent
 from primer.model.harness import (
     Harness,
     HarnessDirection,
@@ -13,6 +16,19 @@ from primer.model.harness import (
     HarnessStatus,
     TrackedEntity,
 )
+
+
+def _make_agent(*, id: str = "ag-bot", harness_id: str | None = None) -> Agent:
+    return Agent(
+        id=id,
+        name="Bot",
+        description="d",
+        harness_id=harness_id,
+        model={"provider_id": "openai", "model_name": "gpt-4"},
+        temperature=0.2,
+        tools=[],
+        created_at=datetime.now(timezone.utc),
+    )
 
 
 # ---------------------------------------------------------------------------
@@ -471,3 +487,60 @@ async def test_create_defaults_to_inbound(client):
     body = r.json()
     assert body["direction"] == "inbound"
     assert body["tracked_entities"] == []
+
+
+# ---------------------------------------------------------------------------
+# GET /v1/harnesses/{id}/bundle.tar.gz — download the built bundle
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_download_bundle_outbound(client, app, fake_storage_provider):
+    # The tracked agent must exist — download builds the bundle from the DB.
+    await fake_storage_provider.get_storage(Agent).create(_make_agent(id="ag-bot"))
+    harness = _make_outbound_harness(id="hns_dl_ok", slug="dl-ok")
+    await fake_storage_provider.get_storage(Harness).create(harness)
+
+    r = await client.get("/v1/harnesses/hns_dl_ok/bundle.tar.gz")
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"] == "application/gzip"
+    disp = r.headers["content-disposition"]
+    assert "attachment" in disp
+    assert "dl-ok-" in disp and disp.endswith('.tar.gz"')
+
+    tf = tarfile.open(fileobj=io.BytesIO(r.content), mode="r:gz")
+    names = set(tf.getnames())
+    assert "harness.yaml" in names
+    assert "overrides.schema.json" in names
+    assert "templates/assistant.yaml" in names
+    # the agent template is non-empty and mentions the entity kind
+    member = tf.extractfile("templates/assistant.yaml").read().decode()
+    assert "kind: agent" in member
+
+
+@pytest.mark.asyncio
+async def test_download_bundle_no_entities(client, app, fake_storage_provider):
+    harness = _make_outbound_harness(
+        id="hns_dl_empty", slug="dl-empty", tracked_entities=[],
+    )
+    await fake_storage_provider.get_storage(Harness).create(harness)
+
+    r = await client.get("/v1/harnesses/hns_dl_empty/bundle.tar.gz")
+    assert r.status_code == 422
+    assert r.json()["code"] == "outbound_no_entities"
+
+
+@pytest.mark.asyncio
+async def test_download_bundle_inbound_rejected(client, app, fake_storage_provider):
+    harness = _make_inbound_harness(id="hns_dl_in", slug="dl-in")
+    await fake_storage_provider.get_storage(Harness).create(harness)
+
+    r = await client.get("/v1/harnesses/hns_dl_in/bundle.tar.gz")
+    assert r.status_code == 409
+    assert r.json()["code"] == "direction_mismatch"
+
+
+@pytest.mark.asyncio
+async def test_download_bundle_not_found(client):
+    r = await client.get("/v1/harnesses/hns_nope/bundle.tar.gz")
+    assert r.status_code == 404

--- a/tests/ui/test_harnesses_outbound_list.py
+++ b/tests/ui/test_harnesses_outbound_list.py
@@ -50,3 +50,12 @@ def test_list_has_drift_indicator():
     # The orange dot for outdated outbound.
     assert "hr-drift-dot" in src
     assert "OUTDATED" in src or "outdated" in src
+
+
+def test_outbound_row_has_download_bundle_link():
+    src = _src()
+    # Outbound rows expose a download affordance targeting the bundle endpoint.
+    assert "harness-download-bundle" in src
+    assert "/bundle.tar.gz" in src
+    # It is a real browser download link (<a download>), not a JS fetch.
+    assert "download" in src

--- a/ui/components/harnesses.jsx
+++ b/ui/components/harnesses.jsx
@@ -285,6 +285,18 @@ function HarnessList() {
                         : <span className="muted">-</span>}
                     </td>
                     <td style={{ textAlign: "right" }} onClick={(e) => e.stopPropagation()}>
+                      {isOutbound && (
+                        <a
+                          className="btn btn-sm btn-ghost"
+                          href={"/v1/harnesses/" + encodeURIComponent(h.id) + "/bundle.tar.gz"}
+                          download
+                          data-testid="harness-download-bundle"
+                          title="Download the bundle as a .tar.gz"
+                          style={{ marginRight: 6 }}
+                        >
+                          Download
+                        </a>
+                      )}
                       {isOutbound && canPush ? (
                         <Btn
                           size="sm"


### PR DESCRIPTION
## Problem

An outbound harness's bundle is produced by `build`/`push`, which run
**asynchronously on ephemeral worker pods**. There is no durable, retrievable
copy of a built bundle and no API surface that returns the bundle content — so
an operator can't get the bundle off the cluster without configuring a git
remote.

## What this adds

**`GET /v1/harnesses/{id}/bundle.tar.gz`** — builds the bundle **fresh,
in-process, from the live DB** via `build_outbound()` and streams a gzipped
tarball. No queue, no worker, no pod-filesystem dependency.

- Tarball layout is **byte-identical to what `push` publishes**: `harness.yaml`,
  `overrides.schema.json`, and each tracked entity's `templates/<name>.yaml`
  (documents ship inline). Members are the same `(template_path, source_bytes)`
  pairs `push_bundle` writes; the new `build_bundle_targz()` packages them in
  sorted order with zeroed mtime for a stable archive.
- `Content-Type: application/gzip`, `Content-Disposition: attachment;
  filename="<slug>-<bundle_hash[:12]>.tar.gz"`.
- Outbound-only, mirroring `build`/`push`: inbound → **409** `direction_mismatch`;
  no tracked entities → **422** `outbound_no_entities`; unknown id → **404**.
  Auth is the router's existing cookie-or-bearer dependency.

**Console:** a "Download" link on outbound rows in the harness list — a
same-origin `<a href=".../bundle.tar.gz" download>` authenticated by the session
cookie, so the browser saves the file (not a JS fetch into memory).

## Tests

- `tests/api/test_harness_outbound_router.py`: 200 (valid gzip containing
  `harness.yaml`/`overrides.schema.json`/`templates/assistant.yaml`), 422
  (no entities), 409 (inbound), 404 (unknown).
- `tests/ui/test_harnesses_outbound_list.py`: the download link is present and
  targets `/bundle.tar.gz`.
- Full harness API/build suites + JSX bundle transpile: **57 passed**; `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)