### PR TITLE
Identity follow-ups: call_tool exposability pin, JWKS kid-rotation, OAuth state binding

### DIFF
--- a/primer/api/routers/sso.py
+++ b/primer/api/routers/sso.py
@@ -521,7 +521,7 @@ async def sso_callback(
     if (
         not isinstance(expected_state, str)
         or not isinstance(state, str)
-        or not secrets.compare_digest(state, expected_state)
+        or not secrets.compare_digest(state.encode("utf-8"), expected_state.encode("utf-8"))
     ):
         raise _reject(400, "invalid_state", "missing or mismatched state parameter")
 

--- a/primer/api/routers/sso.py
+++ b/primer/api/routers/sso.py
@@ -533,7 +533,13 @@ async def sso_callback(
         id_token = token_response.get("id_token")
         if not id_token:
             raise oidc.OidcError("token endpoint response is missing id_token")
-        jwks = await oidc.fetch_jwks(metadata.jwks_uri)
+        # Pass the token's (unverified) kid so fetch_jwks can detect a
+        # provider key rotation and force a bounded refresh instead of
+        # failing closed on a signing key we haven't cached yet -- see
+        # the module docstring in primer/auth/oidc.py.
+        jwks = await oidc.fetch_jwks(
+            metadata.jwks_uri, kid=oidc.unverified_kid(id_token)
+        )
         claims = await oidc.validate_id_token(
             id_token, provider=provider, metadata=metadata, jwks=jwks, nonce=nonce,
         )

--- a/primer/api/routers/sso.py
+++ b/primer/api/routers/sso.py
@@ -13,8 +13,9 @@ Endpoints (all under ``/v1/auth/sso``):
   short-lived, HttpOnly cookie, and 302s the browser to the provider's
   ``authorization_endpoint``.
 * ``GET /{provider_id}/callback`` — completes the flow: verifies the
-  signed state cookie, exchanges the code, validates the id_token, and
-  resolves a local account.
+  signed state cookie, checks the returned ``state`` query param against
+  the value bound inside that cookie, exchanges the code, validates the
+  id_token, and resolves a local account.
 
 Authenticated router (``sso_authed_router``, ``require_user`` applied at
 ``include_router`` time in ``_app_routes.py``) — account linking + the
@@ -71,6 +72,7 @@ from __future__ import annotations
 import contextlib
 import logging
 import re
+import secrets
 import uuid
 from datetime import datetime, timezone
 from urllib.parse import urlencode, urlsplit
@@ -106,7 +108,7 @@ sso_router = APIRouter(prefix="/auth/sso", tags=["auth", "sso"])
 # vice versa.
 sso_authed_router = APIRouter(prefix="/auth/sso", tags=["auth", "sso"])
 
-# Cookie carrying the signed {provider_id, nonce, code_verifier,
+# Cookie carrying the signed {provider_id, state, nonce, code_verifier,
 # return_to} payload between /login and /callback. Short-lived: an
 # abandoned login attempt's cookie is worthless after this window.
 _STATE_COOKIE_NAME = "primer_sso_state"
@@ -415,6 +417,13 @@ async def _begin_oidc_flow(
     secret = request.app.state.session_secret
     state_payload = {
         "provider_id": provider.id,
+        # Bound into the signed cookie AND sent as the OAuth `state` query
+        # param below -- the callback compares the two. Defense-in-depth
+        # on top of the cookie's own signature/expiry + PKCE + id_token
+        # nonce: an attacker who can't forge the cookie gains nothing from
+        # this, but it's the standard OAuth CSRF control and catches any
+        # future weakening of the cookie's own guarantees.
+        "state": state_value,
         "nonce": nonce,
         "code_verifier": code_verifier,
         "return_to": safe_return_to,
@@ -490,6 +499,7 @@ async def sso_callback(
     provider_id: str,
     request: Request,
     code: str | None = Query(default=None),
+    state: str | None = Query(default=None),
     oidc_provider_storage=Depends(get_oidc_provider_storage),
     user_identity_storage=Depends(get_user_identity_storage),
     user_storage=Depends(get_user_storage),
@@ -500,6 +510,20 @@ async def sso_callback(
     state_payload = oidc.verify_state(cookie_value, secret, _STATE_MAX_AGE_SECONDS)
     if state_payload is None:
         raise _reject(400, "invalid_state", "missing, expired, or tampered state cookie")
+
+    # OAuth `state` query param, round-tripped by the IdP, bound against
+    # the value carried inside the (already signature/expiry-verified)
+    # state cookie -- constant-time so a byte-by-byte timing probe can't
+    # be used to guess it. This is IN ADDITION to the cookie's own
+    # signature, the PKCE verifier, and the id_token nonce check below --
+    # none of those checks are weakened or replaced by this one.
+    expected_state = state_payload.get("state")
+    if (
+        not isinstance(expected_state, str)
+        or not isinstance(state, str)
+        or not secrets.compare_digest(state, expected_state)
+    ):
+        raise _reject(400, "invalid_state", "missing or mismatched state parameter")
 
     if not code:
         raise _reject(400, "missing_code")

--- a/primer/auth/oidc.py
+++ b/primer/auth/oidc.py
@@ -29,6 +29,10 @@ keyed by URL so a login flow doesn't round-trip to the provider on
 every request; :func:`fetch_jwks` additionally bypasses the cache
 when asked to look up a ``kid`` it doesn't recognize, so a provider's
 key rotation doesn't lock users out until the TTL happens to expire.
+That bypass is itself rate-limited per JWKS URI (see
+``_JWKS_REFETCH_COOLDOWN_SECONDS``) so an attacker sending id_tokens
+with random ``kid``s can't turn every login attempt into a forced
+network round-trip.
 """
 
 from __future__ import annotations
@@ -59,6 +63,14 @@ _ASYMMETRIC_ALG_PREFIXES = ("RS", "ES", "PS")
 _DISCOVERY_TTL_SECONDS = 3600.0
 _JWKS_TTL_SECONDS = 3600.0
 _HTTP_TIMEOUT_SECONDS = 10.0
+
+# Anti-abuse bound on fetch_jwks's unknown-kid-triggered refresh: without
+# this, an attacker sending id_tokens with random `kid`s could force a
+# JWKS network round-trip on every single login attempt (a DoS on us and
+# on the provider). At most one forced refetch per URI per cooldown
+# window; anything sooner just uses the cache as-is and fails closed,
+# same as before this feature existed.
+_JWKS_REFETCH_COOLDOWN_SECONDS = 60.0
 
 # ~60s leeway on exp/iat/nbf checks to absorb clock skew between us and
 # the provider, per the brief's "exp with ~60s leeway" requirement.
@@ -103,6 +115,11 @@ class _CacheEntry:
 # tasks rather than long-lived threads contending on the dict.
 _discovery_cache: dict[str, _CacheEntry] = {}
 _jwks_cache: dict[str, _CacheEntry] = {}
+
+# Monotonic timestamp of the last unknown-kid-triggered (forced) JWKS
+# refetch per jwks_uri -- NOT updated on ordinary TTL-driven or
+# first-ever fetches, only on the bypass path. Backs the cooldown above.
+_jwks_forced_refetch_at: dict[str, float] = {}
 
 
 def _pick_signing_algs(supported: list[str] | None) -> list[str]:
@@ -180,6 +197,28 @@ def _has_kid(jwks: dict, kid: str) -> bool:
     return any(k.get("kid") == kid for k in jwks.get("keys", []))
 
 
+def unverified_kid(id_token: str) -> str | None:
+    """Best-effort read of the ``kid`` header claim, WITHOUT verifying
+    the token's signature.
+
+    This is purely a hint for :func:`fetch_jwks` -- callers should pass
+    its result as ``fetch_jwks(..., kid=unverified_kid(id_token))``
+    *before* calling :func:`validate_id_token`, so a ``kid`` the cache
+    doesn't recognize (e.g. because the provider just rotated its
+    signing key) triggers a refresh instead of failing closed until the
+    TTL expires. The header is completely attacker-controlled at this
+    point, so this must never be used for anything security-relevant --
+    :func:`validate_id_token` re-parses the header itself and is the
+    only thing that actually enforces anything. Returns ``None`` on any
+    malformed input; a malformed token is still correctly rejected
+    downstream by :func:`validate_id_token`.
+    """
+    try:
+        return jwt.get_unverified_header(id_token).get("kid")
+    except jwt.PyJWTError:
+        return None
+
+
 async def fetch_jwks(jwks_uri: str, *, kid: str | None = None) -> dict:
     """Fetch + TTL-cache the JWKS document at ``jwks_uri``.
 
@@ -188,12 +227,25 @@ async def fetch_jwks(jwks_uri: str, *, kid: str | None = None) -> dict:
     its signing key) and a fresh copy is fetched immediately, bypassing
     the TTL -- this keeps a rotation from stranding logins until the
     next TTL expiry.
+
+    That bypass is rate-limited to at most one forced refetch per
+    ``jwks_uri`` per :data:`_JWKS_REFETCH_COOLDOWN_SECONDS`: a ``kid``
+    that's unknown while a forced refetch for this URI happened more
+    recently than the cooldown just falls through to the still-cached
+    value (and the caller fails closed), instead of hitting the network
+    again. This is what keeps an unknown ``kid`` from being usable as a
+    DoS lever (e.g. an attacker submitting id_tokens with random
+    ``kid``s to force a JWKS round-trip on every request).
     """
     now = time.monotonic()
     cached = _jwks_cache.get(jwks_uri)
     if cached is not None and cached.expires_at > now:
         if kid is None or _has_kid(cached.value, kid):
             return cached.value
+        last_forced = _jwks_forced_refetch_at.get(jwks_uri)
+        if last_forced is not None and now - last_forced < _JWKS_REFETCH_COOLDOWN_SECONDS:
+            return cached.value
+        _jwks_forced_refetch_at[jwks_uri] = now
 
     async with httpx.AsyncClient(timeout=_HTTP_TIMEOUT_SECONDS) as client:
         try:

--- a/tests/api/test_sso_flow.py
+++ b/tests/api/test_sso_flow.py
@@ -159,10 +159,15 @@ async def _login(client, provider_id: str, **params) -> httpx.Response:
     )
 
 
-async def _callback(client, provider_id: str, *, code: str, state: str) -> httpx.Response:
+async def _callback(client, provider_id: str, *, code: str, state: str | None) -> httpx.Response:
+    """``state=None`` OMITS the query param entirely (simulates a provider
+    that dropped it), as opposed to passing an empty string."""
+    params: dict[str, str] = {"code": code}
+    if state is not None:
+        params["state"] = state
     return await client.get(
         f"/v1/auth/sso/{provider_id}/callback",
-        params={"code": code, "state": state},
+        params=params,
         follow_redirects=False,
     )
 
@@ -405,6 +410,73 @@ async def test_jit_role_clamped_to_safe_set(client, app, rsa_keypair):
         user = await app.state.storage_provider.get_storage(User).get(payload.user_id)
         assert user is not None
         assert user.role == expected_role, (configured_access, sub, user.role)
+
+
+# ---------------------------------------------------------------------------
+# OAuth `state` query-param binding -- defense-in-depth on top of the
+# signed state cookie + PKCE + id_token nonce.
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_callback_state_param_round_tripped_happy_path(client, app, rsa_keypair):
+    """The ``state`` value minted at /login is echoed by the (fake) IdP and
+    must match what's bound inside the signed cookie -- happy path."""
+    priv, pub = rsa_keypair
+    idp = _IdpFixture(pub)
+    idp.register()
+    provider = await _seed_provider(app, idp)
+    await app.state.storage_provider.set_sso_jit_enabled(True)
+
+    login_resp = await _login(client, provider.id)
+    qs = _query(login_resp.headers["location"])
+    assert qs["state"]
+
+    idp.queue_id_token(priv, idp.base_claims(sub="sub-state-happy", nonce=qs["nonce"]))
+    cb = await _callback(client, provider.id, code="code-state-happy", state=qs["state"])
+    assert cb.status_code == 302, cb.text
+    assert "primer_session" in cb.cookies
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_callback_mismatched_state_param_rejected(client, app, rsa_keypair):
+    priv, pub = rsa_keypair
+    idp = _IdpFixture(pub)
+    idp.register()
+    provider = await _seed_provider(app, idp)
+    await app.state.storage_provider.set_sso_jit_enabled(True)
+
+    login_resp = await _login(client, provider.id)
+    qs = _query(login_resp.headers["location"])
+    idp.queue_id_token(priv, idp.base_claims(sub="sub-state-mismatch", nonce=qs["nonce"]))
+
+    cb = await _callback(
+        client, provider.id, code="code-state-mismatch", state="not-the-real-state",
+    )
+    assert cb.status_code == 400, cb.text
+    assert cb.json()["detail"]["error"] == "invalid_state"
+    assert "primer_session" not in cb.cookies
+
+
+@pytest.mark.asyncio
+@respx.mock
+async def test_callback_missing_state_param_rejected(client, app, rsa_keypair):
+    priv, pub = rsa_keypair
+    idp = _IdpFixture(pub)
+    idp.register()
+    provider = await _seed_provider(app, idp)
+    await app.state.storage_provider.set_sso_jit_enabled(True)
+
+    login_resp = await _login(client, provider.id)
+    qs = _query(login_resp.headers["location"])
+    idp.queue_id_token(priv, idp.base_claims(sub="sub-state-missing", nonce=qs["nonce"]))
+
+    cb = await _callback(client, provider.id, code="code-state-missing", state=None)
+    assert cb.status_code == 400, cb.text
+    assert cb.json()["detail"]["error"] == "invalid_state"
+    assert "primer_session" not in cb.cookies
 
 
 # ---------------------------------------------------------------------------

--- a/tests/api/test_sso_flow.py
+++ b/tests/api/test_sso_flow.py
@@ -479,6 +479,29 @@ async def test_callback_missing_state_param_rejected(client, app, rsa_keypair):
     assert "primer_session" not in cb.cookies
 
 
+@pytest.mark.asyncio
+@respx.mock
+async def test_callback_non_ascii_state_param_rejected(client, app, rsa_keypair):
+    """A non-ASCII ``state`` query param (attacker-controlled, arbitrary
+    Unicode via percent-encoding) must be rejected as a clean 400
+    ``invalid_state`` -- NOT surface a 500 from ``secrets.compare_digest``,
+    which raises ``TypeError`` on ``str`` operands outside ASCII."""
+    priv, pub = rsa_keypair
+    idp = _IdpFixture(pub)
+    idp.register()
+    provider = await _seed_provider(app, idp)
+    await app.state.storage_provider.set_sso_jit_enabled(True)
+
+    login_resp = await _login(client, provider.id)
+    qs = _query(login_resp.headers["location"])
+    idp.queue_id_token(priv, idp.base_claims(sub="sub-state-non-ascii", nonce=qs["nonce"]))
+
+    cb = await _callback(client, provider.id, code="code-state-non-ascii", state="é")
+    assert cb.status_code == 400, cb.text
+    assert cb.json()["detail"]["error"] == "invalid_state"
+    assert "primer_session" not in cb.cookies
+
+
 # ---------------------------------------------------------------------------
 # Rejections -- the security boundary
 # ---------------------------------------------------------------------------

--- a/tests/auth/test_oidc.py
+++ b/tests/auth/test_oidc.py
@@ -307,9 +307,164 @@ class TestFetchJwks:
         assert route.call_count == 2
         assert _has_kid(refreshed, "key-2")
 
+    @respx.mock
+    async def test_repeated_unknown_kid_within_cooldown_does_not_refetch(
+        self, rsa_keypair, other_rsa_keypair
+    ):
+        """Anti-abuse bound: an attacker sending id_tokens with random
+        `kid`s must not be able to turn every login attempt into a JWKS
+        network round-trip. Once a forced re-fetch has happened for a
+        URI, a second still-unknown kid arriving within the cooldown
+        window is served from the (already-refreshed) cache -- no extra
+        fetch -- and fails closed exactly like before this feature."""
+        _, pub1 = rsa_keypair
+        _, pub2 = other_rsa_keypair
+        url = f"https://idp-{uuid.uuid4().hex}.example.com/jwks.json"
+
+        route = respx.get(url).mock(
+            side_effect=[
+                httpx.Response(200, json=_jwks(pub1, kid="key-1")),
+                httpx.Response(200, json=_jwks(pub2, kid="key-2")),
+            ]
+        )
+
+        await oidc.fetch_jwks(url)
+        assert route.call_count == 1
+
+        # First unknown kid -- forced refetch, consumes the cooldown.
+        refreshed = await oidc.fetch_jwks(url, kid="key-2")
+        assert route.call_count == 2
+        assert _has_kid(refreshed, "key-2")
+
+        # A second, different unknown kid arriving immediately after
+        # (well within the cooldown window) must NOT hit the network
+        # again -- only two side_effect responses were registered above,
+        # so a third fetch attempt would raise StopIteration.
+        still_cached = await oidc.fetch_jwks(url, kid="some-attacker-kid")
+        assert route.call_count == 2
+        assert still_cached == refreshed
+        assert not _has_kid(still_cached, "some-attacker-kid")
+
 
 def _has_kid(jwks: dict, kid: str) -> bool:
     return any(k.get("kid") == kid for k in jwks["keys"])
+
+
+# --- JWKS rotation end-to-end (fetch_jwks + validate_id_token) -------------
+
+
+class TestJwksKeyRotation:
+    """Exercises the real call-site wiring: the caller reads the token's
+    (unverified) `kid` via ``oidc.unverified_kid`` and passes it into
+    ``fetch_jwks`` *before* validation, exactly like
+    ``sso.py::sso_callback`` does -- this is what makes key rotation
+    resilience actually take effect in the login flow, not just in
+    ``fetch_jwks`` isolation."""
+
+    @respx.mock
+    async def test_kid_absent_then_present_after_refetch_validates(
+        self, rsa_keypair, other_rsa_keypair
+    ):
+        old_priv, old_pub = rsa_keypair
+        new_priv, new_pub = other_rsa_keypair
+        url = f"https://idp-{uuid.uuid4().hex}.example.com/jwks.json"
+        route = respx.get(url).mock(
+            side_effect=[
+                httpx.Response(200, json=_jwks(old_pub, kid="old-key")),
+                httpx.Response(200, json=_jwks(new_pub, kid="new-key")),
+            ]
+        )
+
+        # Cache is warmed with the pre-rotation JWKS (e.g. by /login).
+        await oidc.fetch_jwks(url)
+        assert route.call_count == 1
+
+        # The provider rotated: this token is signed with the new key,
+        # whose kid isn't in the cache yet.
+        token = _sign(new_priv, _claims(), kid="new-key")
+        kid = oidc.unverified_kid(token)
+        assert kid == "new-key"
+
+        jwks = await oidc.fetch_jwks(url, kid=kid)
+        assert route.call_count == 2  # the unknown kid forced a re-fetch
+
+        claims = await oidc.validate_id_token(
+            token,
+            provider=_provider(),
+            metadata=_metadata(jwks_uri=url),
+            jwks=jwks,
+            nonce="expected-nonce",
+        )
+        assert claims["sub"] == "user-123"
+
+    @respx.mock
+    async def test_second_unknown_kid_within_cooldown_fails_closed_no_refetch(
+        self, rsa_keypair, other_rsa_keypair
+    ):
+        old_priv, old_pub = rsa_keypair
+        _, rotated_pub = other_rsa_keypair
+        url = f"https://idp-{uuid.uuid4().hex}.example.com/jwks.json"
+        route = respx.get(url).mock(
+            side_effect=[
+                httpx.Response(200, json=_jwks(old_pub, kid="old-key")),
+                httpx.Response(200, json=_jwks(rotated_pub, kid="rotated-key")),
+            ]
+        )
+
+        await oidc.fetch_jwks(url)
+        assert route.call_count == 1
+
+        # First bogus kid -- forced refetch, consumes the cooldown window.
+        first_token = _sign(old_priv, _claims(), kid="attacker-kid-1")
+        await oidc.fetch_jwks(url, kid=oidc.unverified_kid(first_token))
+        assert route.call_count == 2
+
+        # A second, different bogus kid arriving right after must not
+        # trigger a third network round-trip (only 2 responses are
+        # registered above) -- it fails closed against the cache as-is.
+        second_token = _sign(old_priv, _claims(), kid="attacker-kid-2")
+        jwks = await oidc.fetch_jwks(url, kid=oidc.unverified_kid(second_token))
+        assert route.call_count == 2
+
+        with pytest.raises(oidc.OidcError):
+            await oidc.validate_id_token(
+                second_token,
+                provider=_provider(),
+                metadata=_metadata(jwks_uri=url),
+                jwks=jwks,
+                nonce="expected-nonce",
+            )
+
+    @respx.mock
+    async def test_kid_still_unknown_after_refetch_fails_closed(
+        self, rsa_keypair, other_rsa_keypair
+    ):
+        priv, pub = rsa_keypair
+        _, rotated_pub = other_rsa_keypair
+        url = f"https://idp-{uuid.uuid4().hex}.example.com/jwks.json"
+        respx.get(url).mock(
+            side_effect=[
+                httpx.Response(200, json=_jwks(pub, kid="old-key")),
+                httpx.Response(200, json=_jwks(rotated_pub, kid="rotated-key")),
+            ]
+        )
+
+        await oidc.fetch_jwks(url)
+
+        # Token's kid is neither in the cached set NOR in the
+        # post-rotation set fetched on retry (e.g. a garbage/attacker kid).
+        token = _sign(priv, _claims(), kid="not-a-real-kid")
+        jwks = await oidc.fetch_jwks(url, kid=oidc.unverified_kid(token))
+        assert not _has_kid(jwks, "not-a-real-kid")
+
+        with pytest.raises(oidc.OidcError):
+            await oidc.validate_id_token(
+                token,
+                provider=_provider(),
+                metadata=_metadata(jwks_uri=url),
+                jwks=jwks,
+                nonce="expected-nonce",
+            )
 
 
 # --- id_token validation ---------------------------------------------------

--- a/tests/mcp/test_required_role_completeness.py
+++ b/tests/mcp/test_required_role_completeness.py
@@ -108,3 +108,52 @@ async def test_every_exposable_reserved_tool_declares_a_role(
         "exposable tools without an explicit required_role: "
         f"{sorted(missing)}"
     )
+
+
+@pytest.mark.asyncio
+async def test_call_tool_meta_dispatcher_never_exposable(
+    reserved_provider_registry: ProviderRegistry,
+) -> None:
+    """Regression pin: ``system__call_tool`` must never pass ``is_exposable``.
+
+    WHY THIS MATTERS (read before "fixing" this test): ``call_tool``'s
+    handler (``primer.toolset._system_crud._call_tool_tool``) invokes
+    ``provider.call(...)`` DIRECTLY. It does NOT go through
+    ``primer.mcp.dispatch``'s ``invoke_exposed`` path, which is where the
+    RBAC gate lives (comparing the caller's role against each tool's
+    declared ``required_role``). So ``call_tool`` bypasses RBAC entirely
+    for whatever inner tool it dispatches to.
+
+    That is safe TODAY only because ``call_tool`` is declared
+    ``yields=True`` (it can park mid-dispatch for tool-approval), which
+    makes ``is_exposable`` reject it via the "yielding_unsupported" branch
+    before RBAC would ever matter — a non-admin MCP caller can never reach
+    the meta-dispatcher at all. That safety is COINCIDENTAL — a side
+    effect of ``yields=True`` — not an explicit guard.
+
+    If a future change ever drops ``yields=True`` from ``call_tool`` (say,
+    to make its non-approval-gated path exposable), this test starts
+    failing. That failure is the signal that a user-role MCP caller could
+    now reach ``call_tool`` and use its direct ``provider.call(...)`` to
+    invoke ANY tool from ANY toolset with no RBAC check — silent full-admin
+    privilege escalation. Do not just delete/relax this test to make it
+    pass; either keep ``call_tool`` yielding, or first route it through
+    ``invoke_exposed`` (or add back an explicit hard-deny) so RBAC is
+    re-checked on the inner dispatch.
+    """
+    provider = await reserved_provider_registry.get_toolset("system")
+    call_tool = None
+    async for tool in provider.list_tools():
+        if tool.id == "call_tool":
+            call_tool = tool
+            break
+    assert call_tool is not None, "system toolset must still define call_tool"
+
+    ok, reason = is_exposable(call_tool, provider=provider)
+
+    assert ok is False, (
+        "system__call_tool became exposable over MCP — its handler "
+        "bypasses the invoke_exposed RBAC gate via a direct "
+        "provider.call(...); see this test's docstring before relaxing it"
+    )
+    assert reason == "yielding_unsupported"


### PR DESCRIPTION
Three small identity/auth hardening follow-ups surfaced by the Layer 1/2 reviews. Off `main`. Opus-reviewed (Approved) — auth boundary preserved, all additive, fails closed.

- **A-F1** `test(mcp)`: regression test pinning `system__call_tool` as never MCP-exposable — guards the *coincidental* safety that keeps the meta-dispatcher (which bypasses `invoke_exposed`'s RBAC gate) unreachable. Uses the real provider builders, so it flips if `yields=True` is ever removed.
- **A-F2** `fix(auth)`: JWKS `kid`-rotation. `fetch_jwks` now re-fetches on an unknown `kid`, **bounded** to ≤1 network fetch per JWKS-URI per 60s (monotonic-clock cooldown, timestamp set before the call). Wired into `sso_callback` via a header-only `unverified_kid` (was previously dead code). Provider key rotation no longer breaks logins until the TTL. `validate_id_token` rigor untouched (alg-pinning, key provenance, iss/aud/azp/exp/nonce/sub all unchanged).
- **A-F3** `fix(auth)`: OAuth `state` bind + **constant-time** verify (defense-in-depth atop PKCE + nonce + signed HttpOnly cookie), plus a non-ASCII-`state` fix (400 instead of an uncaught 500).

Please review; do not merge on my behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)