### PR TITLE
Studio interactive sessions — backend (auto-wake, reset/restart, Stop, autonomy)

### DIFF
--- a/primer/api/routers/sessions.py
+++ b/primer/api/routers/sessions.py
@@ -61,6 +61,14 @@ class SessionCreateBody(BaseModel):
     initial_instructions: str | None = None
     parent_session_id: str | None = None
     auto_start: bool = False
+    autonomous: bool | None = Field(
+        default=None,
+        description=(
+            "Interactive-vs-autonomous control signal. None => derive from "
+            "binding kind (graph autonomous, agent interactive). True marks "
+            "an agent self-driving loop autonomous."
+        ),
+    )
     metadata: dict[str, Any] = Field(default_factory=dict)
     graph_input: Any | None = Field(
         default=None,
@@ -130,6 +138,7 @@ async def create_session(
         auto_start=body.auto_start,
         metadata=body.metadata,
         parent_session_id=body.parent_session_id,
+        autonomous=body.autonomous,
         deps=deps,
     )
 

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -801,6 +801,58 @@ async def steer_session(
     )
 
 
+class RestartBody(BaseModel):
+    """Body of ``POST /v1/workspaces/{id}/sessions/{sid}/restart``."""
+
+    input: str | None = Field(
+        default=None,
+        description=(
+            "Optional new initial input to invoke the re-opened session "
+            "with. Omit to re-open and invoke with the existing queued "
+            "state only."
+        ),
+    )
+
+
+@sessions_router.post(
+    "/workspaces/{workspace_id}/sessions/{session_id}/restart",
+    response_model=WorkspaceSession,
+    summary="Reset an ended session and re-invoke (reset-same-session + wake)",
+    responses=common_responses(404, 409, 422, 500),
+)
+async def restart_session_route(
+    body: RestartBody,
+    workspace_id: str = Path(...),
+    session_id: str = Path(...),
+    registry: WorkspaceRegistry = Depends(get_workspace_registry),
+    scheduler=Depends(get_scheduler),
+    engine=Depends(get_claim_engine),
+    storage_provider=Depends(get_storage_provider),
+    event_bus=Depends(get_event_bus),
+) -> WorkspaceSession:
+    """Re-open an ENDED session and invoke it (studio-agents-interact §5.3)."""
+    from primer.session.enqueue import SessionWakeDeps
+    from primer.session.reset import SessionResetDeps, restart_session
+
+    return await restart_session(
+        workspace_id=workspace_id,
+        session_id=session_id,
+        instruction=body.input,
+        reset_deps=SessionResetDeps(
+            storage_provider=storage_provider,
+            workspace_registry=registry,
+            event_bus=event_bus,
+        ),
+        wake_deps=SessionWakeDeps(
+            storage_provider=storage_provider,
+            scheduler=scheduler,
+            claim_engine=engine,
+            workspace_registry=registry,
+            event_bus=event_bus,
+        ),
+    )
+
+
 # ===========================================================================
 # Files sub-resource
 # ===========================================================================

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -34,6 +34,7 @@ from fastapi.responses import JSONResponse, StreamingResponse
 from pydantic import BaseModel, Field
 
 from primer.api.deps import (
+    get_claim_engine,
     get_event_bus,
     get_scheduler,
     get_session_storage,
@@ -70,6 +71,7 @@ from primer.model.workspace import (
     WorkspaceTemplate,
     WorkspaceTemplateOverrides,
 )
+from primer.model.workspace_session import WorkspaceSession
 
 
 logger = logging.getLogger(__name__)
@@ -761,7 +763,8 @@ async def get_session(
 
 @sessions_router.post(
     "/workspaces/{workspace_id}/sessions/{session_id}/steer",
-    summary="Append a steering user instruction",
+    response_model=WorkspaceSession,
+    summary="Send a message — invoke / steer / resume (auto-wake)",
     responses=common_responses(404, 409, 422, 500),
 )
 async def steer_session(
@@ -769,16 +772,33 @@ async def steer_session(
     workspace_id: str = Path(...),
     session_id: str = Path(...),
     registry: WorkspaceRegistry = Depends(get_workspace_registry),
-) -> dict:
-    ws = await registry.get_workspace(workspace_id)
-    session = await ws.get_session(session_id)
-    if session is None:
-        raise NotFoundError(
-            f"Session {session_id!r} does not exist on workspace "
-            f"{workspace_id!r}"
-        )
-    instruction = await session.append_instruction(body.instruction)
-    return instruction.model_dump(mode="json")
+    scheduler=Depends(get_scheduler),
+    engine=Depends(get_claim_engine),
+    storage_provider=Depends(get_storage_provider),
+    event_bus=Depends(get_event_bus),
+) -> WorkspaceSession:
+    """Send a user message to a session and auto-wake it.
+
+    One input, three behaviours (studio-agents-interact §5.1): a message to
+    a CREATED session invokes it; to a RUNNING/WAITING session it queues as
+    the next turn (steer); to a PAUSED session it resumes. 409 when the
+    session has ENDED — restart it first.
+    """
+    from primer.session.enqueue import SessionWakeDeps, wake_session
+
+    deps = SessionWakeDeps(
+        storage_provider=storage_provider,
+        scheduler=scheduler,
+        claim_engine=engine,
+        workspace_registry=registry,
+        event_bus=event_bus,
+    )
+    return await wake_session(
+        workspace_id=workspace_id,
+        session_id=session_id,
+        instruction=body.instruction,
+        deps=deps,
+    )
 
 
 # ===========================================================================

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -71,7 +71,8 @@ from primer.model.workspace import (
     WorkspaceTemplate,
     WorkspaceTemplateOverrides,
 )
-from primer.model.workspace_session import WorkspaceSession
+from primer.model.workspace_session import SessionStatus, WorkspaceSession
+from primer.session.mutation_lock import session_lifecycle_lock
 
 
 logger = logging.getLogger(__name__)
@@ -851,6 +852,50 @@ async def restart_session_route(
             event_bus=event_bus,
         ),
     )
+
+
+@sessions_router.post(
+    "/workspaces/{workspace_id}/sessions/{session_id}/interrupt",
+    response_model=WorkspaceSession,
+    summary="Stop the in-flight turn but keep the session alive",
+    responses=common_responses(404, 409, 500),
+)
+async def interrupt_session(
+    workspace_id: str = Path(...),
+    session_id: str = Path(...),
+    sessions=Depends(get_session_storage),
+    event_bus=Depends(get_event_bus),
+) -> WorkspaceSession:
+    """Stop (interrupt) the running turn without ending the session.
+
+    RUNNING: flag ``interrupt_requested`` + publish ``session:{sid}:cancel``
+    so the worker preempts the turn and lands the session in WAITING (alive).
+    Non-running: 200 no-op. ENDED: 409 (studio-agents-interact §4.4).
+    """
+    async with session_lifecycle_lock().acquire(session_id):
+        s = await sessions.get(session_id)
+        if s is None or s.workspace_id != workspace_id:
+            raise NotFoundError(
+                f"Session {session_id!r} does not exist on workspace "
+                f"{workspace_id!r}"
+            )
+        if s.status == SessionStatus.ENDED:
+            raise ConflictError(f"Session {session_id!r} has ended")
+        if s.status == SessionStatus.RUNNING:
+            s.interrupt_requested = True
+            s.cancel_requested_at = datetime.now(timezone.utc)
+            await sessions.update(s)
+            if event_bus is not None:
+                try:
+                    await event_bus.publish(
+                        f"session:{session_id}:cancel", {}
+                    )
+                except Exception:  # noqa: BLE001
+                    logger.warning(
+                        "interrupt_session: bus publish failed for %s",
+                        session_id,
+                    )
+        return s
 
 
 # ===========================================================================

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -1388,6 +1388,48 @@ async def list_pending_yields(
     return {"items": items}
 
 
+@yields_pending_router.get(
+    "/workspaces/{workspace_id}/sessions/{session_id}/yields/pending",
+    summary="Pending yields for one session (inline session-stream affordances)",
+    responses=common_responses(404, 500),
+)
+async def list_session_pending_yields(
+    workspace_id: str = Path(...),
+    session_id: str = Path(...),
+    session_storage=Depends(get_session_storage),
+) -> dict:
+    """Return the pending yield(s) for a single session.
+
+    Same item shape as the aggregated ``/workspaces/{wid}/yields/pending``
+    but scoped to one session, so the run-view can render Approve/Deny /
+    respond affordances inline in the stream while the right sidebar keeps
+    the global Action-Required list (studio-agents-interact §5.4 / §4.5).
+    """
+    sess = await session_storage.get(session_id)
+    if sess is None or sess.workspace_id != workspace_id:
+        raise NotFoundError(
+            f"Session {session_id!r} does not exist on workspace "
+            f"{workspace_id!r}"
+        )
+    items: list[dict] = []
+    if sess.parked_status == "parked":
+        blob: dict = sess.parked_state or {}
+        yielded_blob: dict = blob.get("yielded") or {}
+        tool_name: str = yielded_blob.get("tool_name") or ""
+        metadata: dict = yielded_blob.get("resume_metadata") or {}
+        items.append({
+            "session_id": sess.id,
+            "kind": _extract_yield_kind(tool_name),
+            "prompt": _extract_yield_prompt(tool_name, metadata),
+            "tool_call_id": _tool_call_id_from_blob(blob),
+            "parked_at": (
+                sess.parked_at.isoformat()
+                if sess.parked_at is not None else None
+            ),
+        })
+    return {"items": items}
+
+
 # ===========================================================================
 # Helpers
 # ===========================================================================

--- a/primer/model/workspace_session.py
+++ b/primer/model/workspace_session.py
@@ -347,6 +347,16 @@ class WorkspaceSession(Identifiable):
     parent_session_id: str | None = Field(default=None)
     initial_instructions: str | None = Field(default=None)
     metadata: dict[str, Any] = Field(default_factory=dict)
+    autonomous: bool | None = Field(
+        default=None,
+        description=(
+            "Interactive-vs-autonomous control signal (studio-agents-interact "
+            "§8.1). None => derive from binding kind (graph ⇒ autonomous, "
+            "agent ⇒ interactive). True marks an agent self-driving loop as "
+            "autonomous; False forces interactive. Read via "
+            "primer.session.autonomy.session_is_autonomous."
+        ),
+    )
     created_at: datetime
     started_at: datetime | None = Field(default=None)
     last_turn_at: datetime | None = Field(default=None)

--- a/primer/model/workspace_session.py
+++ b/primer/model/workspace_session.py
@@ -384,6 +384,15 @@ class WorkspaceSession(Identifiable):
     # Cancel/pause request flags (set by API, read by worker)
     pause_requested: bool = Field(default=False)
     cancel_requested: bool = Field(default=False)
+    interrupt_requested: bool = Field(
+        default=False,
+        description=(
+            "Set by POST .../interrupt (Stop). The worker preempts the "
+            "in-flight turn like a cancel but transitions the session to "
+            "WAITING (alive/idle) instead of ENDED, so the user can keep "
+            "chatting (studio-agents-interact §4.4). Cleared by the worker."
+        ),
+    )
 
     # ----------------------------------------------------------------------
     # Yielding-tool park state (M1 of the yielding-tools feature).

--- a/primer/model/workspace_session.py
+++ b/primer/model/workspace_session.py
@@ -518,6 +518,10 @@ class SessionMessageKind(StrEnum):
     #    "status": str | None}`` (status populated on exit with the node
     # outcome, None on enter).
     GRAPH_TRANSITION = "graph_transition"
+    # Written by reset_session on ENDED->CREATED re-open. Payload:
+    # ``{"invocation": int}``. Rendered by the UI session adapter as a
+    # "— invocation N —" divider row (studio-agents-interact §5.2 / §3).
+    INVOCATION_DIVIDER = "invocation_divider"
 
 
 class SessionMessageRecord(BaseModel):

--- a/primer/session/autonomy.py
+++ b/primer/session/autonomy.py
@@ -1,0 +1,28 @@
+"""Derive whether a session is autonomous (self-driving) or interactive.
+
+Autonomous sessions (graphs, agent loops) get Pause/Cancel controls and END
+after a clean turn; interactive sessions (agents awaiting a human) get
+Stop/End and STAY ALIVE after a clean turn so the user can keep chatting.
+See docs/superpowers/reqs/studio-agents-interact.md §4.4 / §8.1.
+"""
+
+from __future__ import annotations
+
+from primer.model.workspace_session import (
+    GraphSessionBinding,
+    WorkspaceSession,
+)
+
+
+def session_is_autonomous(session: WorkspaceSession) -> bool:
+    """True when the session should be treated as self-driving.
+
+    Explicit ``session.autonomous`` wins; otherwise derive from binding
+    kind (graph ⇒ autonomous, agent ⇒ interactive).
+    """
+    if session.autonomous is not None:
+        return session.autonomous
+    return isinstance(session.binding, GraphSessionBinding)
+
+
+__all__ = ["session_is_autonomous"]

--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -544,9 +544,14 @@ async def run_one_session_turn(
     # ------------------------------------------------------------------
     await writer.flush()
 
+    from primer.session.autonomy import session_is_autonomous
+
     last_done_reason = getattr(executor, "last_done_reason", None)
     agent_status = await _read_agent_session_status(executor)
-    new_status, ended_reason = _post_turn_status(last_done_reason, agent_status)
+    new_status, ended_reason = _post_turn_status(
+        last_done_reason, agent_status,
+        is_autonomous=session_is_autonomous(session),
+    )
     await _transition_session_status(
         session_storage,
         session,
@@ -709,30 +714,57 @@ _STOP_REASON_TO_STATUS: dict[str, tuple[SessionStatus, str | None]] = {
 def _post_turn_status(
     last_done_reason: str | None,
     agent_status: SessionStatus | None,
+    *,
+    is_autonomous: bool = True,
 ) -> tuple[SessionStatus, str | None]:
     """Decide the WorkspaceSession.status to write after a clean turn.
 
     Precedence: a definitive AgentSession decision wins (the executor
     set ENDED on internal error, WAITING on a user-input prompt heuristic,
     etc.). Otherwise fall back to the LLM's last stop reason. The default
-    when neither is informative is ENDED/completed — a one-shot session
-    shouldn't perpetually sit at RUNNING.
+    when neither is informative is ENDED/completed for autonomous sessions.
+
+    For INTERACTIVE sessions (``is_autonomous=False``) a clean terminal
+    ``ENDED/completed`` result is downgraded to ``WAITING`` so the session
+    stays alive — awaiting the user's next message — instead of dead-ending
+    (studio-agents-interact §4.4). Autonomous sessions (graphs, agent loops)
+    keep the existing end-on-completion behaviour.
     """
     # An executor-set ENDED is authoritative.
     if agent_status == SessionStatus.ENDED:
         # Translate ended-but-stop-reason into a finer reason when we can.
         mapped = _STOP_REASON_TO_STATUS.get(last_done_reason or "", (None, None))
-        return (SessionStatus.ENDED, mapped[1] or "completed")
+        return _apply_interactive(
+            SessionStatus.ENDED, mapped[1] or "completed", is_autonomous,
+        )
     # Executor-set WAITING (e.g. assistant asked a question heuristic).
     if agent_status == SessionStatus.WAITING:
         return (SessionStatus.WAITING, None)
     # Stop-reason mapping.
     if last_done_reason is None:
-        return (SessionStatus.ENDED, "completed")
+        return _apply_interactive(SessionStatus.ENDED, "completed", is_autonomous)
     mapped = _STOP_REASON_TO_STATUS.get(last_done_reason)
     if mapped is None:
-        return (SessionStatus.ENDED, "completed")
+        return _apply_interactive(SessionStatus.ENDED, "completed", is_autonomous)
+    status, reason = mapped
+    if status == SessionStatus.ENDED and reason == "completed":
+        return _apply_interactive(status, reason, is_autonomous)
     return mapped
+
+
+def _apply_interactive(
+    status: SessionStatus,
+    reason: str | None,
+    is_autonomous: bool,
+) -> tuple[SessionStatus, str | None]:
+    """Downgrade a clean ENDED/completed to WAITING for interactive sessions."""
+    if (
+        not is_autonomous
+        and status == SessionStatus.ENDED
+        and reason == "completed"
+    ):
+        return (SessionStatus.WAITING, None)
+    return (status, reason)
 
 
 async def _transition_session_status(

--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -515,25 +515,48 @@ async def run_one_session_turn(
     # 5b. Cancel path — write CANCELLED record, transition row to ENDED
     # ------------------------------------------------------------------
     if cancel_requested:
+        # Re-read to see whether this preemption was a Stop (interrupt,
+        # stay alive) or an End/Cancel (terminal). The interrupt path and
+        # the cancel path both fire session:{sid}:cancel on the bus.
+        fresh = await session_storage.get(session_id)
+        is_interrupt = bool(fresh and fresh.interrupt_requested)
         await _safe_turn_log(turn_log, TurnLogCancelled(
             seq=0,
             ts=_now(),
             turn_no=session.turn_no,
-            reason=cancel_reason,
+            reason="operator_interrupt" if is_interrupt else cancel_reason,
         ))
-        rec = _cancelled_record(cancel_reason)
+        rec = _cancelled_record(
+            "operator_interrupt" if is_interrupt else cancel_reason
+        )
         seq = await writer.append(rec)
         await writer.flush()
         await deps.event_bus.publish(
             f"session:{session_id}:tick", {"seq": seq}
         )
-        await _transition_session_status(
-            session_storage,
-            session,
-            new_status=SessionStatus.ENDED,
-            ended_reason="cancelled",
-            executor=executor,
-        )
+        if is_interrupt:
+            new_status, ended_reason = _interrupt_post_status()
+            await _transition_session_status(
+                session_storage,
+                session,
+                new_status=new_status,
+                ended_reason=ended_reason,
+                executor=executor,
+            )
+            # Clear the flag so the next turn is not re-interrupted.
+            latest = await session_storage.get(session_id)
+            if latest is not None and latest.interrupt_requested:
+                await session_storage.update(
+                    latest.model_copy(update={"interrupt_requested": False})
+                )
+        else:
+            await _transition_session_status(
+                session_storage,
+                session,
+                new_status=SessionStatus.ENDED,
+                ended_reason="cancelled",
+                executor=executor,
+            )
         await turn_log.aclose()
         return ReleaseOutcome(success=True, drop_lease=True)
 
@@ -691,6 +714,11 @@ async def _read_agent_session_status(executor) -> SessionStatus | None:
         return await status_fn()
     except Exception:  # noqa: BLE001
         return None
+
+
+def _interrupt_post_status() -> tuple[SessionStatus, str | None]:
+    """Stop (interrupt) leaves the session alive/idle, awaiting input."""
+    return (SessionStatus.WAITING, None)
 
 
 # Mapping from Done.stop_reason -> (new_status, ended_reason).

--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -168,11 +168,19 @@ async def run_one_session_turn(
     #   (_run_one_turn) into this function; without it a paused parked
     #   session gets silently resumed to completion (e2e t0867).
     if session.pause_requested:
-        await _transition_session_status(
-            session_storage,
-            session,
-            new_status=SessionStatus.PAUSED,
-        )
+        # Serialize the status transition + interrupt-flag clear against a
+        # concurrent resume/pause/cancel/interrupt API call (T0432-style
+        # lost update; see primer.session.mutation_lock). A stale
+        # interrupt_requested carried into the PAUSED row must not leak
+        # into the turn that eventually resumes it, else it could downgrade
+        # a later genuine Cancel to a Stop.
+        async with session_lifecycle_lock().acquire(session_id):
+            await _transition_session_status(
+                session_storage,
+                session,
+                new_status=SessionStatus.PAUSED,
+            )
+            await _clear_interrupt_requested(session_storage, session_id)
         # Drop the lease but preserve the park columns: a paused session that
         # was 'resumable' keeps its marker + parked_state so a later /resume
         # re-arms the lease and replays the hook. preserve_park also blocks

--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -46,6 +46,7 @@ from primer.model.turn_log import (
     TurnLogYielded,
 )
 from primer.model.yield_ import YieldToWorker
+from primer.session.mutation_lock import session_lifecycle_lock
 from primer.session.persistence import (
     WorkspaceIO,
     WorkspaceMessageWriter,
@@ -181,6 +182,38 @@ async def run_one_session_turn(
         )
 
     # ------------------------------------------------------------------
+    # 1.5 Consume the claimable signal before running the turn.
+    # ------------------------------------------------------------------
+    # wake_session() sets turn_status="claimable" on every steer, INCLUDING
+    # the case where a worker already holds this session's lease (steering
+    # a RUNNING session). That write can't create a new claim by itself
+    # (the lease is already held -- ClaimEngine.upsert on an already-claimed
+    # lease is a no-op on claimed_by), so the only way the queued
+    # instruction is not stranded is for THIS turn to notice, once it's
+    # done, that a steer landed. Consuming the signal here (flipping it
+    # back to "idle" under the session lifecycle lock, same lock
+    # wake_session uses for its own read-modify-write) means:
+    #   * a wake_session() call that lands BEFORE this point is exactly
+    #     what executor.invoke() below will read from messages.jsonl (a
+    #     one-shot snapshot taken at invoke() entry) -- no re-arm needed.
+    #   * a wake_session() call that lands AFTER this point (during the
+    #     turn, or in the gap before release) re-sets turn_status to
+    #     "claimable" again, which the caller (WorkerPool._run_engine_session
+    #     / _maybe_rearm_session) detects post-release and re-arms a fresh
+    #     lease for -- since every ReleaseOutcome this function returns
+    #     drops the lease.
+    # Without this consume step a turn_status="claimable" written by a much
+    # earlier, already-serviced steer would never be cleared (nothing else
+    # writes turn_status back to "idle") and would spin-claim this session
+    # forever.
+    async with session_lifecycle_lock().acquire(session_id):
+        fresh_before_turn = await session_storage.get(session_id)
+        if fresh_before_turn is not None and fresh_before_turn.turn_status == "claimable":
+            await session_storage.update(
+                fresh_before_turn.model_copy(update={"turn_status": "idle"})
+            )
+
+    # ------------------------------------------------------------------
     # 2. Build executor
     # ------------------------------------------------------------------
     # Building the executor can raise a fatal resolution error BEFORE the
@@ -198,12 +231,17 @@ async def run_one_session_turn(
             "session %s failed to build executor; ending failed",
             session_id,
         )
-        await _transition_session_status(
-            session_storage,
-            session,
-            new_status=SessionStatus.ENDED,
-            ended_reason="failed",
-        )
+        # Serialize the terminal transition + interrupt-flag clear against
+        # a concurrent resume/pause/cancel/interrupt API call (T0432-style
+        # lost update; see primer.session.mutation_lock).
+        async with session_lifecycle_lock().acquire(session_id):
+            await _transition_session_status(
+                session_storage,
+                session,
+                new_status=SessionStatus.ENDED,
+                ended_reason="failed",
+            )
+            await _clear_interrupt_requested(session_storage, session_id)
         return ReleaseOutcome(success=False, drop_lease=True)
     if executor is None:
         logger.warning("executor builder returned None for session %s", session_id)
@@ -427,6 +465,14 @@ async def run_one_session_turn(
             session_id, yielded.tool_name, yielded.event_key, timeout,
         )
 
+        # A park doesn't touch session.status, but a stale interrupt_requested
+        # (e.g. an interrupt fired but the executor parked on a tool before
+        # the cancel_event check ran, so the disambiguation branch below
+        # never got a chance to consume it) must not leak into the turn
+        # that eventually resumes this park.
+        async with session_lifecycle_lock().acquire(session_id):
+            await _clear_interrupt_requested(session_storage, session_id)
+
         return ReleaseOutcome(
             success=True,
             drop_lease=True,
@@ -495,12 +541,14 @@ async def run_one_session_turn(
                 " failure; session will still be transitioned to ENDED",
                 session_id,
             )
-        await _transition_session_status(
-            session_storage,
-            session,
-            new_status=SessionStatus.ENDED,
-            ended_reason="failed",
-        )
+        async with session_lifecycle_lock().acquire(session_id):
+            await _transition_session_status(
+                session_storage,
+                session,
+                new_status=SessionStatus.ENDED,
+                ended_reason="failed",
+            )
+            await _clear_interrupt_requested(session_storage, session_id)
         await turn_log.aclose()
         return ReleaseOutcome(success=False, drop_lease=True)
 
@@ -517,9 +565,17 @@ async def run_one_session_turn(
     if cancel_requested:
         # Re-read to see whether this preemption was a Stop (interrupt,
         # stay alive) or an End/Cancel (terminal). The interrupt path and
-        # the cancel path both fire session:{sid}:cancel on the bus.
+        # the cancel path both fire session:{sid}:cancel on the bus, so
+        # both flags can be set on the same row (e.g. a stuck
+        # interrupt_requested left over from an earlier turn that never
+        # consumed it, plus a brand-new hard cancel). Cancel is always the
+        # stronger intent: require interrupt_requested AND NOT
+        # cancel_requested, so a genuine Cancel is never downgraded to a
+        # Stop.
         fresh = await session_storage.get(session_id)
-        is_interrupt = bool(fresh and fresh.interrupt_requested)
+        is_interrupt = bool(
+            fresh and fresh.interrupt_requested and not fresh.cancel_requested
+        )
         await _safe_turn_log(turn_log, TurnLogCancelled(
             seq=0,
             ts=_now(),
@@ -536,6 +592,15 @@ async def run_one_session_turn(
         )
         if is_interrupt:
             new_status, ended_reason = _interrupt_post_status()
+        else:
+            new_status, ended_reason = SessionStatus.ENDED, "cancelled"
+        # Serialize the terminal transition + interrupt-flag clear against
+        # a concurrent resume/pause/cancel/interrupt API call (T0432-style
+        # lost update; see primer.session.mutation_lock). The flag is
+        # cleared on BOTH branches (not just the interrupt one) so a flag
+        # that lost the disambiguation above (Cancel won) can't persist
+        # into a future turn either.
+        async with session_lifecycle_lock().acquire(session_id):
             await _transition_session_status(
                 session_storage,
                 session,
@@ -543,20 +608,7 @@ async def run_one_session_turn(
                 ended_reason=ended_reason,
                 executor=executor,
             )
-            # Clear the flag so the next turn is not re-interrupted.
-            latest = await session_storage.get(session_id)
-            if latest is not None and latest.interrupt_requested:
-                await session_storage.update(
-                    latest.model_copy(update={"interrupt_requested": False})
-                )
-        else:
-            await _transition_session_status(
-                session_storage,
-                session,
-                new_status=SessionStatus.ENDED,
-                ended_reason="cancelled",
-                executor=executor,
-            )
+            await _clear_interrupt_requested(session_storage, session_id)
         await turn_log.aclose()
         return ReleaseOutcome(success=True, drop_lease=True)
 
@@ -575,13 +627,22 @@ async def run_one_session_turn(
         last_done_reason, agent_status,
         is_autonomous=session_is_autonomous(session),
     )
-    await _transition_session_status(
-        session_storage,
-        session,
-        new_status=new_status,
-        ended_reason=ended_reason,
-        executor=executor,
-    )
+    # Serialize the terminal transition + interrupt-flag clear against a
+    # concurrent resume/pause/cancel/interrupt API call (T0432-style lost
+    # update; see primer.session.mutation_lock). A clean completion can
+    # still carry a stale interrupt_requested (e.g. the interrupt fired
+    # too late to be observed by this turn's cancel_event check), so clear
+    # it here too -- every terminal path must, or it leaks into a future
+    # turn and can downgrade a later genuine Cancel to a Stop.
+    async with session_lifecycle_lock().acquire(session_id):
+        await _transition_session_status(
+            session_storage,
+            session,
+            new_status=new_status,
+            ended_reason=ended_reason,
+            executor=executor,
+        )
+        await _clear_interrupt_requested(session_storage, session_id)
 
     await _safe_turn_log(turn_log, TurnLogCompleted(
         seq=0,
@@ -793,6 +854,27 @@ def _apply_interactive(
     ):
         return (SessionStatus.WAITING, None)
     return (status, reason)
+
+
+async def _clear_interrupt_requested(session_storage, session_id: str) -> None:
+    """Best-effort clear of a (possibly stale) ``interrupt_requested`` flag.
+
+    Called on every terminal/park exit from :func:`run_one_session_turn`
+    (clean completion, build/executor failure, park, and both branches of
+    the cancel/interrupt disambiguation) so a flag this turn didn't
+    consume -- e.g. the turn parked or failed before the cancel_event
+    check ever ran, or a concurrent Cancel won the disambiguation instead
+    -- cannot leak into a future turn and downgrade a later genuine
+    Cancel to a Stop. Always called from inside a
+    ``session_lifecycle_lock`` critical section alongside the terminal
+    transition so the two writes can't interleave with a racing
+    resume/pause/cancel/interrupt API call.
+    """
+    fresh = await session_storage.get(session_id)
+    if fresh is not None and fresh.interrupt_requested:
+        await session_storage.update(
+            fresh.model_copy(update={"interrupt_requested": False})
+        )
 
 
 async def _transition_session_status(

--- a/primer/session/enqueue.py
+++ b/primer/session/enqueue.py
@@ -1,0 +1,118 @@
+"""Session auto-wake — the keystone that unifies invoke = steer = resume.
+
+An inbound user message re-arms a session's scheduler claim so the worker
+runs a fresh turn, regardless of the session's current lifecycle state.
+Mirrors ``primer/chat/enqueue.py`` + ``send_chat_message``'s persist+wake
+tail: the session's on-disk ``messages.jsonl`` IS the FIFO queue
+(``AgentSession.append_instruction``); the scheduler-visible
+``WorkspaceSession`` row carries the claim state (``turn_status`` +
+``ClaimEngine`` lease + scheduler enqueue).
+
+Behaviour by status (studio-agents-interact §4.2 / §5.1):
+  * CREATED           -> invoke  (transition to RUNNING; run with the message)
+  * RUNNING / WAITING -> steer   (queue as the next turn; re-arm the claim)
+  * PAUSED            -> resume  (clear pause; transition to RUNNING)
+  * ENDED             -> ConflictError (use restart / reset_session first)
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from primer.int.claim import ClaimKind
+from primer.model.except_ import ConflictError, NotFoundError
+from primer.model.workspace_session import SessionStatus, WorkspaceSession
+from primer.session.mutation_lock import session_lifecycle_lock
+
+logger = logging.getLogger(__name__)
+
+_RESUMABLE = {
+    SessionStatus.CREATED,
+    SessionStatus.PAUSED,
+    SessionStatus.WAITING,
+}
+
+
+@dataclass
+class SessionWakeDeps:
+    """Collaborators :func:`wake_session` needs.
+
+    ``event_bus`` is optional: when present a ``session:{sid}:claimable``
+    event is published for observability (the scheduler enqueue + claim
+    upsert are the load-bearing pulse). ``workspace_registry`` is required
+    when an ``instruction`` is supplied (to reach the on-disk slot's FIFO).
+    """
+
+    storage_provider: Any
+    scheduler: Any
+    claim_engine: Any
+    workspace_registry: Any
+    event_bus: Any | None = None
+
+
+async def wake_session(
+    *,
+    workspace_id: str,
+    session_id: str,
+    instruction: str | None,
+    deps: SessionWakeDeps,
+) -> WorkspaceSession:
+    """Append ``instruction`` (if any) and re-arm the session's claim.
+
+    Raises NotFoundError (missing / workspace mismatch) / ConflictError
+    (already ENDED). Serialised against concurrent cancel/pause/resume via
+    the session lifecycle lock so the ``turn_status`` flip + status
+    transition never interleave with a racing cancel's ENDED write.
+    """
+    sessions = deps.storage_provider.get_storage(WorkspaceSession)
+    async with session_lifecycle_lock().acquire(session_id):
+        row = await sessions.get(session_id)
+        if row is None or row.workspace_id != workspace_id:
+            raise NotFoundError(
+                f"Session {session_id!r} does not exist on workspace "
+                f"{workspace_id!r}"
+            )
+        if row.status == SessionStatus.ENDED:
+            raise ConflictError(
+                f"Session {session_id!r} has ended; restart it to re-open."
+            )
+
+        # 1. Append the user message to the on-disk slot FIFO (the queue).
+        if instruction:
+            ws = await deps.workspace_registry.get_workspace(workspace_id)
+            slot = await ws.get_session(session_id)
+            if slot is not None:
+                await slot.append_instruction(instruction)
+
+        # 2. Re-arm the scheduler-visible row: claimable + clear pause;
+        #    CREATED/PAUSED/WAITING advance to RUNNING (like /resume).
+        row.turn_status = "claimable"
+        row.pause_requested = False
+        row.pause_requested_at = None
+        if row.status in _RESUMABLE:
+            row.status = SessionStatus.RUNNING
+            if row.started_at is None:
+                row.started_at = datetime.now(timezone.utc)
+        await sessions.update(row)
+
+        # 3. Pulse the scheduler + claim engine so a worker runs the turn.
+        await deps.scheduler.enqueue(session_id)
+        if deps.claim_engine is not None:
+            await deps.claim_engine.upsert(ClaimKind.SESSION, session_id)
+        if deps.event_bus is not None:
+            try:
+                await deps.event_bus.publish(
+                    f"session:{session_id}:claimable", {}
+                )
+            except Exception:  # noqa: BLE001 -- never break the wake
+                logger.exception(
+                    "wake_session: failed to publish claimable for %s",
+                    session_id,
+                )
+        return row
+
+
+__all__ = ["SessionWakeDeps", "wake_session"]

--- a/primer/session/persistence.py
+++ b/primer/session/persistence.py
@@ -90,12 +90,19 @@ class WorkspaceMessageWriter:
     Args:
         workspace_io: Dependency satisfying :class:`WorkspaceIO`.
         session_id: Identifies the workspace session being written.
+        start_seq: Initial value of the internal seq counter (default 0).
+            The first appended record gets ``start_seq + 1``. Callers
+            that append to a session with existing history (e.g.
+            ``reset_session`` writing an invocation divider) pass the
+            row's current ``last_seq`` so seqs stay monotonic.
     """
 
-    def __init__(self, *, workspace_io: WorkspaceIO, session_id: str) -> None:
+    def __init__(
+        self, *, workspace_io: WorkspaceIO, session_id: str, start_seq: int = 0,
+    ) -> None:
         self._io = workspace_io
         self._session_id = session_id
-        self._seq: int = 0
+        self._seq: int = start_seq
 
         # Buffer state
         self._buffer: list[bytes] = []

--- a/primer/session/reset.py
+++ b/primer/session/reset.py
@@ -102,6 +102,7 @@ async def reset_session(
             "cancel_requested_at": None,
             "pause_requested": False,
             "pause_requested_at": None,
+            "interrupt_requested": False,
             "parked_status": None,
             "parked_event_key": None,
             "parked_event_keys": None,

--- a/primer/session/reset.py
+++ b/primer/session/reset.py
@@ -1,0 +1,129 @@
+"""Reset-same-session: re-open an ENDED session as a fresh invocation.
+
+A session is a persistent interactive entity (studio-agents-interact §5.2).
+``reset_session`` transitions the scheduler-visible row ENDED -> CREATED,
+clears the terminal + park bookkeeping, reopens the on-disk slot, and
+appends an "invocation N" divider to the append-only ``messages.jsonl`` so
+repeated invocations live in one continuous, legible stream. It does NOT
+invoke; ``restart_session`` (Task 7) chains reset + wake.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from typing import Any
+
+from primer.model.except_ import ConflictError, NotFoundError
+from primer.model.workspace_session import (
+    SessionMessageKind,
+    SessionMessageRecord,
+    SessionStatus,
+    WorkspaceSession,
+)
+from primer.session.mutation_lock import session_lifecycle_lock
+from primer.session.persistence import WorkspaceMessageWriter
+
+logger = logging.getLogger(__name__)
+
+# ended_reasons that are safe to re-open (studio-agents-interact §5.3).
+_RESTARTABLE = {"completed", "failed", "cancelled"}
+
+
+@dataclass
+class SessionResetDeps:
+    storage_provider: Any
+    workspace_registry: Any
+    event_bus: Any | None = None
+
+
+async def reset_session(
+    *,
+    workspace_id: str,
+    session_id: str,
+    deps: SessionResetDeps,
+) -> tuple[WorkspaceSession, int]:
+    """Re-open an ENDED session and append an invocation divider.
+
+    Returns ``(row, invocation_number)``. Raises NotFoundError (missing /
+    workspace mismatch) / ConflictError (not ENDED, or a non-restartable
+    ``ended_reason`` such as ``workspace_lost``/``force_deleted``).
+    """
+    sessions = deps.storage_provider.get_storage(WorkspaceSession)
+    async with session_lifecycle_lock().acquire(session_id):
+        row = await sessions.get(session_id)
+        if row is None or row.workspace_id != workspace_id:
+            raise NotFoundError(
+                f"Session {session_id!r} does not exist on workspace "
+                f"{workspace_id!r}"
+            )
+        if row.status != SessionStatus.ENDED:
+            raise ConflictError(
+                f"Session {session_id!r} is not ENDED (status "
+                f"{row.status.value}); reset only re-opens ended sessions."
+            )
+        if row.ended_reason not in _RESTARTABLE:
+            raise ConflictError(
+                f"Session {session_id!r} ended as {row.ended_reason!r} and "
+                "cannot be re-opened."
+            )
+
+        invocation = int(row.metadata.get("invocation", 1)) + 1
+
+        # 1. Reopen the on-disk slot (ENDED -> RUNNING; sanctioned exception).
+        ws = await deps.workspace_registry.get_workspace(workspace_id)
+        slot = await ws.get_session(session_id)
+        if slot is not None:
+            await slot.reopen()
+
+        # 2. Append the invocation divider to messages.jsonl, seeded past
+        #    existing history so seqs stay monotonic.
+        writer = WorkspaceMessageWriter(
+            workspace_io=ws, session_id=session_id, start_seq=row.last_seq,
+        )
+        new_seq = await writer.append(SessionMessageRecord(
+            seq=1,  # overwritten by the writer's counter
+            kind=SessionMessageKind.INVOCATION_DIVIDER,
+            payload={"invocation": invocation},
+            created_at=datetime.now(timezone.utc),
+        ))
+        await writer.flush()
+
+        # 3. Re-open the scheduler row: ENDED -> CREATED, clear terminal +
+        #    park bookkeeping; bump the invocation counter + last_seq.
+        md = dict(row.metadata)
+        md["invocation"] = invocation
+        reopened = row.model_copy(update={
+            "status": SessionStatus.CREATED,
+            "ended_reason": None,
+            "ended_at": None,
+            "cancel_requested": False,
+            "cancel_requested_at": None,
+            "pause_requested": False,
+            "pause_requested_at": None,
+            "parked_status": None,
+            "parked_event_key": None,
+            "parked_event_keys": None,
+            "parked_until": None,
+            "parked_at": None,
+            "parked_state": None,
+            "turn_status": "idle",
+            "last_seq": new_seq,
+            "metadata": md,
+        })
+        await sessions.update(reopened)
+
+        if deps.event_bus is not None:
+            try:
+                await deps.event_bus.publish(
+                    f"session:{session_id}:tick", {"seq": new_seq}
+                )
+            except Exception:  # noqa: BLE001 -- advisory
+                logger.exception(
+                    "reset_session: tick publish failed for %s", session_id,
+                )
+        return reopened, invocation
+
+
+__all__ = ["SessionResetDeps", "reset_session"]

--- a/primer/session/reset.py
+++ b/primer/session/reset.py
@@ -126,4 +126,30 @@ async def reset_session(
         return reopened, invocation
 
 
-__all__ = ["SessionResetDeps", "reset_session"]
+async def restart_session(
+    *,
+    workspace_id: str,
+    session_id: str,
+    instruction: str | None,
+    reset_deps: "SessionResetDeps",
+    wake_deps,  # primer.session.enqueue.SessionWakeDeps
+) -> WorkspaceSession:
+    """Reset an ENDED session then invoke it (studio-agents-interact §5.3).
+
+    Restart = reset-same-session (§5.2) + auto-wake (§5.1). Works for
+    completed / failed / cancelled sessions.
+    """
+    from primer.session.enqueue import wake_session
+
+    await reset_session(
+        workspace_id=workspace_id, session_id=session_id, deps=reset_deps,
+    )
+    return await wake_session(
+        workspace_id=workspace_id,
+        session_id=session_id,
+        instruction=instruction,
+        deps=wake_deps,
+    )
+
+
+__all__ = ["SessionResetDeps", "reset_session", "restart_session"]

--- a/primer/tap/event.py
+++ b/primer/tap/event.py
@@ -34,6 +34,7 @@ class TapEventClass(StrEnum):
     DONE = "done"
     CANCELLED = "cancelled"
     ERROR = "error"
+    INVOCATION_DIVIDER = "invocation_divider"
 
     # -- tap-layer extension -------------------------------------------------
     GRAPH_TRANSITION = "graph_transition"

--- a/primer/toolset/workspaces.py
+++ b/primer/toolset/workspaces.py
@@ -1330,26 +1330,36 @@ def build_workspaces_toolset(
     registry[name] = entry
 
     async def _steer_session(arguments: dict[str, Any]) -> ToolCallResult:
+        if scheduler is None or claim_engine is None:
+            return _err(
+                "session tools unavailable: scheduler/claim_engine not wired",
+                error_type="unavailable",
+            )
         try:
             args = _SteerArgs.model_validate(arguments)
         except ValidationError as exc:
             return _err_from_validation(exc)
+        from primer.session.enqueue import SessionWakeDeps, wake_session
+
+        deps = SessionWakeDeps(
+            storage_provider=storage_provider,
+            scheduler=scheduler,
+            claim_engine=claim_engine,
+            workspace_registry=workspace_registry,
+            event_bus=event_bus,
+        )
         try:
-            ws = await workspace_registry.get_workspace(args.workspace_id)
+            row = await wake_session(
+                workspace_id=args.workspace_id,
+                session_id=args.session_id,
+                instruction=args.instruction,
+                deps=deps,
+            )
         except NotFoundError as exc:
             return _err_from_primer(exc, error_type="not-found")
-        session = await ws.get_session(args.session_id)
-        if session is None:
-            return _err(
-                f"Session {args.session_id!r} does not exist on "
-                f"workspace {args.workspace_id!r}",
-                error_type="not-found",
-            )
-        try:
-            instruction = await session.append_instruction(args.instruction)
-        except PrimerError as exc:
+        except ConflictError as exc:
             return _err_from_primer(exc, error_type="conflict")
-        return _ok(instruction.model_dump(mode="json"))
+        return _ok(row.model_dump(mode="json"))
 
     name, entry = _tool(
         "steer_workspace_session",

--- a/primer/toolset/workspaces.py
+++ b/primer/toolset/workspaces.py
@@ -24,7 +24,7 @@ Sessions:
     create_workspace_session, cancel_workspace_session,
     list_workspace_sessions, get_workspace_session,
     pause_workspace_session, resume_workspace_session,
-    steer_workspace_session
+    steer_workspace_session, restart_workspace_session
 
 Files:
     list_workspace_files, get_workspace_file_info,
@@ -156,6 +156,13 @@ class _WorkspaceSessionArgs(BaseModel):
 
 class _SteerArgs(_WorkspaceSessionArgs):
     instruction: str = Field(..., min_length=1)
+
+
+class _RestartArgs(_WorkspaceSessionArgs):
+    input: str | None = Field(
+        default=None,
+        description="Optional new initial input for the re-opened session.",
+    )
 
 
 class _WorkspaceListSessionsArgs(BaseModel):
@@ -1383,6 +1390,71 @@ def build_workspaces_toolset(
                     "instruction": "Focus on the failing test first.",
                 },
                 returns="the appended Instruction object",
+            ),
+        ],
+    )
+    registry[name] = entry
+
+    async def _restart_session(arguments: dict[str, Any]) -> ToolCallResult:
+        if scheduler is None or claim_engine is None:
+            return _err(
+                "session tools unavailable: scheduler/claim_engine not wired",
+                error_type="unavailable",
+            )
+        try:
+            args = _RestartArgs.model_validate(arguments)
+        except ValidationError as exc:
+            return _err_from_validation(exc)
+        from primer.session.enqueue import SessionWakeDeps
+        from primer.session.reset import SessionResetDeps, restart_session
+
+        try:
+            row = await restart_session(
+                workspace_id=args.workspace_id,
+                session_id=args.session_id,
+                instruction=args.input,
+                reset_deps=SessionResetDeps(
+                    storage_provider=storage_provider,
+                    workspace_registry=workspace_registry,
+                    event_bus=event_bus,
+                ),
+                wake_deps=SessionWakeDeps(
+                    storage_provider=storage_provider,
+                    scheduler=scheduler,
+                    claim_engine=claim_engine,
+                    workspace_registry=workspace_registry,
+                    event_bus=event_bus,
+                ),
+            )
+        except NotFoundError as exc:
+            return _err_from_primer(exc, error_type="not-found")
+        except ConflictError as exc:
+            return _err_from_primer(exc, error_type="conflict")
+        return _ok(row.model_dump(mode="json"))
+
+    name, entry = _tool(
+        "restart_workspace_session",
+        (
+            "Re-open an ended session and re-invoke it on the same "
+            "workspace. Works for completed, failed, or cancelled sessions; "
+            "appends an 'invocation N' divider to the same stream and "
+            "returns the re-armed session."
+        ),
+        (
+            "Use when you want to run an ended session again (optionally "
+            "with new input) without creating a new one; not to steer a "
+            "live session (use ``steer_workspace_session``)."
+        ),
+        _RestartArgs,
+        _restart_session,
+        examples=[
+            ToolExample(
+                args={
+                    "workspace_id": "ws-1",
+                    "session_id": "sess-1",
+                    "input": "run again with the new config",
+                },
+                returns="the re-armed session {status:\"running\"}",
             ),
         ],
     )

--- a/primer/toolset/workspaces.py
+++ b/primer/toolset/workspaces.py
@@ -143,6 +143,7 @@ class _CreateSessionArgs(BaseModel):
     binding: SessionBinding
     initial_instructions: str | None = None
     auto_start: bool = True
+    autonomous: bool | None = None
     graph_input: Any | None = None
     parent_session_id: str | None = None
     metadata: dict[str, Any] = Field(default_factory=dict)
@@ -1070,6 +1071,7 @@ def build_workspaces_toolset(
                 auto_start=args.auto_start,
                 metadata=args.metadata,
                 parent_session_id=args.parent_session_id,
+                autonomous=args.autonomous,
                 deps=deps,
             )
         except NotFoundError as exc:

--- a/primer/worker/pool.py
+++ b/primer/worker/pool.py
@@ -593,6 +593,68 @@ class WorkerPool:
                 logger.exception(
                     "_run_engine_session: engine.release for %s failed", sid,
                 )
+            else:
+                # C1 fix: a wake_session() steer that lands while this
+                # worker holds the lease sets turn_status="claimable" but
+                # (unable to touch an already-claimed lease) can't create a
+                # new claim itself. Every ReleaseOutcome dispatch.py returns
+                # for a session drops the lease unconditionally, so without
+                # this the queued turn is stranded: no lease exists for the
+                # engine to ever re-claim. Re-arm AFTER the release (once
+                # the old lease is actually gone) so a genuinely queued
+                # turn always gets a fresh claim.
+                await self._maybe_rearm_session(sid)
+
+    async def _maybe_rearm_session(self, session_id: str) -> None:
+        """Re-arm a fresh SESSION claim lease if a turn is still queued.
+
+        Mirrors the CHAT lane's keep-the-lease-while-there's-more-work rule
+        (``primer.worker.pool._run_engine_chat`` maps its turn's
+        disposition to ``drop_lease``, and ``ChatClaimAdapter.on_release``
+        is the single writer of the resulting ``turn_status``). Sessions
+        can't reuse that exact shape because every session
+        ``ReleaseOutcome`` drops the lease unconditionally (see
+        ``primer.session.dispatch``), so instead of keeping the old lease
+        alive this re-upserts a brand-new one, once release has actually
+        dropped the old one -- calling upsert first would just touch the
+        (still held-by-us, about to be dropped) lease's priority and be
+        wiped out the instant release runs.
+
+        ``run_one_session_turn`` consumes ("idle"s) any ``turn_status``
+        it started with before running the turn, so a lingering
+        ``turn_status == "claimable"`` at this point can only mean a
+        ``wake_session()`` steer landed during (or right after) the turn
+        that just released -- not a stale, already-serviced signal.
+
+        No-ops when the session ended (a restart is required, and reset
+        clears turn_status itself) or is not RUNNING/WAITING (e.g.
+        PAUSED, or parked -- its own resume event re-arms it, not this
+        generic path, so re-arming here would race the resumable-park
+        dispatch above).
+        """
+        if self._storage is None:
+            return
+        session_storage = self._storage.get_storage(WorkspaceSession)
+        try:
+            fresh = await session_storage.get(session_id)
+        except Exception:
+            logger.exception(
+                "_maybe_rearm_session: failed to read session %s", session_id,
+            )
+            return
+        if fresh is None or fresh.parked_status is not None:
+            return
+        if fresh.status not in (SessionStatus.RUNNING, SessionStatus.WAITING):
+            return
+        if fresh.turn_status != "claimable":
+            return
+        try:
+            await self._engine.upsert(ClaimKind.SESSION, session_id)
+        except Exception:
+            logger.exception(
+                "_maybe_rearm_session: claim_engine.upsert failed for %s",
+                session_id,
+            )
 
     async def _end_session(self, session, *, reason: str):
         """Write a terminal ENDED status to the session row and return a

--- a/primer/workspace/session.py
+++ b/primer/workspace/session.py
@@ -541,6 +541,34 @@ class AgentSession:
                         extra={"session_id": self.session_id, "error": str(exc)},
                     )
 
+    async def reopen(self) -> None:
+        """Force an ENDED slot back to RUNNING for reset-same-session.
+
+        The ONLY sanctioned way out of the terminal ENDED state
+        (studio-agents-interact §5.2). Bypasses ``_LEGAL_TRANSITIONS`` (which
+        makes ENDED terminal), clears ``ended_reason``/``ended_at``, and
+        commits ``session.json``. Idempotent no-op when not currently ENDED.
+        The append-only ``messages.jsonl`` history is preserved.
+        """
+        async with self._lock:
+            if self._info.status != SessionStatus.ENDED:
+                return
+            now = datetime.now(timezone.utc)
+            updated_info = self._info.model_copy(update={
+                "status": SessionStatus.RUNNING,
+                "ended_reason": None,
+                "ended_at": None,
+                "last_activity_at": now,
+            })
+            sid_short = self.session_id[-12:]
+            await self._state.commit(
+                self.session_id,
+                summary=f"reopen[{sid_short}]: ended -> running",
+                op="status_change",
+                files={"session.json": updated_info.model_dump_json(indent=2)},
+            )
+            self._info = updated_info
+
     async def take_pending_messages(self) -> list[Message]:
         """Return the messages added since the last assistant turn.
 

--- a/primer/workspace/session_factory.py
+++ b/primer/workspace/session_factory.py
@@ -95,6 +95,7 @@ async def start_workspace_session(
     auto_start: bool,
     metadata: dict | None,
     parent_session_id: str | None,
+    autonomous: bool | None = None,
     deps: SessionFactoryDeps,
 ) -> WorkspaceSession:
     """Full create flow shared by the REST route and the workspaces tool:
@@ -237,6 +238,7 @@ async def start_workspace_session(
         auto_start=auto_start,
         metadata=metadata,
         parent_session_id=parent_session_id,
+        autonomous=autonomous,
         session_id=sid,
         deps=SessionFactoryDeps(
             storage_provider=deps.storage_provider,
@@ -258,6 +260,7 @@ async def create_session(
     deps: SessionFactoryDeps,
     parent_session_id: str | None = None,
     session_id: str | None = None,
+    autonomous: bool | None = None,
 ) -> WorkspaceSession:
     """Persist a :class:`WorkspaceSession` row + optionally auto-start.
 
@@ -317,6 +320,7 @@ async def create_session(
         parent_session_id=parent_session_id,
         initial_instructions=initial_instructions,
         metadata=md,
+        autonomous=autonomous,
         created_at=now,
     )
     sessions_storage = deps.storage_provider.get_storage(WorkspaceSession)

--- a/tests/api/test_session_interrupt.py
+++ b/tests/api/test_session_interrupt.py
@@ -1,0 +1,90 @@
+"""REST tests for POST /v1/workspaces/{wid}/sessions/{sid}/interrupt.
+
+Interrupt (Stop) preempts the in-flight turn but leaves the session ALIVE
+(WAITING) for the next message — distinct from Cancel (which ends the run).
+Mirrors ``tests/api/test_session_restart.py``'s convention: seed a
+``WorkspaceSession`` row directly into ``fake_storage_provider`` and drive
+the shared ``client``/``app`` fixtures from ``tests/api/conftest.py``. The
+interrupt route only touches session storage + the event bus (no workspace
+registry lookups), so no fake workspace is needed here.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+
+def _now() -> datetime:
+    return datetime(2026, 6, 5, 10, 0, 0, tzinfo=timezone.utc)
+
+
+@dataclass
+class _Ctx:
+    workspace_id: str
+    session_id: str
+
+
+async def _seed_session(fake_storage_provider, *, sid: str, wid: str, status):
+    from primer.model.workspace_session import (
+        AgentSessionBinding,
+        SessionStatus,
+        WorkspaceSession,
+    )
+
+    sess = WorkspaceSession(
+        id=sid,
+        workspace_id=wid,
+        binding=AgentSessionBinding(agent_id="ag1"),
+        status=status,
+        ended_reason="completed" if status == SessionStatus.ENDED else None,
+        ended_at=_now() if status == SessionStatus.ENDED else None,
+        last_seq=1,
+        turn_status="running" if status == SessionStatus.RUNNING else "idle",
+        created_at=_now(),
+    )
+    await fake_storage_provider.get_storage(WorkspaceSession).create(sess)
+    return sess
+
+
+@pytest.fixture
+async def running_session_client(client, app, fake_storage_provider):
+    """A workspace with a RUNNING agent session."""
+    from primer.model.workspace_session import SessionStatus
+
+    wid, sid = "ws-interrupt", "s-running"
+    await _seed_session(fake_storage_provider, sid=sid, wid=wid, status=SessionStatus.RUNNING)
+    yield client, _Ctx(workspace_id=wid, session_id=sid)
+
+
+@pytest.fixture
+async def ended_session_client(client, app, fake_storage_provider):
+    """A workspace with an ENDED/completed agent session."""
+    from primer.model.workspace_session import SessionStatus
+
+    wid, sid = "ws-interrupt-ended", "s-ended"
+    await _seed_session(fake_storage_provider, sid=sid, wid=wid, status=SessionStatus.ENDED)
+    yield client, _Ctx(workspace_id=wid, session_id=sid)
+
+
+async def test_interrupt_running_session_sets_flag(running_session_client):
+    client, ctx = running_session_client
+    resp = await client.post(
+        f"/v1/workspaces/{ctx.workspace_id}/sessions/{ctx.session_id}/interrupt",
+        json={},
+    )
+    assert resp.status_code == 200, resp.text
+    # The row records the interrupt request for the worker to observe.
+    got = await client.get(f"/v1/sessions/{ctx.session_id}")
+    assert got.json()["interrupt_requested"] is True
+
+
+async def test_interrupt_ended_session_409(ended_session_client):
+    client, ctx = ended_session_client
+    resp = await client.post(
+        f"/v1/workspaces/{ctx.workspace_id}/sessions/{ctx.session_id}/interrupt",
+        json={},
+    )
+    assert resp.status_code == 409

--- a/tests/api/test_session_restart.py
+++ b/tests/api/test_session_restart.py
@@ -1,0 +1,149 @@
+"""REST tests for POST /v1/workspaces/{wid}/sessions/{sid}/restart.
+
+Restart = reset-same-session (Task 6) + auto-wake (Task 3) chained in one
+call (studio-agents-interact §5.3). Mirrors test_session_messages_route.py's
+convention: monkeypatch ``app.state.workspace_registry.get_workspace`` with
+a fake workspace exposing ``get_session`` (slot ``reopen``/``append_instruction``
+for reset + wake) and ``append_message_line``/``read_file``/``state_path``
+(so the recorded invocation divider round-trips through
+``GET /v1/sessions/{sid}/messages``).
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+
+def _now() -> datetime:
+    return datetime(2026, 6, 5, 10, 0, 0, tzinfo=timezone.utc)
+
+
+class _FakeSlot:
+    def __init__(self) -> None:
+        self.reopened = False
+        self.instructions: list[str] = []
+
+    async def reopen(self) -> None:
+        self.reopened = True
+
+    async def append_instruction(self, instruction: str) -> None:
+        self.instructions.append(instruction)
+
+
+class _FakeWorkspace:
+    state_path = ".state"
+
+    def __init__(self) -> None:
+        self._files: dict[str, bytes] = {}
+        self.slots: dict[str, _FakeSlot] = {}
+
+    async def get_session(self, session_id: str) -> _FakeSlot:
+        return self.slots.setdefault(session_id, _FakeSlot())
+
+    async def append_message_line(self, session_id: str, line: bytes) -> None:
+        path = f"{self.state_path}/sessions/{session_id}/messages.jsonl"
+        self._files[path] = self._files.get(path, b"") + line
+
+    async def read_file(self, path: str) -> bytes:
+        return self._files.get(path, b"")
+
+
+@dataclass
+class _Ctx:
+    workspace_id: str
+    session_id: str
+
+
+async def _seed_session(
+    fake_storage_provider, *, sid: str, wid: str, status, ended_reason=None,
+):
+    from primer.model.workspace_session import (
+        AgentSessionBinding,
+        SessionStatus,
+        WorkspaceSession,
+    )
+
+    sess = WorkspaceSession(
+        id=sid,
+        workspace_id=wid,
+        binding=AgentSessionBinding(agent_id="ag1"),
+        status=status,
+        ended_reason=ended_reason,
+        ended_at=_now() if status == SessionStatus.ENDED else None,
+        last_seq=3,
+        turn_status="idle",
+        created_at=_now(),
+    )
+    await fake_storage_provider.get_storage(WorkspaceSession).create(sess)
+    return sess
+
+
+@pytest.fixture
+async def ended_session_client(client, app, fake_storage_provider):
+    """A workspace with an ENDED/completed agent session."""
+    from primer.model.workspace_session import SessionStatus
+
+    wid, sid = "ws-restart", "s-ended"
+    await _seed_session(
+        fake_storage_provider,
+        sid=sid,
+        wid=wid,
+        status=SessionStatus.ENDED,
+        ended_reason="completed",
+    )
+    ws = _FakeWorkspace()
+
+    async def _get(workspace_id: str):
+        return ws if workspace_id == wid else None
+
+    app.state.workspace_registry.get_workspace = _get  # type: ignore[assignment]
+    yield client, _Ctx(workspace_id=wid, session_id=sid)
+
+
+@pytest.fixture
+async def active_session_client(client, app, fake_storage_provider):
+    """A workspace with a RUNNING agent session."""
+    from primer.model.workspace_session import SessionStatus
+
+    wid, sid = "ws-restart-active", "s-running"
+    await _seed_session(
+        fake_storage_provider, sid=sid, wid=wid, status=SessionStatus.RUNNING,
+    )
+    ws = _FakeWorkspace()
+
+    async def _get(workspace_id: str):
+        return ws if workspace_id == wid else None
+
+    app.state.workspace_registry.get_workspace = _get  # type: ignore[assignment]
+    yield client, _Ctx(workspace_id=wid, session_id=sid)
+
+
+async def test_restart_reopens_and_invokes(ended_session_client):
+    """A completed agent session restarts: status -> running, divider written."""
+    client, ctx = ended_session_client
+    resp = await client.post(
+        f"/v1/workspaces/{ctx.workspace_id}/sessions/{ctx.session_id}/restart",
+        json={"input": "go again"},
+    )
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["status"] == "running"
+    assert body["turn_status"] == "claimable"
+    assert body["metadata"]["invocation"] == 2
+
+    # The invocation divider is visible in the recorded message history.
+    msgs = await client.get(f"/v1/sessions/{ctx.session_id}/messages")
+    kinds = [m.get("kind") for m in msgs.json()["items"]]
+    assert "invocation_divider" in kinds
+
+
+async def test_restart_409_when_active(active_session_client):
+    client, ctx = active_session_client
+    resp = await client.post(
+        f"/v1/workspaces/{ctx.workspace_id}/sessions/{ctx.session_id}/restart",
+        json={},
+    )
+    assert resp.status_code == 409

--- a/tests/api/test_session_yields_scoped.py
+++ b/tests/api/test_session_yields_scoped.py
@@ -1,0 +1,130 @@
+"""REST tests for GET /v1/workspaces/{wid}/sessions/{sid}/yields/pending.
+
+Session-scoped variant of the aggregated ``/workspaces/{wid}/yields/pending``
+(covered by ``tests/api/test_workspace_yields_pending.py``): returns the
+pending yield for a single session so the run-view can render Approve/Deny /
+respond affordances inline in the session's own stream (studio-agents-interact
+§5.4, Task 10). Mirrors ``tests/api/test_session_interrupt.py``'s convention:
+seed a ``WorkspaceSession`` row directly into ``fake_storage_provider`` and
+drive the shared ``client``/``app`` fixtures from ``tests/api/conftest.py``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime, timezone
+
+import pytest
+
+
+def _now() -> datetime:
+    return datetime(2026, 7, 5, 10, 0, 0, tzinfo=timezone.utc)
+
+
+@dataclass
+class _Ctx:
+    workspace_id: str
+    session_id: str
+
+
+async def _seed_session(
+    fake_storage_provider,
+    *,
+    sid: str,
+    wid: str,
+    status,
+    parked_status: str | None = None,
+    parked_state: dict | None = None,
+    parked_at: datetime | None = None,
+):
+    from primer.model.workspace_session import (
+        AgentSessionBinding,
+        WorkspaceSession,
+    )
+
+    sess = WorkspaceSession(
+        id=sid,
+        workspace_id=wid,
+        binding=AgentSessionBinding(agent_id="ag1"),
+        status=status,
+        created_at=_now(),
+        parked_status=parked_status,
+        parked_state=parked_state,
+        parked_at=parked_at,
+    )
+    await fake_storage_provider.get_storage(WorkspaceSession).create(sess)
+    return sess
+
+
+@pytest.fixture
+async def parked_session_client(client, app, fake_storage_provider):
+    """A workspace with a session parked on ``ask_user``."""
+    from primer.model.workspace_session import SessionStatus
+
+    wid, sid = "ws-yields-scoped", "s-parked"
+    await _seed_session(
+        fake_storage_provider,
+        sid=sid,
+        wid=wid,
+        status=SessionStatus.WAITING,
+        parked_status="parked",
+        parked_at=_now(),
+        parked_state={
+            "tool_call_id": "tcid-ask-1",
+            "yielded": {
+                "tool_name": "ask_user",
+                "event_key": f"ask_user:{sid}:tcid-ask-1",
+                "resume_metadata": {"prompt": "What is your name?"},
+            },
+        },
+    )
+    yield client, _Ctx(workspace_id=wid, session_id=sid)
+
+
+@pytest.fixture
+async def running_session_client(client, app, fake_storage_provider):
+    """A workspace with a RUNNING (not parked) session."""
+    from primer.model.workspace_session import SessionStatus
+
+    wid, sid = "ws-yields-scoped-running", "s-running"
+    await _seed_session(fake_storage_provider, sid=sid, wid=wid, status=SessionStatus.RUNNING)
+    yield client, _Ctx(workspace_id=wid, session_id=sid)
+
+
+async def test_session_scoped_pending_yields(parked_session_client):
+    client, ctx = parked_session_client  # a session parked on ask_user
+    resp = await client.get(
+        f"/v1/workspaces/{ctx.workspace_id}/sessions/{ctx.session_id}/yields/pending"
+    )
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert len(items) == 1
+    assert items[0]["session_id"] == ctx.session_id
+    assert items[0]["kind"] in ("ask_user", "approval", "watch_files", "sleep")
+    assert items[0]["prompt"] == "What is your name?"
+    assert items[0]["tool_call_id"] == "tcid-ask-1"
+
+
+async def test_session_scoped_pending_yields_empty_when_running(running_session_client):
+    client, ctx = running_session_client
+    resp = await client.get(
+        f"/v1/workspaces/{ctx.workspace_id}/sessions/{ctx.session_id}/yields/pending"
+    )
+    assert resp.status_code == 200
+    assert resp.json()["items"] == []
+
+
+async def test_session_scoped_pending_yields_404_for_wrong_workspace(parked_session_client):
+    """A session id that exists but belongs to a different workspace 404s."""
+    client, ctx = parked_session_client
+    resp = await client.get(
+        f"/v1/workspaces/not-{ctx.workspace_id}/sessions/{ctx.session_id}/yields/pending"
+    )
+    assert resp.status_code == 404
+
+
+async def test_session_scoped_pending_yields_404_for_unknown_session(client):
+    resp = await client.get(
+        "/v1/workspaces/ws-yields-scoped-unknown/sessions/no-such-session/yields/pending"
+    )
+    assert resp.status_code == 404

--- a/tests/api/test_sessions.py
+++ b/tests/api/test_sessions.py
@@ -330,6 +330,20 @@ async def test_create_session_with_auto_start_enqueues(
     assert body["started_at"] is not None
 
 
+async def test_create_session_persists_autonomous_flag(
+    sessions_client, seeded_workspace, seeded_agent,
+):
+    resp = await sessions_client.post(
+        f"/v1/workspaces/{seeded_workspace.id}/sessions",
+        json={
+            "binding": {"kind": "agent", "agent_id": seeded_agent.id},
+            "autonomous": True,
+        },
+    )
+    assert resp.status_code == 201, resp.text
+    assert resp.json()["autonomous"] is True
+
+
 async def test_create_session_unknown_workspace_404(
     sessions_client, seeded_agent,
 ):

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -1448,8 +1448,9 @@ class TestWorkspacesToolsetRegistration:
         ):
             assert name in names, f"missing {name}"
         # 28 minus watch_files + invoke_graph (moved to workspace_ext) = 26,
-        # plus workspace_tap (the workspace tap MCP drain tool) = 27.
-        assert len(names) == 27
+        # plus workspace_tap (the workspace tap MCP drain tool) = 27, plus
+        # restart_workspace_session (Task 8) = 28.
+        assert len(names) == 28
         assert "create_workspace_session" in names
         assert "cancel_workspace_session" in names
         assert "workspace_tap" in names

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -1034,14 +1034,57 @@ class TestSessionsSubResource:
         assert resume.json()["status"] == "running"
 
     @pytest.mark.asyncio
-    async def test_steer(self, client, wsr) -> None:
+    async def test_steer(self, client, wsr, sp) -> None:
+        # Steer now auto-wakes (Task 4): the route requires a persisted
+        # WorkspaceSession row to re-arm, same seeding as pause/resume above.
+        from primer.model.workspace_session import (
+            AgentSessionBinding,
+            WorkspaceSession,
+        )
+
         wid = await self._setup(client, wsr)
+        session = WorkspaceSession(
+            id="sess-1",
+            workspace_id=wid,
+            binding=AgentSessionBinding(agent_id="agt-1"),
+            status=SessionStatus.RUNNING,
+            created_at=datetime.now(timezone.utc),
+            started_at=datetime.now(timezone.utc),
+        )
+        await sp.get_storage(WorkspaceSession).create(session)
         resp = await client.post(
             f"/v1/workspaces/{wid}/sessions/sess-1/steer",
             json={"instruction": "please write tests"},
         )
-        assert resp.status_code == 200
-        assert resp.json()["content"] == "please write tests"
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "running"
+        assert body["turn_status"] == "claimable"
+
+    @pytest.mark.asyncio
+    async def test_steer_wakes_created_session(self, client, wsr, sp) -> None:
+        from primer.model.workspace_session import (
+            AgentSessionBinding,
+            WorkspaceSession,
+        )
+
+        wid = await self._setup(client, wsr)
+        session = WorkspaceSession(
+            id="sess-1",
+            workspace_id=wid,
+            binding=AgentSessionBinding(agent_id="agt-1"),
+            status=SessionStatus.CREATED,
+            created_at=datetime.now(timezone.utc),
+        )
+        await sp.get_storage(WorkspaceSession).create(session)
+        resp = await client.post(
+            f"/v1/workspaces/{wid}/sessions/sess-1/steer",
+            json={"instruction": "start working"},
+        )
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["status"] == "running"
+        assert body["turn_status"] == "claimable"
 
 
 # ===========================================================================

--- a/tests/session/test_autonomy.py
+++ b/tests/session/test_autonomy.py
@@ -1,0 +1,39 @@
+from datetime import datetime, timezone
+
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    GraphSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+from primer.session.autonomy import session_is_autonomous
+
+
+def _mk(binding, autonomous=None):
+    return WorkspaceSession(
+        id="sess-x",
+        workspace_id="ws-1",
+        binding=binding,
+        status=SessionStatus.CREATED,
+        autonomous=autonomous,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def test_graph_binding_defaults_autonomous():
+    s = _mk(GraphSessionBinding(graph_id="g1"))
+    assert session_is_autonomous(s) is True
+
+
+def test_agent_binding_defaults_interactive():
+    s = _mk(AgentSessionBinding(agent_id="a1"))
+    assert session_is_autonomous(s) is False
+
+
+def test_explicit_flag_overrides_binding():
+    # An agent running a self-driving loop is marked autonomous at create.
+    s = _mk(AgentSessionBinding(agent_id="a1"), autonomous=True)
+    assert session_is_autonomous(s) is True
+    # A graph explicitly forced interactive (rare) honours the flag.
+    g = _mk(GraphSessionBinding(graph_id="g1"), autonomous=False)
+    assert session_is_autonomous(g) is False

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -451,6 +451,50 @@ async def test_cancel_requested_on_entry_ends_without_executor(
 
 
 @pytest.mark.asyncio
+async def test_pause_requested_on_entry_clears_stale_interrupt_requested(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """A row that carries pause_requested=True AND a stale
+    interrupt_requested=True (left over from an earlier turn that never
+    consumed it) must transition to PAUSED with interrupt_requested cleared
+    — otherwise a later /resume could downgrade a genuine Cancel to a Stop."""
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    seeded_session.pause_requested = True
+    seeded_session.pause_requested_at = _now()
+    seeded_session.interrupt_requested = True
+    await storage.update(seeded_session)
+
+    executor_called = False
+
+    async def _build_executor(session: WorkspaceSession):
+        nonlocal executor_called
+        executor_called = True
+        return FakeExecutor([])
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    lease = _make_lease(seeded_session.id)
+    outcome = await run_one_session_turn(lease, deps)
+
+    assert outcome.success is True
+    assert outcome.drop_lease is True
+    assert outcome.preserve_park is True
+    assert not executor_called, (
+        "executor must NOT be built when pause_requested is set on entry"
+    )
+    row = await storage.get(seeded_session.id)
+    assert row.status == SessionStatus.PAUSED
+    assert row.interrupt_requested is False
+
+
+@pytest.mark.asyncio
 async def test_already_ended_row_drops_lease_without_executor(
     seeded_session: WorkspaceSession,
     fake_workspace_io: FakeWorkspaceIO,

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -779,3 +779,184 @@ async def test_interrupt_mid_stream_lands_waiting_and_clears_flag(
     )
     assert row.ended_at is None
     assert row.interrupt_requested is False
+
+
+@pytest.mark.asyncio
+async def test_real_cancel_wins_over_stuck_interrupt_flag(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """I2 regression: a stale interrupt_requested=True (leaked from an
+    earlier turn that never consumed it) must not downgrade a genuine
+    concurrent Cancel to a Stop. Cancel is the stronger intent: when
+    cancel_requested is ALSO true at the disambiguation point, the row
+    must land ENDED/cancelled, not WAITING."""
+    import json
+
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    # Stale interrupt flag, as if left over from a previous turn that
+    # completed/parked/failed before ever consuming it.
+    seeded_session.interrupt_requested = True
+    await storage.update(seeded_session)
+
+    gate = asyncio.Event()
+
+    class _SlowExecutor:
+        async def invoke(self, messages: list[Any], **kwargs: Any):
+            yield TextDelta(text="starting…", index=0)
+            await gate.wait()
+            yield TextDelta(text="should-not-persist", index=0)
+
+    async def _build_executor(session: WorkspaceSession):
+        return _SlowExecutor()
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    lease = _make_lease(seeded_session.id)
+
+    turn_task = asyncio.create_task(run_one_session_turn(lease, deps))
+
+    await asyncio.sleep(0.05)
+    # A genuine hard cancel lands mid-turn (mirrors cancel_session()'s
+    # cancel_requested=True write; both interrupt and cancel publish the
+    # same "session:{id}:cancel" bus event).
+    row = await storage.get(seeded_session.id)
+    row.cancel_requested = True
+    await storage.update(row)
+    await fake_event_bus.publish(f"session:{seeded_session.id}:cancel", {})
+    await asyncio.sleep(0.05)
+    gate.set()
+
+    outcome = await asyncio.wait_for(turn_task, timeout=2.0)
+
+    assert outcome.success is True
+    assert outcome.drop_lease is True
+
+    lines = fake_workspace_io.read_lines(seeded_session.id)
+    records = [json.loads(ln) for ln in lines]
+    kinds = [r["kind"] for r in records]
+    assert SessionMessageKind.CANCELLED in kinds
+
+    # The functionally meaningful assertion: cancel must win the
+    # disambiguation, landing the row ENDED/cancelled (terminal) rather
+    # than WAITING (a Stop leaves the session alive). Note the CANCELLED
+    # record's payload["reason"] text is not a reliable signal here: it's
+    # sourced from a `cancel_reason` local that's hardcoded to
+    # "operator_interrupt" on both branches (a pre-existing, unrelated
+    # cosmetic gap) -- the row's status/ended_reason is the real contract.
+    row = await storage.get(seeded_session.id)
+    assert row.status == SessionStatus.ENDED, (
+        f"cancel was downgraded to a stop: row left at {row.status!r} "
+        "instead of ENDED"
+    )
+    assert row.ended_reason == "cancelled"
+
+
+@pytest.mark.asyncio
+async def test_interrupt_requested_cleared_after_clean_completion(
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """I2 regression: a stale interrupt_requested=True that this turn
+    never consumed (e.g. it completed cleanly before any cancel event
+    fired) must not survive past the turn -- every terminal path clears
+    it, not just the interrupt-disambiguation branch, so it can't leak
+    into and downgrade a future genuine Cancel."""
+    session = await _seed_session(fake_storage_provider, autonomous=True)
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    session.interrupt_requested = True
+    await storage.update(session)
+
+    fake_executor = FakeExecutor([
+        Done(stop_reason="stop", raw_reason="stop"),
+    ])
+
+    async def _build_executor(_session: WorkspaceSession):
+        return fake_executor
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    lease = _make_lease(session.id)
+    outcome = await run_one_session_turn(lease, deps)
+
+    assert outcome.success is True
+    row = await storage.get(session.id)
+    assert row.status == SessionStatus.ENDED
+    assert row.ended_reason == "completed"
+    assert row.interrupt_requested is False
+
+
+# ---------------------------------------------------------------------------
+# C1 — steering a RUNNING session must not strand the queued turn
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_turn_start_consumes_claimable_and_mid_turn_steer_survives(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """C1 regression (dispatch-side half): run_one_session_turn must (a)
+    consume ("idle") a turn_status="claimable" it started with -- proving
+    a stale, already-serviced claimable can't spin-claim this session
+    forever -- and (b) leave turn_status="claimable" on the row if a NEW
+    wake_session() steer lands mid-turn, so the worker pool's
+    post-release re-arm (WorkerPool._maybe_rearm_session, exercised
+    end-to-end in tests/worker/test_pool.py) has a real signal to act on."""
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    seeded_session.turn_status = "claimable"
+    await storage.update(seeded_session)
+
+    seen_turn_status_at_start = None
+
+    class _SteeringExecutor:
+        async def invoke(self, messages: list[Any], **kwargs: Any):
+            nonlocal seen_turn_status_at_start
+            # By the time the executor is invoked, the turn-start consume
+            # step must already have cleared turn_status to "idle".
+            row = await storage.get(seeded_session.id)
+            seen_turn_status_at_start = row.turn_status
+            yield TextDelta(text="thinking", index=0)
+            # Simulate a wake_session() steer landing mid-turn (its
+            # row-write half; the messages.jsonl append is irrelevant to
+            # this assertion).
+            fresh = await storage.get(seeded_session.id)
+            fresh.turn_status = "claimable"
+            await storage.update(fresh)
+            yield Done(stop_reason="stop", raw_reason="stop")
+
+    async def _build_executor(session: WorkspaceSession):
+        return _SteeringExecutor()
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    lease = _make_lease(seeded_session.id)
+    outcome = await run_one_session_turn(lease, deps)
+
+    assert outcome.success is True
+    assert seen_turn_status_at_start == "idle", (
+        "turn-start must consume ('idle') a claimable it started with, "
+        f"but the executor saw {seen_turn_status_at_start!r}"
+    )
+    row = await storage.get(seeded_session.id)
+    assert row.turn_status == "claimable", (
+        "a steer landing mid-turn must survive to release so the pool's "
+        "re-arm can see it"
+    )

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -702,3 +702,80 @@ async def test_build_executor_notfound_converges_to_ended_failed(
         f"session left at {row.status!r} instead of ENDED"
     )
     assert row.ended_reason == "failed"
+
+
+# ---------------------------------------------------------------------------
+# Task 9 — Stop (interrupt) stays alive: WAITING, not ENDED
+# ---------------------------------------------------------------------------
+
+
+def test_interrupt_transitions_to_waiting_not_ended() -> None:
+    from primer.session.dispatch import _interrupt_post_status
+
+    assert _interrupt_post_status() == (SessionStatus.WAITING, None)
+
+
+@pytest.mark.asyncio
+async def test_interrupt_mid_stream_lands_waiting_and_clears_flag(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """Interrupt (Stop) published mid-stream: CANCELLED record written
+    (reason='operator_interrupt'), but the row lands WAITING — alive —
+    instead of ENDED, and interrupt_requested is cleared so the next
+    turn is not re-interrupted."""
+    import json
+
+    # Flip the row's interrupt flag on disk — mirrors what the
+    # /interrupt route does for a RUNNING session.
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    seeded_session.interrupt_requested = True
+    await storage.update(seeded_session)
+
+    gate = asyncio.Event()
+
+    class _SlowExecutor:
+        async def invoke(self, messages: list[Any], **kwargs: Any):
+            yield TextDelta(text="starting…", index=0)
+            await gate.wait()
+            yield TextDelta(text="should-not-persist", index=0)
+
+    async def _build_executor(session: WorkspaceSession):
+        return _SlowExecutor()
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    lease = _make_lease(seeded_session.id)
+
+    turn_task = asyncio.create_task(run_one_session_turn(lease, deps))
+
+    await asyncio.sleep(0.05)
+    await fake_event_bus.publish(f"session:{seeded_session.id}:cancel", {})
+    await asyncio.sleep(0.05)
+    gate.set()
+
+    outcome = await asyncio.wait_for(turn_task, timeout=2.0)
+
+    assert outcome.success is True
+    assert outcome.drop_lease is True
+
+    lines = fake_workspace_io.read_lines(seeded_session.id)
+    records = [json.loads(ln) for ln in lines]
+    kinds = [r["kind"] for r in records]
+    assert SessionMessageKind.CANCELLED in kinds
+    assert SessionMessageKind.DONE not in kinds
+    cancelled = next(r for r in records if r["kind"] == SessionMessageKind.CANCELLED)
+    assert cancelled["payload"]["reason"] == "operator_interrupt"
+
+    row = await storage.get(seeded_session.id)
+    assert row.status == SessionStatus.WAITING, (
+        f"interrupted session left at {row.status!r} instead of WAITING"
+    )
+    assert row.ended_at is None
+    assert row.interrupt_requested is False

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -95,12 +95,15 @@ class FakeExecutor:
 async def _seed_session(
     storage_provider,
     session_id: str = "s1",
+    *,
+    autonomous: bool | None = None,
 ) -> WorkspaceSession:
     sess = WorkspaceSession(
         id=session_id,
         workspace_id="w1",
         binding=AgentSessionBinding(agent_id="ag1"),
         status=SessionStatus.RUNNING,
+        autonomous=autonomous,
         created_at=_now(),
         turn_status="running",
     )
@@ -483,14 +486,16 @@ async def test_already_ended_row_drops_lease_without_executor(
 
 @pytest.mark.asyncio
 async def test_clean_completion_transitions_to_ended_completed(
-    seeded_session: WorkspaceSession,
     fake_workspace_io: FakeWorkspaceIO,
     fake_event_bus: InMemoryEventBus,
     fake_storage_provider,
 ) -> None:
-    """After a clean turn (Done with stop_reason='stop'), the session
-    row MUST transition to ENDED/completed. Pre-fix the row stayed
-    at RUNNING forever — a one-shot session would never end."""
+    """After a clean turn (Done with stop_reason='stop'), an AUTONOMOUS
+    session's row MUST transition to ENDED/completed. Pre-fix the row
+    stayed at RUNNING forever — a one-shot session would never end.
+    (Seeded ``autonomous=True`` — an interactive agent session now stays
+    WAITING instead; see test_dispatch_interactive_alive.py.)"""
+    session = await _seed_session(fake_storage_provider, autonomous=True)
     fake_executor = FakeExecutor([
         TextDelta(text="4", index=0),
         Done(stop_reason="stop", raw_reason="stop"),
@@ -505,13 +510,13 @@ async def test_clean_completion_transitions_to_ended_completed(
         event_bus=fake_event_bus,
         build_executor=_build_executor,
     )
-    lease = _make_lease(seeded_session.id)
+    lease = _make_lease(session.id)
     outcome = await run_one_session_turn(lease, deps)
 
     assert outcome.success is True
 
     storage = fake_storage_provider.get_storage(WorkspaceSession)
-    row = await storage.get(seeded_session.id)
+    row = await storage.get(session.id)
     assert row.status == SessionStatus.ENDED
     assert row.ended_reason == "completed"
     assert row.ended_at is not None
@@ -540,7 +545,6 @@ class _ExecutorWithSession(FakeExecutor):
 
 @pytest.mark.asyncio
 async def test_clean_completion_mirrors_ended_onto_agent_session_slot(
-    seeded_session: WorkspaceSession,
     fake_workspace_io: FakeWorkspaceIO,
     fake_event_bus: InMemoryEventBus,
     fake_storage_provider,
@@ -551,7 +555,10 @@ async def test_clean_completion_mirrors_ended_onto_agent_session_slot(
     worker-run session as still ``running``. The executor leaves its
     AgentSession at RUNNING after a clean ``stop`` (dispatch decides ENDED),
     so without the mirror the slot would stay RUNNING forever.
+    (Seeded ``autonomous=True`` so this AUTONOMOUS-session case is unaffected
+    by the interactive-stays-WAITING behaviour.)
     """
+    session = await _seed_session(fake_storage_provider, autonomous=True)
     slot = _RecordingSlotSession()
     fake_executor = _ExecutorWithSession(
         [TextDelta(text="ok", index=0), Done(stop_reason="stop", raw_reason="stop")],
@@ -567,11 +574,11 @@ async def test_clean_completion_mirrors_ended_onto_agent_session_slot(
         event_bus=fake_event_bus,
         build_executor=_build_executor,
     )
-    outcome = await run_one_session_turn(_make_lease(seeded_session.id), deps)
+    outcome = await run_one_session_turn(_make_lease(session.id), deps)
     assert outcome.success is True
     # The scheduler row AND the on-disk slot both reached ENDED/completed.
     storage = fake_storage_provider.get_storage(WorkspaceSession)
-    assert (await storage.get(seeded_session.id)).status == SessionStatus.ENDED
+    assert (await storage.get(session.id)).status == SessionStatus.ENDED
     assert slot.calls == [(SessionStatus.ENDED, "completed")]
 
 

--- a/tests/session/test_dispatch_interactive_alive.py
+++ b/tests/session/test_dispatch_interactive_alive.py
@@ -1,0 +1,32 @@
+from primer.model.workspace_session import SessionStatus
+from primer.session.dispatch import _post_turn_status
+
+
+def test_interactive_clean_stop_stays_waiting():
+    status, reason = _post_turn_status("stop", None, is_autonomous=False)
+    assert status == SessionStatus.WAITING
+    assert reason is None
+
+
+def test_interactive_default_stays_waiting():
+    status, reason = _post_turn_status(None, None, is_autonomous=False)
+    assert status == SessionStatus.WAITING
+
+
+def test_autonomous_clean_stop_ends():
+    status, reason = _post_turn_status("stop", None, is_autonomous=True)
+    assert status == SessionStatus.ENDED
+    assert reason == "completed"
+
+
+def test_error_ends_for_both():
+    for auto in (True, False):
+        status, reason = _post_turn_status("error", None, is_autonomous=auto)
+        assert status == SessionStatus.ENDED
+        assert reason == "failed"
+
+
+def test_tool_use_keeps_running_for_both():
+    for auto in (True, False):
+        status, _ = _post_turn_status("tool_use", None, is_autonomous=auto)
+        assert status == SessionStatus.RUNNING

--- a/tests/session/test_enqueue.py
+++ b/tests/session/test_enqueue.py
@@ -1,0 +1,161 @@
+from datetime import datetime, timezone
+
+import pytest
+
+from primer.int.claim import ClaimKind
+from primer.model.except_ import ConflictError, NotFoundError
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+from primer.session.enqueue import SessionWakeDeps, wake_session
+
+
+class _FakeStorage:
+    def __init__(self, row):
+        self._row = row
+
+    async def get(self, sid):
+        return self._row if self._row and self._row.id == sid else None
+
+    async def update(self, row):
+        self._row = row
+        return row
+
+
+class _FakeSP:
+    def __init__(self, row):
+        self._s = _FakeStorage(row)
+
+    def get_storage(self, cls):
+        return self._s
+
+
+class _FakeSlot:
+    def __init__(self):
+        self.appended = []
+
+    async def append_instruction(self, content):
+        self.appended.append(content)
+
+
+class _FakeWorkspace:
+    def __init__(self, slot):
+        self._slot = slot
+
+    async def get_session(self, sid):
+        return self._slot
+
+
+class _FakeRegistry:
+    def __init__(self, ws):
+        self._ws = ws
+
+    async def get_workspace(self, wid):
+        return self._ws
+
+
+class _FakeScheduler:
+    def __init__(self):
+        self.enqueued = []
+
+    async def enqueue(self, sid):
+        self.enqueued.append(sid)
+
+
+class _FakeEngine:
+    def __init__(self):
+        self.upserts = []
+
+    async def upsert(self, kind, sid, *, priority=100, next_attempt_at=None):
+        self.upserts.append((kind, sid))
+
+
+def _row(status, autonomous=None):
+    return WorkspaceSession(
+        id="sess-1",
+        workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="a1"),
+        status=status,
+        autonomous=autonomous,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+def _deps(row):
+    slot = _FakeSlot()
+    sched = _FakeScheduler()
+    eng = _FakeEngine()
+    deps = SessionWakeDeps(
+        storage_provider=_FakeSP(row),
+        scheduler=sched,
+        claim_engine=eng,
+        workspace_registry=_FakeRegistry(_FakeWorkspace(slot)),
+    )
+    return deps, slot, sched, eng
+
+
+@pytest.mark.asyncio
+async def test_created_session_is_invoked_and_claimable():
+    row = _row(SessionStatus.CREATED)
+    deps, slot, sched, eng = _deps(row)
+    out = await wake_session(
+        workspace_id="ws-1", session_id="sess-1",
+        instruction="hello", deps=deps,
+    )
+    assert out.status == SessionStatus.RUNNING
+    assert out.turn_status == "claimable"
+    assert slot.appended == ["hello"]
+    assert sched.enqueued == ["sess-1"]
+    assert (ClaimKind.SESSION, "sess-1") in eng.upserts
+
+
+@pytest.mark.asyncio
+async def test_running_session_is_steered_without_status_change():
+    row = _row(SessionStatus.RUNNING)
+    deps, slot, sched, eng = _deps(row)
+    out = await wake_session(
+        workspace_id="ws-1", session_id="sess-1",
+        instruction="steer me", deps=deps,
+    )
+    assert out.status == SessionStatus.RUNNING
+    assert out.turn_status == "claimable"
+    assert slot.appended == ["steer me"]
+    assert sched.enqueued == ["sess-1"]
+
+
+@pytest.mark.asyncio
+async def test_paused_session_resumes_and_clears_pause():
+    row = _row(SessionStatus.PAUSED)
+    row.pause_requested = True
+    deps, slot, sched, eng = _deps(row)
+    out = await wake_session(
+        workspace_id="ws-1", session_id="sess-1",
+        instruction=None, deps=deps,
+    )
+    assert out.status == SessionStatus.RUNNING
+    assert out.pause_requested is False
+    assert slot.appended == []  # no instruction supplied
+    assert sched.enqueued == ["sess-1"]
+
+
+@pytest.mark.asyncio
+async def test_ended_session_raises_conflict():
+    row = _row(SessionStatus.ENDED)
+    deps, *_ = _deps(row)
+    with pytest.raises(ConflictError):
+        await wake_session(
+            workspace_id="ws-1", session_id="sess-1",
+            instruction="x", deps=deps,
+        )
+
+
+@pytest.mark.asyncio
+async def test_missing_session_raises_not_found():
+    deps, *_ = _deps(None)
+    with pytest.raises(NotFoundError):
+        await wake_session(
+            workspace_id="ws-1", session_id="sess-1",
+            instruction="x", deps=deps,
+        )

--- a/tests/session/test_reset.py
+++ b/tests/session/test_reset.py
@@ -96,6 +96,21 @@ async def test_reset_reopens_row_and_writes_divider():
 
 
 @pytest.mark.asyncio
+async def test_reset_clears_stale_interrupt_requested():
+    row = _ended_row()
+    row.interrupt_requested = True
+    slot = _Slot()
+    ws = _WS(slot)
+    deps = SessionResetDeps(
+        storage_provider=_SP(row), workspace_registry=_Registry(ws),
+    )
+    out, _invocation = await reset_session(
+        workspace_id="ws-1", session_id="sess-1", deps=deps,
+    )
+    assert out.interrupt_requested is False
+
+
+@pytest.mark.asyncio
 async def test_reset_rejects_non_ended():
     row = _ended_row()
     row.status = SessionStatus.RUNNING

--- a/tests/session/test_reset.py
+++ b/tests/session/test_reset.py
@@ -1,0 +1,116 @@
+# tests/session/test_reset.py
+from datetime import datetime, timezone
+
+import pytest
+
+from primer.model.except_ import ConflictError
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionMessageKind,
+    SessionStatus,
+    WorkspaceSession,
+)
+from primer.session.reset import SessionResetDeps, reset_session
+
+
+class _Storage:
+    def __init__(self, row):
+        self._row = row
+
+    async def get(self, sid):
+        return self._row if self._row and self._row.id == sid else None
+
+    async def update(self, row):
+        self._row = row
+        return row
+
+
+class _SP:
+    def __init__(self, row):
+        self._s = _Storage(row)
+
+    def get_storage(self, cls):
+        return self._s
+
+
+class _Slot:
+    def __init__(self):
+        self.reopened = False
+
+    async def reopen(self):
+        self.reopened = True
+
+
+class _WS:
+    def __init__(self, slot):
+        self._slot = slot
+        self.lines = []
+
+    async def get_session(self, sid):
+        return self._slot
+
+    async def append_message_line(self, session_id, line):
+        self.lines.append(line)
+
+
+class _Registry:
+    def __init__(self, ws):
+        self._ws = ws
+
+    async def get_workspace(self, wid):
+        return self._ws
+
+
+def _ended_row(reason="completed", last_seq=5):
+    return WorkspaceSession(
+        id="sess-1",
+        workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="a1"),
+        status=SessionStatus.ENDED,
+        ended_reason=reason,
+        ended_at=datetime.now(timezone.utc),
+        last_seq=last_seq,
+        created_at=datetime.now(timezone.utc),
+    )
+
+
+@pytest.mark.asyncio
+async def test_reset_reopens_row_and_writes_divider():
+    row = _ended_row()
+    slot = _Slot()
+    ws = _WS(slot)
+    deps = SessionResetDeps(
+        storage_provider=_SP(row), workspace_registry=_Registry(ws),
+    )
+    out, invocation = await reset_session(
+        workspace_id="ws-1", session_id="sess-1", deps=deps,
+    )
+    assert out.status == SessionStatus.CREATED
+    assert out.ended_reason is None
+    assert out.ended_at is None
+    assert out.turn_status == "idle"
+    assert slot.reopened is True
+    assert invocation == 2
+    assert len(ws.lines) == 1
+    assert SessionMessageKind.INVOCATION_DIVIDER.value in ws.lines[0].decode()
+
+
+@pytest.mark.asyncio
+async def test_reset_rejects_non_ended():
+    row = _ended_row()
+    row.status = SessionStatus.RUNNING
+    deps = SessionResetDeps(
+        storage_provider=_SP(row), workspace_registry=_Registry(_WS(_Slot())),
+    )
+    with pytest.raises(ConflictError):
+        await reset_session(workspace_id="ws-1", session_id="sess-1", deps=deps)
+
+
+@pytest.mark.asyncio
+async def test_reset_rejects_workspace_lost():
+    row = _ended_row(reason="workspace_lost")
+    deps = SessionResetDeps(
+        storage_provider=_SP(row), workspace_registry=_Registry(_WS(_Slot())),
+    )
+    with pytest.raises(ConflictError):
+        await reset_session(workspace_id="ws-1", session_id="sess-1", deps=deps)

--- a/tests/test_session_models.py
+++ b/tests/test_session_models.py
@@ -357,6 +357,9 @@ class TestSessionMessageKind:
             # Graph-runtime node enter/exit transition (spec §2.6 /
             # plan Task 3.1). Shared 1:1 with TapEventClass.GRAPH_TRANSITION.
             "graph_transition",
+            # Reset-same-session ENDED->CREATED marker (studio-agents-interact
+            # §5.2 / plan Task 6).
+            "invocation_divider",
         }
         actual = {k.value for k in SessionMessageKind}
         assert actual == expected

--- a/tests/toolset/test_restart_workspace_session.py
+++ b/tests/toolset/test_restart_workspace_session.py
@@ -1,0 +1,225 @@
+"""Unit tests for the ``restart_workspace_session`` internal tool.
+
+Mirrors ``tests/api/test_session_restart.py``'s fakes (a workspace slot
+with ``reopen``/``append_instruction`` for reset + wake, and
+``append_message_line`` so the invocation divider round-trips through
+``primer.session.reset.reset_session``) but drives the toolset handler
+directly instead of the REST route.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from primer.toolset.workspaces import build_workspaces_toolset
+
+
+def _now() -> datetime:
+    return datetime(2026, 6, 5, 10, 0, 0, tzinfo=timezone.utc)
+
+
+class _FakeSlot:
+    def __init__(self) -> None:
+        self.reopened = False
+        self.instructions: list[str] = []
+
+    async def reopen(self) -> None:
+        self.reopened = True
+
+    async def append_instruction(self, instruction: str) -> None:
+        self.instructions.append(instruction)
+
+
+class _FakeWorkspace:
+    state_path = ".state"
+
+    def __init__(self) -> None:
+        self._files: dict[str, bytes] = {}
+        self.slots: dict[str, _FakeSlot] = {}
+
+    async def get_session(self, session_id: str) -> _FakeSlot:
+        return self.slots.setdefault(session_id, _FakeSlot())
+
+    async def append_message_line(self, session_id: str, line: bytes) -> None:
+        path = f"{self.state_path}/sessions/{session_id}/messages.jsonl"
+        self._files[path] = self._files.get(path, b"") + line
+
+
+class _Registry:
+    def __init__(self, ws: _FakeWorkspace) -> None:
+        self._ws = ws
+
+    async def get_workspace(self, workspace_id: str) -> _FakeWorkspace:
+        return self._ws
+
+
+class _Storage:
+    def __init__(self) -> None:
+        self._data: dict = {}
+
+    async def get(self, sid):
+        return self._data.get(sid)
+
+    async def create(self, row):
+        self._data[row.id] = row
+        return row
+
+    async def update(self, row):
+        self._data[row.id] = row
+        return row
+
+
+class _SP:
+    def __init__(self) -> None:
+        self._s = _Storage()
+
+    def get_storage(self, cls):
+        return self._s
+
+
+class _FakeScheduler:
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+
+    async def enqueue(self, sid: str) -> None:
+        self.enqueued.append(sid)
+
+
+class _FakeClaimEngine:
+    def __init__(self) -> None:
+        self.upserts: list[tuple] = []
+
+    async def upsert(self, kind, entity_id, *, priority=100, next_attempt_at=None):
+        self.upserts.append((kind, entity_id))
+
+    async def delete_lease(self, kind, entity_id):
+        pass
+
+
+def _seed_session(sp: _SP, *, sid: str, wid: str, status, ended_reason=None):
+    from primer.model.workspace_session import (
+        AgentSessionBinding,
+        WorkspaceSession,
+    )
+
+    sess = WorkspaceSession(
+        id=sid,
+        workspace_id=wid,
+        binding=AgentSessionBinding(agent_id="ag1"),
+        status=status,
+        ended_reason=ended_reason,
+        ended_at=_now() if ended_reason is not None else None,
+        last_seq=3,
+        turn_status="idle",
+        created_at=_now(),
+    )
+    sp._s._data[sid] = sess
+    return sess
+
+
+@pytest.fixture
+def sp() -> _SP:
+    return _SP()
+
+
+@pytest.fixture
+def ws() -> _FakeWorkspace:
+    return _FakeWorkspace()
+
+
+@pytest.fixture
+def registry(ws) -> _Registry:
+    return _Registry(ws)
+
+
+@pytest.fixture
+def session_toolset(sp, registry):
+    return build_workspaces_toolset(
+        storage_provider=sp,
+        workspace_registry=registry,
+        scheduler=_FakeScheduler(),
+        claim_engine=_FakeClaimEngine(),
+        event_bus=None,
+    )
+
+
+class TestRestartWorkspaceSession:
+    @pytest.mark.asyncio
+    async def test_restart_tool_reopens_ended_session(
+        self, session_toolset, sp
+    ) -> None:
+        from primer.model.workspace_session import SessionStatus
+
+        _seed_session(
+            sp,
+            sid="sess-1",
+            wid="ws-1",
+            status=SessionStatus.ENDED,
+            ended_reason="completed",
+        )
+        result = await session_toolset.call(
+            tool_name="restart_workspace_session",
+            arguments={
+                "workspace_id": "ws-1",
+                "session_id": "sess-1",
+                "input": "restarted by tool",
+            },
+        )
+        assert not result.is_error, result.output
+        payload = json.loads(result.output)
+        assert payload["status"] == "running"
+        assert payload["turn_status"] == "claimable"
+        assert payload["metadata"]["invocation"] == 2
+
+    @pytest.mark.asyncio
+    async def test_restart_active_session_is_conflict(
+        self, session_toolset, sp
+    ) -> None:
+        from primer.model.workspace_session import SessionStatus
+
+        _seed_session(
+            sp, sid="sess-1", wid="ws-1", status=SessionStatus.RUNNING,
+        )
+        result = await session_toolset.call(
+            tool_name="restart_workspace_session",
+            arguments={"workspace_id": "ws-1", "session_id": "sess-1"},
+        )
+        assert result.is_error
+        assert json.loads(result.output)["type"] == "conflict"
+
+    @pytest.mark.asyncio
+    async def test_restart_missing_session_is_not_found(
+        self, session_toolset
+    ) -> None:
+        result = await session_toolset.call(
+            tool_name="restart_workspace_session",
+            arguments={"workspace_id": "ws-1", "session_id": "nope"},
+        )
+        assert result.is_error
+        assert json.loads(result.output)["type"] == "not-found"
+
+    @pytest.mark.asyncio
+    async def test_restart_without_scheduler_is_unavailable(
+        self, sp, registry
+    ) -> None:
+        ts = build_workspaces_toolset(
+            storage_provider=sp,
+            workspace_registry=registry,
+            scheduler=None,
+            claim_engine=None,
+            event_bus=None,
+        )
+        result = await ts.call(
+            tool_name="restart_workspace_session",
+            arguments={"workspace_id": "ws-1", "session_id": "sess-1"},
+        )
+        assert result.is_error
+        assert json.loads(result.output)["type"] == "unavailable"
+
+    @pytest.mark.asyncio
+    async def test_restart_is_registered_in_catalog(self, session_toolset) -> None:
+        ids = [t.id async for t in session_toolset.list_tools()]
+        assert "restart_workspace_session" in ids

--- a/tests/toolset/test_workspaces.py
+++ b/tests/toolset/test_workspaces.py
@@ -396,11 +396,13 @@ class TestCatalog:
         assert WORKSPACES_TOOLSET_ID == "workspaces"
         names = [t.id async for t in toolset.list_tools()]
         # 28 minus watch_files + invoke_graph (both moved to the
-        # ``workspace_ext`` toolset) = 26, plus workspace_tap = 27.
-        assert len(names) == 27
+        # ``workspace_ext`` toolset) = 26, plus workspace_tap = 27, plus
+        # restart_workspace_session (Task 8) = 28.
+        assert len(names) == 28
         assert "create_workspace_session" in names
         assert "cancel_workspace_session" in names
         assert "workspace_tap" in names
+        assert "restart_workspace_session" in names
         # watch_files + invoke_graph moved to workspace_ext.
         assert "watch_files" not in names
         assert "invoke_graph" not in names
@@ -498,8 +500,9 @@ class TestBootstrapIngestsWorkspacesTools:
             if doc_id.startswith("workspaces::")
         }
         # 28 minus watch_files + invoke_graph (moved to workspace_ext) = 26,
-        # plus workspace_tap = 27.
-        assert len(ws_ingested) == 27
+        # plus workspace_tap = 27, plus restart_workspace_session (Task 8)
+        # = 28.
+        assert len(ws_ingested) == 28
         for expected in (
             "workspaces::list_workspace_providers",
             "workspaces::create_workspace_template",

--- a/tests/toolset/test_workspaces.py
+++ b/tests/toolset/test_workspaces.py
@@ -595,16 +595,9 @@ class TestSubResourceHandlers:
             arguments={"workspace_id": seeded, "session_id": "sess-1"},
         )
         assert not resume.is_error
-        steer = await toolset.call(
-            tool_name="steer_workspace_session",
-            arguments={
-                "workspace_id": seeded,
-                "session_id": "sess-1",
-                "instruction": "go",
-            },
-        )
-        assert not steer.is_error
-        assert json.loads(steer.output)["content"] == "go"
+        # steer_workspace_session now auto-wakes (needs scheduler/claim_engine
+        # + a persisted WorkspaceSession row) — covered by TestSteerWorkspaceSession
+        # below via ``session_toolset``.
 
     @pytest.mark.asyncio
     async def test_file_ops_text_round_trip(self, toolset, seeded) -> None:
@@ -863,8 +856,11 @@ class TestErrorPaths:
             assert json.loads(result.output)["type"] == "not-found"
 
     @pytest.mark.asyncio
-    async def test_steer_unknown_session(self, toolset, seeded) -> None:
-        result = await toolset.call(
+    async def test_steer_unknown_session(self, session_toolset, seeded) -> None:
+        # steer_workspace_session now needs scheduler/claim_engine wired
+        # (auto-wake) to get past the ``unavailable`` guard — use
+        # ``session_toolset`` (defined below, alongside its fakes).
+        result = await session_toolset.call(
             tool_name="steer_workspace_session",
             arguments={
                 "workspace_id": seeded,
@@ -876,8 +872,8 @@ class TestErrorPaths:
         assert json.loads(result.output)["type"] == "not-found"
 
     @pytest.mark.asyncio
-    async def test_steer_unknown_workspace(self, toolset) -> None:
-        result = await toolset.call(
+    async def test_steer_unknown_workspace(self, session_toolset) -> None:
+        result = await session_toolset.call(
             tool_name="steer_workspace_session",
             arguments={
                 "workspace_id": "no-such",
@@ -970,13 +966,14 @@ class TestErrorPaths:
     async def test_validation_error_on_each_subresource(self, toolset) -> None:
         # Each sub-resource handler validates its arg model before the
         # workspace lookup; supplying empty args triggers the
-        # validation-error branch.
+        # validation-error branch. ``steer_workspace_session`` is excluded
+        # here (like create/cancel) since it now checks scheduler/claim_engine
+        # availability before arg validation — see TestSteerWorkspaceSession.
         for tool_name in (
             "list_workspace_sessions",
             "get_workspace_session",
             "pause_workspace_session",
             "resume_workspace_session",
-            "steer_workspace_session",
             "list_workspace_files",
             "get_workspace_file_info",
             "read_workspace_file",
@@ -1216,6 +1213,77 @@ class TestCancelWorkspaceSession:
         result = await ts.call(
             tool_name="cancel_workspace_session",
             arguments={"workspace_id": "ws-stub", "session_id": "x"},
+        )
+        assert result.is_error
+        assert json.loads(result.output)["type"] == "unavailable"
+
+
+# ===========================================================================
+# steer_workspace_session tool (Task 4: auto-wake)
+# ===========================================================================
+
+
+class TestSteerWorkspaceSession:
+    @pytest.mark.asyncio
+    async def test_steer_wakes_created_session(
+        self, session_toolset, seeded, sp
+    ) -> None:
+        from primer.model.workspace_session import SessionStatus
+
+        _seed_session(
+            sp, status=SessionStatus.CREATED, sid="sess-c1", workspace_id=seeded
+        )
+        result = await session_toolset.call(
+            tool_name="steer_workspace_session",
+            arguments={
+                "workspace_id": seeded,
+                "session_id": "sess-c1",
+                "instruction": "go",
+            },
+        )
+        assert not result.is_error, result.output
+        body = json.loads(result.output)
+        assert body["status"] == "running"
+        assert body["turn_status"] == "claimable"
+
+    @pytest.mark.asyncio
+    async def test_steer_ended_session_is_conflict(
+        self, session_toolset, seeded, sp
+    ) -> None:
+        from primer.model.workspace_session import SessionStatus
+
+        _seed_session(
+            sp, status=SessionStatus.ENDED, sid="sess-c1", workspace_id=seeded
+        )
+        result = await session_toolset.call(
+            tool_name="steer_workspace_session",
+            arguments={
+                "workspace_id": seeded,
+                "session_id": "sess-c1",
+                "instruction": "go",
+            },
+        )
+        assert result.is_error
+        assert json.loads(result.output)["type"] == "conflict"
+
+    @pytest.mark.asyncio
+    async def test_steer_without_scheduler_is_unavailable(
+        self, sp, workspace_registry
+    ) -> None:
+        ts = build_workspaces_toolset(
+            storage_provider=sp,
+            workspace_registry=workspace_registry,
+            scheduler=None,
+            claim_engine=None,
+            event_bus=None,
+        )
+        result = await ts.call(
+            tool_name="steer_workspace_session",
+            arguments={
+                "workspace_id": "ws-stub",
+                "session_id": "x",
+                "instruction": "y",
+            },
         )
         assert result.is_error
         assert json.loads(result.output)["type"] == "unavailable"

--- a/tests/worker/test_pool.py
+++ b/tests/worker/test_pool.py
@@ -747,6 +747,147 @@ async def test_run_engine_session_releases_engine_lease_on_success(
     assert released[0][1].success is True
 
 
+# ---------------------------------------------------------------------------
+# C1 — steering a RUNNING (leased) session must not strand the queued turn
+# ---------------------------------------------------------------------------
+
+
+async def test_steering_a_running_session_rearms_a_fresh_claim(scheduler, monkeypatch):
+    """C1 regression, end-to-end at the claim-engine level.
+
+    Uses a REAL InMemoryClaimEngine + SessionClaimAdapter (not the old
+    unconditionally-recording _FakeEngine) so the held-lease upsert-is-a-
+    no-op semantics of the real engine are exercised. Sequence:
+      1. Genuinely claim the session's lease (mirrors claim_due handing it
+         to this worker).
+      2. Simulate a wake_session() steer landing WHILE the lease is held:
+         set turn_status="claimable" and upsert -- on the real engine this
+         is a no-op on the held lease's claimed_by, exactly the bug.
+      3. Drive _run_engine_session to completion (a fake run_one_session_turn
+         mirrors dispatch.py's real behaviour: it always drops the lease).
+      4. Assert a FRESH claim is now possible -- proving the queued turn is
+         not stranded.
+    """
+    from tests.conftest import _FakeStorageProvider
+    from primer.claim.adapters.sessions import SessionClaimAdapter
+    from primer.claim.in_memory import InMemoryClaimEngine
+
+    sid = "sess-steer-rearm-1"
+    sp = _FakeStorageProvider()
+    session_storage = sp.get_storage(WorkspaceSession)
+    fake_session = WorkspaceSession(
+        id=sid, workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="ag-1"),
+        status=SessionStatus.RUNNING,
+        created_at=datetime.now(timezone.utc),
+        turn_no=0,
+    )
+    await session_storage.create(fake_session)
+
+    adapter = SessionClaimAdapter(session_storage=session_storage)
+    real_engine = InMemoryClaimEngine(adapters={ClaimKind.SESSION: adapter})
+
+    pool = WorkerPool(
+        config=WorkerConfig(concurrency=1),
+        scheduler=scheduler,
+        storage=sp,
+        workspace_registry=None,     # type: ignore[arg-type]
+        provider_registry=None,      # type: ignore[arg-type]
+        engine=real_engine,
+        event_bus=None,
+    )
+    pool._worker_id = "wrk-test"
+
+    # 1. Genuinely claim the lease (as claim_due would for the worker
+    # about to run this session's turn).
+    await real_engine.upsert(ClaimKind.SESSION, sid)
+    [engine_lease] = await real_engine.claim_due("wrk-test", max_count=1)
+    assert engine_lease.entity_id == sid
+
+    # 2. Steer while the lease is held -- wake_session()'s exact write:
+    # flip turn_status + upsert. On the real engine this touches only
+    # priority/next_attempt_at on the still-claimed row.
+    row = await session_storage.get(sid)
+    row.turn_status = "claimable"
+    await session_storage.update(row)
+    await real_engine.upsert(ClaimKind.SESSION, sid)
+    held = real_engine._leases[(ClaimKind.SESSION, sid)]
+    assert held.claimed_by == "wrk-test", (
+        "steering while held must not itself release/reassign the lease"
+    )
+
+    # 3. Run the turn. dispatch.py always returns drop_lease=True.
+    with patch(
+        "primer.worker.pool.run_one_session_turn",
+        return_value=ReleaseOutcome(success=True, drop_lease=True),
+    ):
+        await pool._run_engine_session(engine_lease)
+
+    # The old lease is gone...
+    assert (ClaimKind.SESSION, sid) not in real_engine._leases or (
+        real_engine._leases[(ClaimKind.SESSION, sid)].claimed_by is None
+    )
+
+    # 4. ...but a FRESH claim must be possible: the queued turn is not
+    # stranded. A second worker can pick it up right away.
+    fresh_leases = await real_engine.claim_due("wrk-test-2", max_count=1)
+    assert [l.entity_id for l in fresh_leases] == [sid], (
+        "steering a RUNNING session left the queued turn unclaimable -- "
+        "the C1 regression"
+    )
+
+
+async def test_steering_a_running_session_no_rearm_when_nothing_queued(
+    scheduler, monkeypatch,
+):
+    """Sibling of the C1 regression test: when NO steer lands during the
+    turn, the post-release re-arm must be a no-op (no spin-claiming an
+    empty session)."""
+    from tests.conftest import _FakeStorageProvider
+    from primer.claim.adapters.sessions import SessionClaimAdapter
+    from primer.claim.in_memory import InMemoryClaimEngine
+
+    sid = "sess-steer-rearm-2"
+    sp = _FakeStorageProvider()
+    session_storage = sp.get_storage(WorkspaceSession)
+    fake_session = WorkspaceSession(
+        id=sid, workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="ag-1"),
+        status=SessionStatus.RUNNING,
+        created_at=datetime.now(timezone.utc),
+        turn_no=0,
+        turn_status="idle",
+    )
+    await session_storage.create(fake_session)
+
+    adapter = SessionClaimAdapter(session_storage=session_storage)
+    real_engine = InMemoryClaimEngine(adapters={ClaimKind.SESSION: adapter})
+
+    pool = WorkerPool(
+        config=WorkerConfig(concurrency=1),
+        scheduler=scheduler,
+        storage=sp,
+        workspace_registry=None,     # type: ignore[arg-type]
+        provider_registry=None,      # type: ignore[arg-type]
+        engine=real_engine,
+        event_bus=None,
+    )
+    pool._worker_id = "wrk-test"
+
+    await real_engine.upsert(ClaimKind.SESSION, sid)
+    [engine_lease] = await real_engine.claim_due("wrk-test", max_count=1)
+
+    with patch(
+        "primer.worker.pool.run_one_session_turn",
+        return_value=ReleaseOutcome(success=True, drop_lease=True),
+    ):
+        await pool._run_engine_session(engine_lease)
+
+    assert (ClaimKind.SESSION, sid) not in real_engine._leases, (
+        "no steer landed -- the session must not be re-armed"
+    )
+
+
 async def test_build_session_executor_returns_callable(scheduler, engine, monkeypatch):
     """pool._build_session_executor(session) returns an awaitable executor
     by delegating to _build_executor after resolving the workspace."""


### PR DESCRIPTION
Backend half of **studio-agents-interact**: turns a workspace `WorkspaceSession` into a persistent, *interactive* entity so the Studio can drive agents/graphs conversationally. Off `feat/studio-terminal-backend`; the UI half (session-backed chat run-view, tasks 11–14) follows after chat-refactor lands. Disjoint from the chat-refactor branch (session-side files only).

**What's in it (T1–T10):**
- **Autonomy model** — `WorkspaceSession.autonomous` + `session_is_autonomous()` (graph ⇒ autonomous; agent ⇒ interactive unless flagged), threaded through create route/factory/tool.
- **Auto-wake keystone** — `primer/session/enqueue.py::wake_session` unifies **invoke = steer = resume = "send a message"** (mirrors the chat lane); wired into `/steer` + the tool. Interactive sessions land `WAITING` (alive) after a clean turn instead of ENDED.
- **Reset-same-session** — guarded `ENDED→CREATED` reopen + an `INVOCATION_DIVIDER` marker (append-only history preserved), + `POST /sessions/{sid}/restart` route + `restart_workspace_session` tool.
- **Stop-interrupt** — interrupts the in-flight turn but stays `WAITING` (distinct from Cancel→ENDED).
- **Session-scoped pending yields** endpoint for inline stream affordances.

**Review:** opus checkpoint review → found a Critical auto-wake lease-stranding bug + an interrupt/cancel race → **fixed** (`5f87b04f`: re-arm steered sessions after lease release, `is_interrupt = interrupt_requested and not cancel_requested`, short lifecycle-lock critical sections) → **opus re-review: Approved** (steer-a-running-session responds, no deadlock/lost-event race) + a defense-in-depth Minor fix (`ac8b4292`). The ENDED-immutability relaxation is safely guarded (reset is the only sanctioned reopen). Autonomous graphs/loops unaffected.

Please review; do not merge on my behalf.

🤖 Generated with [Claude Code](https://claude.com/claude-code)