### PR TITLE
fix(console): seven Studio/chat/graph/workspace bug fixes

### DIFF
--- a/primer/api/routers/chats.py
+++ b/primer/api/routers/chats.py
@@ -1022,11 +1022,36 @@ async def _recv_loop(
                 {"kind": "error", "message": str(exc)},
             )
             continue
-        # Re-fetch the chat row so we have the latest last_seq.
+        # Optional client-generated id (a uuid per send). Carried through
+        # so the client can reconcile its optimistic "(queued)" placeholder
+        # with the realized row when it eventually arrives over the WS.
+        _cid = incoming.get("client_msg_id")
+        client_msg_id = _cid if isinstance(_cid, str) and _cid else None
+        # Re-fetch the chat row so we have the latest last_seq / turn_status.
         chat = await chats_storage.get(chat_id)
         if chat is None or chat.status == "ended":
             return
-        # Persist the user_message row + update chat.last_seq / title.
+        # Deferred-queue branch. When a turn is already active
+        # (claimable/running) we must NOT allocate this follow-up a seq
+        # mid-turn — that is exactly what collided with the in-flight
+        # turn's assistant_token seq and aborted the turn. Instead hold
+        # it on ``pending_user_messages`` (no seq); the dispatch loop
+        # realizes it AFTER the turn's terminal row. When idle, keep the
+        # original behaviour: append a real seq'd row + wake a worker.
+        if chat.turn_status in ("claimable", "running"):
+            pending = list(chat.pending_user_messages or [])
+            pending.append({
+                "parts": [p.model_dump(mode="json") for p in user_parts],
+                "attribution": None,
+                "client_msg_id": client_msg_id,
+                "queued_at": datetime.now(timezone.utc).isoformat(),
+            })
+            chat.pending_user_messages = pending
+            await chats_storage.update(chat)
+            # Do NOT publish chat-claimable: no new claimable work landed;
+            # the client already renders this optimistically.
+            continue
+        # Idle: persist the user_message row + update chat.last_seq / title.
         # Delegate to the canonical service helper so the WS path and
         # the trigger dispatcher write user_messages identically.
         from primer.chat.enqueue import append_user_message
@@ -1035,6 +1060,7 @@ async def _recv_loop(
             chat=chat,
             parts=user_parts,
             storage_provider=storage_provider,
+            client_msg_id=client_msg_id,
         )
         # Flip turn_status to claimable and wake workers.
         latest = await chats_storage.get(chat_id)

--- a/primer/api/routers/chats.py
+++ b/primer/api/routers/chats.py
@@ -738,6 +738,39 @@ def _usage_envelope(chat_id: str, context_length: int) -> dict[str, Any]:
     }
 
 
+async def _seed_usage_cache_from_history(sp, chat_id: str) -> None:
+    """Warm the volatile usage cache from the last persisted ``done`` row.
+
+    The per-chat token counters live only in the in-memory
+    :mod:`primer.chat.usage_cache`, so a fresh process (e.g. after a
+    restart) has a cold cache and the context meter would read 0 for any
+    chat whose turns ran previously. Each ``done`` row now carries the
+    turn's ``input_tokens``/``output_tokens``; recover the newest one here.
+    Best-effort and non-clobbering: a warm cache (a live or just-finished
+    turn) always wins.
+    """
+    from primer.chat.usage_cache import get_usage, set_usage
+    from primer.model.storage import OffsetPage
+
+    cur = get_usage(chat_id)
+    if cur["input_tokens"] or cur["output_tokens"]:
+        return
+    messages = sp.get_storage(ChatMessage)
+    q = Q(ChatMessage).where("chat_id", chat_id).where("kind", "done")
+    result = await messages.find(
+        q.build(),
+        OffsetPage(offset=0, length=1),
+        order_by=[OrderBy(field="seq", direction="desc")],
+    )
+    for row in result.items:
+        payload = row.payload or {}
+        input_t = int(payload.get("input_tokens") or 0)
+        output_t = int(payload.get("output_tokens") or 0)
+        if input_t or output_t:
+            set_usage(chat_id, input_t, output_t)
+        return
+
+
 async def _resolve_context_length(sp, chat_id: str) -> int:
     """Resolve the agent's model ``context_length`` for a chat.
 
@@ -863,6 +896,16 @@ async def chat_ws(
             # counters live in primer.chat.usage_cache and are updated
             # by ChatTurnRunner after every Usage event.
             context_length = await _resolve_context_length(sp, chat_id)
+
+            # Recover the usage numerator from the last persisted turn when
+            # this process's in-memory cache is cold (e.g. after a restart)
+            # so the context meter isn't stuck at 0. Best-effort.
+            try:
+                await _seed_usage_cache_from_history(sp, chat_id)
+            except Exception:  # noqa: BLE001 -- never fail the WS connect
+                logger.debug(
+                    "usage cache seed from history failed", exc_info=True,
+                )
 
             # Spec §6.4: send an initial ``usage`` frame so the
             # client's TokenMeter renders immediately on connect,

--- a/primer/api/routers/sessions.py
+++ b/primer/api/routers/sessions.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import asyncio
 import json
 import logging
 from datetime import datetime, timezone
@@ -399,31 +398,20 @@ async def delete_session(
                 },
             )
 
-    # Best-effort: reap the on-disk session slot AND drop the
-    # in-memory session handle so list_sessions() stops returning it.
+    # Best-effort: drop the in-memory session handle AND reap the persisted
+    # on-disk slot so list_sessions() stops returning it. Each backend reaps
+    # its OWN slot inside remove_session (LocalWorkspace rmtrees
+    # .state/sessions/<sid>/; SandboxWorkspace git-rm's the slot in the pod's
+    # runtime state repo). The previous local-only host rmtree here silently
+    # skipped the sandbox backend -- which keeps its slot via _state_repo,
+    # not _state -- so the pod slot survived and rehydrated the "deleted"
+    # session on the next list.
     try:
         live_workspace = await workspace_registry.get_workspace(workspace_id)
-        # Unbind the in-memory handle first — the workspace exposes the
-        # ABC method since the diagnostic-report follow-up landed.
-        try:
-            await live_workspace.remove_session(session_id)
-        except Exception:  # noqa: BLE001
-            logger.debug(
-                "delete_session: remove_session raised; continuing",
-                exc_info=True,
-            )
-        state_root = getattr(live_workspace, "_state", None)
-        state_path = getattr(state_root, "path", None) if state_root else None
-        if state_path is not None:
-            import shutil
-            session_dir = state_path / "sessions" / session_id
-            if session_dir.exists():
-                await asyncio.to_thread(
-                    shutil.rmtree, session_dir, ignore_errors=True
-                )
+        await live_workspace.remove_session(session_id)
     except Exception as exc:  # noqa: BLE001
         logger.warning(
-            "delete_session: on-disk cleanup failed (row still removed)",
+            "delete_session: session-slot cleanup failed (row still removed)",
             extra={
                 "session_id": session_id,
                 "workspace_id": workspace_id,

--- a/primer/chat/dispatch.py
+++ b/primer/chat/dispatch.py
@@ -62,6 +62,69 @@ async def _apply_switch_handoff(
     return "claimable"  # re-serve: new claim runs the new agent
 
 
+async def _realize_pending_messages(
+    deps: "ChatDispatchDeps",
+    chat_id: str,
+) -> bool:
+    """Realize deferred follow-ups (``Chat.pending_user_messages``) into
+    real seq'd user_messages once the active turn has completed.
+
+    Called at the drain-empty checkpoint — AFTER the completed turn's
+    terminal row and BEFORE the chat would otherwise go idle. Each
+    pending entry is appended via ``append_user_message`` in order, so it
+    gets the next real seq (strictly greater than the terminal row),
+    which fixes BOTH the seq-collision (no seq is assigned mid-turn) and
+    the ordering (the follow-up sorts AFTER the response). The
+    ``client_msg_id`` is carried onto the realized row so the client can
+    reconcile its optimistic "(queued)" placeholder.
+
+    Returns True when at least one message was realized (the caller
+    continues its drain loop so the realized rows run as the next
+    turn(s)); False when there was nothing to realize.
+    """
+    from primer.chat.enqueue import append_user_message
+
+    chat_storage = deps.storage_provider.get_storage(Chat)
+    chat = await chat_storage.get(chat_id)
+    if chat is None or not chat.pending_user_messages:
+        return False
+
+    pending = list(chat.pending_user_messages)
+    # Clear on the in-memory copy first so the per-append chat persists
+    # (append_user_message writes the whole row) don't keep re-persisting
+    # the now-draining queue.
+    chat.pending_user_messages = []
+    realized_any = False
+    max_seq = chat.last_seq
+    for entry in pending:
+        raw_parts = entry.get("parts") or []
+        if not raw_parts:
+            continue
+        row = await append_user_message(
+            chat=chat,
+            parts=raw_parts,
+            storage_provider=deps.storage_provider,
+            attribution=entry.get("attribution") or None,
+            client_msg_id=entry.get("client_msg_id"),
+        )
+        max_seq = max(max_seq, row.seq)
+        realized_any = True
+
+    if not realized_any:
+        # The queue held only unusable (part-less) entries: still clear it
+        # so the drain loop doesn't spin re-reading the same junk.
+        fresh = await chat_storage.get(chat_id)
+        if fresh is not None and fresh.pending_user_messages:
+            fresh.pending_user_messages = []
+            await chat_storage.update(fresh)
+        return False
+
+    # Publish a tick so the client receives the realized rows promptly
+    # (carrying client_msg_id) even before the next turn's first token.
+    await deps.event_bus.publish(f"chat:{chat_id}:tick", {"seq": max_seq})
+    return True
+
+
 @dataclass
 class ChatDispatchDeps:
     """Bundle of runtime dependencies the worker injects per task."""
@@ -277,6 +340,18 @@ async def run_one_chat_turn(
                 continue
             next_um = await _find_next_user_message(deps, chat_id)
             if next_um is None:
+                # Deferred-queue realization. The FIFO queue is drained
+                # (the just-completed turn's terminal row has landed);
+                # BEFORE going idle, realize any follow-ups that were
+                # queued while this turn was active into real seq'd
+                # user_messages ordered AFTER that terminal row, then loop
+                # so they run as the next turn(s) on this same claim. This
+                # is the structural fix: no seq is ever assigned to a
+                # follow-up mid-turn, so it can never collide with an
+                # in-flight assistant_token, and it always sorts after the
+                # response. See Chat.pending_user_messages.
+                if await _realize_pending_messages(deps, chat_id):
+                    continue
                 final = await chat_storage.get(chat_id)
                 if final is not None and final.cancel_requested_at is not None:
                     final.cancel_requested_at = None

--- a/primer/chat/enqueue.py
+++ b/primer/chat/enqueue.py
@@ -101,6 +101,7 @@ async def append_user_message(
     parts: list,
     storage_provider: Any,
     attribution: dict | None = None,
+    client_msg_id: str | None = None,
 ) -> ChatMessage:
     """Persist a ``user_message`` row, bump ``chat.last_seq``, derive title.
 
@@ -123,6 +124,13 @@ async def append_user_message(
         "fire_id": ...}`` dict. Stamped onto ``payload["trigger"]`` so
         downstream UIs can render which trigger fired this turn. ``None``
         for human-driven turns from the WS recv loop.
+    client_msg_id:
+        Optional client-generated id carried on a deferred-queue
+        follow-up. Stamped onto ``payload["client_msg_id"]`` so the
+        client can reconcile its optimistic "(queued)" placeholder with
+        the realized row when it arrives over the WS. ``None`` on the
+        ordinary idle send path (the client renders the server echo
+        directly and has no placeholder to reconcile).
     """
     chats_storage = storage_provider.get_storage(Chat)
     messages_storage = storage_provider.get_storage(ChatMessage)
@@ -135,6 +143,8 @@ async def append_user_message(
         payload["content"] = flat
     if attribution:
         payload["trigger"] = dict(attribution)
+    if client_msg_id:
+        payload["client_msg_id"] = client_msg_id
 
     next_seq = chat.last_seq + 1
     row = ChatMessage(

--- a/primer/chat/executor.py
+++ b/primer/chat/executor.py
@@ -1257,12 +1257,23 @@ class ChatTurnRunner:
         ``cancel_requested_at`` (an interrupt frame) and ``agent_id`` (a
         mid-chat agent switch). Without this the running turn's writes would
         clobber them.
+
+        Also refreshes ``last_seq`` to ``max(in-memory, storage)`` as
+        defense in depth: should storage's counter ever move ahead of this
+        turn's stale in-memory copy (a concurrent writer), the next
+        ``_append`` computes its seq from the refreshed value and can
+        never re-use an already-taken seq (which would raise a composite
+        (chat_id, seq) ConflictError and abort the turn). Also carries
+        forward the deferred follow-up queue so a turn's persist doesn't
+        clobber a follow-up that landed on ``pending_user_messages``.
         """
         latest = await self._chats.get(chat.id)
         if latest is not None:
             chat.cancel_requested_at = latest.cancel_requested_at
             chat.agent_id = latest.agent_id
             chat.pending_handoff = latest.pending_handoff
+            chat.pending_user_messages = latest.pending_user_messages
+            chat.last_seq = max(chat.last_seq, latest.last_seq)
         await self._chats.update(chat)
 
     async def _sanitize_unsupported_attachments(self, chat: Chat) -> int:

--- a/primer/chat/executor.py
+++ b/primer/chat/executor.py
@@ -579,7 +579,14 @@ class ChatTurnRunner:
                 done_msg = await self._append(
                     chat,
                     kind="done",
-                    payload={"stop_reason": stop_reason},
+                    payload={
+                        "stop_reason": stop_reason,
+                        # Persist the turn's token usage so the context meter
+                        # can recover it after a process restart (the live
+                        # usage_cache is volatile and cold on reconnect).
+                        "input_tokens": self._last_input_tokens or 0,
+                        "output_tokens": self._last_output_tokens or 0,
+                    },
                 )
                 yield done_msg
                 return

--- a/primer/graph/_node_refs.py
+++ b/primer/graph/_node_refs.py
@@ -426,12 +426,22 @@ def _resolve_initial_ready_node(graph: "Graph") -> str:
     """Return the id of the unique :class:`_BeginNode` that seeds the
     executor's initial ready set.
 
-    Spec §2.3: the topology validator already guarantees exactly one
-    Begin node; this guard is defence in depth against bypassed
-    validators (e.g. ``Graph.model_construct``).
+    Graph *creation* now permits empty / partial drafts (runnability is
+    enforced at session-start via :meth:`Graph.assert_runnable`). This is
+    defence in depth for the executor: if an unrunnable graph reaches
+    ``invoke`` anyway (e.g. a bypassed session-start check, or a graph
+    built via ``Graph.model_construct``), surface the same clear,
+    enumerated runnability error rather than a bare mid-run ``ValueError``
+    (or an ``IndexError`` on ``begins[0]`` for an empty graph).
     """
     begins = [n for n in graph.nodes if isinstance(n, _BeginNode)]
     if len(begins) != 1:
+        # Route through the shared runnability check so the caller gets the
+        # clear, enumerated message (empty graph / wrong Begin count / …)
+        # instead of a bare mid-run ValueError or an IndexError on
+        # ``begins[0]``. assert_runnable always raises when the Begin count
+        # is wrong; the explicit raise below is an unreachable safety net.
+        graph.assert_runnable()
         raise ValueError(
             f"graph {graph.id!r} must have exactly one Begin node; got {len(begins)}"
         )

--- a/primer/model/chats.py
+++ b/primer/model/chats.py
@@ -172,6 +172,23 @@ class Chat(Identifiable):
             "pending_tool_call (which awaits a human reply)."
         ),
     )
+    pending_user_messages: list[dict[str, Any]] = Field(
+        default_factory=list,
+        description=(
+            "Deferred-queue: follow-up user_messages received over the WS "
+            "recv loop WHILE a turn is active (turn_status in "
+            "{'claimable','running'}). They are NOT assigned a seq at "
+            "receipt — that is what collided with the in-flight turn's "
+            "assistant_token seq allocation and aborted the turn. Instead "
+            "each is held here as a raw dict "
+            "``{parts, attribution, client_msg_id, queued_at}`` and "
+            "REALIZED (drained via append_user_message, ordered AFTER the "
+            "turn's terminal row) by the dispatch loop once the current "
+            "turn completes. Cleared on realization. The client renders "
+            "these optimistically with a '(queued)' badge and reconciles "
+            "by ``client_msg_id`` when the realized row arrives."
+        ),
+    )
     channel_binding: ChatChannelBinding | None = Field(
         default=None,
         description=(

--- a/primer/model/graph.py
+++ b/primer/model/graph.py
@@ -754,9 +754,14 @@ class Graph(Describeable):
     _id_prefix: ClassVar[str] = "graph"
 
     nodes: list[GraphNode] = Field(
-        ...,
-        min_length=1,
-        description="Discriminated union of agent / subgraph / terminal nodes.",
+        default_factory=list,
+        description=(
+            "Discriminated union of agent / subgraph / terminal nodes. "
+            "May be empty: an empty or partial graph is a valid *draft* "
+            "that persists fine but is not runnable until it satisfies the "
+            "runnability invariants checked by :meth:`assert_runnable` "
+            "(enforced at session-start, not at creation)."
+        ),
     )
     edges: list[GraphEdge] = Field(
         default_factory=list,
@@ -792,16 +797,25 @@ class Graph(Describeable):
 
     @model_validator(mode="after")
     def _validate_topology(self) -> "Graph":
-        # Spec §1.5 topology rules:
+        # Persist-time validation enforces only *referential integrity* —
+        # the rules that must hold for the stored row to make sense at
+        # all, regardless of whether the graph is a finished, runnable
+        # graph or a half-built draft:
         #   - Unique node ids
-        #   - Exactly one Begin node
-        #   - At least one End node
-        #   - Begin has no incoming edges
-        #   - End nodes have no outgoing edges
-        #   - Every End reachable from Begin (forward BFS)
+        #   - ``on_max_iterations`` (when set) references an existing node
         #   - Every edge endpoint (static to_node, conditional router
-        #     branch to_node, conditional router default_to) references
-        #     an existing node id
+        #     branch to_node / default_to, from_node) references an
+        #     existing node id
+        #   - Begin has no incoming edges / End has no outgoing edges
+        #   - FanOut / FanIn structural rules (Spec B §1.3)
+        #
+        # The *runnability* invariants (exactly one Begin, >=1 End, every
+        # End reachable from Begin, bounded loops) are intentionally NOT
+        # enforced here: an empty or partial graph is a valid draft. Those
+        # are checked at session-start via :meth:`assert_runnable`.
+        #
+        # An empty graph (no nodes) trivially satisfies every referential
+        # rule below, so it early-returns as a valid draft.
         ids: set[str] = set()
         for n in self.nodes:
             if n.id in ids:
@@ -818,14 +832,11 @@ class Graph(Describeable):
 
         begins = [n for n in self.nodes if n.kind == "begin"]
         ends = [n for n in self.nodes if n.kind == "end"]
-        if len(begins) != 1:
-            raise ValueError(
-                f"graph must have exactly one Begin node; got {len(begins)}"
-            )
-        if len(ends) < 1:
-            raise ValueError("graph must have at least one End node")
-
-        begin_id = begins[0].id
+        # NOTE: exactly-one-Begin / >=1-End are *runnability* invariants
+        # (see assert_runnable), not persist-time rules. Resolve the unique
+        # Begin id only when there IS exactly one; the incoming-edge rule
+        # below is skipped for zero-or-many-Begin drafts.
+        begin_id = begins[0].id if len(begins) == 1 else None
         end_ids = {e.id for e in ends}
 
         # Build adjacency from static + conditional edges; conditional
@@ -882,7 +893,7 @@ class Graph(Describeable):
                             continue
                         outgoing[edge.from_node].add(nid)
 
-        if incoming[begin_id]:
+        if begin_id is not None and incoming[begin_id]:
             raise ValueError(
                 f"Begin node {begin_id!r} must have no incoming edges"
             )
@@ -963,80 +974,151 @@ class Graph(Describeable):
                     f"FanIn {n.id!r} must have at least one incoming edge"
                 )
 
-        # Reachability through FanOut implicit edges - rebuild adjacency
-        # extending the static/conditional graph with FanOut-spec targets.
-        adj: dict[str, set[str]] = {n.id: set(outgoing[n.id]) for n in self.nodes}
-        for n in self.nodes:
-            if n.kind != "fan_out":
-                continue
-            for spec in n.specs:
-                if spec.kind in ("broadcast", "map"):
-                    if spec.target_node_id is not None:
-                        adj[n.id].add(spec.target_node_id)
-                else:
-                    for tid in (spec.target_node_ids or []):
-                        adj[n.id].add(tid)
+        # Runnability invariants (End reachability, loopability, exactly
+        # one Begin, >=1 End) are deliberately NOT enforced here — see
+        # :meth:`assert_runnable`, called at session-start.
+        return self
 
-        # ===== Loopability rule =====
-        # A graph that can loop without an iteration ceiling runs
-        # unbounded (cyclic supersteps never terminate). Require
-        # ``max_iterations`` whenever the graph can loop: either a
-        # directed cycle exists over the statically-known edges
-        # (static + json-path conditional + fanout-spec targets), OR a
-        # callable router is present (it can return ANY node id at run
-        # time, so treat its mere presence as making the graph
-        # potentially cyclic). The callable router's synthetic
+    def assert_runnable(self) -> None:
+        """Raise ``ValueError`` if this graph cannot be executed.
+
+        Persist-time validation (:meth:`_validate_topology`) permits empty
+        and partial graphs as drafts; a graph must only satisfy these
+        *runnability* invariants when a session actually binds to it
+        (session-start):
+
+        * the graph has at least one node,
+        * exactly one Begin node,
+        * at least one End node,
+        * every End is forward-reachable from Begin, and
+        * any loop (directed cycle or callable router) is bounded by
+          ``max_iterations``.
+
+        The message enumerates *every* problem found so the operator can
+        fix them in one pass rather than one-at-a-time.
+        """
+        problems = self._runnability_problems()
+        if problems:
+            raise ValueError(
+                f"graph {self.id!r} is not runnable: " + "; ".join(problems)
+            )
+
+    def _runnability_problems(self) -> list[str]:
+        """Return a list of human-readable runnability problems (empty
+        when the graph is runnable). Backs :meth:`assert_runnable`."""
+        problems: list[str] = []
+        if not self.nodes:
+            problems.append("graph is empty (no nodes)")
+            return problems
+
+        begins = [n for n in self.nodes if n.kind == "begin"]
+        ends = [n for n in self.nodes if n.kind == "end"]
+        if len(begins) != 1:
+            problems.append(
+                f"graph must have exactly one Begin node; got {len(begins)}"
+            )
+        if len(ends) < 1:
+            problems.append("graph must have at least one End node")
+
+        # ===== Loopability =====
+        # A graph that can loop without an iteration ceiling runs unbounded
+        # (cyclic supersteps never terminate). Require ``max_iterations``
+        # whenever the graph can loop: either a directed cycle exists over
+        # the statically-known edges (static + json-path conditional +
+        # fanout-spec targets), OR a callable router is present (it can
+        # return ANY node id at run time). The callable router's synthetic
         # "routes-to-any-node" edges are intentionally EXCLUDED from the
-        # cycle adjacency below; its presence alone triggers the rule.
+        # cycle adjacency; its presence alone triggers the rule.
         has_callable_router = any(
             isinstance(e, _ConditionalEdge) and isinstance(e.router, _CallableRouter)
             for e in self.edges
         )
         cycle_adj: dict[str, set[str]] = {n.id: set() for n in self.nodes}
         for edge in self.edges:
+            if edge.from_node not in cycle_adj:
+                continue
             if isinstance(edge, _StaticEdge):
-                cycle_adj[edge.from_node].add(edge.to_node)
+                if edge.to_node in cycle_adj:
+                    cycle_adj[edge.from_node].add(edge.to_node)
             elif isinstance(edge, _ConditionalEdge) and isinstance(
                 edge.router, _JsonPathRouter
             ):
                 for branch in edge.router.branches:
-                    cycle_adj[edge.from_node].add(branch.to_node)
-                if edge.router.default_to is not None:
+                    if branch.to_node in cycle_adj:
+                        cycle_adj[edge.from_node].add(branch.to_node)
+                if edge.router.default_to is not None and edge.router.default_to in cycle_adj:
                     cycle_adj[edge.from_node].add(edge.router.default_to)
         for n in self.nodes:
             if n.kind != "fan_out":
                 continue
             for spec in n.specs:
                 if spec.kind in ("broadcast", "map"):
-                    if spec.target_node_id is not None:
+                    if spec.target_node_id is not None and spec.target_node_id in cycle_adj:
                         cycle_adj[n.id].add(spec.target_node_id)
                 else:
                     for tid in (spec.target_node_ids or []):
-                        cycle_adj[n.id].add(tid)
+                        if tid in cycle_adj:
+                            cycle_adj[n.id].add(tid)
 
-        has_cycle = self._has_cycle(cycle_adj)
-        if (has_cycle or has_callable_router) and self.max_iterations is None:
-            raise ValueError(
+        if (self._has_cycle(cycle_adj) or has_callable_router) and (
+            self.max_iterations is None
+        ):
+            problems.append(
                 "cyclic graph (or callable router) requires max_iterations "
                 "to bound execution"
             )
 
-        # Reachability: BFS from Begin must visit every End.
-        seen_nodes: set[str] = {begin_id}
-        frontier: list[str] = [begin_id]
-        while frontier:
-            cur = frontier.pop()
-            for nxt in adj.get(cur, ()):
-                if nxt in seen_nodes:
+        # ===== End reachability (only meaningful with a unique Begin) =====
+        if len(begins) == 1 and ends:
+            begin_id = begins[0].id
+            end_ids = {e.id for e in ends}
+            adj: dict[str, set[str]] = {n.id: set() for n in self.nodes}
+            for edge in self.edges:
+                if edge.from_node not in adj:
                     continue
-                seen_nodes.add(nxt)
-                frontier.append(nxt)
-        missing = end_ids - seen_nodes
-        if missing:
-            raise ValueError(
-                f"End nodes not reachable from Begin: {sorted(missing)}"
-            )
-        return self
+                if isinstance(edge, _StaticEdge):
+                    if edge.to_node in adj:
+                        adj[edge.from_node].add(edge.to_node)
+                elif isinstance(edge, _ConditionalEdge):
+                    router = edge.router
+                    if isinstance(router, _JsonPathRouter):
+                        for branch in router.branches:
+                            if branch.to_node in adj:
+                                adj[edge.from_node].add(branch.to_node)
+                        if router.default_to is not None and router.default_to in adj:
+                            adj[edge.from_node].add(router.default_to)
+                    else:
+                        # _CallableRouter: may route to any non-Begin node.
+                        for nid in adj:
+                            if nid != begin_id:
+                                adj[edge.from_node].add(nid)
+            for n in self.nodes:
+                if n.kind != "fan_out":
+                    continue
+                for spec in n.specs:
+                    if spec.kind in ("broadcast", "map"):
+                        if spec.target_node_id is not None and spec.target_node_id in adj:
+                            adj[n.id].add(spec.target_node_id)
+                    else:
+                        for tid in (spec.target_node_ids or []):
+                            if tid in adj:
+                                adj[n.id].add(tid)
+            seen_nodes: set[str] = {begin_id}
+            frontier: list[str] = [begin_id]
+            while frontier:
+                cur = frontier.pop()
+                for nxt in adj.get(cur, ()):
+                    if nxt in seen_nodes:
+                        continue
+                    seen_nodes.add(nxt)
+                    frontier.append(nxt)
+            missing = end_ids - seen_nodes
+            if missing:
+                problems.append(
+                    f"End nodes not reachable from Begin: {sorted(missing)}"
+                )
+
+        return problems
 
     @staticmethod
     def _has_cycle(adj: dict[str, set[str]]) -> bool:

--- a/primer/workspace/local/workspace.py
+++ b/primer/workspace/local/workspace.py
@@ -298,14 +298,22 @@ class LocalWorkspace(Workspace):
             return session
 
     async def remove_session(self, session_id: str) -> bool:
-        """Drop the in-memory handle for ``session_id``.
+        """Drop the in-memory handle for ``session_id`` and reap its slot.
 
-        The on-disk slot under ``.state/sessions/<sid>/`` is removed by
-        the API handler; this just unbinds the in-memory cache entry so
-        ``list_sessions()`` stops reporting it.
+        Pops the cached handle and best-effort removes the persisted slot
+        under ``.state/sessions/<sid>/`` so a rehydrating ``get_session`` /
+        ``list_sessions`` no longer resurrects the deleted session. The reap
+        lives here (not in the API handler) so each backend removes its OWN
+        persisted slot. Returns ``True`` when a cached entry was removed.
         """
         async with self._lock:
-            return self._sessions.pop(session_id, None) is not None
+            removed = self._sessions.pop(session_id, None) is not None
+            # Best-effort, held under the lock so the pop + reap are atomic
+            # w.r.t. a concurrent rehydrate. ignore_errors keeps a slow /
+            # failed rmtree from wedging the delete.
+            slot = self._state.path / "sessions" / session_id
+            await asyncio.to_thread(shutil.rmtree, slot, ignore_errors=True)
+            return removed
 
     async def list_files(
         self,

--- a/primer/workspace/sandbox/state.py
+++ b/primer/workspace/sandbox/state.py
@@ -359,6 +359,47 @@ class SandboxStateRepo:
             raise
 
     # ------------------------------------------------------------------
+    # delete_session
+    # ------------------------------------------------------------------
+
+    async def delete_session(self, session_id: str) -> None:
+        """Reap a session's persisted slot from the runtime state repo.
+
+        Removes ``sessions/<session_id>/session.json``, ``agent.json`` and
+        ``waiting.json`` via a state-op commit (a ``git rm`` inside the pod).
+        Dropping ``session.json`` / ``agent.json`` is sufficient to make
+        :meth:`SandboxWorkspace._rehydrate_locked` skip the session on the
+        next :meth:`SandboxWorkspace.list_sessions`: ``load_session_info`` /
+        ``load_agent_binding`` then read the (now absent) files and return
+        ``None``.
+
+        Uses the state ops -- not an ``exec rm`` or file ``delete`` -- on
+        purpose: the slot lives in the runtime-managed working tree that
+        ``state_read`` consults, so a ``git rm`` commit removes exactly the
+        file ``state_read`` would otherwise return. A raw filesystem delete
+        of a separately-computed path could miss (or, in FakeSandbox, never
+        touch) the tracked copy. Idempotent: git rm uses
+        ``--ignore-unmatch`` and the commit is ``--allow-empty``, so
+        deleting an already-gone slot is a harmless no-op.
+
+        Best-effort at the caller: exceptions propagate so the workspace
+        layer can log-and-continue when the workspace is unreachable.
+        """
+        self._require_state_ops()
+        _validate_session_id(session_id)
+        await self.commit_arbitrary(
+            summary=f"{session_id}: detach",
+            delete_files=[
+                f"sessions/{session_id}/session.json",
+                f"sessions/{session_id}/agent.json",
+                f"sessions/{session_id}/waiting.json",
+            ],
+            trailers={_TRAILER_SESSION: session_id},
+        )
+        # Drop the agent-id cache entry so a stale binding can't linger.
+        self._agent_by_session.pop(session_id, None)
+
+    # ------------------------------------------------------------------
     # commit
     # ------------------------------------------------------------------
 

--- a/primer/workspace/sandbox/workspace.py
+++ b/primer/workspace/sandbox/workspace.py
@@ -258,16 +258,31 @@ class SandboxWorkspace(Workspace):
             return await self._rehydrate_locked(session_id)
 
     async def remove_session(self, session_id: str) -> bool:
-        """Drop the in-memory handle for ``session_id``.
+        """Drop the in-memory handle for ``session_id`` and reap its slot.
 
-        Mirrors :meth:`LocalWorkspace.remove_session`: the on-disk slot is
-        reaped by the API handler; this just unbinds the in-memory cache so
-        a subsequent :meth:`list_sessions` (which rehydrates) won't surface
-        a session whose persisted slot has been removed. Returns ``True``
-        when an entry was removed.
+        Pops the cached handle, then best-effort removes the persisted slot
+        (``sessions/<sid>/session.json`` + ``agent.json``) from the pod's
+        runtime state repo so a rehydrating :meth:`list_sessions` /
+        :meth:`get_session` no longer surfaces the deleted session. The
+        sandbox backend keeps its slot inside the pod's ``.state`` git repo
+        (via ``_state_repo``), which the API handler's local-only host
+        rmtree never reached -- so the reap has to happen here. Returns
+        ``True`` when a cached entry was removed.
         """
         async with self._lock:
-            return self._sessions.pop(session_id, None) is not None
+            removed = self._sessions.pop(session_id, None) is not None
+        # Reap outside the lock: it's a runtime RPC round-trip that must
+        # never wedge the in-memory registry, and it's best-effort -- an
+        # unreachable workspace must not fail the delete.
+        try:
+            await self._state_repo.delete_session(session_id)
+        except Exception:  # noqa: BLE001
+            logger.debug(
+                "SandboxWorkspace.remove_session: slot reap failed for %s",
+                session_id,
+                exc_info=True,
+            )
+        return removed
 
     async def _rehydrate_locked(self, session_id: str) -> AgentSession | None:
         """Rebuild one session handle from persisted state. Caller holds

--- a/primer/workspace/sandbox/workspace.py
+++ b/primer/workspace/sandbox/workspace.py
@@ -379,13 +379,20 @@ class SandboxWorkspace(Workspace):
             out.sort(key=lambda fe: fe.path)
             return out
         for fs in await self._sandbox.list_dir(target):
-            child = f"{target}/{fs.path}"
+            # The runtime's list_dir returns each entry's ABSOLUTE path
+            # (/workspace/foo); FakeSandbox returns a basename. Take the
+            # basename either way so we don't double-anchor the workspace
+            # root (which yielded an absolute FileEntry.path that the read
+            # endpoint then re-anchored a second time -> ENOENT).
+            name = fs.path.rsplit("/", 1)[-1]
+            child = f"{target}/{name}"
             out.append(self._file_entry_from_stat(fs, child))
         return out
 
     async def _walk(self, dir_abs: str, out: list[FileEntry]) -> None:
         for fs in await self._sandbox.list_dir(dir_abs):
-            child = f"{dir_abs}/{fs.path}"
+            name = fs.path.rsplit("/", 1)[-1]
+            child = f"{dir_abs}/{name}"
             out.append(self._file_entry_from_stat(fs, child))
             if fs.kind == "dir":
                 await self._walk(child, out)

--- a/primer/workspace/session_factory.py
+++ b/primer/workspace/session_factory.py
@@ -129,6 +129,16 @@ async def start_workspace_session(
             raise ValidationError(
                 f"Graph {binding.graph_id!r} does not exist"
             )
+        # Enforce runnability at session-start (the canonical create path
+        # for REST + create_workspace_session MCP). Graph *creation* now
+        # permits empty / partial drafts; a graph must actually be runnable
+        # — exactly one Begin, >=1 End, End reachable, bounded loops —
+        # before a session may bind to it. Surface as 422, not a mid-run
+        # crash.
+        try:
+            resolved_graph.assert_runnable()
+        except ValueError as exc:
+            raise ValidationError(str(exc)) from exc
         # Pre-validate graph_input against the graph's Begin.input_schema
         # before persisting the session row. The workspace executor reads
         # ``session.metadata['graph_input']`` as the initial input, so any

--- a/tests/api/test_chat_recv_loop_pending.py
+++ b/tests/api/test_chat_recv_loop_pending.py
@@ -1,0 +1,138 @@
+"""The WS recv loop must DEFER a user_message that arrives while a turn
+is active (turn_status in {claimable, running}) onto
+``Chat.pending_user_messages`` — NOT allocate it a seq mid-turn (which
+is what collided with the executor's assistant_token seq). When the
+chat is idle it keeps the current behaviour: append a real seq'd row
+and flip turn_status to claimable.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from fastapi import WebSocketDisconnect
+
+from primer.api.routers.chats import _recv_loop
+from primer.model.chats import Chat, ChatMessage
+from primer.model.storage import OffsetPage, OrderBy, Predicate, FieldRef, Op, Value
+
+
+class _FakeWS:
+    """Yields queued frames then signals a normal disconnect."""
+
+    def __init__(self, frames):
+        self._frames = list(frames)
+        self.sent: list[dict] = []
+
+    async def receive_json(self):
+        if self._frames:
+            return self._frames.pop(0)
+        raise WebSocketDisconnect()
+
+    async def send_json(self, obj):
+        self.sent.append(obj)
+
+
+class _RecordingBus:
+    def __init__(self):
+        self.published: list[tuple[str, dict]] = []
+
+    async def publish(self, key, payload):
+        self.published.append((key, payload))
+
+
+async def _all_messages(msgs, chat_id):
+    page = await msgs.find(
+        Predicate(left=FieldRef(name="chat_id"), op=Op.EQ,
+                  right=Value(value=chat_id)),
+        OffsetPage(offset=0, length=200),
+        order_by=[OrderBy(field="seq", direction="asc")],
+    )
+    return list(page.items)
+
+
+@pytest.mark.asyncio
+async def test_recv_loop_appends_real_row_when_idle(fake_storage_provider):
+    chats = fake_storage_provider.get_storage(Chat)
+    msgs = fake_storage_provider.get_storage(ChatMessage)
+    await chats.create(Chat(
+        id="c1", agent_id="ag", created_at=datetime.now(timezone.utc),
+        turn_status="idle", last_seq=0,
+    ))
+    bus = _RecordingBus()
+    ws = _FakeWS([{"kind": "user_message", "content": "hello",
+                   "client_msg_id": "cid-1"}])
+
+    await _recv_loop(
+        ws, "c1", chats, msgs, bus,
+        claim_engine=None, storage_provider=fake_storage_provider,
+    )
+
+    rows = await _all_messages(msgs, "c1")
+    assert len(rows) == 1
+    assert rows[0].kind == "user_message"
+    assert rows[0].seq == 1
+
+    chat = await chats.get("c1")
+    assert chat.last_seq == 1
+    assert chat.turn_status == "claimable"
+    assert chat.pending_user_messages == []
+    assert any(k == "chat-claimable" for k, _ in bus.published)
+
+
+@pytest.mark.asyncio
+async def test_recv_loop_defers_when_running(fake_storage_provider):
+    chats = fake_storage_provider.get_storage(Chat)
+    msgs = fake_storage_provider.get_storage(ChatMessage)
+    await chats.create(Chat(
+        id="c1", agent_id="ag", created_at=datetime.now(timezone.utc),
+        turn_status="running", last_seq=3,
+    ))
+    bus = _RecordingBus()
+    ws = _FakeWS([{"kind": "user_message", "content": "queued while busy",
+                   "client_msg_id": "cid-2"}])
+
+    await _recv_loop(
+        ws, "c1", chats, msgs, bus,
+        claim_engine=None, storage_provider=fake_storage_provider,
+    )
+
+    # No mid-turn seq allocated: no new ChatMessage row, last_seq unchanged.
+    rows = await _all_messages(msgs, "c1")
+    assert rows == []
+
+    chat = await chats.get("c1")
+    assert chat.last_seq == 3
+    assert chat.turn_status == "running"  # not flipped
+    # Held on the deferred queue with its client_msg_id for reconcile.
+    assert len(chat.pending_user_messages) == 1
+    entry = chat.pending_user_messages[0]
+    assert entry["client_msg_id"] == "cid-2"
+    assert entry["parts"] == [{"type": "text", "text": "queued while busy"}]
+    # A deferred message does NOT wake a worker.
+    assert all(k != "chat-claimable" for k, _ in bus.published)
+
+
+@pytest.mark.asyncio
+async def test_recv_loop_defers_when_claimable(fake_storage_provider):
+    chats = fake_storage_provider.get_storage(Chat)
+    msgs = fake_storage_provider.get_storage(ChatMessage)
+    await chats.create(Chat(
+        id="c1", agent_id="ag", created_at=datetime.now(timezone.utc),
+        turn_status="claimable", last_seq=2,
+    ))
+    bus = _RecordingBus()
+    ws = _FakeWS([{"kind": "user_message", "content": "also queued"}])
+
+    await _recv_loop(
+        ws, "c1", chats, msgs, bus,
+        claim_engine=None, storage_provider=fake_storage_provider,
+    )
+
+    rows = await _all_messages(msgs, "c1")
+    assert rows == []
+    chat = await chats.get("c1")
+    assert len(chat.pending_user_messages) == 1
+    # client_msg_id is optional on the frame; stored as None when absent.
+    assert chat.pending_user_messages[0]["client_msg_id"] is None

--- a/tests/api/test_chat_ws_envelopes.py
+++ b/tests/api/test_chat_ws_envelopes.py
@@ -234,3 +234,69 @@ class TestUsageEnvelopeOnConnect:
         # And the pong arrives after the usage frame — proves the
         # initial envelope didn't displace normal protocol traffic.
         assert frames[1].get("kind") == "pong", frames
+
+
+class TestUsageRecoveryFromHistory:
+    """The usage numerator must survive a process restart: the live cache
+    is volatile, so a cold cache is re-seeded from the last persisted
+    ``done`` row (which now carries the turn's token counts)."""
+
+    @pytest.mark.asyncio
+    async def test_seed_recovers_last_done_usage_when_cache_cold(
+        self, fake_storage_provider,
+    ) -> None:
+        from primer.api.routers.chats import _seed_usage_cache_from_history
+        from primer.chat.usage_cache import get_usage
+        from primer.model.chats import Chat
+
+        sp = fake_storage_provider
+        await sp.get_storage(Chat).create(
+            Chat(
+                id="c9", agent_id="ag",
+                created_at=datetime.now(timezone.utc),
+                last_seq=3, next_unprocessed_seq=4,
+            )
+        )
+        await sp.get_storage(ChatMessage).create(
+            ChatMessage(
+                id=ChatMessage.make_id("c9", 3), chat_id="c9", seq=3,
+                kind="done",
+                payload={
+                    "stop_reason": "stop",
+                    "input_tokens": 4096, "output_tokens": 128,
+                },
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        # Cold cache (post-restart) → numerator would be 0 without recovery.
+        assert get_usage("c9") == {"input_tokens": 0, "output_tokens": 0}
+        await _seed_usage_cache_from_history(sp, "c9")
+        assert get_usage("c9") == {"input_tokens": 4096, "output_tokens": 128}
+
+    @pytest.mark.asyncio
+    async def test_seed_is_noop_when_cache_already_warm(
+        self, fake_storage_provider,
+    ) -> None:
+        from primer.api.routers.chats import _seed_usage_cache_from_history
+        from primer.chat.usage_cache import get_usage, set_usage
+        from primer.model.chats import Chat
+
+        sp = fake_storage_provider
+        set_usage("c9", input_tokens=999, output_tokens=9)  # a live turn
+        await sp.get_storage(Chat).create(
+            Chat(
+                id="c9", agent_id="ag",
+                created_at=datetime.now(timezone.utc),
+                last_seq=3, next_unprocessed_seq=4,
+            )
+        )
+        await sp.get_storage(ChatMessage).create(
+            ChatMessage(
+                id=ChatMessage.make_id("c9", 3), chat_id="c9", seq=3,
+                kind="done", payload={"input_tokens": 1, "output_tokens": 1},
+                created_at=datetime.now(timezone.utc),
+            )
+        )
+        await _seed_usage_cache_from_history(sp, "c9")
+        # Live counters win — history must not clobber a warmer cache.
+        assert get_usage("c9") == {"input_tokens": 999, "output_tokens": 9}

--- a/tests/api/test_graphs.py
+++ b/tests/api/test_graphs.py
@@ -1,10 +1,16 @@
 """CRUD coverage for the /v1/graphs router with Begin/End topology.
 
 Spec §7.1 acceptance: the REST surface accepts/rejects the new node
-shapes (Begin / End), preserves conditional edges with
-:class:`BranchCondition` lists across save+load round-trips, and emits
-422 on topology violations (two Begin nodes, missing End, unreachable
-End, malformed JSON Schema).
+shapes (Begin / End) and preserves conditional edges with
+:class:`BranchCondition` lists across save+load round-trips.
+
+NOTE (runnability split): graph *creation* is a draft operation — empty
+and partial graphs (including topologies that aren't yet runnable: two
+Begin nodes, no End, an unreachable End) are accepted with 201. The
+"is this graph runnable?" invariants are enforced later, at session-start
+(``Graph.assert_runnable`` via the session factory), NOT at POST /graphs.
+Only *referential* problems (bad edge endpoints, duplicate ids, malformed
+JSON Schema) still 422 at creation.
 
 Uses the shared ``client`` fixture from ``tests/api/conftest.py``:
 in-memory storage + auto-registered test user. Each test posts a fresh
@@ -103,8 +109,10 @@ async def test_create_minimal_begin_end_graph_returns_201(client) -> None:
 
 
 @pytest.mark.asyncio
-async def test_create_two_begin_nodes_returns_422(client) -> None:
-    """Topology rule (spec §1.5): exactly one Begin node per graph."""
+async def test_create_two_begin_nodes_now_allowed(client) -> None:
+    """Two-Begin is a runnability problem, not a creation problem: the
+    draft persists with 201; ``assert_runnable`` rejects it at
+    session-start (see tests/workspace/test_session_factory.py)."""
     body = _minimal_begin_end_body("g-two-begin")
     # Inject a second Begin node — both with valid ids.
     body["nodes"].insert(
@@ -112,12 +120,13 @@ async def test_create_two_begin_nodes_returns_422(client) -> None:
         {"kind": "begin", "id": "rogue_begin"},
     )
     resp = await client.post("/v1/graphs", json=body)
-    assert resp.status_code == 422, resp.text
+    assert resp.status_code == 201, resp.text
 
 
 @pytest.mark.asyncio
-async def test_create_no_end_node_returns_422(client) -> None:
-    """Topology rule (spec §1.5): at least one End node per graph."""
+async def test_create_no_end_node_now_allowed(client) -> None:
+    """A graph with no End persists as a draft (201); the missing End is
+    a runnability problem enforced at session-start, not creation."""
     body = {
         "id": "g-no-end",
         "description": "missing End",
@@ -130,12 +139,13 @@ async def test_create_no_end_node_returns_422(client) -> None:
         ],
     }
     resp = await client.post("/v1/graphs", json=body)
-    assert resp.status_code == 422, resp.text
+    assert resp.status_code == 201, resp.text
 
 
 @pytest.mark.asyncio
-async def test_create_unreachable_end_returns_422(client) -> None:
-    """Topology rule (spec §1.5): every End reachable from Begin via forward BFS."""
+async def test_create_unreachable_end_now_allowed(client) -> None:
+    """An unreachable End is a runnability problem, not a creation one:
+    the draft persists (201) and is rejected at session-start instead."""
     body = {
         "id": "g-unreachable",
         "description": "End not reachable from Begin",
@@ -149,9 +159,38 @@ async def test_create_unreachable_end_returns_422(client) -> None:
         ],
     }
     resp = await client.post("/v1/graphs", json=body)
+    assert resp.status_code == 201, resp.text
+
+
+@pytest.mark.asyncio
+async def test_create_empty_graph_now_allowed(client) -> None:
+    """An empty graph (no nodes/edges) is a valid draft — 201 at creation.
+    Runnability is enforced later, at session-start."""
+    body = {"id": "g-empty", "description": "empty draft", "nodes": [], "edges": []}
+    resp = await client.post("/v1/graphs", json=body)
+    assert resp.status_code == 201, resp.text
+    out = resp.json()
+    assert out["nodes"] == []
+
+
+@pytest.mark.asyncio
+async def test_create_bad_edge_endpoint_still_returns_422(client) -> None:
+    """Referential integrity is still enforced at creation: an edge whose
+    endpoint references a missing node id is rejected with 422 even though
+    runnability checks are deferred."""
+    body = {
+        "id": "g-bad-edge",
+        "description": "edge to nowhere",
+        "nodes": [
+            {"kind": "begin", "id": "start"},
+            {"kind": "end", "id": "finish"},
+        ],
+        "edges": [
+            {"kind": "static", "from_node": "start", "to_node": "ghost"},
+        ],
+    }
+    resp = await client.post("/v1/graphs", json=body)
     assert resp.status_code == 422, resp.text
-    # The error message should reference the orphan node id.
-    assert "orphan" in resp.text
 
 
 # ===========================================================================

--- a/tests/chat/test_dispatch_pending_realize.py
+++ b/tests/chat/test_dispatch_pending_realize.py
@@ -1,0 +1,191 @@
+"""Deferred-queue: a follow-up sent while the agent is still "Thinking…"
+must NOT collide with the in-flight turn's seq allocation, and must be
+realized as a real user_message ordered AFTER the turn's terminal row.
+
+This is the critical regression the older
+``test_dispatch_queue_while_compacting`` test does NOT cover: that test
+seeds the second user_message AFTER the first ``TextDelta`` (so the
+assistant token already claimed ``seq=2`` and there is no collision
+window). Here the follow-up is enqueued BEFORE the first assistant
+token — the exact window where the old code allocated a real ``seq=2``
+row for the follow-up that then collided with the executor's first
+``assistant_token`` (also ``seq=2``), raising ``ConflictError`` and
+aborting the turn.
+
+With the deferred queue the follow-up is held on
+``Chat.pending_user_messages`` (no seq) until the turn's terminal row
+lands, then realized via ``append_user_message`` — so it is impossible
+for it to share a seq with an in-flight row, and it sorts AFTER the
+response.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from pydantic import SecretStr
+
+from primer.bus.in_memory import InMemoryEventBus
+from primer.chat.dispatch import ChatDispatchDeps, run_one_chat_turn
+from primer.chat.tick_router import ChatTickRouter
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import Done, StreamEvent, TextDelta
+from primer.model.chats import Chat, ChatMessage
+from primer.model.provider import (
+    AnthropicConfig, Limits, LLMModel, LLMProvider, LLMProviderType,
+)
+from primer.model.storage import (
+    FieldRef, Op, OffsetPage, OrderBy, Predicate, Value,
+)
+
+
+class _ThinkingSeederLLM:
+    """Fake LLM that — during the FIRST turn, BEFORE the first assistant
+    token — enqueues a follow-up onto ``chat.pending_user_messages``,
+    simulating the deferred-queue WS recv loop receiving a second send
+    while the agent is still "Thinking…". Later turns stream a plain
+    ``TextDelta`` + ``Done`` so the drain loop terminates cleanly."""
+
+    def __init__(self, *, on_first_thinking) -> None:
+        self._on_first_thinking = on_first_thinking
+        self._calls_seen = 0
+        self.calls: list[dict[str, Any]] = []
+
+    async def list_models(self):
+        return ["m"]
+
+    def stream(self, *, model, messages, **kwargs):
+        self._calls_seen += 1
+        self.calls.append({"model": model, "messages": list(messages)})
+        return self._stream_impl(first=self._calls_seen == 1)
+
+    async def _stream_impl(self, *, first: bool) -> AsyncIterator[StreamEvent]:
+        # Fire the side effect BEFORE any token lands — this is the
+        # "Thinking…" collision window the old code tripped on.
+        if first:
+            await self._on_first_thinking()
+        yield TextDelta(text="hi", index=0)
+        yield Done(stop_reason="stop", raw_reason="stop")
+
+    async def aclose(self) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_followup_during_thinking_is_deferred_and_realized_after_turn(
+    fake_storage_provider, fake_provider_registry,
+) -> None:
+    await fake_storage_provider.get_storage(LLMProvider).create(
+        LLMProvider(
+            id="p", provider=LLMProviderType.ANTHROPIC,
+            models=[LLMModel(name="m", context_length=8192)],
+            config=AnthropicConfig(api_key=SecretStr("test")),
+            limits=Limits(max_concurrency=1),
+        ),
+    )
+    await fake_storage_provider.get_storage(Agent).create(Agent(
+        id="ag", description="x",
+        model=AgentModel(provider_id="p", model_name="m"),
+    ))
+
+    chats = fake_storage_provider.get_storage(Chat)
+    msgs = fake_storage_provider.get_storage(ChatMessage)
+
+    now = datetime.now(timezone.utc)
+    chat = Chat(
+        id="c1", agent_id="ag", created_at=now,
+        turn_status="running",  # the worker pool has already claimed it
+        last_seq=1,
+    )
+    await chats.create(chat)
+    await msgs.create(ChatMessage(
+        id=ChatMessage.make_id("c1", 1),
+        chat_id="c1", seq=1, kind="user_message",
+        payload={"content": "first"}, created_at=now,
+    ))
+
+    async def _enqueue_pending_followup() -> None:
+        # Mirror exactly what the WS recv loop does when a frame arrives
+        # while a turn is active: hold it on pending_user_messages (NO seq).
+        cur = await chats.get("c1")
+        cur.pending_user_messages = [
+            {
+                "parts": [{"type": "text", "text": "second"}],
+                "attribution": None,
+                "client_msg_id": "cid-2",
+                "queued_at": datetime.now(timezone.utc).isoformat(),
+            }
+        ]
+        await chats.update(cur)
+
+    fake_llm = _ThinkingSeederLLM(on_first_thinking=_enqueue_pending_followup)
+
+    async def _get_llm(_pid):
+        return fake_llm
+    fake_provider_registry.get_llm = _get_llm  # type: ignore[assignment]
+
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    deps = ChatDispatchDeps(
+        storage_provider=fake_storage_provider,
+        provider_registry=fake_provider_registry,
+        event_bus=bus,
+        chat_tick_router=ChatTickRouter(),
+        fake_llm=fake_llm,
+    )
+
+    try:
+        disposition = await run_one_chat_turn(deps, chat_id="c1", worker_id="w1")
+    finally:
+        await bus.aclose()
+
+    # (a) The turn did NOT abort on a seq collision: two clean LLM turns ran.
+    assert fake_llm._calls_seen == 2, (
+        f"expected 2 stream calls (turn 1 + the realized follow-up); "
+        f"got {fake_llm._calls_seen}"
+    )
+
+    page = await msgs.find(
+        Predicate(left=FieldRef(name="chat_id"), op=Op.EQ,
+                  right=Value(value="c1")),
+        OffsetPage(offset=0, length=200),
+        order_by=[OrderBy(field="seq", direction="asc")],
+    )
+    rows = page.items
+    kinds = [r.kind for r in rows]
+
+    # (b) The first turn completed with its assistant + done rows, and the
+    #     follow-up turn also completed — two of each terminal.
+    assert kinds.count("user_message") == 2, kinds
+    assert kinds.count("done") == 2, kinds
+
+    # No colliding / duplicate seqs anywhere.
+    seqs = [r.seq for r in rows]
+    assert len(seqs) == len(set(seqs)), f"duplicate seq detected: {seqs}"
+
+    # (c) The realized follow-up sorts AFTER the first turn's done row.
+    user_rows = [r for r in rows if r.kind == "user_message"]
+    first_done_seq = next(r.seq for r in rows if r.kind == "done")
+    realized = user_rows[1]
+    assert realized.payload.get("content") == "second"
+    assert realized.seq > first_done_seq, (
+        f"realized follow-up seq {realized.seq} must be > first done "
+        f"seq {first_done_seq}"
+    )
+    # client_msg_id is carried onto the realized row for client reconcile.
+    assert realized.payload.get("client_msg_id") == "cid-2"
+
+    # (d) It was processed as the next turn (its own done row follows it).
+    realized_idx = rows.index(realized)
+    assert any(
+        r.kind == "done" and r.seq > realized.seq
+        for r in rows[realized_idx:]
+    ), kinds
+
+    # Pending list drained; clean disposition.
+    final = await chats.get("c1")
+    assert final.pending_user_messages == []
+    assert disposition == "idle"

--- a/tests/chat/test_executor_persist.py
+++ b/tests/chat/test_executor_persist.py
@@ -42,3 +42,30 @@ async def test_append_preserves_externally_switched_agent_id():
     assert chats.updated is not None
     assert chats.updated.agent_id == "agent-B"
     assert chats.updated.last_seq == 6
+
+
+@pytest.mark.asyncio
+async def test_persist_chat_refreshes_last_seq_from_storage():
+    """Defense in depth: if storage's last_seq has moved ahead of this
+    turn's stale in-memory counter, `_persist_chat` refreshes it to the
+    max so the next `_append` can never reuse an already-taken seq."""
+    stored = Chat(id="chat-1", agent_id="a", created_at=_now(), last_seq=9)
+    chats = _Chats(stored)
+    runner = _runner(chats, _Msgs())
+    stale = Chat(id="chat-1", agent_id="a", created_at=_now(), last_seq=4)
+    await runner._persist_chat(stale)
+    assert chats.updated is not None
+    assert chats.updated.last_seq == 9
+
+
+@pytest.mark.asyncio
+async def test_persist_chat_keeps_higher_in_memory_last_seq():
+    """The refresh takes the max — it must never REGRESS a fresher
+    in-memory last_seq back to a stale storage value."""
+    stored = Chat(id="chat-1", agent_id="a", created_at=_now(), last_seq=3)
+    chats = _Chats(stored)
+    runner = _runner(chats, _Msgs())
+    current = Chat(id="chat-1", agent_id="a", created_at=_now(), last_seq=7)
+    await runner._persist_chat(current)
+    assert chats.updated is not None
+    assert chats.updated.last_seq == 7

--- a/tests/graph/test_executor_begin_seed.py
+++ b/tests/graph/test_executor_begin_seed.py
@@ -1,8 +1,11 @@
 """Executor's initial ready set seeds from the unique Begin node.
 
-The new topology rules forbid zero-Begin graphs at construction time, so
-the only valid case is the happy path; the multi-Begin guard remains as
-defence in depth against bypassed validators (e.g. ``model_construct``).
+Runnability (exactly one Begin, etc.) is enforced at session-start via
+``Graph.assert_runnable``; graph construction now permits partial drafts.
+``_resolve_initial_ready_node`` re-checks runnability as defence in depth
+so an unrunnable graph that reaches ``invoke`` (e.g. via ``model_construct``
+or a bypassed session-start check) surfaces the clear enumerated error
+rather than a bare mid-run ``ValueError`` / ``IndexError``.
 """
 
 from __future__ import annotations

--- a/tests/graph/test_topology.py
+++ b/tests/graph/test_topology.py
@@ -1,5 +1,13 @@
-"""Spec §1.5: exactly one Begin, >=1 End, Begin has no incoming, End
-has no outgoing, every End reachable from Begin."""
+"""Spec §1.5 topology rules, split across two phases:
+
+* Persist-time (``Graph(...)`` construction) enforces *referential
+  integrity* only — unique node ids, edge endpoints reference existing
+  nodes, Begin has no incoming edge, End has no outgoing edge.
+* *Runnability* invariants — exactly one Begin, >=1 End, every End
+  reachable from Begin, bounded loops — are enforced later, at
+  session-start, via :meth:`Graph.assert_runnable`. An empty or partial
+  graph is a valid draft that constructs fine but fails ``assert_runnable``.
+"""
 
 from __future__ import annotations
 
@@ -30,28 +38,33 @@ def test_minimal_valid_begin_end_graph() -> None:
     )
 
 
-def test_rejects_zero_begin() -> None:
-    with pytest.raises(ValidationError):
-        _g(
-            [_AgentNodeRef(id="a", agent_id="ag"), _EndNode(id="e")],
-            [_StaticEdge(from_node="a", to_node="e")],
-        )
+def test_zero_begin_constructs_but_not_runnable() -> None:
+    # Runnability moved to session-start: construction succeeds, but the
+    # graph is not runnable (no Begin).
+    g = _g(
+        [_AgentNodeRef(id="a", agent_id="ag"), _EndNode(id="e")],
+        [_StaticEdge(from_node="a", to_node="e")],
+    )
+    with pytest.raises(ValueError):
+        g.assert_runnable()
 
 
-def test_rejects_two_begin() -> None:
-    with pytest.raises(ValidationError):
-        _g(
-            [_BeginNode(id="b1"), _BeginNode(id="b2"), _EndNode(id="e")],
-            [_StaticEdge(from_node="b1", to_node="e")],
-        )
+def test_two_begin_constructs_but_not_runnable() -> None:
+    g = _g(
+        [_BeginNode(id="b1"), _BeginNode(id="b2"), _EndNode(id="e")],
+        [_StaticEdge(from_node="b1", to_node="e")],
+    )
+    with pytest.raises(ValueError):
+        g.assert_runnable()
 
 
-def test_rejects_zero_end() -> None:
-    with pytest.raises(ValidationError):
-        _g(
-            [_BeginNode(id="b"), _AgentNodeRef(id="a", agent_id="ag")],
-            [_StaticEdge(from_node="b", to_node="a")],
-        )
+def test_zero_end_constructs_but_not_runnable() -> None:
+    g = _g(
+        [_BeginNode(id="b"), _AgentNodeRef(id="a", agent_id="ag")],
+        [_StaticEdge(from_node="b", to_node="a")],
+    )
+    with pytest.raises(ValueError):
+        g.assert_runnable()
 
 
 def test_rejects_incoming_edge_into_begin() -> None:
@@ -85,12 +98,14 @@ def test_rejects_outgoing_edge_from_end() -> None:
         )
 
 
-def test_rejects_unreachable_end() -> None:
-    with pytest.raises(ValidationError):
-        _g(
-            [_BeginNode(id="b"), _EndNode(id="e1"), _EndNode(id="e_orphan")],
-            [_StaticEdge(from_node="b", to_node="e1")],
-        )
+def test_unreachable_end_constructs_but_not_runnable() -> None:
+    g = _g(
+        [_BeginNode(id="b"), _EndNode(id="e1"), _EndNode(id="e_orphan")],
+        [_StaticEdge(from_node="b", to_node="e1")],
+    )
+    with pytest.raises(ValueError) as exc:
+        g.assert_runnable()
+    assert "e_orphan" in str(exc.value)
 
 
 def test_rejects_unknown_edge_endpoint() -> None:
@@ -125,10 +140,13 @@ def _cyclic_nodes_edges():
     return nodes, edges
 
 
-def test_cyclic_graph_without_max_iterations_rejected() -> None:
+def test_cyclic_graph_without_max_iterations_not_runnable() -> None:
+    # Construction succeeds (loopability is a runnability rule now); the
+    # unbounded cycle is caught at session-start instead.
     nodes, edges = _cyclic_nodes_edges()
-    with pytest.raises(ValidationError):
-        _g(nodes, edges)
+    g = _g(nodes, edges)
+    with pytest.raises(ValueError):
+        g.assert_runnable()
 
 
 def test_cyclic_graph_with_max_iterations_ok() -> None:
@@ -150,20 +168,21 @@ def test_acyclic_linear_graph_without_max_iterations_ok() -> None:
     )
 
 
-def test_callable_router_without_max_iterations_rejected() -> None:
-    with pytest.raises(ValidationError):
-        _g(
-            [
-                _BeginNode(id="b"),
-                _AgentNodeRef(id="a", agent_id="ag"),
-                _EndNode(id="e"),
-            ],
-            [
-                _StaticEdge(from_node="b", to_node="a"),
-                _StaticEdge(from_node="b", to_node="e"),
-                _ConditionalEdge(
-                    from_node="a",
-                    router=_CallableRouter(callable_id="r"),
-                ),
-            ],
-        )
+def test_callable_router_without_max_iterations_not_runnable() -> None:
+    g = _g(
+        [
+            _BeginNode(id="b"),
+            _AgentNodeRef(id="a", agent_id="ag"),
+            _EndNode(id="e"),
+        ],
+        [
+            _StaticEdge(from_node="b", to_node="a"),
+            _StaticEdge(from_node="b", to_node="e"),
+            _ConditionalEdge(
+                from_node="a",
+                router=_CallableRouter(callable_id="r"),
+            ),
+        ],
+    )
+    with pytest.raises(ValueError):
+        g.assert_runnable()

--- a/tests/model/test_graph_runnable.py
+++ b/tests/model/test_graph_runnable.py
@@ -1,0 +1,137 @@
+"""Graph creation vs. runnability split.
+
+Graph *construction* (persist-time ``_validate_topology``) permits empty
+and partial/incomplete graphs — those are valid drafts. Only *referential*
+integrity is enforced at construction (edge endpoints reference existing
+node ids, unique node ids, ``on_max_iterations`` target exists).
+
+Whether a graph can actually run — exactly one Begin, at least one End,
+End reachable from Begin, bounded loops — is a separate *runnability*
+invariant enforced at session-start via :meth:`Graph.assert_runnable`.
+"""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from primer.model.graph import (
+    Graph,
+    _AgentNodeRef,
+    _BeginNode,
+    _EndNode,
+    _StaticEdge,
+)
+
+
+def _g(nodes, edges, **overrides):
+    base = dict(id="g", description="t", nodes=nodes, edges=edges)
+    base.update(overrides)
+    return Graph(**base)
+
+
+# ---------------------------------------------------------------------------
+# Construction now tolerates empty / partial graphs.
+# ---------------------------------------------------------------------------
+
+
+def test_empty_graph_constructs() -> None:
+    """An empty graph (no nodes, no edges) is a valid draft."""
+    g = _g([], [])
+    assert g.nodes == []
+    assert g.edges == []
+
+
+def test_partial_graph_without_begin_or_end_constructs() -> None:
+    """A single agent node with no Begin/End still constructs."""
+    g = _g([_AgentNodeRef(id="a", agent_id="ag")], [])
+    assert len(g.nodes) == 1
+
+
+def test_empty_graph_round_trips_through_model_dump() -> None:
+    g = _g([], [])
+    reloaded = Graph.model_validate(g.model_dump())
+    assert reloaded.nodes == []
+
+
+# ---------------------------------------------------------------------------
+# Referential integrity is STILL enforced at construction.
+# ---------------------------------------------------------------------------
+
+
+def test_edge_referencing_missing_node_still_raises_at_construction() -> None:
+    with pytest.raises(ValidationError):
+        _g(
+            [_BeginNode(id="b"), _EndNode(id="e")],
+            [_StaticEdge(from_node="b", to_node="ghost")],
+        )
+
+
+def test_duplicate_node_ids_still_raise_at_construction() -> None:
+    with pytest.raises(ValidationError):
+        _g([_BeginNode(id="x"), _EndNode(id="x")], [])
+
+
+def test_on_max_iterations_unknown_target_still_raises_at_construction() -> None:
+    with pytest.raises(ValidationError):
+        _g(
+            [_BeginNode(id="b"), _EndNode(id="e")],
+            [_StaticEdge(from_node="b", to_node="e")],
+            max_iterations=3,
+            on_max_iterations="nope",
+        )
+
+
+# ---------------------------------------------------------------------------
+# assert_runnable() enforces the runnability invariants.
+# ---------------------------------------------------------------------------
+
+
+def test_assert_runnable_raises_for_empty_graph() -> None:
+    g = _g([], [])
+    with pytest.raises(ValueError):
+        g.assert_runnable()
+
+
+def test_assert_runnable_raises_when_no_begin() -> None:
+    g = _g(
+        [_AgentNodeRef(id="a", agent_id="ag"), _EndNode(id="e")],
+        [_StaticEdge(from_node="a", to_node="e")],
+    )
+    with pytest.raises(ValueError):
+        g.assert_runnable()
+
+
+def test_assert_runnable_raises_when_no_end() -> None:
+    g = _g(
+        [_BeginNode(id="b"), _AgentNodeRef(id="a", agent_id="ag")],
+        [_StaticEdge(from_node="b", to_node="a")],
+    )
+    with pytest.raises(ValueError):
+        g.assert_runnable()
+
+
+def test_assert_runnable_raises_when_end_unreachable() -> None:
+    g = _g(
+        [_BeginNode(id="b"), _EndNode(id="e1"), _EndNode(id="orphan")],
+        [_StaticEdge(from_node="b", to_node="e1")],
+    )
+    with pytest.raises(ValueError) as exc:
+        g.assert_runnable()
+    assert "orphan" in str(exc.value)
+
+
+def test_assert_runnable_passes_for_valid_begin_agent_end() -> None:
+    g = _g(
+        [
+            _BeginNode(id="b"),
+            _AgentNodeRef(id="a", agent_id="ag"),
+            _EndNode(id="e"),
+        ],
+        [
+            _StaticEdge(from_node="b", to_node="a"),
+            _StaticEdge(from_node="a", to_node="e"),
+        ],
+    )
+    # Does not raise.
+    g.assert_runnable()

--- a/tests/ui/test_chats_queued_optimistic.py
+++ b/tests/ui/test_chats_queued_optimistic.py
@@ -1,0 +1,52 @@
+"""Static JSX checks for the optimistic "queued" follow-up render path.
+
+When the user sends a message while the agent is still "Thinking…" the
+UI must render it immediately AFTER the Thinking indicator with a
+"(queued)" badge, tag it with a client-generated ``client_msg_id``, and
+reconcile (remove the optimistic placeholder) when the real seq'd row
+arrives over the WS carrying the same ``client_msg_id``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+CHATS = Path(__file__).resolve().parents[2] / "ui" / "components" / "chats.jsx"
+
+
+def _src() -> str:
+    return CHATS.read_text(encoding="utf-8")
+
+
+def test_sendmessage_generates_and_sends_client_msg_id():
+    src = _src()
+    # A per-send client id is generated (uuid) and attached to the frame.
+    assert "client_msg_id" in src
+    assert "randomUUID" in src
+    # The generated id is stamped onto the outbound user_message frame.
+    assert "client_msg_id: clientMsgId" in src
+
+
+def test_optimistic_queued_message_appended_when_turn_active():
+    src = _src()
+    # Optimistic placeholder carries a queued flag + the client id.
+    assert "queued: true" in src
+    # Rendered with a visible "(queued)" indicator.
+    assert "(queued)" in src
+    # The queued placeholder row is addressable for tests / styling.
+    assert "chat-queued-msg" in src
+
+
+def test_queued_rows_render_below_thinking_indicator():
+    src = _src()
+    # The queued placeholders are split out of the main list so they can
+    # render after the Thinking bubble (pinned at the bottom).
+    assert "m.queued" in src or ".queued" in src
+
+
+def test_reconcile_removes_placeholder_by_client_msg_id():
+    src = _src()
+    # When the real row arrives the matching optimistic placeholder is
+    # removed by client_msg_id (seq de-dupe alone can't — temps have no seq).
+    assert "p.client_msg_id === msg.client_msg_id" in src

--- a/tests/ui/test_graphs_new_modal_seed_optional.py
+++ b/tests/ui/test_graphs_new_modal_seed_optional.py
@@ -1,0 +1,41 @@
+"""Static JSX checks: the New-graph modal makes the seed agent OPTIONAL.
+
+Graph creation no longer requires a seed agent — an empty graph can be
+created and its runnability is enforced at session-start, not creation.
+The Create button is therefore gated only on the in-flight mutation, and
+the modal has an empty-graph submit path when no seed agent is chosen.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+
+GRAPHS = Path(__file__).resolve().parents[2] / "ui" / "components" / "graphs.jsx"
+
+
+def _src() -> str:
+    return GRAPHS.read_text(encoding="utf-8")
+
+
+def test_create_button_not_gated_on_seed_agent() -> None:
+    src = _src()
+    # Create is disabled only while the create mutation is running.
+    assert "disabled={create.loading}" in src
+    # The old seed-agent gate is gone.
+    assert "disabled={!seedAgentId || create.loading}" not in src
+
+
+def test_empty_graph_submit_path_exists() -> None:
+    src = _src()
+    # When no seed agent is chosen the modal submits an empty graph.
+    assert "nodes: []" in src
+    assert "edges: []" in src
+
+
+def test_seed_agent_hint_marks_optional_not_required() -> None:
+    src = _src()
+    # The seed-agent hint now advertises it as optional.
+    assert "optional" in src
+    # The old "required" seed-agent hint copy is gone.
+    assert "required · the new graph starts with Begin" not in src

--- a/tests/ui/test_studio_terminal_resize.py
+++ b/tests/ui/test_studio_terminal_resize.py
@@ -1,0 +1,121 @@
+"""Structural guards for the Studio terminal vertical-resize fix.
+
+BUG: the bottom TERMINAL panel could not be dragged/resized — there was no
+resize handle between StudioCenter and TerminalPanel and the panel height was a
+hard-coded CSS constant (`.st-term-panel { flex: 0 0 240px }`) with no backing
+state.
+
+FIX: mirror the working left/right column-resize pattern, rotated to the Y
+axis. A `terminalHeight` state field (persisted) drives the panel's flex-basis
+via a `--st-term-h` CSS var; a `.st-term-resize` divider between the editor and
+the terminal runs `startTermResize`, which grows the panel as it is dragged up.
+
+Static-source checks only (no React rendering), matching test_studio_shell.py /
+test_studio_ux_bugs.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+STUDIO = UI / "components" / "studio.jsx"
+STYLES = UI / "styles.css"
+
+
+def _studio_src() -> str:
+    return STUDIO.read_text(encoding="utf-8")
+
+
+def _styles_src() -> str:
+    return STYLES.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# terminalHeight state — default + persisted, mirroring leftWidth/rightWidth.
+# ---------------------------------------------------------------------------
+
+def test_terminal_height_state_exists() -> None:
+    src = _studio_src()
+    # Default state carries a numeric terminalHeight (backs the panel height).
+    assert "terminalHeight: 240" in src
+    # And it round-trips through localStorage like the column widths.
+    assert '"terminalHeight"' in src
+
+
+def test_set_terminal_height_action_exposed() -> None:
+    src = _studio_src()
+    # The setter exists alongside setLeftWidth/setRightWidth...
+    assert "var setTerminalHeight = React.useCallback(" in src
+    assert "{ terminalHeight: h }" in src
+    # ...and is surfaced on the store's returned object.
+    assert "setTerminalHeight: setTerminalHeight" in src
+
+
+# ---------------------------------------------------------------------------
+# Drag handler + handle element — mirror startResize on the Y axis.
+# ---------------------------------------------------------------------------
+
+def test_start_term_resize_handler_present() -> None:
+    src = _studio_src()
+    assert "function startTermResize(" in src
+    # Uses clientY (vertical) and inverts the delta so dragging UP grows the
+    # panel (the terminal sits below the content).
+    assert "e.clientY" in src
+    assert "d.startY - ev.clientY" in src
+    # Writes the clamped height through the exposed setter.
+    assert "studio.setTerminalHeight(" in src
+    # Tears down its window listeners on mouseup, like startResize.
+    assert 'window.removeEventListener("mousemove", onMove)' in src
+    assert 'window.removeEventListener("mouseup", onUp)' in src
+
+
+def test_terminal_resize_handle_rendered_between_center_and_panel() -> None:
+    src = _studio_src()
+    # The divider is gated on terminalOpen and wired to the drag handler.
+    assert 'data-testid="terminal-resize"' in src
+    assert 'className="st-term-resize"' in src
+    assert "onMouseDown={startTermResize}" in src
+    # It must sit BEFORE the TerminalPanel mount inside the center column.
+    handle = src.index('data-testid="terminal-resize"')
+    panel = src.index("<TerminalPanel wid={wid}")
+    assert handle < panel, "resize handle must precede the terminal panel"
+
+
+# ---------------------------------------------------------------------------
+# Height is state-driven via a CSS var, not a hard-coded constant.
+# ---------------------------------------------------------------------------
+
+def test_term_height_css_var_wired_on_root() -> None:
+    src = _studio_src()
+    # The var is written inline on .st-root next to --st-left-w / --st-right-w.
+    assert '"--st-term-h": s.terminalHeight + "px"' in src
+
+
+def test_term_panel_flex_reads_css_var() -> None:
+    css = _styles_src()
+    # The panel's flex-basis reads the var (240px fallback), not a fixed 240px.
+    assert "flex: 0 0 var(--st-term-h, 240px);" in css
+    assert "flex: 0 0 240px;" not in css  # old hard-coded value is gone
+
+
+def test_term_resize_handle_styled() -> None:
+    css = _styles_src()
+    assert ".st-term-resize {" in css
+    assert "cursor: row-resize;" in css
+    # A thin horizontal hit-area, mirroring .st-resize.
+    assert "height: 5px;" in css
+
+
+# ---------------------------------------------------------------------------
+# The whole bundle still transpiles with these edits.
+# ---------------------------------------------------------------------------
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio.jsx === */" in text

--- a/tests/workspace/sandbox/test_sandbox_workspace.py
+++ b/tests/workspace/sandbox/test_sandbox_workspace.py
@@ -94,6 +94,58 @@ async def test_list_files_recursive(tmp_path: Path) -> None:
     assert any(p.endswith("b.txt") for p in paths)
 
 
+class _AbsPathSandbox(FakeSandbox):
+    """Mimics the real container/k8s runtime, whose ``list_dir`` returns
+    ABSOLUTE entry paths (``/workspace/...``) — unlike FakeSandbox, which
+    returns basenames. Reproduces the list/read path double-anchor bug so
+    it can't regress."""
+
+    async def list_dir(self, path):  # type: ignore[override]
+        from primer.int.sandbox import FileStat
+        base = path.rstrip("/")
+        return [
+            FileStat(
+                path=f"{base}/{e.path}",
+                kind=e.kind,
+                size_bytes=e.size_bytes,
+                mode=e.mode,
+                modified_at=e.modified_at,
+            )
+            for e in await super().list_dir(path)
+        ]
+
+
+@pytest.mark.asyncio
+async def test_list_files_roundtrip_with_absolute_runtime_paths(tmp_path: Path) -> None:
+    """The real runtime returns ABSOLUTE list_dir paths; the consumer must
+    still emit workspace-RELATIVE FileEntry.path that round-trips through
+    read_file (bug: root files 404), and must list nested dirs (bug: the
+    artifacts directory can't be expanded)."""
+    sb = _AbsPathSandbox(root=tmp_path)
+    ws = await SandboxWorkspace.materialise(
+        workspace_id="ws-1", template=_template(),
+        sandbox=sb, backend_kind="container",
+        runtime_meta=_runtime_meta(),
+    )
+    await ws.write_file(".runtime.ready", b"ok")
+    await ws.write_file("artifacts/sess/recommendation.md", b"# rec")
+
+    # Flat root listing -> relative paths, never absolute /workspace/...
+    entries = await ws.list_files(".", recursive=False)
+    by_path = {e.path for e in entries}
+    assert ".runtime.ready" in by_path
+    assert "artifacts" in by_path
+    assert not any(p.startswith("/workspace") for p in by_path)
+
+    # Reading the LISTED path round-trips (the .runtime.ready 404 bug).
+    ready = next(e for e in entries if e.path.endswith(".runtime.ready"))
+    assert await ws.read_file(ready.path) == b"ok"
+
+    # Expanding a nested directory works (the artifacts-expand bug).
+    sub = await ws.list_files("artifacts", recursive=False)
+    assert any(e.path == "artifacts/sess" for e in sub)
+
+
 @pytest.mark.asyncio
 async def test_make_dir_then_listed(tmp_path: Path) -> None:
     sb = FakeSandbox(root=tmp_path)

--- a/tests/workspace/sandbox/test_sandbox_workspace.py
+++ b/tests/workspace/sandbox/test_sandbox_workspace.py
@@ -470,10 +470,51 @@ async def test_remove_session_drops_in_memory_handle(tmp_path: Path) -> None:
     await ws.start_session(_binding(), id="sess-rm-1")
     assert await ws.remove_session("sess-rm-1") is True
     assert "sess-rm-1" not in ws._sessions
-    # No persisted slot was reaped in this test, so a rehydrating
-    # list_sessions would re-surface it -- remove_session only unbinds the
-    # cache, exactly like LocalWorkspace.remove_session.
+    # remove_session also reaps the persisted slot (see
+    # test_remove_session_reaps_persisted_slot); removing a session that was
+    # never started returns False and is a harmless no-op reap.
     assert await ws.remove_session("never-existed") is False
+
+
+@pytest.mark.asyncio
+async def test_remove_session_reaps_persisted_slot(tmp_path: Path) -> None:
+    """remove_session reaps the persisted slot so a rehydrating
+    list_sessions / get_session no longer resurrects the deleted session.
+
+    Regression test for the console "deleted session reappears" bug: the
+    sandbox backend keeps its slot inside the pod's ``.state`` git repo
+    (via ``_state_repo``), which the old local-only host rmtree in the API
+    delete handler never reached, so ``_rehydrate_all_sessions`` kept
+    re-surfacing the session on the next list.
+    """
+    sb = FakeSandbox(root=tmp_path)
+    ws = await SandboxWorkspace.materialise(
+        workspace_id="ws-reap", template=_template(),
+        sandbox=sb, backend_kind="container",
+        runtime_meta=_runtime_meta(),
+    )
+    await ws.start_session(_binding(), id="sess-reap-1")
+    # Persisted + listed before removal.
+    infos = await ws.list_sessions()
+    assert [i.session_id for i in infos] == ["sess-reap-1"]
+
+    assert await ws.remove_session("sess-reap-1") is True
+
+    # Same wrapper: the in-memory handle is gone AND the rehydrating
+    # list_sessions no longer surfaces it (the persisted slot was reaped).
+    assert await ws.list_sessions() == []
+    assert await ws.get_session("sess-reap-1") is None
+
+    # A fresh wrapper over the same sandbox has an empty in-memory registry,
+    # so it can only learn about the session by rehydrating persisted state.
+    # If the slot had survived it would re-surface here -- exactly the bug.
+    ws_fresh = await SandboxWorkspace.materialise(
+        workspace_id="ws-reap", template=_template(),
+        sandbox=sb, backend_kind="container",
+        runtime_meta=_runtime_meta(),
+    )
+    assert await ws_fresh.list_sessions() == []
+    assert await ws_fresh.get_session("sess-reap-1") is None
 
 
 @pytest.mark.asyncio

--- a/tests/workspace/test_local.py
+++ b/tests/workspace/test_local.py
@@ -414,6 +414,28 @@ class TestWorkspaceSessions:
         with pytest.raises(ConflictError):
             await ws.start_session(_binding(), id="dup")
 
+    async def test_remove_session_reaps_on_disk_slot(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        """remove_session reaps the on-disk slot so a rehydrating
+        get_session no longer resurrects the deleted session.
+
+        Regression: the reap used to live only in the API delete handler
+        (a host rmtree), so remove_session alone left the persisted slot
+        under ``.state/sessions/<sid>/`` on disk and get_session rebuilt
+        the handle straight back from it.
+        """
+        ws = await provider.create(_template())
+        await ws.start_session(_binding(), id="sess-reap-local")
+        slot = ws.state_repo.path / "sessions" / "sess-reap-local"
+        assert slot.exists()
+
+        assert await ws.remove_session("sess-reap-local") is True
+
+        # Slot reaped on disk, so the rehydrating get_session returns None.
+        assert not slot.exists()
+        assert await ws.get_session("sess-reap-local") is None
+
     async def test_get_session_heals_stale_cached_status_from_disk(
         self, provider: LocalWorkspaceBackend
     ) -> None:

--- a/tests/workspace/test_session_factory.py
+++ b/tests/workspace/test_session_factory.py
@@ -21,6 +21,13 @@ from primer.model.except_ import (
     NotFoundError,
     ValidationError,
 )
+from primer.model.graph import (
+    Graph,
+    _AgentNodeRef,
+    _BeginNode,
+    _EndNode,
+    _StaticEdge,
+)
 from primer.model.storage import OffsetPage
 from primer.model.workspace import Workspace as WorkspaceRow
 from primer.model.workspace_session import (
@@ -604,6 +611,83 @@ async def test_start_workspace_session_missing_workspace_raises_not_found(
             deps=deps,
         )
     assert live.started == []
+
+
+async def _seed_graph(sp, graph: Graph) -> None:
+    await sp.get_storage(Graph).create(graph)
+
+
+def _runnable_graph(graph_id="gr-run") -> Graph:
+    return Graph(
+        id=graph_id,
+        description="Begin -> agent -> End",
+        nodes=[
+            _BeginNode(id="b"),
+            _AgentNodeRef(id="a", agent_id="ag-1"),
+            _EndNode(id="e"),
+        ],
+        edges=[
+            _StaticEdge(from_node="b", to_node="a"),
+            _StaticEdge(from_node="a", to_node="e"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_start_workspace_session_unrunnable_graph_raises_validation(
+    fake_storage_provider, fake_scheduler, fake_claim_engine,
+):
+    """Binding a session to an empty / unrunnable graph is rejected at
+    session-start (not at graph creation) with a ValidationError -> 422."""
+    await _seed_workspace(fake_storage_provider)
+    # An empty graph now persists fine, but it is not runnable.
+    await _seed_graph(fake_storage_provider, Graph(id="gr-empty", description="draft", nodes=[], edges=[]))
+    live = _FakeLiveWorkspace()
+    deps = _full_deps(
+        fake_storage_provider, fake_scheduler, fake_claim_engine, live,
+    )
+
+    with pytest.raises(ValidationError):
+        await start_workspace_session(
+            workspace_id="ws-1",
+            binding=GraphSessionBinding(graph_id="gr-empty"),
+            initial_instructions=None,
+            graph_input=None,
+            auto_start=False,
+            metadata={},
+            parent_session_id=None,
+            deps=deps,
+        )
+    # No on-disk slot allocated when runnability validation fails.
+    assert live.started == []
+
+
+@pytest.mark.asyncio
+async def test_start_workspace_session_runnable_graph_happy_path(
+    fake_storage_provider, fake_scheduler, fake_claim_engine,
+):
+    """A runnable Begin -> agent -> End graph still starts a session."""
+    await _seed_workspace(fake_storage_provider)
+    await _seed_graph(fake_storage_provider, _runnable_graph())
+    live = _FakeLiveWorkspace()
+    deps = _full_deps(
+        fake_storage_provider, fake_scheduler, fake_claim_engine, live,
+    )
+
+    sess = await start_workspace_session(
+        workspace_id="ws-1",
+        binding=GraphSessionBinding(graph_id="gr-run"),
+        initial_instructions=None,
+        graph_input=None,
+        auto_start=False,
+        metadata={},
+        parent_session_id=None,
+        deps=deps,
+    )
+
+    assert isinstance(sess, WorkspaceSession)
+    assert isinstance(sess.binding, GraphSessionBinding)
+    assert len(live.started) == 1
 
 
 # ---------------------------------------------------------------------------

--- a/ui/components/chats.jsx
+++ b/ui/components/chats.jsx
@@ -848,8 +848,19 @@ function ChatDetail({ chatId, onBack, pushToast }) {
         if (typeof msg.seq === "number") {
           if (msg.seq > latestSeq) latestSeq = msg.seq;
           setMessages((prev) => {
-            if (prev.some((p) => p.seq === msg.seq)) return prev;
-            return [...prev, msg];
+            // Reconcile an optimistic "(queued)" placeholder: a realized
+            // follow-up row carries the same client_msg_id we stamped on
+            // the placeholder. Drop the placeholder (it has no seq, so
+            // the seq de-dupe below never catches it) before appending
+            // the real row. Supports multiple queued messages.
+            let base = prev;
+            if (msg.kind === "user_message" && msg.client_msg_id) {
+              base = prev.filter(
+                (p) => !(p.queued && p.client_msg_id === msg.client_msg_id),
+              );
+            }
+            if (base.some((p) => typeof p.seq === "number" && p.seq === msg.seq)) return base;
+            return [...base, msg];
           });
           setLastSeq((prev) => (msg.seq > prev ? msg.seq : prev));
           // The agent is now producing output (or finished); drop the
@@ -939,17 +950,43 @@ function ChatDetail({ chatId, onBack, pushToast }) {
       }
       return false;
     }
-    const frame = { kind: "user_message" };
+    // Per-send client id (uuid) so we can reconcile an optimistic
+    // "(queued)" placeholder with the realized seq'd row when it later
+    // arrives over the WS carrying the same id.
+    const clientMsgId = (typeof crypto !== "undefined" && crypto.randomUUID)
+      ? crypto.randomUUID()
+      : `cmid-${Date.now()}-${Math.random().toString(16).slice(2)}`;
+    const parts = (atts && atts.length > 0)
+      ? atts.map((a) => ({
+          type: a.kind,           // "image" or "document"
+          data: a.dataB64,
+          mime_type: a.mime,
+          ...(a.kind === "document" && a.name ? { filename: a.name } : {}),
+        }))
+      : null;
+    const frame = { kind: "user_message", client_msg_id: clientMsgId };
     if (text) frame.content = text;
-    if (atts && atts.length > 0) {
-      frame.parts = atts.map((a) => ({
-        type: a.kind,           // "image" or "document"
-        data: a.dataB64,
-        mime_type: a.mime,
-        ...(a.kind === "document" && a.name ? { filename: a.name } : {}),
-      }));
-    }
+    if (parts) frame.parts = parts;
     ws.send(JSON.stringify(frame));
+    // If a turn is already in flight the server DEFERS this message
+    // (holds it on pending_user_messages with no seq) and won't echo it
+    // until the current turn finishes. Render it optimistically now —
+    // AFTER the Thinking bubble, with a "(queued)" badge — so the user
+    // sees it immediately. It is removed/reconciled by client_msg_id
+    // when the realized row arrives. When idle the server echoes the
+    // message right away, so we skip the placeholder to avoid a dup.
+    const turnActive = waitingForReply
+      || (chatRow
+        && (chatRow.turn_status === "claimable" || chatRow.turn_status === "running"));
+    if (turnActive) {
+      setMessages((prev) => [...prev, {
+        kind: "user_message",
+        queued: true,
+        client_msg_id: clientMsgId,
+        content: text || "",
+        parts: parts || [],
+      }]);
+    }
     setWaitingForReply(true);
     return true;
   };
@@ -1159,7 +1196,10 @@ function ChatDetail({ chatId, onBack, pushToast }) {
               {wsState === "connecting" ? "Connecting…" : "No messages yet. Say hello to the agent."}
             </div>
           )}
-          {CT_coalesceMessages(messages).map((m) =>
+          {/* Optimistic "(queued)" placeholders are held out of the main
+              list so they can render AFTER the Thinking bubble (pinned at
+              the bottom) — see below. */}
+          {CT_coalesceMessages(messages.filter((m) => !m.queued)).map((m) =>
             m.kind === "assistant_message" ? (
               <Message key={`am-${m.startSeq}-${m.endSeq}`} m={m} />
             ) : (
@@ -1196,6 +1236,28 @@ function ChatDetail({ chatId, onBack, pushToast }) {
               || (turnInFlight && !lastIsQuiet);
             return showThinking ? <CT_ThinkingBubble /> : null;
           })()}
+
+          {/* Optimistic queued follow-ups. Rendered AFTER the Thinking
+              bubble so a message the user sent while the agent is still
+              "Thinking…" appears pinned at the bottom with a "(queued)"
+              badge. Each is removed when its realized seq'd row arrives
+              (reconciled by client_msg_id in onmessage above). Supports
+              multiple queued messages. */}
+          {messages.filter((m) => m.queued).map((m) => (
+            <div
+              key={`queued-${m.client_msg_id}`}
+              data-testid="chat-queued-msg"
+              style={{ opacity: 0.72 }}
+            >
+              <Message m={m} />
+              <div
+                className="muted mono"
+                style={{ marginLeft: 60, marginTop: -8, marginBottom: 12, fontSize: 11 }}
+              >
+                (queued)
+              </div>
+            </div>
+          ))}
 
           {/* Compaction in-progress indicator. Shown from the moment the
               operator clicks Compact until the server's compaction

--- a/ui/components/graphs.jsx
+++ b/ui/components/graphs.jsx
@@ -73,21 +73,29 @@ function GR_NewGraphModal({ onClose, onCreate, pushToast }) {
 
   const submit = async () => {
     setFieldErrors({});
-    // Seed a minimal valid graph: Begin → agent → End, wired by
-    // static edges. The Graph model validator requires exactly one
-    // Begin node and at least one End node reachable from Begin.
+    // The seed agent is OPTIONAL. When one is chosen, seed a minimal
+    // runnable skeleton (Begin → agent → End wired by static edges) so
+    // the new graph runs out of the box. When none is chosen, create an
+    // EMPTY graph — it persists fine, but isn't runnable until it has a
+    // Begin → … → End (runnability is enforced at session-start, not at
+    // creation).
+    const skeleton = seedAgentId
+      ? {
+          nodes: [
+            { kind: "begin", id: "begin" },
+            { kind: "agent", id: "start", agent_id: seedAgentId },
+            { kind: "end", id: "end", output_template: "" },
+          ],
+          edges: [
+            { kind: "static", from_node: "begin", to_node: "start" },
+            { kind: "static", from_node: "start", to_node: "end" },
+          ],
+        }
+      : { nodes: [], edges: [] };
     const body = {
       ...(id ? { id } : {}),
       description: description || "(no description)",
-      nodes: [
-        { kind: "begin", id: "begin" },
-        { kind: "agent", id: "start", agent_id: seedAgentId },
-        { kind: "end", id: "end", output_template: "" },
-      ],
-      edges: [
-        { kind: "static", from_node: "begin", to_node: "start" },
-        { kind: "static", from_node: "start", to_node: "end" },
-      ],
+      ...skeleton,
     };
     try { await create.mutate(body); } catch (_e) { /* surfaced via onError */ }
   };
@@ -103,7 +111,7 @@ function GR_NewGraphModal({ onClose, onCreate, pushToast }) {
             kind="primary"
             icon="plus"
             onClick={submit}
-            disabled={!seedAgentId || create.loading}
+            disabled={create.loading}
           >
             {create.loading ? "Creating…" : "Create"}
           </Btn>
@@ -145,7 +153,9 @@ function GR_NewGraphModal({ onClose, onCreate, pushToast }) {
         <label className="field-label">
           Seed agent{" "}
           <span className="hint">
-            required · the new graph starts with Begin → agent → End
+            optional · with one, the graph starts as Begin → agent → End;
+            without, it's created empty (not runnable until it has a
+            Begin → … → End)
           </span>
         </label>
         <div style={{ display: "flex", gap: 6 }}>

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -36,6 +36,7 @@ var ST_PERSIST_KEYS = [
   "activeChips",
   "leftWidth",
   "rightWidth",
+  "terminalHeight",
 ];
 
 function ST_storageKey(wid) {
@@ -174,6 +175,7 @@ function ST_defaultState() {
     fileModes: {},
     // Terminal placeholders (P7)
     terminalOpen: false,
+    terminalHeight: 240,
     termTabs: [{ id: "bash", title: "bash" }],
     activeTermId: "bash",
     // Right sidebar activity-feed chip filter
@@ -427,6 +429,10 @@ function useStudioState(wid, initialOpen) {
   var setRightWidth = React.useCallback(function (w) {
     setState(function (s) { return Object.assign({}, s, { rightWidth: w }); });
   }, []);
+  // Terminal (bottom panel) vertical resize — persisted like the column widths.
+  var setTerminalHeight = React.useCallback(function (h) {
+    setState(function (s) { return Object.assign({}, s, { terminalHeight: h }); });
+  }, []);
 
   // Generic patch escape hatch for B2–B4 to set fields not covered above
   // (fileModes, lastSelection, etc.) without re-plumbing the hook each time.
@@ -451,6 +457,7 @@ function useStudioState(wid, initialOpen) {
     toggleChip: toggleChip,
     setLeftWidth: setLeftWidth,
     setRightWidth: setRightWidth,
+    setTerminalHeight: setTerminalHeight,
     patch: patch,
     // B5: palette / quick-open
     openPalette: openPalette,
@@ -705,6 +712,32 @@ function Studio({ wid, pushToast, initialOpen }) {
     window.addEventListener("mouseup", onUp);
   }
 
+  // Terminal vertical resize: mirror startResize but on the Y axis. The panel
+  // sits BELOW StudioCenter, so dragging the divider UP must GROW the terminal
+  // — hence delta = startY - clientY (inverted vs. the column handles). Clamp
+  // to a sane band so it can't collapse to nothing or eat the whole viewport;
+  // xterm re-fits automatically via its ResizeObserver as the height changes.
+  var termDragRef = React.useRef(null);
+  function startTermResize(e) {
+    e.preventDefault();
+    termDragRef.current = { startY: e.clientY, startH: s.terminalHeight };
+    function onMove(ev) {
+      var d = termDragRef.current;
+      if (!d) return;
+      var delta = d.startY - ev.clientY;
+      var maxH = Math.min(800, Math.round(window.innerHeight * 0.7));
+      var h = Math.max(120, Math.min(maxH, d.startH + delta));
+      studio.setTerminalHeight(h);
+    }
+    function onUp() {
+      termDragRef.current = null;
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    }
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+  }
+
   function selectWorkspace(newWid) {
     // Navigate to the new workspace route; the hook re-hydrates from that
     // wid's persisted layout. Drop any stale ?open= from the previous ws.
@@ -741,7 +774,7 @@ function Studio({ wid, pushToast, initialOpen }) {
       data-theme={s.theme}
       data-density={s.density}
       data-testid="studio-root"
-      style={{ "--st-left-w": s.leftWidth + "px", "--st-right-w": s.rightWidth + "px" }}
+      style={{ "--st-left-w": s.leftWidth + "px", "--st-right-w": s.rightWidth + "px", "--st-term-h": s.terminalHeight + "px" }}
     >
       <StudioHeader
         wid={wid}
@@ -775,6 +808,11 @@ function Studio({ wid, pushToast, initialOpen }) {
         {/* ---- CENTER: B3 StudioCenter (tabs + active panel) + P7 terminal ---- */}
         <div className="st-col st-col-center" data-testid="studio-center">
           <StudioCenter wid={wid} studio={studio} />
+          {/* Horizontal splitter: drag to resize the terminal (writes
+              terminalHeight → --st-term-h). Mirrors the column handles. */}
+          {s.terminalOpen && (
+            <div className="st-term-resize" data-testid="terminal-resize" onMouseDown={startTermResize} />
+          )}
           {/* Collapsible bottom terminal panel (Ctrl-` / the header toggle
               flip terminalOpen). Only mounted while open — unmounting tears
               down every tab's xterm instance + WS (see studio-terminal.jsx),

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -276,6 +276,19 @@
 }
 .st-resize:hover, .st-resize.is-active { background: var(--accent-border); }
 
+/* Terminal splitter (horizontal). 5px hit area straddling the panel's top
+   border; row-resize cursor. Mirrors .st-resize, rotated to the Y axis. */
+.st-term-resize {
+  position: relative;
+  z-index: 5;
+  flex: 0 0 5px;
+  height: 5px;
+  margin: -3px 0;
+  cursor: row-resize;
+  background: transparent;
+}
+.st-term-resize:hover, .st-term-resize.is-active { background: var(--accent-border); }
+
 /* Collapsible sidebar sections (VS Code style). */
 .st-section { display: flex; flex-direction: column; min-height: 0; }
 .st-section + .st-section { border-top: 1px solid var(--border); }
@@ -556,7 +569,7 @@
    mobile media query below): xterm.js + a PTY needs real keyboard/paste
    affordances the touch shell doesn't have room for in v1. */
 .st-term-panel {
-  flex: 0 0 240px;
+  flex: 0 0 var(--st-term-h, 240px);
   display: flex;
   flex-direction: column;
   min-height: 0;


### PR DESCRIPTION
Batch of seven independent console/runtime bug fixes found during a QA pass. Each is a focused commit; all root-caused before fixing and covered by tests (TDD — failing test first where practical).

### 1 + 6 — Workspace file tree: root files 404 on open, `artifacts/` can't be expanded
`SandboxWorkspace.list_files`/`_walk` joined the runtime's `list_dir` entry path onto the listed dir, but the container/k8s runtime returns each entry's **absolute** path (`/workspace/foo`) → `/workspace//workspace/foo`, reduced to an absolute `FileEntry.path`; the read endpoint then re-anchored it under `/workspace` again → `/workspace/workspace/foo` → ENOENT. Take the basename of the entry path so listings are robust whether the sandbox returns an absolute path or a basename. (`primer/workspace/sandbox/workspace.py`)

### 2 — Chat: a message sent while the agent is "Thinking…" was invisible until refresh, then mis-ordered
Three compounding defects: a mid-turn user_message got a `seq` at receipt that collided with the in-flight turn's first `assistant_token` seq → **the turn aborted** (`(chat_id, seq)` ConflictError); no optimistic render/live tick; and seq-at-receipt sorted it before the reply. Fixed with a **deferred queue**: follow-ups received while a turn is active are held on `Chat.pending_user_messages` (no seq), then **realized after the turn's terminal row** (correct ordering, no collision) and run as the next turn. Executor `_persist_chat` now refreshes `last_seq=max(mem,storage)` and carries the queue forward (defense in depth). Frontend renders the queued message with a `(queued)` badge below "Thinking…" and reconciles by `client_msg_id`. (`primer/model/chats.py`, `primer/chat/{dispatch,executor,enqueue}.py`, `primer/api/routers/chats.py`, `ui/components/chats.jsx`)

### 3 — Deleting a session left it in the list; retry said "does not exist"
The delete handler reaped the on-disk slot via `getattr(ws,"_state").path` + host `rmtree`, which only works for `LocalWorkspace`. Sandbox (container/k8s) workspaces use `_state_repo` (in-pod git state), so the reap was skipped, the DB row was deleted, and `list_sessions` rehydrated the session from the pod. Each backend now reaps its own persisted slot in `remove_session` (sandbox: git-rm `session.json`/`agent.json`/`waiting.json` so rehydration skips it). (`primer/api/routers/sessions.py`, `primer/workspace/{local,sandbox}/…`)

### 4 — Context-window meter stuck at `0 / N (0%)`
The usage numerator lived only in the volatile in-memory `usage_cache`, never persisted, so a fresh WS connect (e.g. after a pod restart) read 0. Persist the turn's tokens on the `done` row and warm a cold cache from the most recent `done` row on connect. (`primer/chat/executor.py`, `primer/api/routers/chats.py`)

### 5 — Graph creation required a seed agent
`Graph` blocked empty/partial graphs at creation (`nodes min_length=1` + `_validate_topology`). Empty/arbitrary graphs are now creatable; runnability is enforced at graph-session start via `Graph.assert_runnable()` (→422). Referential checks (edge endpoints, dup ids) still fire at construction. Seed agent is optional in the dialog. (`primer/model/graph.py`, `primer/workspace/session_factory.py`, `primer/graph/_node_refs.py`, `ui/components/graphs.jsx`)

### 7 — Terminal panel not resizable
There was no resize handle between the editor and the terminal, and the height was a hard-coded CSS constant. Added a `terminalHeight` state + `startTermResize` drag handler + a `row-resize` divider, mirroring the existing column-resizers. (`ui/components/studio.jsx`, `ui/styles.css`)

### Tests
Full affected-area suite: **2714 passed**, 5 skipped, 1 xfailed. (One pre-existing environmental failure — `test_docker_backend.py::test_get_sandbox_reattaches_to_running_container`, needs a live container; unchanged from `main`, no docker files touched.) `ruff` clean; JSX bundle transpiles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)