### PR TITLE
build(release): publish fat + slim docker images; dependency-aware bootstrap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -177,15 +177,37 @@ jobs:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Build + push primer
+      # Fat image (default): batteries-included, every optional backend
+      # (huggingface, docling, lance, channels, docker, kubernetes). The
+      # unsuffixed :{version} / :latest tags stay = fat for backward compat.
+      - name: Build + push primer (fat)
         uses: docker/build-push-action@v7
         with:
           context: .
           file: ./Dockerfile
           push: true
+          build-args: |
+            UV_SYNC_EXTRAS=--all-extras
           tags: |
             ghcr.io/primerhq/primer:${{ needs.release.outputs.version }}
             ghcr.io/primerhq/primer:latest
+            ghcr.io/primerhq/primer:${{ needs.release.outputs.version }}-fat
+            ghcr.io/primerhq/primer:latest-fat
+      # Slim image: core + the light operational extras only (kubernetes,
+      # docker, channels, lance); drops the multi-GB huggingface + docling
+      # torch stack. BootstrapRunner self-skips the dep-backed default
+      # providers whose extra is absent, so it boots cleanly.
+      - name: Build + push primer (slim)
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: ./Dockerfile
+          push: true
+          build-args: |
+            UV_SYNC_EXTRAS=--extra kubernetes --extra docker --extra channels --extra lance
+          tags: |
+            ghcr.io/primerhq/primer:${{ needs.release.outputs.version }}-slim
+            ghcr.io/primerhq/primer:latest-slim
       - name: Build + push primer-runtime
         uses: docker/build-push-action@v7
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -56,11 +56,18 @@ WORKDIR /app
 # ----- Layer 2/3: dependency install (cached on pyproject+lock) -----
 # README.md is referenced by pyproject.toml's `readme = "README.md"`
 # field, so hatchling needs it present even for a deps-only sync.
-# --all-extras: the published image is batteries-included (primer-ai[full]),
-# shipping every optional backend (huggingface, docling, lance, channels,
-# docker, kubernetes). Slim is for pip/pipx users who opt out via extras.
+# UV_SYNC_EXTRAS selects which optional backends are installed. The default
+# builds the batteries-included "fat" image (--all-extras: huggingface,
+# docling, lance, channels, docker, kubernetes). The release also builds a
+# "slim" image by passing only the light operational extras, dropping the
+# multi-GB huggingface + docling torch stack:
+#   --build-arg UV_SYNC_EXTRAS="--extra kubernetes --extra docker \
+#                               --extra channels --extra lance"
+# BootstrapRunner self-skips dep-backed default providers whose extra is
+# absent, so a slim image boots cleanly.
+ARG UV_SYNC_EXTRAS="--all-extras"
 COPY pyproject.toml uv.lock README.md ./
-RUN uv sync --all-extras --frozen --no-install-project --no-dev
+RUN uv sync ${UV_SYNC_EXTRAS} --frozen --no-install-project --no-dev
 
 # ----- Layer 4: project source -----
 COPY primer ./primer
@@ -72,7 +79,7 @@ RUN chmod +x /usr/local/bin/primer-entrypoint.sh
 # ----- Layer 5: install the project itself -----
 # Editable install (uv default) so /app/primer is the live tree -
 # necessary for the console mount's `_UI_DIR` path math.
-RUN uv sync --all-extras --frozen --no-dev
+RUN uv sync ${UV_SYNC_EXTRAS} --frozen --no-dev
 
 EXPOSE 8000
 

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,12 @@ PYTEST_IGNORES := \
 	--ignore=tests/integration \
 	--ignore=tests/llm
 
-.PHONY: help setup test lint fmt cov docs-hygiene serve docker-build
+.PHONY: help setup test lint fmt cov docs-hygiene serve docker-build docker-build-slim docker-build-all
+
+# Optional-backend extras baked into the slim image: the light operational
+# set (k8s/docker/channels/lance), dropping the multi-GB huggingface + docling
+# torch stack. Override on the CLI to curate a different slim set.
+SLIM_EXTRAS ?= --extra kubernetes --extra docker --extra channels --extra lance
 
 help: ## Show this help
 	@grep -hE '^[a-zA-Z_-]+:.*?## .*$$' $(MAKEFILE_LIST) \
@@ -45,5 +50,10 @@ docs-hygiene: ## Run the docs hygiene suite (em-dash ban, links, frontmatter)
 serve: ## Start the API server (with embedded worker)
 	uv run primer api
 
-docker-build: ## Build the primer container image
+docker-build: ## Build the primer container image (fat — all extras)
 	docker compose build primer
+
+docker-build-slim: ## Build the slim primer image (core + light extras, no huggingface/docling)
+	docker build --build-arg UV_SYNC_EXTRAS="$(SLIM_EXTRAS)" -t primer-primer:slim .
+
+docker-build-all: docker-build docker-build-slim ## Build both the fat and slim images

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -55,6 +55,11 @@ services:
     build:
       context: .
       dockerfile: Dockerfile
+      args:
+        # Fat (all extras) by default. Build slim by exporting e.g.
+        # UV_SYNC_EXTRAS="--extra kubernetes --extra docker --extra channels --extra lance"
+        # before `docker compose build primer` (or use `make docker-build-slim`).
+        UV_SYNC_EXTRAS: ${UV_SYNC_EXTRAS:---all-extras}
     container_name: primer-app
     restart: unless-stopped
     depends_on:

--- a/primer/bootstrap/runner.py
+++ b/primer/bootstrap/runner.py
@@ -28,6 +28,7 @@ Usage example (from the lifespan)::
 from __future__ import annotations
 
 import copy
+import importlib.util
 import logging
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -241,6 +242,20 @@ class BootstrapRunner:
                 result.skipped.append(reserved_id)
                 return
 
+            # Only register the default HuggingFace embedder when its backing
+            # dependency is installed. The slim image ships without the
+            # 'huggingface' extra (sentence-transformers), so registering the
+            # row here would create a default provider that fails at use time.
+            if importlib.util.find_spec("sentence_transformers") is None:
+                result.skipped.append(reserved_id)
+                logger.info(
+                    "bootstrap: skipping default embedder %r — the "
+                    "'huggingface' extra (sentence-transformers) is not "
+                    "installed",
+                    reserved_id,
+                )
+                return
+
             spec = copy.deepcopy(RESERVED_EMBEDDERS[reserved_id])
             entity = EmbeddingProvider(**spec)
             await self._embedder_storage.create(entity)
@@ -260,6 +275,18 @@ class BootstrapRunner:
             existing = await self._ssp_storage.get(reserved_id)
             if existing is not None:
                 result.skipped.append(reserved_id)
+                return
+
+            # Only register the default Lance SSP when lancedb is installed
+            # (the 'lance' extra). A build without it shouldn't carry a
+            # default provider that can't open a store.
+            if importlib.util.find_spec("lancedb") is None:
+                result.skipped.append(reserved_id)
+                logger.info(
+                    "bootstrap: skipping default Lance SSP %r — the 'lance' "
+                    "extra (lancedb) is not installed",
+                    reserved_id,
+                )
                 return
 
             raw_spec = RESERVED_SSPS[reserved_id]
@@ -282,6 +309,18 @@ class BootstrapRunner:
             existing = await self._cross_encoder_storage.get(reserved_id)
             if existing is not None:
                 result.skipped.append(reserved_id)
+                return
+
+            # Slim image ships without the 'huggingface' extra; don't register
+            # a default cross-encoder that can't import at rerank time.
+            if importlib.util.find_spec("sentence_transformers") is None:
+                result.skipped.append(reserved_id)
+                logger.info(
+                    "bootstrap: skipping default cross-encoder %r — the "
+                    "'huggingface' extra (sentence-transformers) is not "
+                    "installed",
+                    reserved_id,
+                )
                 return
 
             spec = copy.deepcopy(RESERVED_CROSS_ENCODERS[reserved_id])

--- a/tests/bootstrap/test_runner.py
+++ b/tests/bootstrap/test_runner.py
@@ -331,3 +331,78 @@ async def test_bootstrap_skips_existing_local_workspace_template(
     got = await tpl_storage.get(RESERVED_LOCAL_WORKSPACE_TEMPLATE)
     assert got is not None
     assert got.description == "operator-pre-seeded description"
+
+
+@pytest.mark.asyncio
+async def test_run_skips_huggingface_defaults_when_dep_missing(
+    storage_provider: SqliteStorageProvider,
+    root_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Slim image: without the 'huggingface' extra (sentence-transformers)
+    the default embedder + cross-encoder are SKIPPED (not created, not
+    errored) so no unusable default provider is registered; bootstrap still
+    completes and dep-independent defaults (e.g. the Lance SSP) are created."""
+    import importlib.util as _ilu
+
+    from primer.model.provider import CrossEncoderProvider, EmbeddingProvider
+
+    real_find_spec = _ilu.find_spec
+
+    def fake_find_spec(name: str, *args: Any, **kwargs: Any):
+        if name == "sentence_transformers":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(_ilu, "find_spec", fake_find_spec)
+
+    runner = _make_runner(storage_provider, root_dir)
+    result = await runner.run()
+
+    assert RESERVED_HUGGINGFACE_EMBEDDER not in result.created
+    assert RESERVED_HUGGINGFACE_CROSS_ENCODER not in result.created
+    assert RESERVED_HUGGINGFACE_EMBEDDER in result.skipped
+    assert RESERVED_HUGGINGFACE_CROSS_ENCODER in result.skipped
+    assert result.errors == []
+    # The provider rows were NOT persisted.
+    assert await storage_provider.get_storage(EmbeddingProvider).get(
+        RESERVED_HUGGINGFACE_EMBEDDER) is None
+    assert await storage_provider.get_storage(CrossEncoderProvider).get(
+        RESERVED_HUGGINGFACE_CROSS_ENCODER) is None
+    # Skips are not errors, so bootstrap completes + the marker is stamped.
+    state = await storage_provider.get_system_state()
+    assert state.bootstrap_completed_at is not None
+    # lancedb is present here, so the Lance SSP is still created.
+    assert RESERVED_LANCE_SSP in result.created
+
+
+@pytest.mark.asyncio
+async def test_run_skips_lance_ssp_when_lancedb_missing(
+    storage_provider: SqliteStorageProvider,
+    root_dir: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the 'lance' extra (lancedb) the default Lance SSP is skipped."""
+    import importlib.util as _ilu
+
+    from primer.model.provider import SemanticSearchProvider
+
+    real_find_spec = _ilu.find_spec
+
+    def fake_find_spec(name: str, *args: Any, **kwargs: Any):
+        if name == "lancedb":
+            return None
+        return real_find_spec(name, *args, **kwargs)
+
+    monkeypatch.setattr(_ilu, "find_spec", fake_find_spec)
+
+    runner = _make_runner(storage_provider, root_dir)
+    result = await runner.run()
+
+    assert RESERVED_LANCE_SSP not in result.created
+    assert RESERVED_LANCE_SSP in result.skipped
+    assert result.errors == []
+    assert await storage_provider.get_storage(SemanticSearchProvider).get(
+        RESERVED_LANCE_SSP) is None
+    # sentence-transformers present → huggingface defaults still created.
+    assert RESERVED_HUGGINGFACE_EMBEDDER in result.created


### PR DESCRIPTION
Split the single batteries-included image into **two** published images, and make first-boot bootstrap dependency-aware so the slim image runs cleanly.

## Images
Parameterized the Dockerfile deps install via a build ARG (`UV_SYNC_EXTRAS`, default `--all-extras` — the fat image is byte-for-byte unchanged). `release.yml`'s `publish-images` now builds both:

- **Fat** — `:{version}`, `:latest` (unchanged, backward-compatible), plus `-fat` aliases. All extras: huggingface, docling, lance, channels, docker, kubernetes.
- **Slim** — `:{version}-slim`, `:latest-slim`. Core + the light operational extras (kubernetes, docker, channels, lance) only; **drops the multi-GB huggingface + docling torch stack**.

Also: `make docker-build-slim` / `make docker-build-all`, and a `docker-compose` `UV_SYNC_EXTRAS` build-arg for local parity.

## Dependency-aware bootstrap
The optional extras register default providers at first boot (huggingface → default embedder + cross-encoder; lance → default Lance SSP). Those `_ensure_*` steps only write the provider **row** — they don't import the backing dep — so a build without the extra would register a default provider that fails only at use time. `BootstrapRunner` now gates each on its backing module being importable (`sentence_transformers` for the huggingface embedder/cross-encoder, `lancedb` for the Lance SSP): **skip (not error) when absent**, so bootstrap still completes and no unusable default is created. (`InternalCollectionsConfig.cross_encoder` is already `| None`, so reranking degrades gracefully.)

## Verification
- **Slim = 1.88 GB vs fat = 12.8 GB (≈85% smaller).**
- Slim deps confirmed: `sentence_transformers`/`docling` absent; `lancedb`/`kubernetes_asyncio`/`aiodocker` present; `primer` (incl. `create_app`) imports clean.
- **Slim image boots healthy** on the SQLite default (`{"status":"ok"}`, all toolsets assembled, `GET /v1/health 200`) — bootstrap self-skipped the huggingface defaults with no crash.
- `tests/bootstrap/test_runner.py`: 13 passed (2 new: huggingface defaults skipped when `sentence_transformers` missing; Lance SSP skipped when `lancedb` missing). ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)