### PR TITLE
Layer 3: Identity in the execution context (ctx.identity + attribution)

### DIFF
--- a/primer/agent/base.py
+++ b/primer/agent/base.py
@@ -50,7 +50,7 @@ from primer.agent.events import (
     Subscription,
     _ExecutorToolResult,
 )
-from primer.agent.prompt_render import render_system_prompt
+from primer.agent.prompt_render import render_system_prompt_or_raw
 from primer.agent.tool_manager import ToolExecutionManager
 from primer.model.chat import (
     ExtendedEvent,
@@ -335,7 +335,7 @@ class _BaseAgentExecutor(ABC):
         """Assemble the full prompt: system + history + new user input."""
         parts: list[Message] = []
         if self._agent.system_prompt:
-            sys_text = render_system_prompt(
+            sys_text = render_system_prompt_or_raw(
                 self._agent.system_prompt, self._execution_context
             )
             parts.append(

--- a/primer/agent/invoke.py
+++ b/primer/agent/invoke.py
@@ -7,9 +7,13 @@ from __future__ import annotations
 import contextlib
 import contextvars
 import os
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from primer.model.chat import Message, TextPart
+
+
+if TYPE_CHECKING:
+    from primer.model.principal import PrincipalRef
 
 
 MAX_INVOCATION_DEPTH = int(os.environ.get("PRIMER_MAX_INVOCATION_DEPTH", "8"))
@@ -174,6 +178,7 @@ async def run_subagent(
     workspace_id: str | None = None,
     chat_id: str | None = None,
     invoke_tool_call_id: str | None = None,
+    identity: "PrincipalRef | None" = None,
 ) -> str:
     """Run agent ``agent_id`` once on ``prompt`` (stateless: system prompt +
     prompt, no shared history) and return the final assistant text.
@@ -215,7 +220,20 @@ async def run_subagent(
         approval_resolver=approval_resolver,
     )
 
-    sys_text = "\n\n".join(agent.system_prompt) if agent.system_prompt else ""
+    from primer.model.graph import build_execution_context
+    from primer.agent.prompt_render import render_system_prompt_or_raw
+
+    surface = "workspace" if workspace_id else ("chat" if chat_id else "memory")
+    _sub_ctx = build_execution_context(
+        surface=surface,
+        workspace_id=workspace_id,
+        session_id=session_id,
+        identity=identity,
+    )
+    sys_text = (
+        render_system_prompt_or_raw(agent.system_prompt, _sub_ctx)
+        if agent.system_prompt else ""
+    )
     prompt_msgs: list[Message] = []
     if sys_text:
         prompt_msgs.append(Message(role="system", parts=[TextPart(text=sys_text)]))

--- a/primer/agent/prompt_render.py
+++ b/primer/agent/prompt_render.py
@@ -15,6 +15,7 @@ than a shared import: ``agent/`` must not import ``graph/`` (``graph/`` imports
 from __future__ import annotations
 
 import json
+import logging
 import re
 from typing import Any
 
@@ -24,6 +25,9 @@ from jinja2.sandbox import SandboxedEnvironment
 
 from primer.model.except_ import BadRequestError
 from primer.model.graph import ExecutionContext
+
+
+logger = logging.getLogger(__name__)
 
 
 def _fromjson(value: Any) -> Any:
@@ -56,6 +60,7 @@ _ENV: SandboxedEnvironment = SandboxedEnvironment(
     autoescape=False,
     trim_blocks=False,
     lstrip_blocks=False,
+    keep_trailing_newline=True,
 )
 _ENV.filters["fromjson"] = _fromjson
 _ENV.filters["strip_fences"] = _strip_fences
@@ -84,3 +89,27 @@ def render_system_prompt(
         raise BadRequestError(
             f"render_system_prompt: render error: {exc!s}"
         ) from exc
+
+
+def render_system_prompt_or_raw(
+    system_prompt: list[str], ctx: ExecutionContext
+) -> str:
+    """Render ``system_prompt`` against ``ctx``; on a render/syntax error log a
+    warning and fall back to the raw ``"\\n\\n".join(...)`` (§8.5 always-render +
+    fallback). This is the single entry point every assembly site uses so the
+    fallback behaviour is uniform across the chat, agent, subagent, and graph
+    paths. NOTE (§8.5): this bounds only the CRASH case — a well-formed
+    ``{# comment #}`` or ``{{ "literal" }}`` renders *differently* with no error
+    and cannot be caught here; agent prompts are Jinja-rendered so ``{{``, ``{%``,
+    and ``{#`` are significant.
+    """
+    try:
+        return render_system_prompt(system_prompt, ctx)
+    except BadRequestError as exc:
+        logger.warning(
+            "render_system_prompt failed; using raw fragment: %s", exc,
+        )
+        return "\n\n".join(system_prompt)
+
+
+__all__ = ["render_system_prompt", "render_system_prompt_or_raw"]

--- a/primer/agent/tool_manager.py
+++ b/primer/agent/tool_manager.py
@@ -47,6 +47,7 @@ from primer.model.except_ import (
     PrimerError,
     UnsupportedContentError,
 )
+from primer.model.principal import PrincipalRef
 from primer.model.yield_ import ToolContext, Yielded, YieldToWorker
 from primer.observability import tracing as _tracing
 import primer.observability.metrics as _metrics
@@ -111,6 +112,7 @@ class ToolExecutionManager:
         tools: list[str] | None = None,
         chat_id: str | None = None,
         graph_invocation_services: "Any | None" = None,
+        initiated_by: "PrincipalRef | None" = None,
     ) -> None:
         self._toolsets: dict[str, ToolsetProvider] = dict(toolset_providers or {})
         self._workspace_tools: dict[str, "WorkspaceTool"] = dict(workspace_tools or {})
@@ -122,6 +124,13 @@ class ToolExecutionManager:
         # Any to avoid importing primer.graph here). None outside a
         # workspace-session dispatch; stamped onto the workspace ToolContext.
         self._graph_services = graph_invocation_services
+        # Persisted attribution of the enclosing run (the workspace
+        # session's own ``initiated_by``, or a richer per-call identity a
+        # future MCP dispatch thread supplies). Stamped onto every
+        # ``ToolContext`` this manager builds so a tool that creates a
+        # child session (``create_workspace_session``) can propagate it —
+        # see ``ToolContext.initiated_by``.
+        self._initiated_by = initiated_by
         self._inform_sink: "Callable[[str], Awaitable[int]] | None" = None
         # The agent's scoped-tool surface. Filters list_tools() to just
         # the listed ids and execute() rejects calls for anything else.
@@ -181,6 +190,7 @@ class ToolExecutionManager:
         provider_registry: object | None = None,
         tools: list[str] | None = None,
         graph_invocation_services: "Any | None" = None,
+        initiated_by: "PrincipalRef | None" = None,
     ) -> "ToolExecutionManager":
         """Build a manager pre-wired for a :class:`WorkspaceAgentExecutor`.
 
@@ -190,6 +200,9 @@ class ToolExecutionManager:
         see :class:`primer.model.agent.Agent.tools`.
         ``graph_invocation_services`` (when supplied) wires invoke_graph
         so the dispatched tool can run a child graph in this session.
+        ``initiated_by`` (when supplied) is the enclosing session's own
+        attribution, propagated onto every ``ToolContext`` this manager
+        builds — see ``ToolContext.initiated_by``.
         """
         ws_tools = {t.id: t for t in session.workspace_tools}
         return cls(
@@ -200,6 +213,7 @@ class ToolExecutionManager:
             provider_registry=provider_registry,
             tools=tools,
             graph_invocation_services=graph_invocation_services,
+            initiated_by=initiated_by,
         )
 
     async def list_tools(
@@ -447,6 +461,7 @@ class ToolExecutionManager:
                 workspace_id=sess.workspace_id,
                 inform=self._inform_sink,
                 graph_services=self._graph_services,
+                initiated_by=self._initiated_by,
             )
         elif self._chat_id is not None:
             ctx = ToolContext(
@@ -455,6 +470,7 @@ class ToolExecutionManager:
                 workspace_id=None,
                 chat_id=self._chat_id,
                 inform=self._inform_sink,
+                initiated_by=self._initiated_by,
             )
         try:
             result = await provider.call(

--- a/primer/agent/workspace_executor.py
+++ b/primer/agent/workspace_executor.py
@@ -36,6 +36,7 @@ from primer.model.yield_ import YieldToWorker
 if TYPE_CHECKING:
     from primer.int.llm import LLM
     from primer.model.agent import Agent
+    from primer.model.principal import PrincipalRef
     from primer.model.provider import LLMModel
     from primer.workspace.session import AgentSession
 
@@ -62,6 +63,7 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
         session: "AgentSession",
         compaction: CompactionStrategy | None = None,
         principal: str | None = None,
+        identity: "PrincipalRef | None" = None,
     ) -> None:
         # Extend the agent's system prompt with the workspace fragment
         # so the LLM sees workspace-tool documentation in its system
@@ -96,6 +98,7 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
             workspace_id=session.workspace_id,
             session_id=session.session_id,
             principal=principal,
+            identity=identity,
         )
         # Trailing :class:`Done.stop_reason` from the most recent
         # :meth:`invoke` call. ``None`` until the first invoke completes.

--- a/primer/api/routers/chats.py
+++ b/primer/api/routers/chats.py
@@ -52,6 +52,7 @@ from primer.api.pagination import parse_page
 from primer.model.agent import Agent
 from primer.model.chats import Chat, ChatMessage
 from primer.model.except_ import ConfigError, ConflictError, NotFoundError
+from primer.model.principal import PrincipalRef
 from primer.model.provider import LLMProvider
 from primer.model.storage import (
     Op,
@@ -92,19 +93,34 @@ class ChatCreateBody(BaseModel):
     responses=common_responses(404, 422, 500),
 )
 async def create_chat(
+    request: Request,
     body: ChatCreateBody,
     sp=Depends(get_storage_provider),
     agents=Depends(get_agent_storage),
 ) -> Chat:
-    """Allocate a new chat row + an id. Validates the agent exists."""
+    """Allocate a new chat row + an id. Validates the agent exists.
+
+    Attribution (spec §8.4): project the request's resolved actor (Layer 1
+    AuthMiddleware, ``request.state.actor``) into the persisted
+    ``PrincipalRef``, mirroring ``create_session`` (spec §8.1). ``actor``
+    is only absent when auth is enabled and the request carries no valid
+    session/token -- require_auth already 401s that case before this
+    handler runs, so the fallback below is a defensive belt-and-braces
+    rather than a reachable production path.
+    """
     agent = await agents.get(body.agent_id)
     if agent is None:
         raise NotFoundError(f"Agent {body.agent_id!r} does not exist")
     chats_storage = sp.get_storage(Chat)
+    actor = getattr(request.state, "actor", None)
     chat = Chat(
         id=f"chat-{uuid.uuid4().hex[:12]}",
         agent_id=body.agent_id,
         created_at=datetime.now(timezone.utc),
+        initiated_by=(
+            PrincipalRef.from_principal(actor) if actor is not None
+            else PrincipalRef.system()
+        ),
     )
     return await chats_storage.create(chat)
 
@@ -517,6 +533,7 @@ async def compact_chat(
     from primer.agent.compaction_mixin import force_compact
     from primer.agent.prompts import DEFAULT_COMPACTION_PROMPT
     from primer.chat.executor import ChatTurnRunner
+    from primer.model.graph import build_execution_context
 
     # 1) Chat exists?
     chat_storage = sp.get_storage(Chat)
@@ -576,6 +593,9 @@ async def compact_chat(
     runner._marker_persisted = False
     runner._last_input_tokens = None
     runner._last_output_tokens = None
+    # Compaction never renders a system prompt, but keep the attribute
+    # present so ChatTurnRunner invariants hold (§8.4).
+    runner._execution_context = build_execution_context(surface="chat")
     history = await runner._load_history(chat_id)
 
     # 5) Force-compact (bypasses the should_compact threshold check).

--- a/primer/api/routers/sessions.py
+++ b/primer/api/routers/sessions.py
@@ -7,7 +7,7 @@ import logging
 from datetime import datetime, timezone
 from typing import Annotated, Any
 
-from fastapi import APIRouter, Depends, Path, Query
+from fastapi import APIRouter, Depends, Path, Query, Request
 from pydantic import BaseModel, Field
 
 from primer.api.deps import (
@@ -92,6 +92,7 @@ class SessionCreateBody(BaseModel):
 )
 async def create_session(
     body: SessionCreateBody,
+    request: Request,
     workspace_id: str = Path(...),
     scheduler=Depends(get_scheduler),
     workspace_registry=Depends(get_workspace_registry),
@@ -119,6 +120,7 @@ async def create_session(
     5. If ``auto_start``: bump status to ``RUNNING``, stamp
        ``started_at``, and enqueue with the scheduler.
     """
+    from primer.model.principal import PrincipalRef
     from primer.workspace.session_factory import (
         SessionFactoryDeps,
         start_workspace_session,
@@ -130,6 +132,18 @@ async def create_session(
         scheduler=scheduler,
         workspace_registry=workspace_registry,
     )
+    # Attribution (spec §8.1): project the request's resolved actor (Layer 1
+    # AuthMiddleware, ``request.state.actor``) into the persisted
+    # PrincipalRef. ``actor`` is only absent when auth is enabled and the
+    # request carries no valid session/token -- require_auth already 401s
+    # that case before this handler runs, so the fallback below is a
+    # defensive belt-and-braces rather than a reachable production path.
+    actor = getattr(request.state, "actor", None)
+    initiated_by = (
+        PrincipalRef.from_principal(actor)
+        if actor is not None
+        else PrincipalRef.system()
+    )
     return await start_workspace_session(
         workspace_id=workspace_id,
         binding=body.binding,
@@ -139,6 +153,7 @@ async def create_session(
         metadata=body.metadata,
         parent_session_id=body.parent_session_id,
         name=body.name,
+        initiated_by=initiated_by,
         deps=deps,
     )
 

--- a/primer/chat/dispatch.py
+++ b/primer/chat/dispatch.py
@@ -24,6 +24,8 @@ from primer.model.agent import Agent
 from primer.model.chat import TextPart
 from primer.model.chats import Chat, ChatMessage
 from primer.model.except_ import ConfigError, NotFoundError
+from primer.model.graph import build_execution_context
+from primer.model.principal import PrincipalRef
 from primer.model.provider import LLMProvider
 from primer.model.storage import (
     FieldRef, Op, OffsetPage, OrderBy, Predicate, Value,
@@ -489,6 +491,10 @@ async def _build_runner(
         except Exception:
             logger.warning("chat runner: no default artifact store available")
     from primer.model.tool_approval import ToolApprovalRecord
+    exec_ctx = build_execution_context(
+        surface="chat",
+        identity=(chat.initiated_by or PrincipalRef.system()),
+    )
     return ChatTurnRunner(
         agent=agent,
         llm=llm,
@@ -501,6 +507,7 @@ async def _build_runner(
         approval_record_storage=deps.storage_provider.get_storage(
             ToolApprovalRecord
         ),
+        execution_context=exec_ctx,
     ), None
 
 

--- a/primer/chat/executor.py
+++ b/primer/chat/executor.py
@@ -39,6 +39,7 @@ from primer.agent.compaction_mixin import (
     apply_compaction as _mixin_apply_compaction,
     should_compact as _mixin_should_compact,
 )
+from primer.agent.prompt_render import render_system_prompt_or_raw
 from primer.agent.prompts import DEFAULT_COMPACTION_PROMPT
 from primer.int.storage import Storage
 from primer.model.chat import (
@@ -55,6 +56,7 @@ from primer.model.chat import (
     Usage,
 )
 from primer.model.chats import Chat, ChatMessage
+from primer.model.graph import ExecutionContext, build_execution_context
 from primer.model.yield_ import YieldToWorker
 from primer.model.storage import (
     CursorPage,
@@ -266,6 +268,7 @@ class ChatTurnRunner:
         cancel_event: asyncio.Event | None = None,
         artifact_storage: object | None = None,
         approval_record_storage: object | None = None,
+        execution_context: "ExecutionContext | None" = None,
     ) -> None:
         self._agent = agent
         self._llm = llm
@@ -274,6 +277,15 @@ class ChatTurnRunner:
         self._chats = chat_storage
         self._messages = message_storage
         self._cancel_event = cancel_event
+        # ExecutionContext (§8.4): exposes ``ctx.identity`` (the persisted
+        # ``Chat.initiated_by`` projection) to the agent's system_prompt
+        # template. Callers that don't pass one (legacy direct construction,
+        # the compaction ``__new__`` path guarded separately) still get a
+        # valid chat-surface context so ``_build_prompt`` never has to
+        # special-case ``None``.
+        self._execution_context = execution_context or build_execution_context(
+            surface="chat",
+        )
         # Optional storage for durable resolved tool-approval records. When
         # wired, an approval resolved on the chat surface (operator yes/no, or
         # a cancel-while-awaiting) writes a ToolApprovalRecord. None -> skip.
@@ -1208,7 +1220,9 @@ class ChatTurnRunner:
     ) -> list[Message]:
         prompt: list[Message] = []
         if self._agent.system_prompt:
-            sys_text = "\n\n".join(self._agent.system_prompt)
+            sys_text = render_system_prompt_or_raw(
+                self._agent.system_prompt, self._execution_context,
+            )
             prompt.append(
                 Message(role="system", parts=[TextPart(text=sys_text)]),
             )

--- a/primer/graph/_agent_node.py
+++ b/primer/graph/_agent_node.py
@@ -25,7 +25,7 @@ import json
 from typing import TYPE_CHECKING, Any
 
 from primer.agent.loop import run_agent_turn
-from primer.agent.prompt_render import render_system_prompt
+from primer.agent.prompt_render import render_system_prompt_or_raw
 from primer.agent.tool_manager import ToolExecutionManager
 from primer.graph._node_refs import _NodeDone, _PendingAgentYield
 from primer.graph.template import render_input_template
@@ -142,7 +142,7 @@ class _AgentNodeMixin:
         history = await self._load_node_history(node.id)
         prompt: list[Message] = []
         if agent.system_prompt:
-            sys_text = render_system_prompt(agent.system_prompt, context.ctx)
+            sys_text = render_system_prompt_or_raw(agent.system_prompt, context.ctx)
             prompt.append(
                 Message(role="system", parts=[TextPart(text=sys_text)])
             )
@@ -217,7 +217,7 @@ class _AgentNodeMixin:
         history = await self._load_node_history(node.id)
         prompt: list[Message] = []
         if agent.system_prompt:
-            sys_text = "\n\n".join(agent.system_prompt)
+            sys_text = render_system_prompt_or_raw(agent.system_prompt, context.ctx)
             prompt.append(Message(role="system", parts=[TextPart(text=sys_text)]))
         prompt.extend(history)
         prompt.append(new_user_msg)

--- a/primer/graph/template.py
+++ b/primer/graph/template.py
@@ -94,6 +94,7 @@ _ENV: SandboxedEnvironment = SandboxedEnvironment(
     autoescape=False,  # rendering plain text, not HTML
     trim_blocks=False,
     lstrip_blocks=False,
+    keep_trailing_newline=True,
 )
 # Custom filters. ``fromjson`` parses a JSON string (e.g. a tool_call node's
 # ``text`` output) so downstream nodes can index into it; see ``_fromjson``.

--- a/primer/graph/workspace_executor.py
+++ b/primer/graph/workspace_executor.py
@@ -116,7 +116,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             agent_resolver, workspace_session
         )
         wrapped_tool_manager_resolver = self._wrap_tool_manager_resolver(
-            tool_manager_resolver, workspace_session
+            tool_manager_resolver, workspace_session, identity
         )
         super().__init__(
             graph=graph,
@@ -131,6 +131,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
         self._state_repo = state_repo
         self._graph_session_id = graph_session_id
         self._workspace_session = workspace_session
+        self._identity = identity
         # Override the base's in-memory context with real workspace ids so node
         # templates can reference {{ ctx.artifact_dir }} etc. Subgraph children
         # get their own scope automatically: _build_sub_executor constructs the
@@ -312,6 +313,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
     def _wrap_tool_manager_resolver(
         base: Callable[["Agent"], Awaitable[ToolExecutionManager]] | None,
         workspace_session: "AgentSession | None",
+        identity: "PrincipalRef | None" = None,
     ) -> Callable[["Agent"], Awaitable[ToolExecutionManager]] | None:
         """Compose the workspace's tools onto every per-node tool manager."""
         if workspace_session is None:
@@ -325,6 +327,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             return ToolExecutionManager.for_workspace(
                 toolset_providers=providers,
                 session=workspace_session,
+                initiated_by=identity,
             )
 
         return _resolve
@@ -611,6 +614,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             graph_resolver=self._graph_resolver,
             router_registry=self._router_registry,
             principal=self._principal,
+            identity=self._identity,
             toolset_resolver=self._toolset_resolver,
             approval_resolver=self._approval_resolver,
             # Inherit the parent's per-superstep fan-out cap (BE5).

--- a/primer/graph/workspace_executor.py
+++ b/primer/graph/workspace_executor.py
@@ -62,6 +62,7 @@ from primer.observability.turn_log_writer import (
 if TYPE_CHECKING:
     from primer.int.llm import LLM
     from primer.model.agent import Agent
+    from primer.model.principal import PrincipalRef
     from primer.model.provider import LLMModel
     from primer.workspace.session import AgentSession
     from primer.workspace.local.state import LocalStateRepo
@@ -103,6 +104,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
         graph_resolver: Callable[[str], Awaitable[Graph]] | None = None,
         router_registry: RouterRegistry | None = None,
         principal: str | None = None,
+        identity: "PrincipalRef | None" = None,
         graph_input: Any = None,
         tool_manager: ToolExecutionManager | None = None,
         owns_session_lifecycle: bool = False,
@@ -143,6 +145,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             session_id=graph_session_id,
             graph_id=graph.id,
             principal=principal,
+            identity=identity,
         )
         # Only the top-level (worker-built) executor owns the on-disk
         # session holder's lifecycle. Subgraph child executors share the

--- a/primer/model/chats.py
+++ b/primer/model/chats.py
@@ -22,6 +22,7 @@ from typing import Any, Literal
 from pydantic import BaseModel, Field
 
 from primer.model.common import Identifiable
+from primer.model.principal import PrincipalRef
 
 
 ChatStatus = Literal["active", "ended"]
@@ -92,6 +93,14 @@ class Chat(Identifiable):
         ),
     )
     created_at: datetime = Field(...)
+    initiated_by: PrincipalRef | None = Field(
+        default=None,
+        description=(
+            "Persisted projection of the actor that created this chat "
+            "(§8.2); rehydrated into ctx.identity by the worker-side "
+            "ChatTurnRunner. None on historical rows -> system fallback."
+        ),
+    )
     status: ChatStatus = Field(default="active")
     title: str | None = Field(
         default=None,

--- a/primer/model/graph.py
+++ b/primer/model/graph.py
@@ -27,6 +27,7 @@ from pydantic import (
 
 from primer.model.chat import Message
 from primer.model.common import Describeable, Identifiable
+from primer.model.principal import PrincipalRef
 from primer.model.workspace_session import SessionStatus
 
 
@@ -162,6 +163,16 @@ class ExecutionContext(BaseModel):
         ),
     )
     principal: str | None = None
+    identity: PrincipalRef | None = Field(
+        default=None,
+        description=(
+            "Rich actor projection for this run (§8.4), exposed to templates "
+            "as ctx.identity.{type,id,display,role,source}. Sourced from the "
+            "session/chat's persisted initiated_by (system fallback for "
+            "historical rows). Exposes no secrets. Distinct from the bare "
+            "back-compat `principal` string above."
+        ),
+    )
     now: str | None = Field(
         default=None, description="ISO-8601 UTC, captured once at construction."
     )
@@ -174,6 +185,7 @@ def build_execution_context(
     session_id: str | None = None,
     graph_id: str | None = None,
     principal: str | None = None,
+    identity: PrincipalRef | None = None,
     now: str | None = None,
 ) -> "ExecutionContext":
     """Single source of truth for an :class:`ExecutionContext`.
@@ -193,6 +205,7 @@ def build_execution_context(
         graph_id=graph_id,
         artifact_dir=artifact_dir,
         principal=principal,
+        identity=identity,
         now=now,
     )
 

--- a/primer/model/principal.py
+++ b/primer/model/principal.py
@@ -14,7 +14,7 @@ from __future__ import annotations
 
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 
 class Principal(BaseModel):
@@ -44,4 +44,47 @@ class Principal(BaseModel):
     )
 
 
-__all__ = ["Principal"]
+class PrincipalRef(BaseModel):
+    """Persisted PROJECTION of a :class:`Principal` (Layer 3, §8.2).
+
+    :class:`Principal` is a per-request value object that is NEVER
+    persisted. When a run must record *who initiated it* on a durable
+    row (``WorkspaceSession.initiated_by`` / ``Chat.initiated_by``) we
+    store this small frozen projection instead, then re-hydrate it into
+    ``ctx.identity`` on the async/worker side so the originating identity
+    survives the boundary (a trigger-fired run stays a trigger). Carries
+    no secrets — exactly the five fields exposed as ``ctx.identity``.
+    """
+
+    model_config = ConfigDict(frozen=True)
+
+    type: Literal["user", "trigger", "api_token", "system"] = Field(
+        ..., description="Kind of actor that initiated the run.",
+    )
+    id: str = Field(..., description="Stable id of the initiating actor.")
+    display: str = Field(..., description="Human-readable label for logs / UI.")
+    role: str | None = Field(
+        default=None, description="RBAC role the run was initiated under, when known.",
+    )
+    source: str = Field(
+        ..., description='Auth channel: "local" | "<oidc-provider-id>" | "internal".',
+    )
+
+    @classmethod
+    def from_principal(cls, p: "Principal") -> "PrincipalRef":
+        """Project a live :class:`Principal` into its persisted form."""
+        return cls(
+            type=p.type, id=p.id, display=p.display, role=p.role, source=p.source,
+        )
+
+    @classmethod
+    def system(cls) -> "PrincipalRef":
+        """The reserved system principal — the fallback for missing/historical
+        ``initiated_by`` (§8.2, §13) and for auth-disabled / internal runs."""
+        return cls(
+            type="system", id="system", display="system", role=None,
+            source="internal",
+        )
+
+
+__all__ = ["Principal", "PrincipalRef"]

--- a/primer/model/workspace_session.py
+++ b/primer/model/workspace_session.py
@@ -33,6 +33,7 @@ from typing import TYPE_CHECKING, Annotated, Any, Literal, Union
 from pydantic import BaseModel, Field
 
 from primer.model.common import Identifiable
+from primer.model.principal import PrincipalRef
 
 if TYPE_CHECKING:
     from primer.model.agent import Agent
@@ -364,6 +365,16 @@ class WorkspaceSession(Identifiable):
     parent_session_id: str | None = Field(default=None)
     initial_instructions: str | None = Field(default=None)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    initiated_by: PrincipalRef | None = Field(
+        default=None,
+        description=(
+            "Persisted projection of the Principal that created this session "
+            "(§8.2). Read back on worker/scheduler resume to populate "
+            "ctx.identity so the originating identity survives the async "
+            "boundary. None on historical rows -> readers fall back to the "
+            "system principal (PrincipalRef.system())."
+        ),
+    )
     created_at: datetime
     started_at: datetime | None = Field(default=None)
     last_turn_at: datetime | None = Field(default=None)

--- a/primer/model/yield_.py
+++ b/primer/model/yield_.py
@@ -41,6 +41,8 @@ from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any
 
+from primer.model.principal import PrincipalRef
+
 
 # ===========================================================================
 # Sentinels returned by yielding tools
@@ -208,6 +210,15 @@ class ToolContext:
         ``None`` outside a workspace-session tool dispatch. Typed ``Any``
         to avoid a layering import cycle (primer.graph depends on this
         module, not vice versa).
+    initiated_by
+        Persisted attribution of the enclosing run, so a tool that
+        CREATES a session (``create_workspace_session``) can stamp the
+        child's ``initiated_by``. Set by :class:`ToolExecutionManager`
+        from the enclosing workspace session's own ``initiated_by`` (or
+        a richer per-call identity if the dispatch layer threads one);
+        ``None`` outside a workspace-session tool dispatch, in which
+        case the MCP session-create handler falls back to the system
+        principal rather than fabricating a ``user`` attribution.
     """
 
     tool_call_id: str
@@ -217,6 +228,7 @@ class ToolContext:
     chat_id: str | None = None
     inform: Callable[[str], Awaitable[int]] | None = None
     graph_services: Any | None = None
+    initiated_by: PrincipalRef | None = None
 
 
 # ===========================================================================

--- a/primer/toolset/system.py
+++ b/primer/toolset/system.py
@@ -698,6 +698,7 @@ def build_system_toolset(
                     workspace_id=getattr(ctx, "workspace_id", None),
                     chat_id=getattr(ctx, "chat_id", None),
                     invoke_tool_call_id=getattr(ctx, "tool_call_id", None),
+                    identity=getattr(ctx, "initiated_by", None),
                 )
         except InvocationDepthExceeded as exc:
             return _err(

--- a/primer/toolset/workspaces.py
+++ b/primer/toolset/workspaces.py
@@ -1055,7 +1055,9 @@ def build_workspaces_toolset(
     registry[name] = entry
 
     # ------------------- Sessions sub-resource ------------------------
-    async def _create_session(arguments: dict[str, Any]) -> ToolCallResult:
+    async def _create_session(
+        arguments: dict[str, Any], ctx: ToolContext | None = None,
+    ) -> ToolCallResult:
         if scheduler is None or claim_engine is None:
             return _err(
                 "session tools unavailable: scheduler/claim_engine not wired",
@@ -1065,6 +1067,7 @@ def build_workspaces_toolset(
             args = _CreateSessionArgs.model_validate(arguments)
         except ValidationError as exc:
             return _err_from_validation(exc)
+        from primer.model.principal import PrincipalRef
         from primer.workspace.session_factory import (
             SessionFactoryDeps,
             start_workspace_session,
@@ -1085,6 +1088,9 @@ def build_workspaces_toolset(
                 auto_start=args.auto_start,
                 metadata=args.metadata,
                 parent_session_id=args.parent_session_id,
+                initiated_by=(
+                    getattr(ctx, "initiated_by", None) or PrincipalRef.system()
+                ),
                 deps=deps,
             )
         except NotFoundError as exc:

--- a/primer/trigger/subscribers/agent_fresh_session.py
+++ b/primer/trigger/subscribers/agent_fresh_session.py
@@ -17,6 +17,7 @@ from __future__ import annotations
 
 import logging
 
+from primer.model.principal import PrincipalRef
 from primer.model.storage import Op, OffsetPage
 from primer.model.trigger import Subscription
 from primer.model.workspace_session import (
@@ -99,6 +100,13 @@ class AgentFreshSessionDispatcher:
                     "fired_at": fire_context.get("fired_at"),
                 },
                 parent_session_id=None,
+                initiated_by=PrincipalRef(
+                    type="trigger",
+                    id=sub.trigger_id,
+                    display=sub.trigger_id,
+                    role=None,
+                    source="internal",
+                ),
                 deps=factory_deps,
             )
         except Exception as exc:  # noqa: BLE001 — defensive perimeter

--- a/primer/trigger/subscribers/graph_fresh_session.py
+++ b/primer/trigger/subscribers/graph_fresh_session.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import json
 import logging
 
+from primer.model.principal import PrincipalRef
 from primer.model.storage import Op, OffsetPage
 from primer.model.trigger import Subscription
 from primer.model.workspace_session import (
@@ -128,6 +129,13 @@ class GraphFreshSessionDispatcher:
                     "graph_input": graph_input,
                 },
                 parent_session_id=None,
+                initiated_by=PrincipalRef(
+                    type="trigger",
+                    id=sub.trigger_id,
+                    display=sub.trigger_id,
+                    role=None,
+                    source="internal",
+                ),
                 deps=factory_deps,
             )
         except Exception as exc:  # noqa: BLE001 — defensive perimeter

--- a/primer/worker/executor_builders.py
+++ b/primer/worker/executor_builders.py
@@ -142,6 +142,7 @@ def build_graph_invocation_services(
             graph_resolver=graph_resolver,
             router_registry=router_registry,
             principal=None,
+            identity=initiated_by,
             owns_session_lifecycle=False,
             toolset_resolver=toolset_resolver,
             approval_resolver=pool._approval_resolver,
@@ -262,6 +263,7 @@ async def build_agent_executor(pool: "WorkerPool", session: WorkspaceSession, wo
         llm_model=llm_model,
         tool_manager=tool_manager,
         session=agent_session,
+        identity=initiated_by,
     )
     return _TurnDriver(executor)
 
@@ -437,6 +439,7 @@ async def build_graph_executor(pool: "WorkerPool", session: WorkspaceSession, wo
         router_registry=router_registry,
         graph_input=graph_input,
         principal=None,
+        identity=initiated_by,
         owns_session_lifecycle=True,
         toolset_resolver=toolset_resolver,
         approval_resolver=pool._approval_resolver,

--- a/primer/worker/executor_builders.py
+++ b/primer/worker/executor_builders.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 
 from typing import TYPE_CHECKING
 
+from primer.model.principal import PrincipalRef
 from primer.model.workspace_session import WorkspaceSession, SessionStatus
 from primer.worker.pool import _toolset_ids_from_scoped
 
@@ -65,13 +66,23 @@ async def build_session_executor(pool: "WorkerPool", session: WorkspaceSession):
 
 
 def build_graph_invocation_services(
-    pool: "WorkerPool", *, workspace, workspace_session, graph_session_id: str,
+    pool: "WorkerPool",
+    *,
+    workspace,
+    workspace_session,
+    graph_session_id: str,
+    initiated_by: "PrincipalRef | None" = None,
 ):
     """Build the GraphInvocationServices bundle for invoke_graph, or None
     when this workspace can't host a child graph executor (no state_repo /
     no holder session). Mirrors the per-node resolvers in
     _build_graph_executor so an invoked graph nests under the session's
-    state with full parity (routers, approvals, subgraphs)."""
+    state with full parity (routers, approvals, subgraphs).
+
+    ``initiated_by`` is the enclosing (durable) session's attribution —
+    threaded onto the child graph's ``ToolExecutionManager`` so a nested
+    ``create_workspace_session`` call inherits the run's identity rather
+    than falling back to the system principal."""
     from primer.agent.tool_manager import ToolExecutionManager
     from primer.graph.invoke_graph import GraphInvocationServices
     from primer.graph.workspace_executor import WorkspaceGraphExecutor
@@ -105,6 +116,7 @@ def build_graph_invocation_services(
             approval_resolver=pool._approval_resolver,
             provider_registry=pool._provider_registry,
             tools=agent.tools,
+            initiated_by=initiated_by,
         )
 
     async def graph_resolver(graph_id: str):
@@ -211,10 +223,18 @@ async def build_agent_executor(pool: "WorkerPool", session: WorkspaceSession, wo
     # ``tools`` list is the agent's scoped-tool surface - the
     # manager exposes exactly those tools to the LLM and rejects
     # dispatch on anything else.
+    #
+    # ``initiated_by`` propagates this session's own attribution onto the
+    # ToolExecutionManager so a tool that spawns a child session
+    # (create_workspace_session) inherits it instead of falling back to
+    # the system principal. ``session.initiated_by`` is only absent for
+    # historical rows created before this attribution landed.
+    initiated_by = session.initiated_by or PrincipalRef.system()
     gis = pool._build_graph_invocation_services(
         workspace=workspace,
         workspace_session=agent_session,
         graph_session_id=session.id,
+        initiated_by=initiated_by,
     )
     tool_manager = ToolExecutionManager.for_workspace(
         toolset_providers=toolset_providers,
@@ -223,6 +243,7 @@ async def build_agent_executor(pool: "WorkerPool", session: WorkspaceSession, wo
         provider_registry=pool._provider_registry,
         tools=agent.tools,
         graph_invocation_services=gis,
+        initiated_by=initiated_by,
     )
 
     from primer.agent.inform import SessionInformSink
@@ -335,6 +356,11 @@ async def build_graph_executor(pool: "WorkerPool", session: WorkspaceSession, wo
     # system prompt augmentation + workspace tools per-node.
     workspace_session = await workspace.get_session(session.id)
 
+    # This graph session's own attribution, propagated onto every
+    # per-node ToolExecutionManager so a tool_call node's
+    # create_workspace_session inherits it (see build_agent_executor).
+    initiated_by = session.initiated_by or PrincipalRef.system()
+
     async def tool_manager_resolver(agent):
         toolset_ids = _toolset_ids_from_scoped(agent.tools)
         toolset_providers: dict = {}
@@ -348,6 +374,7 @@ async def build_graph_executor(pool: "WorkerPool", session: WorkspaceSession, wo
                 workspace=workspace,
                 workspace_session=workspace_session,
                 graph_session_id=session.id,
+                initiated_by=initiated_by,
             )
             return ToolExecutionManager.for_workspace(
                 toolset_providers=toolset_providers,
@@ -356,12 +383,14 @@ async def build_graph_executor(pool: "WorkerPool", session: WorkspaceSession, wo
                 provider_registry=pool._provider_registry,
                 tools=agent.tools,
                 graph_invocation_services=gis,
+                initiated_by=initiated_by,
             )
         return ToolExecutionManager(
             toolset_providers=toolset_providers,
             approval_resolver=pool._approval_resolver,
             provider_registry=pool._provider_registry,
             tools=agent.tools,
+            initiated_by=initiated_by,
         )
 
     # (4) Optional handles wired in later phases.

--- a/primer/worker/pool.py
+++ b/primer/worker/pool.py
@@ -780,13 +780,19 @@ class WorkerPool:
         return await executor_builders.build_session_executor(self, session)
 
     def _build_graph_invocation_services(
-        self, *, workspace, workspace_session, graph_session_id: str,
+        self,
+        *,
+        workspace,
+        workspace_session,
+        graph_session_id: str,
+        initiated_by=None,
     ):
         return executor_builders.build_graph_invocation_services(
             self,
             workspace=workspace,
             workspace_session=workspace_session,
             graph_session_id=graph_session_id,
+            initiated_by=initiated_by,
         )
 
     async def _build_agent_executor(self, session: WorkspaceSession, workspace):

--- a/primer/workspace/session_factory.py
+++ b/primer/workspace/session_factory.py
@@ -44,6 +44,7 @@ from primer.model.except_ import (
     ValidationError,
 )
 from primer.model.graph import Graph
+from primer.model.principal import PrincipalRef
 from primer.model.workspace import Workspace as WorkspaceRow
 from primer.session.mutation_lock import session_lifecycle_lock
 from primer.model.workspace_session import (
@@ -97,6 +98,7 @@ async def start_workspace_session(
     parent_session_id: str | None,
     deps: SessionFactoryDeps,
     name: str | None = None,
+    initiated_by: PrincipalRef | None = None,
 ) -> WorkspaceSession:
     """Full create flow shared by the REST route and the workspaces tool:
     validate workspace + binding (+ graph_input vs Begin.input_schema),
@@ -252,6 +254,7 @@ async def start_workspace_session(
         parent_session_id=parent_session_id,
         session_id=sid,
         name=name,
+        initiated_by=initiated_by,
         deps=SessionFactoryDeps(
             storage_provider=deps.storage_provider,
             claim_engine=deps.claim_engine,
@@ -273,6 +276,7 @@ async def create_session(
     parent_session_id: str | None = None,
     session_id: str | None = None,
     name: str | None = None,
+    initiated_by: PrincipalRef | None = None,
 ) -> WorkspaceSession:
     """Persist a :class:`WorkspaceSession` row + optionally auto-start.
 
@@ -333,6 +337,7 @@ async def create_session(
         parent_session_id=parent_session_id,
         initial_instructions=initial_instructions,
         metadata=md,
+        initiated_by=initiated_by,
         created_at=now,
     )
     sessions_storage = deps.storage_provider.get_storage(WorkspaceSession)

--- a/tests/agent/test_prompt_render.py
+++ b/tests/agent/test_prompt_render.py
@@ -54,3 +54,28 @@ def test_raw_block_passes_literal_braces() -> None:
     ctx = build_execution_context(surface="chat")
     out = render_system_prompt(["{% raw %}{{ literal }}{% endraw %}"], ctx)
     assert out == "{{ literal }}"
+
+
+def test_trailing_newline_preserved_byte_identical() -> None:
+    """A marker-free prompt must render byte-for-byte identical to the old
+    '\\n\\n'.join(...), INCLUDING a trailing newline (keep_trailing_newline)."""
+    ctx = build_execution_context(surface="chat")
+    frags = ["line1\n", "line2\n"]
+    assert render_system_prompt(frags, ctx) == "\n\n".join(frags)
+
+
+def test_render_or_raw_falls_back_on_bad_template() -> None:
+    from primer.agent.prompt_render import render_system_prompt_or_raw
+
+    ctx = build_execution_context(surface="workspace", session_id="s")
+    frags = ["{{ ctx.surfce }}"]  # typo -> StrictUndefined -> BadRequestError
+    # render_system_prompt raises; the wrapper logs + returns the raw join.
+    assert render_system_prompt_or_raw(frags, ctx) == "\n\n".join(frags)
+
+
+def test_render_or_raw_renders_when_valid() -> None:
+    from primer.agent.prompt_render import render_system_prompt_or_raw
+
+    ctx = build_execution_context(surface="workspace", session_id="sess-1")
+    out = render_system_prompt_or_raw(["dir={{ ctx.artifact_dir }}"], ctx)
+    assert out == "dir=artifacts/sess-1"

--- a/tests/agent/test_workspace_executor_execution_context.py
+++ b/tests/agent/test_workspace_executor_execution_context.py
@@ -12,6 +12,7 @@ import pytest
 from primer.agent.tool_manager import ToolExecutionManager
 from primer.agent.workspace_executor import WorkspaceAgentExecutor
 from primer.model.chat import Done, Message, TextDelta, TextPart
+from primer.model.principal import PrincipalRef
 from tests.agent.test_workspace_executor import (
     _FakeLLM,
     _agent,
@@ -67,3 +68,22 @@ async def test_workspace_invoke_creates_artifact_dir(tmp_path: Path) -> None:
     root = session.workspace_root
     assert root is not None
     assert (root / "artifacts" / session.session_id).is_dir()
+
+
+@pytest.mark.asyncio
+async def test_workspace_execution_context_identity(tmp_path: Path) -> None:
+    _backend, _workspace, session = await _build_session(tmp_path)
+    mgr = ToolExecutionManager.for_workspace(toolset_providers={}, session=session)
+    ref = PrincipalRef(
+        type="user", id="u-1", display="alice", role="user", source="local",
+    )
+    ex = WorkspaceAgentExecutor(
+        agent=_agent(system_prompt=["base"]),
+        llm=_FakeLLM(scripts=[]),  # type: ignore[arg-type]
+        llm_model=_model(),
+        tool_manager=mgr,
+        session=session,
+        identity=ref,
+    )
+    assert ex._execution_context.identity is not None
+    assert ex._execution_context.identity.id == "u-1"

--- a/tests/agent/test_workspace_prompt_identity_e2e.py
+++ b/tests/agent/test_workspace_prompt_identity_e2e.py
@@ -1,0 +1,87 @@
+"""End-to-end guard (Task 6, Spec §8.4): the COMPOSITE workspace system
+prompt — the base :class:`Agent`'s ``system_prompt`` fragments PLUS the
+session's ``system_prompt_fragment`` — renders as a whole through the
+identity-aware :func:`render_system_prompt_or_raw`, not just the base
+fragment alone.
+
+``WorkspaceAgentExecutor.__init__`` (``primer/agent/workspace_executor.py``
+:72-99) rebuilds a ``composite_agent`` whose ``system_prompt`` is
+``list(agent.system_prompt) + [session.system_prompt_fragment]`` and hands
+it to ``_BaseAgentExecutor.__init__``; ``_BaseAgentExecutor._build_prompt``
+(``primer/agent/base.py``:337) then renders ``self._agent.system_prompt``
+(the WHOLE composite) against ``self._execution_context``, which carries
+``identity`` (T3). This test drives one real ``invoke()`` turn and inspects
+the system message the (fake) LLM actually received, proving both halves of
+the composite made it through the identity-carrying render together.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from primer.agent.tool_manager import ToolExecutionManager
+from primer.agent.workspace_executor import WorkspaceAgentExecutor
+from primer.model.chat import Done, Message, TextDelta, TextPart
+from primer.model.principal import PrincipalRef
+from tests.agent.test_workspace_executor import (
+    _FakeLLM,
+    _agent,
+    _build_session,
+    _model,
+)
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git CLI not available on PATH (StateRepo needs it)",
+)
+
+
+@pytest.mark.asyncio
+async def test_composite_system_prompt_renders_identity(tmp_path: Path) -> None:
+    backend, _, session = await _build_session(tmp_path)
+    try:
+        ref = PrincipalRef(
+            type="trigger",
+            id="t-1",
+            display="nightly",
+            role=None,
+            source="internal",
+        )
+        llm = _FakeLLM(
+            scripts=[
+                [
+                    TextDelta(text="ok", index=0),
+                    Done(stop_reason="stop", raw_reason="stop"),
+                ]
+            ]
+        )
+        mgr = ToolExecutionManager.for_workspace(
+            toolset_providers={}, session=session
+        )
+        executor = WorkspaceAgentExecutor(
+            agent=_agent(system_prompt=["actor={{ ctx.identity.type }}"]),
+            llm=llm,  # type: ignore[arg-type]
+            llm_model=_model(),
+            tool_manager=mgr,
+            session=session,
+            identity=ref,
+        )
+        async for _ in executor.invoke(
+            [Message(role="user", parts=[TextPart(text="hi")])]
+        ):
+            pass
+
+        sys_msg = llm.calls[0]["messages"][0]
+        assert sys_msg.role == "system"
+        sys_text = sys_msg.parts[0].text
+        # Base-agent fragment rendered against the identity-carrying ctx.
+        assert "actor=trigger" in sys_text
+        # Workspace fragment (appended by the composite builder) present too
+        # -- proves the WHOLE composite reached the render, not just the base.
+        assert session.session_id in sys_text
+    finally:
+        await session.aclose()
+        await backend.aclose()

--- a/tests/api/test_chat_create_attribution.py
+++ b/tests/api/test_chat_create_attribution.py
@@ -1,0 +1,86 @@
+"""REST chat-create attribution — Layer 3 Task 5 (spec §8.4).
+
+``POST /v1/chats`` must stamp the created row's ``initiated_by`` from the
+authenticated caller (``request.state.actor``, Layer 1's
+``AuthMiddleware``), falling back to the reserved system principal when
+the request carries no actor. Mirrors
+``tests/api/test_session_create_attribution.py`` for the chat surface.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.api.conftest import raw_client as client, app, fake_provider_registry  # noqa: F401
+
+from primer.model.agent import Agent, AgentModel
+from primer.model.chats import Chat
+from primer.model.user import User
+
+
+async def _seed_agent(app) -> Agent:
+    sp = app.state.storage_provider
+    agent = Agent(
+        id="ag-attr-1",
+        description="attribution test agent",
+        model=AgentModel(provider_id="p", model_name="m"),
+    )
+    await sp.get_storage(Agent).create(agent)
+    return agent
+
+
+@pytest.mark.asyncio
+async def test_create_chat_stamps_user_initiated_by(client, app) -> None:
+    """A logged-in user's chat create stamps ``initiated_by`` from them."""
+    agent = await _seed_agent(app)
+
+    reg = await client.post(
+        "/v1/auth/register",
+        json={"username": "attruser", "password": "attrpassword"},
+    )
+    assert reg.status_code == 200, reg.text
+
+    users = app.state.storage_provider.get_storage(User)
+    user_row = next(
+        u for u in users._data.values() if u.username == "attruser"  # noqa: SLF001
+    )
+
+    resp = await client.post("/v1/chats", json={"agent_id": agent.id})
+    assert resp.status_code == 201, resp.text
+    chat_id = resp.json()["id"]
+
+    chats = app.state.storage_provider.get_storage(Chat)
+    row = await chats.get(chat_id)
+    assert row is not None
+    assert row.initiated_by is not None
+    assert row.initiated_by.type == "user"
+    assert row.initiated_by.id == user_row.id
+    assert row.initiated_by.source in {"local", "internal"}
+
+
+@pytest.mark.asyncio
+async def test_create_chat_falls_back_to_system_when_unauthenticated(
+    client, app,
+) -> None:
+    """No real actor on the request -> ``initiated_by`` is ``system``.
+
+    With auth *enabled* (the default), an unauthenticated request never
+    reaches the handler at all -- ``require_auth`` 401s first. The only
+    way a real request reaches ``create_chat`` with no genuine user actor
+    is auth-disabled mode, where ``AuthMiddleware`` stamps a synthetic
+    system ``Principal`` onto ``request.state.actor`` -- this exercises
+    the same ``PrincipalRef`` projection code path the ``actor is None``
+    fallback covers.
+    """
+    app.state.config.auth.enabled = False
+    agent = await _seed_agent(app)
+
+    resp = await client.post("/v1/chats", json={"agent_id": agent.id})
+    assert resp.status_code == 201, resp.text
+    chat_id = resp.json()["id"]
+
+    chats = app.state.storage_provider.get_storage(Chat)
+    row = await chats.get(chat_id)
+    assert row is not None
+    assert row.initiated_by is not None
+    assert row.initiated_by.type == "system"

--- a/tests/api/test_session_create_attribution.py
+++ b/tests/api/test_session_create_attribution.py
@@ -1,0 +1,145 @@
+"""REST session-create attribution — Layer 3 Task 2 (spec §8.1).
+
+``POST /v1/workspaces/{workspace_id}/sessions`` must stamp the created
+row's ``initiated_by`` from the authenticated caller
+(``request.state.actor``, Layer 1's ``AuthMiddleware``), falling back to
+the reserved system principal when the request carries no actor.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+from typing import Any
+
+import pytest
+from pydantic import SecretStr
+
+from tests.api.conftest import raw_client as client, app, fake_provider_registry  # noqa: F401
+
+from primer.model.agent import Agent, AgentModel
+from primer.model.user import User
+from primer.model.workspace import Workspace, WorkspaceRuntimeMeta
+from primer.model.workspace_session import WorkspaceSession
+
+
+class _FakeWorkspace:
+    """Enough of the ``Workspace`` surface for the agent-binding create path.
+
+    Mirrors ``tests/trigger/conftest.py``'s ``_FakeWorkspace`` — the REST
+    handler's ``start_workspace_session`` call drives
+    ``live_workspace.start_session(...)`` to allocate the on-disk slot; this
+    double just records the call so the fake registry can hand out a live
+    instance without touching a real backend.
+    """
+
+    def __init__(self, workspace_id: str) -> None:
+        self.id = workspace_id
+        self.started_slots: list[dict[str, Any]] = []
+
+    async def start_session(
+        self,
+        binding: Any,
+        *,
+        id: str,
+        instructions: Any = None,
+        parent_session_id: Any = None,
+        name: Any = None,
+    ) -> None:
+        self.started_slots.append({"id": id, "binding": binding})
+
+
+class _FakeWorkspaceRegistry:
+    """Hands out a per-id ``_FakeWorkspace``, installed on ``app.state``."""
+
+    def __init__(self) -> None:
+        self.workspaces: dict[str, _FakeWorkspace] = {}
+
+    async def get_workspace(self, workspace_id: str) -> _FakeWorkspace:
+        return self.workspaces.setdefault(workspace_id, _FakeWorkspace(workspace_id))
+
+
+async def _seed_workspace_and_agent(app) -> tuple[Workspace, Agent]:
+    sp = app.state.storage_provider
+    ws = Workspace(
+        id="ws-attr-1",
+        description="attribution test workspace",
+        template_id="tpl-1",
+        provider_id="p-1",
+        created_at=datetime.now(timezone.utc),
+        runtime_meta=WorkspaceRuntimeMeta(
+            url="ws://127.0.0.1:5959/", token=SecretStr("t"),
+        ),
+    )
+    await sp.get_storage(Workspace).create(ws)
+    agent = Agent(
+        id="ag-attr-1",
+        description="attribution test agent",
+        model=AgentModel(provider_id="p", model_name="m"),
+    )
+    await sp.get_storage(Agent).create(agent)
+    return ws, agent
+
+
+@pytest.mark.asyncio
+async def test_create_session_stamps_user_initiated_by(client, app) -> None:
+    """A logged-in user's session create stamps ``initiated_by`` from them."""
+    app.state.workspace_registry = _FakeWorkspaceRegistry()
+    ws, agent = await _seed_workspace_and_agent(app)
+
+    reg = await client.post(
+        "/v1/auth/register",
+        json={"username": "attruser", "password": "attrpassword"},
+    )
+    assert reg.status_code == 200, reg.text
+
+    users = app.state.storage_provider.get_storage(User)
+    user_row = next(
+        u for u in users._data.values() if u.username == "attruser"  # noqa: SLF001
+    )
+
+    resp = await client.post(
+        f"/v1/workspaces/{ws.id}/sessions",
+        json={"binding": {"kind": "agent", "agent_id": agent.id}},
+    )
+    assert resp.status_code == 201, resp.text
+    sid = resp.json()["id"]
+
+    sessions = app.state.storage_provider.get_storage(WorkspaceSession)
+    row = await sessions.get(sid)
+    assert row is not None
+    assert row.initiated_by is not None
+    assert row.initiated_by.type == "user"
+    assert row.initiated_by.id == user_row.id
+    assert row.initiated_by.source in {"local", "internal"}
+
+
+@pytest.mark.asyncio
+async def test_create_session_falls_back_to_system_when_unauthenticated(
+    client, app,
+) -> None:
+    """No real actor on the request -> ``initiated_by`` is ``system``.
+
+    With auth *enabled* (the default), an unauthenticated request never
+    reaches the handler at all -- ``require_auth`` 401s first. The only
+    way a real request reaches ``create_session`` with no genuine user
+    actor is auth-disabled mode, where ``AuthMiddleware`` stamps a
+    synthetic system ``Principal`` onto ``request.state.actor`` -- this
+    exercises the same ``PrincipalRef`` projection code path the
+    ``actor is None`` fallback covers.
+    """
+    app.state.workspace_registry = _FakeWorkspaceRegistry()
+    app.state.config.auth.enabled = False
+    ws, agent = await _seed_workspace_and_agent(app)
+
+    resp = await client.post(
+        f"/v1/workspaces/{ws.id}/sessions",
+        json={"binding": {"kind": "agent", "agent_id": agent.id}},
+    )
+    assert resp.status_code == 201, resp.text
+    sid = resp.json()["id"]
+
+    sessions = app.state.storage_provider.get_storage(WorkspaceSession)
+    row = await sessions.get(sid)
+    assert row is not None
+    assert row.initiated_by is not None
+    assert row.initiated_by.type == "system"

--- a/tests/chat/test_executor_execution_context.py
+++ b/tests/chat/test_executor_execution_context.py
@@ -1,0 +1,73 @@
+"""ChatTurnRunner builds/consumes an ExecutionContext when rendering the
+agent's system prompt (Layer 3 Task 5, spec §8.4).
+
+Mirrors ``tests/agent/test_executor_execution_context.py`` for the chat
+surface: ``ctx.identity`` must be reachable from a chat agent's
+``system_prompt`` template, and a marker-free prompt must still render
+byte-identical to the old raw ``"\\n\\n".join(...)``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.chat.executor import ChatTurnRunner
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import Message, TextPart
+from primer.model.chats import Chat, ChatMessage
+from primer.model.graph import build_execution_context
+from primer.model.principal import PrincipalRef
+from primer.model.provider import LLMModel
+
+
+def _runner(*, system_prompt: list[str], execution_context=None) -> ChatTurnRunner:
+    agent = Agent(
+        id="ag", description="x",
+        model=AgentModel(provider_id="p", model_name="m"),
+        system_prompt=system_prompt,
+    )
+    return ChatTurnRunner(
+        agent=agent,
+        llm=None,
+        llm_model=LLMModel(name="m", context_length=4096),
+        tool_manager=None,
+        chat_storage=None,
+        message_storage=None,
+        execution_context=execution_context,
+    )
+
+
+def test_build_prompt_renders_ctx_identity() -> None:
+    ctx = build_execution_context(
+        surface="chat",
+        identity=PrincipalRef(
+            type="user", id="u-1", display="alice", role="user", source="local",
+        ),
+    )
+    runner = _runner(
+        system_prompt=["I am {{ ctx.identity.display }}"], execution_context=ctx,
+    )
+    new_msg = Message(role="user", parts=[TextPart(text="hi")])
+    prompt = runner._build_prompt(history=[], new_user_msg=new_msg)
+    sys_text = prompt[0].parts[0].text
+    assert sys_text == "I am alice"
+
+
+def test_build_prompt_marker_free_is_byte_identical() -> None:
+    fragments = ["line one.", "line two."]
+    runner = _runner(
+        system_prompt=fragments,
+        execution_context=build_execution_context(surface="chat"),
+    )
+    new_msg = Message(role="user", parts=[TextPart(text="hi")])
+    prompt = runner._build_prompt(history=[], new_user_msg=new_msg)
+    sys_text = prompt[0].parts[0].text
+    assert sys_text == "\n\n".join(fragments)
+
+
+def test_execution_context_defaults_to_chat_surface_when_omitted() -> None:
+    """Legacy callers that don't pass ``execution_context`` still get a
+    valid ``ExecutionContext`` (the compaction ``__new__`` path + any
+    stray direct construction)."""
+    runner = _runner(system_prompt=["hi"])
+    assert runner._execution_context.surface == "chat"

--- a/tests/graph/test_template.py
+++ b/tests/graph/test_template.py
@@ -236,3 +236,8 @@ class TestCtx:
         )
         result = render_template_safely("{{ ctx.artifact_dir }}", ctx)
         assert result == "artifacts/gsid-2"
+
+
+def test_node_template_preserves_trailing_newline() -> None:
+    ctx = GraphContext(initial_input=[], iteration=0, nodes={})
+    assert render_input_template("hello\n", context=ctx) == "hello\n"

--- a/tests/graph/test_workspace_executor.py
+++ b/tests/graph/test_workspace_executor.py
@@ -1360,3 +1360,181 @@ class TestToolCallApprovalWiring:
         node = _ToolCallNode(id="t", tool_id="workspace__write", arguments={})
         await executor._dispatch_toolcall_with_bypass(node, {})
         assert seen["bypass"] is True
+
+
+# ===========================================================================
+# Identity propagation (Layer 3, §8.4) — subgraph children + tool managers
+# ===========================================================================
+
+
+class TestIdentityPropagation:
+    @pytest.mark.asyncio
+    async def test_nested_subgraph_ctx_identity_matches_run_identity(
+        self, tmp_path: Path
+    ) -> None:
+        """A subgraph node's child executor must inherit ``ctx.identity``
+        from the parent run, not silently fall back to ``None``.
+
+        Regression: ``_build_sub_executor`` rebuilt the child WITHOUT
+        ``identity=``, so nested subgraph nodes always saw
+        ``context.ctx.identity is None`` regardless of the parent run's
+        identity.
+        """
+        from primer.model.principal import PrincipalRef
+
+        ref = PrincipalRef(
+            type="user", id="u-42", display="alice", role="admin", source="local",
+        )
+
+        inner_graph = Graph(
+            id="inner",
+            description="single agent that renders ctx.identity into its prompt",
+            nodes=[
+                _BeginNode(id="begin"),
+                _AgentNodeRef(id="inner-A", agent_id="x"),
+                _EndNode(id="inner-exit"),
+            ],
+            edges=[
+                _StaticEdge(from_node="begin", to_node="inner-A"),
+                _StaticEdge(from_node="inner-A", to_node="inner-exit"),
+            ],
+        )
+        outer_graph = Graph(
+            id="outer",
+            description="subgraph then exit",
+            nodes=[
+                _BeginNode(id="begin"),
+                _GraphNodeRef(id="SUB", graph_id="inner"),
+                _EndNode(id="exit"),
+            ],
+            edges=[
+                _StaticEdge(from_node="begin", to_node="SUB"),
+                _StaticEdge(from_node="SUB", to_node="exit"),
+            ],
+        )
+        llm = _FakeLLM(
+            scripts=[
+                [
+                    TextDelta(text="from-inner", index=0),
+                    Done(stop_reason="stop", raw_reason="stop"),
+                ]
+            ]
+        )
+
+        async def graph_resolver(graph_id: str) -> Graph:
+            assert graph_id == "inner"
+            return inner_graph
+
+        agent_with_identity_prompt = Agent(
+            id="x",
+            description="agent x",
+            model=AgentModel(provider_id="p", model_name="m"),
+            system_prompt=["Actor: {{ ctx.identity.id }}"],
+        )
+
+        async def agent_resolver(agent_id: str) -> Agent:
+            return agent_with_identity_prompt
+
+        async def llm_resolver(_a: Agent):
+            return (llm, _model())
+
+        repo = await _make_state_repo(tmp_path)
+        executor = WorkspaceGraphExecutor(
+            graph=outer_graph,
+            agent_resolver=agent_resolver,
+            llm_resolver=llm_resolver,  # type: ignore[arg-type]
+            state_repo=repo,
+            graph_session_id="gsid-outer-identity",
+            graph_resolver=graph_resolver,
+            identity=ref,
+        )
+        await _drain(executor.invoke([]))
+
+        assert len(llm.calls) == 1
+        sys_msgs = [m for m in llm.calls[0]["messages"] if m.role == "system"]
+        assert len(sys_msgs) == 1
+        sys_text = "".join(
+            p.text for p in sys_msgs[0].parts if hasattr(p, "text")
+        )
+        assert sys_text == "Actor: u-42"
+
+    @pytest.mark.asyncio
+    async def test_graph_node_tool_manager_receives_initiated_by(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A graph agent-node's per-node tool manager (built through
+        ``_wrap_tool_manager_resolver`` when a ``workspace_session`` is
+        wired) must be constructed WITH the graph's ``identity`` as
+        ``initiated_by``, so a ``create_workspace_session`` tool call
+        dispatched from a graph node inherits the graph's initiator
+        instead of silently falling back to ``PrincipalRef.system()``.
+
+        Regression: ``_wrap_tool_manager_resolver`` rebuilt via
+        ``ToolExecutionManager.for_workspace(toolset_providers=...,
+        session=...)`` only, discarding the ``initiated_by`` that
+        ``build_graph_executor`` threads into the raw resolver it wraps.
+        """
+        from primer.agent import tool_manager as tm
+        from primer.model.principal import PrincipalRef
+
+        ref = PrincipalRef(
+            type="trigger", id="trig-1", display="nightly", role=None,
+            source="internal",
+        )
+        captured: dict = {}
+
+        class _FakeMgr:
+            toolset_providers: dict = {}
+
+        def _fake_for_workspace(
+            cls, *, toolset_providers, session, initiated_by=None, **_kw
+        ):
+            captured["initiated_by"] = initiated_by
+            return _FakeMgr()
+
+        monkeypatch.setattr(
+            tm.ToolExecutionManager, "for_workspace",
+            classmethod(_fake_for_workspace),
+        )
+
+        graph = Graph(
+            id="g-init",
+            description="A -> exit",
+            nodes=[
+                _BeginNode(id="begin"),
+                _AgentNodeRef(id="A", agent_id="x"),
+                _EndNode(id="exit"),
+            ],
+            edges=[
+                _StaticEdge(from_node="begin", to_node="A"),
+                _StaticEdge(from_node="A", to_node="exit"),
+            ],
+        )
+        llm = _FakeLLM(
+            scripts=[
+                [
+                    TextDelta(text="hi", index=0),
+                    Done(stop_reason="stop", raw_reason="stop"),
+                ]
+            ]
+        )
+
+        async def agent_resolver(agent_id: str) -> Agent:
+            return _agent(agent_id)
+
+        async def llm_resolver(_a: Agent):
+            return (llm, _model())
+
+        repo = await _make_state_repo(tmp_path)
+        executor = WorkspaceGraphExecutor(
+            graph=graph,
+            agent_resolver=agent_resolver,
+            llm_resolver=llm_resolver,  # type: ignore[arg-type]
+            state_repo=repo,
+            graph_session_id="gsid-init",
+            workspace_session=_FakeWorkspaceSession(),  # type: ignore[arg-type]
+            identity=ref,
+        )
+        await _drain(executor.invoke([]))
+
+        assert captured.get("initiated_by") is ref

--- a/tests/model/test_execution_context_identity.py
+++ b/tests/model/test_execution_context_identity.py
@@ -1,0 +1,32 @@
+"""ctx.identity projection on ExecutionContext (Layer 3, §8.4)."""
+
+from __future__ import annotations
+
+from primer.agent.prompt_render import render_system_prompt
+from primer.model.graph import build_execution_context
+from primer.model.principal import PrincipalRef
+
+
+def test_identity_defaults_none() -> None:
+    ctx = build_execution_context(surface="chat")
+    assert ctx.identity is None
+
+
+def test_identity_populated_and_frozen() -> None:
+    ref = PrincipalRef(
+        type="user", id="user-1", display="alice", role="admin", source="local",
+    )
+    ctx = build_execution_context(surface="workspace", session_id="s", identity=ref)
+    assert ctx.identity is ref
+    assert ctx.identity.display == "alice"
+
+
+def test_identity_renders_in_system_prompt() -> None:
+    ref = PrincipalRef(
+        type="trigger", id="t-1", display="nightly", role=None, source="internal",
+    )
+    ctx = build_execution_context(surface="workspace", session_id="s", identity=ref)
+    out = render_system_prompt(
+        ["Actor: {{ ctx.identity.type }}/{{ ctx.identity.display }}"], ctx
+    )
+    assert out == "Actor: trigger/nightly"

--- a/tests/model/test_principal_ref.py
+++ b/tests/model/test_principal_ref.py
@@ -1,0 +1,43 @@
+"""Unit tests for the PrincipalRef persisted projection (Layer 3)."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from primer.model.principal import Principal, PrincipalRef
+
+
+def test_from_principal_projects_five_fields() -> None:
+    p = Principal(
+        type="user", id="user-1", display="alice", role="admin", source="local",
+    )
+    ref = PrincipalRef.from_principal(p)
+    assert ref.type == "user"
+    assert ref.id == "user-1"
+    assert ref.display == "alice"
+    assert ref.role == "admin"
+    assert ref.source == "local"
+
+
+def test_system_fallback() -> None:
+    ref = PrincipalRef.system()
+    assert ref.type == "system"
+    assert ref.id == "system"
+    assert ref.display == "system"
+    assert ref.role is None
+    assert ref.source == "internal"
+
+
+def test_frozen() -> None:
+    ref = PrincipalRef.system()
+    with pytest.raises(ValidationError):
+        ref.id = "mutated"  # type: ignore[misc]
+
+
+def test_roundtrips_through_json() -> None:
+    ref = PrincipalRef(
+        type="trigger", id="trig-1", display="nightly", role=None,
+        source="internal",
+    )
+    assert PrincipalRef.model_validate(ref.model_dump(mode="json")) == ref

--- a/tests/toolset/test_workspaces_session_attribution.py
+++ b/tests/toolset/test_workspaces_session_attribution.py
@@ -1,0 +1,260 @@
+"""MCP ``create_workspace_session`` attribution — Layer 3 Task 2 (§6.6, §8.1).
+
+The ``create_workspace_session`` tool is a ctx-taking handler:
+``InternalToolsetProvider`` injects the enclosing ``ToolContext`` when the
+handler declares it, and the handler stamps
+``ctx.initiated_by or PrincipalRef.system()`` onto the created session so
+a sub-session an agent spawns inherits the enclosing run's attribution,
+while a caller with no threaded identity falls back to the system
+principal rather than fabricating a ``user`` attribution.
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from primer.api.registries import WorkspaceRegistry
+from primer.model.except_ import ConflictError, NotFoundError
+from primer.model.principal import PrincipalRef
+from primer.model.storage import OffsetPage, OffsetPageResponse
+from primer.model.workspace import (
+    LocalWorkspaceConfig,
+    WorkspaceProvider,
+    WorkspaceProviderType,
+)
+from primer.model.yield_ import ToolContext
+from primer.toolset.workspaces import build_workspaces_toolset
+
+
+# ===========================================================================
+# In-memory fakes (minimal subset copied from tests/toolset/test_workspaces.py)
+# ===========================================================================
+
+
+class _Storage:
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    async def get(self, id):
+        return self._data.get(id)
+
+    async def create(self, e):
+        if e.id in self._data:
+            raise ConflictError(f"id {e.id!r} already exists")
+        self._data[e.id] = e
+        return e
+
+    async def update(self, e):
+        if e.id not in self._data:
+            raise NotFoundError(f"no entity with id {e.id!r}")
+        self._data[e.id] = e
+        return e
+
+    async def delete(self, id):
+        if id not in self._data:
+            raise NotFoundError(f"no entity with id {id!r}")
+        del self._data[id]
+
+    async def list(self, page, *, order_by=None):
+        items = list(self._data.values())
+        if isinstance(page, OffsetPage):
+            return OffsetPageResponse(
+                offset=page.offset,
+                length=len(items[page.offset : page.offset + page.length]),
+                total=len(items),
+                items=items[page.offset : page.offset + page.length],
+            )
+        return OffsetPageResponse(
+            offset=0, length=len(items), total=len(items), items=items
+        )
+
+    async def find(self, predicate, page, *, order_by=None):
+        return await self.list(page, order_by=order_by)
+
+
+class _SP:
+    def __init__(self) -> None:
+        self._stores: dict[type, _Storage] = {}
+
+    def get_storage(self, cls):
+        return self._stores.setdefault(cls, _Storage())
+
+
+class _LiveWorkspace:
+    def __init__(self, workspace_id="ws-stub") -> None:
+        from pydantic import SecretStr
+
+        from primer.model.workspace import WorkspaceRuntimeMeta
+
+        self.id = workspace_id
+        self._sessions: dict[str, Any] = {}
+        self.runtime_meta = WorkspaceRuntimeMeta(
+            url="ws://127.0.0.1:5959/", token=SecretStr("t"),
+        )
+
+    async def get_session(self, session_id):
+        return self._sessions.get(session_id)
+
+    async def start_session(
+        self, binding, *, id, instructions=None, parent_session_id=None, name=None
+    ):
+        self._sessions[id] = object()
+        return self._sessions[id]
+
+    async def aclose(self):
+        return
+
+
+class _StubBackend:
+    def __init__(self, _provider) -> None:
+        self._workspaces: dict[str, Any] = {}
+
+    async def initialize(self):
+        return
+
+    async def aclose(self):
+        return
+
+    async def create(self, template, *, overrides=None, resolvers=None):
+        ws = _LiveWorkspace("ws-stub")
+        self._workspaces[ws.id] = ws
+        return ws
+
+    async def get(self, workspace_id, *, template=None):
+        return self._workspaces.get(workspace_id)
+
+
+class _FakeScheduler:
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+
+    async def enqueue(self, sid: str) -> None:
+        self.enqueued.append(sid)
+
+
+class _FakeClaimEngine:
+    async def upsert(self, kind, entity_id, *, priority=100, next_attempt_at=None):
+        return
+
+    async def delete_lease(self, kind, entity_id):
+        return
+
+
+def _seed_agent(sp, agent_id="code-reviewer") -> None:
+    from primer.model.agent import Agent, AgentModel
+
+    sp.get_storage(Agent)._data[agent_id] = Agent(
+        id=agent_id,
+        description="x",
+        model=AgentModel(provider_id="p", model_name="m"),
+    )
+
+
+def _provider() -> WorkspaceProvider:
+    return WorkspaceProvider(
+        id="local-1",
+        provider=WorkspaceProviderType.LOCAL,
+        config=LocalWorkspaceConfig(root_path="/tmp/x"),
+    )
+
+
+# ===========================================================================
+# Fixtures
+# ===========================================================================
+
+
+@pytest.fixture
+def sp() -> _SP:
+    return _SP()
+
+
+@pytest.fixture
+def workspace_registry(sp) -> WorkspaceRegistry:
+    return WorkspaceRegistry(sp, factory=_StubBackend)
+
+
+@pytest.fixture
+def session_toolset(sp, workspace_registry):
+    return build_workspaces_toolset(
+        storage_provider=sp,
+        workspace_registry=workspace_registry,
+        scheduler=_FakeScheduler(),
+        claim_engine=_FakeClaimEngine(),
+        event_bus=None,
+    )
+
+
+@pytest.fixture
+async def seeded(session_toolset, sp):
+    """Seed provider + template + workspace + agent; return the workspace id."""
+    await session_toolset.call(
+        tool_name="create_workspace_provider",
+        arguments={"entity": _provider().model_dump(mode="json")},
+    )
+    await session_toolset.call(
+        tool_name="create_workspace_template",
+        arguments={
+            "entity": {"id": "tpl-1", "description": "dev", "provider_id": "local-1"},
+        },
+    )
+    create = await session_toolset.call(
+        tool_name="create_workspace",
+        arguments={"id": "ws-stub", "template_id": "tpl-1"},
+    )
+    assert not create.is_error, create.output
+    _seed_agent(sp)
+    return "ws-stub"
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_create_session_stamps_ctx_initiated_by(
+    session_toolset, seeded,
+) -> None:
+    """A ctx carrying a per-call identity stamps the child row from it."""
+    ctx = ToolContext(
+        tool_call_id="tc-1",
+        session_id="sess-parent",
+        workspace_id=seeded,
+        initiated_by=PrincipalRef(
+            type="api_token", id="tok-1", display="ci", role="user",
+            source="internal",
+        ),
+    )
+    result = await session_toolset.call(
+        tool_name="create_workspace_session",
+        arguments={
+            "workspace_id": seeded,
+            "binding": {"kind": "agent", "agent_id": "code-reviewer"},
+        },
+        ctx=ctx,
+    )
+    assert not result.is_error, result.output
+    body = json.loads(result.output)
+    assert body["initiated_by"]["type"] == "api_token"
+    assert body["initiated_by"]["id"] == "tok-1"
+    assert body["initiated_by"]["source"] == "internal"
+
+
+@pytest.mark.asyncio
+async def test_create_session_falls_back_to_system_with_no_manager_identity(
+    session_toolset, seeded,
+) -> None:
+    """No ctx at all (or a ctx with no initiated_by) -> system fallback."""
+    result = await session_toolset.call(
+        tool_name="create_workspace_session",
+        arguments={
+            "workspace_id": seeded,
+            "binding": {"kind": "agent", "agent_id": "code-reviewer"},
+        },
+    )
+    assert not result.is_error, result.output
+    body = json.loads(result.output)
+    assert body["initiated_by"]["type"] == "system"

--- a/tests/trigger/test_fresh_session_attribution.py
+++ b/tests/trigger/test_fresh_session_attribution.py
@@ -1,0 +1,119 @@
+"""Trigger fresh-session attribution — Layer 3 Task 2 (spec §8.1, §8.3).
+
+``agent_fresh_session`` / ``graph_fresh_session`` subscriptions fire
+sessions on the trigger's own behalf; the created row's
+``initiated_by`` must reflect the trigger, not a human or the system
+fallback, so a resumed/audited run is traceable to the subscription
+that spawned it.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from primer.model.trigger import (
+    AgentFreshSubConfig,
+    GraphFreshSubConfig,
+    Subscription,
+)
+from primer.model.workspace_session import WorkspaceSession
+from primer.trigger.subscribers import DispatchDeps
+from primer.trigger.subscribers.agent_fresh_session import (
+    AgentFreshSessionDispatcher,
+)
+from primer.trigger.subscribers.graph_fresh_session import (
+    GraphFreshSessionDispatcher,
+)
+
+
+def _agent_sub(workspace_id, agent_id) -> Subscription:
+    return Subscription(
+        id="sb-attr-1",
+        trigger_id="tr-attr-1",
+        config=AgentFreshSubConfig(
+            workspace_id=workspace_id, agent_id=agent_id,
+        ),
+        parallelism="queue",
+        enabled=True,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def _graph_sub(workspace_id, graph_id) -> Subscription:
+    return Subscription(
+        id="sb-attr-2",
+        trigger_id="tr-attr-2",
+        config=GraphFreshSubConfig(
+            workspace_id=workspace_id, graph_id=graph_id,
+        ),
+        parallelism="queue",
+        enabled=True,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_agent_fresh_session_stamps_trigger_initiated_by(
+    fake_storage_provider, fake_claim_engine, fake_scheduler,
+    fake_workspace_registry, seeded_workspace, seeded_agent,
+):
+    deps = DispatchDeps(
+        storage_provider=fake_storage_provider,
+        claim_engine=fake_claim_engine,
+        scheduler=fake_scheduler,
+        workspace_registry=fake_workspace_registry,
+    )
+    sub = _agent_sub(seeded_workspace.id, seeded_agent.id)
+    res = await AgentFreshSessionDispatcher().dispatch(
+        sub,
+        rendered_payload="run a check",
+        fire_context={"trigger_id": sub.trigger_id, "fired_at": "2026-06-01T09:00:00+00:00"},
+        fire_id="fire-tr-attr-1-100",
+        deps=deps,
+    )
+    assert res.ok and not res.skipped
+
+    sessions = fake_storage_provider.get_storage(WorkspaceSession)
+    sess = await sessions.get(res.artefact_id)
+    assert sess is not None
+    assert sess.initiated_by is not None
+    assert sess.initiated_by.type == "trigger"
+    assert sess.initiated_by.id == sub.trigger_id
+    assert sess.initiated_by.display == sub.trigger_id
+    assert sess.initiated_by.role is None
+    assert sess.initiated_by.source == "internal"
+
+
+@pytest.mark.asyncio
+async def test_graph_fresh_session_stamps_trigger_initiated_by(
+    fake_storage_provider, fake_claim_engine, fake_scheduler,
+    fake_workspace_registry, seeded_workspace, seeded_graph,
+):
+    deps = DispatchDeps(
+        storage_provider=fake_storage_provider,
+        claim_engine=fake_claim_engine,
+        scheduler=fake_scheduler,
+        workspace_registry=fake_workspace_registry,
+    )
+    sub = _graph_sub(seeded_workspace.id, seeded_graph.id)
+    res = await GraphFreshSessionDispatcher().dispatch(
+        sub,
+        rendered_payload=json.dumps({"tenant_id": "acme"}),
+        fire_context={"trigger_id": sub.trigger_id},
+        fire_id="fire-tr-attr-2-200",
+        deps=deps,
+    )
+    assert res.ok
+
+    sessions = fake_storage_provider.get_storage(WorkspaceSession)
+    sess = await sessions.get(res.artefact_id)
+    assert sess is not None
+    assert sess.initiated_by is not None
+    assert sess.initiated_by.type == "trigger"
+    assert sess.initiated_by.id == sub.trigger_id
+    assert sess.initiated_by.display == sub.trigger_id
+    assert sess.initiated_by.role is None
+    assert sess.initiated_by.source == "internal"

--- a/tests/worker/test_resume_attribution.py
+++ b/tests/worker/test_resume_attribution.py
@@ -1,0 +1,189 @@
+"""Task 6, end-to-end: attribution survives the worker resume boundary.
+
+Spec §8.2: a session's ``initiated_by`` is persisted at creation time and
+re-hydrated into ``ctx.identity`` whenever the worker (re-)builds the
+executor for that session -- including on resume, when the row is
+re-``get``-fetched from storage rather than reusing the in-memory object
+the create call handed back. A trigger-fired (or created-without-invoke)
+session must stay attributed to the ORIGINATING principal -- never
+silently promoted to a live/stale identity -- and a historical row with no
+``initiated_by`` falls back to the reserved system principal (§13).
+
+Mirrors the fixtures in
+``tests/workspace/test_session_factory_initiated_by.py`` (persist via the
+real ``create_session`` factory) and
+``tests/worker/test_pool.py::test_build_agent_executor_returns_turn_driver``
+(drive the worker's executor-build path with fake provider/workspace
+stubs).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.claim.in_memory import InMemoryClaimEngine
+from primer.model.agent import Agent, AgentModel
+from primer.model.principal import PrincipalRef
+from primer.model.provider import LLMModel
+from primer.model.scheduler import WorkerConfig
+from primer.model.workspace_session import AgentSessionBinding, WorkspaceSession
+from primer.worker.pool import WorkerPool
+from primer.workspace.session_factory import SessionFactoryDeps, create_session
+
+from tests.conftest import _FakeStorageProvider
+
+
+class _FakeScheduler:
+    async def enqueue(self, sid: str) -> None:
+        pass
+
+
+class _FakeClaimEngineForFactory:
+    async def upsert(self, kind, entity_id, *, priority=100, next_attempt_at=None):
+        pass
+
+
+class _FakeAgentSessionForBuild:
+    """Just enough on-disk AgentSession surface for the executor's
+    composite-prompt builder + ``ToolExecutionManager.for_workspace``."""
+
+    def __init__(self, sid: str, workspace_id: str) -> None:
+        self.session_id = sid
+        self.workspace_id = workspace_id
+        self.workspace_tools: list = []
+        self.system_prompt_fragment = "[fake workspace prompt]"
+
+
+class _FakeWorkspaceForBuild:
+    def __init__(self, session_stub: _FakeAgentSessionForBuild) -> None:
+        self.id = session_stub.workspace_id
+        self._session = session_stub
+
+    async def get_session(self, session_id):
+        if session_id != self._session.session_id:
+            return None
+        return self._session
+
+
+def _build_pool(storage_provider: _FakeStorageProvider) -> WorkerPool:
+    pool = WorkerPool(
+        config=WorkerConfig(concurrency=1),
+        scheduler=None,  # type: ignore[arg-type]
+        storage=storage_provider,
+        workspace_registry=None,  # type: ignore[arg-type]
+        provider_registry=None,  # type: ignore[arg-type]
+        engine=InMemoryClaimEngine(adapters={}),
+    )
+
+    fake_llm = object()
+    fake_llm_model = LLMModel(name="m-1", context_length=8000)
+
+    async def _get_llm(provider_id):
+        return fake_llm
+
+    async def _get_toolset(_id):
+        raise AssertionError("this test's agent registers no toolsets")
+
+    async def _resolve_llm_model(_agent):
+        return fake_llm_model
+
+    pool._provider_registry = type(
+        "R",
+        (),
+        {
+            "get_llm": staticmethod(_get_llm),
+            "get_toolset": staticmethod(_get_toolset),
+        },
+    )()
+    pool._resolve_llm_model = _resolve_llm_model
+    return pool
+
+
+async def _persist_and_refetch(
+    fake_storage_provider: _FakeStorageProvider,
+    *,
+    initiated_by: PrincipalRef | None,
+) -> WorkspaceSession:
+    """Persist a session row via the REAL ``create_session`` factory (the
+    same path the REST router / trigger dispatcher use), then re-``get`` it
+    off storage -- mirroring the worker's resume-side read
+    (``pool._load_session``) instead of reusing the in-memory row the
+    factory call returned."""
+    await fake_storage_provider.get_storage(Agent).create(
+        Agent(
+            id="ag-1",
+            description="test agent",
+            model=AgentModel(provider_id="prov-1", model_name="m-1"),
+            tools=[],
+            system_prompt=["sys"],
+        )
+    )
+    deps = SessionFactoryDeps(
+        storage_provider=fake_storage_provider,
+        claim_engine=_FakeClaimEngineForFactory(),
+        scheduler=_FakeScheduler(),
+        workspace_registry=None,
+    )
+    created = await create_session(
+        workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="ag-1"),
+        initial_instructions=None,
+        graph_input=None,
+        auto_start=False,
+        metadata={},
+        deps=deps,
+        initiated_by=initiated_by,
+    )
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    refetched = await storage.get(created.id)
+    assert refetched is not None
+    return refetched
+
+
+@pytest.mark.asyncio
+async def test_resume_reconstructs_trigger_identity_not_worker(
+    fake_storage_provider: _FakeStorageProvider,
+) -> None:
+    """A trigger-fired session, rebuilt on the worker/resume side, still
+    carries the ORIGINATING trigger identity -- a trigger stays a trigger,
+    never impersonates a user or the resuming worker's own principal."""
+    ref = PrincipalRef(
+        type="trigger", id="t-1", display="nightly", role=None, source="internal",
+    )
+    session = await _persist_and_refetch(fake_storage_provider, initiated_by=ref)
+    assert session.initiated_by is not None
+    assert session.initiated_by.type == "trigger"  # sanity: row round-tripped
+
+    workspace = _FakeWorkspaceForBuild(
+        _FakeAgentSessionForBuild(session.id, session.workspace_id)
+    )
+    pool = _build_pool(fake_storage_provider)
+
+    driver = await pool._build_executor(session, workspace)
+
+    identity = driver._executor._execution_context.identity
+    assert identity is not None
+    assert identity.type == "trigger"
+    assert identity.id == "t-1"
+
+
+@pytest.mark.asyncio
+async def test_resume_historical_row_without_initiated_by_falls_back_to_system(
+    fake_storage_provider: _FakeStorageProvider,
+) -> None:
+    """A historical row created before attribution landed (``initiated_by``
+    is ``None``) resolves to the reserved system principal on resume, per
+    §13 -- never left ``None`` and never silently promoted to a live
+    identity."""
+    session = await _persist_and_refetch(fake_storage_provider, initiated_by=None)
+    assert session.initiated_by is None  # sanity: historical row shape
+
+    workspace = _FakeWorkspaceForBuild(
+        _FakeAgentSessionForBuild(session.id, session.workspace_id)
+    )
+    pool = _build_pool(fake_storage_provider)
+
+    driver = await pool._build_executor(session, workspace)
+
+    identity = driver._executor._execution_context.identity
+    assert identity == PrincipalRef.system()

--- a/tests/workspace/test_session_factory_initiated_by.py
+++ b/tests/workspace/test_session_factory_initiated_by.py
@@ -1,0 +1,176 @@
+"""Unit tests for ``initiated_by`` threading through the session factory.
+
+Spec §8.2: WorkspaceSession persists a PrincipalRef projection of the
+actor that created it, so worker/scheduler resume can rehydrate
+ctx.identity. Mirrors the fixture setup in test_session_factory.py.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+from pydantic import SecretStr
+
+from primer.model.agent import Agent, AgentModel
+from primer.model.principal import PrincipalRef
+from primer.model.workspace import Workspace as WorkspaceRow
+from primer.model.workspace import WorkspaceRuntimeMeta
+from primer.model.workspace_session import AgentSessionBinding, WorkspaceSession
+from primer.workspace.session_factory import (
+    SessionFactoryDeps,
+    create_session,
+    start_workspace_session,
+)
+
+
+class _FakeScheduler:
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+
+    async def enqueue(self, sid: str) -> None:
+        self.enqueued.append(sid)
+
+
+class _FakeClaimEngine:
+    def __init__(self) -> None:
+        self.upserts: list[tuple] = []
+
+    async def upsert(
+        self, kind, entity_id: str, *, priority: int = 100, next_attempt_at=None,
+    ) -> None:
+        self.upserts.append((kind, entity_id, priority))
+
+
+class _FakeLiveWorkspace:
+    def __init__(self) -> None:
+        self.started: list[dict] = []
+
+    async def start_session(
+        self, binding, *, id, instructions, parent_session_id, name=None
+    ) -> None:
+        self.started.append({"id": id})
+
+
+class _FakeWorkspaceRegistry:
+    def __init__(self, live: _FakeLiveWorkspace) -> None:
+        self._live = live
+
+    async def get_workspace(self, workspace_id: str) -> _FakeLiveWorkspace:
+        return self._live
+
+
+@pytest.fixture
+def fake_scheduler() -> _FakeScheduler:
+    return _FakeScheduler()
+
+
+@pytest.fixture
+def fake_claim_engine() -> _FakeClaimEngine:
+    return _FakeClaimEngine()
+
+
+@pytest.fixture
+def deps(fake_storage_provider, fake_scheduler, fake_claim_engine) -> SessionFactoryDeps:
+    return SessionFactoryDeps(
+        storage_provider=fake_storage_provider,
+        claim_engine=fake_claim_engine,
+        scheduler=fake_scheduler,
+        workspace_registry=None,
+    )
+
+
+def _binding() -> AgentSessionBinding:
+    return AgentSessionBinding(agent_id="ag-1")
+
+
+@pytest.mark.asyncio
+async def test_create_session_persists_initiated_by(fake_storage_provider, deps):
+    ref = PrincipalRef(
+        type="user", id="user-1", display="alice", role="user", source="local",
+    )
+    sess = await create_session(
+        workspace_id="ws-1",
+        binding=_binding(),
+        initial_instructions=None,
+        graph_input=None,
+        auto_start=False,
+        metadata={},
+        deps=deps,
+        initiated_by=ref,
+    )
+
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    rehydrated = await storage.get(sess.id)
+    assert rehydrated is not None
+    assert rehydrated.initiated_by is not None
+    assert rehydrated.initiated_by.type == "user"
+    assert rehydrated.initiated_by.id == "user-1"
+
+
+@pytest.mark.asyncio
+async def test_create_session_without_initiated_by_persists_none(
+    fake_storage_provider, deps,
+):
+    sess = await create_session(
+        workspace_id="ws-1",
+        binding=_binding(),
+        initial_instructions=None,
+        graph_input=None,
+        auto_start=False,
+        metadata={},
+        deps=deps,
+    )
+
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    rehydrated = await storage.get(sess.id)
+    assert rehydrated is not None
+    assert rehydrated.initiated_by is None
+
+
+@pytest.mark.asyncio
+async def test_start_workspace_session_propagates_initiated_by(
+    fake_storage_provider, fake_scheduler, fake_claim_engine,
+):
+    await fake_storage_provider.get_storage(WorkspaceRow).create(
+        WorkspaceRow(
+            id="ws-1",
+            template_id="tpl-1",
+            provider_id="local-1",
+            created_at=datetime.now(timezone.utc),
+            runtime_meta=WorkspaceRuntimeMeta(
+                url="ws://127.0.0.1:5959/",
+                token=SecretStr("t"),
+            ),
+        ),
+    )
+    await fake_storage_provider.get_storage(Agent).create(
+        Agent(
+            id="ag-1", description="x",
+            model=AgentModel(provider_id="p", model_name="m"),
+        ),
+    )
+    live = _FakeLiveWorkspace()
+    full_deps = SessionFactoryDeps(
+        storage_provider=fake_storage_provider,
+        claim_engine=fake_claim_engine,
+        scheduler=fake_scheduler,
+        workspace_registry=_FakeWorkspaceRegistry(live),
+    )
+
+    sess = await start_workspace_session(
+        workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="ag-1"),
+        initial_instructions=None,
+        graph_input=None,
+        auto_start=False,
+        metadata={},
+        parent_session_id=None,
+        deps=full_deps,
+        initiated_by=PrincipalRef.system(),
+    )
+
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    rehydrated = await storage.get(sess.id)
+    assert rehydrated is not None
+    assert rehydrated.initiated_by == PrincipalRef.system()


### PR DESCRIPTION
Layer 3 of the identity effort. Makes the **originating identity** available to agent/graph/chat runs as `ctx.identity`, sourced from a persisted `initiated_by` on sessions **and** chats so it survives the async/worker boundary (a trigger-fired run stays a trigger, even when a worker resumes it). Also unifies system-prompt templating across all five assembly sites. Off `main`, builds on the merged #98 identity work.

**What's in it (T1–T6 + review fixes):**
- `PrincipalRef` projection (frozen, no secrets); `WorkspaceSession.initiated_by` + `Chat.initiated_by`, stamped per initiation path (user / trigger / api_token / MCP / system-fallback), threaded through the factories.
- `ExecutionContext.identity` populated from the persisted `initiated_by` across the workspace/graph executors, subgraph children, and per-node tool managers.
- Templating unified: `keep_trailing_newline=True` on both Jinja envs (byte-identity for marker-free prompts) + a `render_system_prompt_or_raw` **always-render-with-fail-safe-fallback** wrapper, migrating the remaining raw-join sites so all 5 runtime prompt sites are identity-aware.
- Verification: worker-resume attribution e2e + workspace composite-prompt e2e.

**Review:** opus whole-plan review + a T1–T3 checkpoint review — **Ready to merge**, no Critical/Important; both guarantees (byte-identity, chat-identity-across-worker) verified. Three **Minor** optional follow-ups: CRLF byte-identity edge (Jinja normalizes `\r\n`→`\n`; LF prompts unaffected); coalesce `run_subagent` `ctx.identity` to `system()` for cross-surface parity; (compaction ctx is harmless — uses a fixed prompt).

Please review; do not merge on my behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)