### PR TITLE
Studio interactive sessions — UI (session-backed chat, agent/graph run views, debug sidebar)

### DIFF
--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -214,12 +214,22 @@ async def run_one_session_turn(
     # earlier, already-serviced steer would never be cleared (nothing else
     # writes turn_status back to "idle") and would spin-claim this session
     # forever.
+    # Capture the row's CURRENT last_seq under the lifecycle lock — the SAME
+    # lock wake_session/reset_session hold for their own USER_INPUT / divider
+    # seq writes — so the per-turn writer is seeded with a value that already
+    # reflects any seq a preceding wake_session wrote before it pulsed the
+    # scheduler. This is the authoritative fresh read (not the possibly-cached
+    # `session` object loaded above), so it also covers the case where the
+    # worker's `session` snapshot predates that write.
+    seed_seq = session.last_seq
     async with session_lifecycle_lock().acquire(session_id):
         fresh_before_turn = await session_storage.get(session_id)
-        if fresh_before_turn is not None and fresh_before_turn.turn_status == "claimable":
-            await session_storage.update(
-                fresh_before_turn.model_copy(update={"turn_status": "idle"})
-            )
+        if fresh_before_turn is not None:
+            seed_seq = fresh_before_turn.last_seq
+            if fresh_before_turn.turn_status == "claimable":
+                await session_storage.update(
+                    fresh_before_turn.model_copy(update={"turn_status": "idle"})
+                )
 
     # ------------------------------------------------------------------
     # 2. Build executor
@@ -261,6 +271,10 @@ async def run_one_session_turn(
     writer = WorkspaceMessageWriter(
         workspace_io=deps.workspace_io,
         session_id=session_id,
+        # Seed past the row's existing history so this turn's records continue
+        # the per-session (session_id, seq) sequence monotonically instead of
+        # restarting at seq=1 and colliding with prior turns / USER_INPUT rows.
+        start_seq=seed_seq,
     )
     turn_log = deps.turn_log_writer_factory(deps.workspace_io, session_id)
 
@@ -480,6 +494,7 @@ async def run_one_session_turn(
         # that eventually resumes this park.
         async with session_lifecycle_lock().acquire(session_id):
             await _clear_interrupt_requested(session_storage, session_id)
+            await _persist_last_seq(session_storage, session_id, writer.last_seq)
 
         return ReleaseOutcome(
             success=True,
@@ -557,6 +572,7 @@ async def run_one_session_turn(
                 ended_reason="failed",
             )
             await _clear_interrupt_requested(session_storage, session_id)
+            await _persist_last_seq(session_storage, session_id, writer.last_seq)
         await turn_log.aclose()
         return ReleaseOutcome(success=False, drop_lease=True)
 
@@ -617,6 +633,7 @@ async def run_one_session_turn(
                 executor=executor,
             )
             await _clear_interrupt_requested(session_storage, session_id)
+            await _persist_last_seq(session_storage, session_id, writer.last_seq)
         await turn_log.aclose()
         return ReleaseOutcome(success=True, drop_lease=True)
 
@@ -651,6 +668,7 @@ async def run_one_session_turn(
             executor=executor,
         )
         await _clear_interrupt_requested(session_storage, session_id)
+        await _persist_last_seq(session_storage, session_id, writer.last_seq)
 
     await _safe_turn_log(turn_log, TurnLogCompleted(
         seq=0,
@@ -862,6 +880,28 @@ def _apply_interactive(
     ):
         return (SessionStatus.WAITING, None)
     return (status, reason)
+
+
+async def _persist_last_seq(
+    session_storage, session_id: str, seq: int,
+) -> None:
+    """Persist the turn writer's advancing seq back to the session row.
+
+    Seeds the NEXT turn's :class:`WorkspaceMessageWriter` (and any later
+    ``wake_session`` / ``reset_session``) so ``(session_id, seq)`` stays
+    strictly monotonic across turns instead of every turn restarting at
+    seq=1. Re-reads the fresh row and only ADVANCES ``last_seq`` (never
+    downgrades) so a concurrent steer that already wrote a higher USER_INPUT
+    seq is not clobbered. Always called from inside a
+    ``session_lifecycle_lock`` critical section — the same lock
+    ``wake_session``/``reset_session`` use for their own ``last_seq`` writes —
+    so this read-modify-write cannot interleave with a racing seq write.
+    """
+    fresh = await session_storage.get(session_id)
+    if fresh is not None and seq > fresh.last_seq:
+        await session_storage.update(
+            fresh.model_copy(update={"last_seq": seq})
+        )
 
 
 async def _clear_interrupt_requested(session_storage, session_id: str) -> None:

--- a/primer/session/enqueue.py
+++ b/primer/session/enqueue.py
@@ -24,8 +24,14 @@ from typing import Any
 
 from primer.int.claim import ClaimKind
 from primer.model.except_ import ConflictError, NotFoundError
-from primer.model.workspace_session import SessionStatus, WorkspaceSession
+from primer.model.workspace_session import (
+    SessionMessageKind,
+    SessionMessageRecord,
+    SessionStatus,
+    WorkspaceSession,
+)
 from primer.session.mutation_lock import session_lifecycle_lock
+from primer.session.persistence import WorkspaceMessageWriter
 
 logger = logging.getLogger(__name__)
 
@@ -80,18 +86,38 @@ async def wake_session(
                 f"Session {session_id!r} has ended; restart it to re-open."
             )
 
-        # 1. Append the user message to the on-disk slot FIFO (the queue).
+        # 1. Append the user message to the on-disk slot FIFO (the queue) and
+        #    persist a USER_INPUT record to messages.jsonl so the sent message
+        #    shows in the session transcript. The slot FIFO is the worker's
+        #    queue; messages.jsonl is the display log — separate surfaces, so
+        #    the USER_INPUT record is written even when the slot is absent
+        #    (mirrors the chat lane's append_user_message + reset_session's
+        #    divider write via WorkspaceMessageWriter). Exactly one record per
+        #    supplied instruction, so a steer/invoke never double-records.
+        user_input_seq: int | None = None
         if instruction:
             ws = await deps.workspace_registry.get_workspace(workspace_id)
             slot = await ws.get_session(session_id)
             if slot is not None:
                 await slot.append_instruction(instruction)
+            writer = WorkspaceMessageWriter(
+                workspace_io=ws, session_id=session_id, start_seq=row.last_seq,
+            )
+            user_input_seq = await writer.append(SessionMessageRecord(
+                seq=1,  # overwritten by the writer's monotonic counter
+                kind=SessionMessageKind.USER_INPUT,
+                payload={"text": instruction},
+                created_at=datetime.now(timezone.utc),
+            ))
+            await writer.flush()
 
         # 2. Re-arm the scheduler-visible row: claimable + clear pause;
         #    CREATED/PAUSED/WAITING advance to RUNNING (like /resume).
         row.turn_status = "claimable"
         row.pause_requested = False
         row.pause_requested_at = None
+        if user_input_seq is not None:
+            row.last_seq = user_input_seq
         if row.status in _RESUMABLE:
             row.status = SessionStatus.RUNNING
             if row.started_at is None:
@@ -112,6 +138,19 @@ async def wake_session(
                     "wake_session: failed to publish claimable for %s",
                     session_id,
                 )
+            # Tick so the workspace tap surfaces the just-persisted USER_INPUT
+            # record live (reset_session publishes the same event for its
+            # invocation divider). Advisory — never break the wake.
+            if user_input_seq is not None:
+                try:
+                    await deps.event_bus.publish(
+                        f"session:{session_id}:tick", {"seq": user_input_seq}
+                    )
+                except Exception:  # noqa: BLE001 -- advisory
+                    logger.exception(
+                        "wake_session: failed to publish tick for %s",
+                        session_id,
+                    )
         return row
 
 

--- a/primer/session/persistence.py
+++ b/primer/session/persistence.py
@@ -109,6 +109,17 @@ class WorkspaceMessageWriter:
         self._buffer_size: int = 0
         self._oldest_at: float | None = None  # monotonic clock at first buffered record
 
+    @property
+    def last_seq(self) -> int:
+        """The highest seq assigned so far (== ``start_seq`` before any append).
+
+        Callers persist this back to the session row's ``last_seq`` at turn
+        boundaries so the next turn's writer (and any concurrent
+        ``wake_session``/``reset_session``) seed past this turn's records and
+        ``(session_id, seq)`` stays monotonic across turns.
+        """
+        return self._seq
+
     async def append(self, record: SessionMessageRecord) -> int:
         """Append a record; flush per buffer policy.
 

--- a/tests/api/test_session_messages_route.py
+++ b/tests/api/test_session_messages_route.py
@@ -31,6 +31,24 @@ class _FakeWorkspace:
             raise NotFoundError(f"{path!r} not found")
         return self._files[path]
 
+    # -- WorkspaceIO write surface (used by WorkspaceMessageWriter) ----------
+    async def append_message_line(self, session_id: str, line: bytes) -> None:
+        path = f"{self.state_path}/sessions/{session_id}/messages.jsonl"
+        self._files[path] = self._files.get(path, b"") + line
+
+    async def get_session(self, session_id: str):
+        return _FakeSlot()
+
+
+class _FakeSlot:
+    async def append_instruction(self, content: str) -> None:
+        pass
+
+
+class _NoopScheduler:
+    async def enqueue(self, session_id: str) -> None:
+        pass
+
 
 async def _seed_session(fake_storage_provider, sid: str, status):
     from primer.model.workspace_session import (
@@ -105,3 +123,42 @@ async def test_missing_file_is_empty_not_500(client, app, fake_storage_provider)
 async def test_unknown_session_404(client, app, fake_storage_provider):
     r = await client.get("/v1/sessions/nope/messages")
     assert r.status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_wake_persists_one_user_input_retrievable_via_endpoint(
+    client, app, fake_storage_provider,
+):
+    """A steer/invoke (wake_session) persists exactly one USER_INPUT record,
+    retrievable via GET /sessions/{id}/messages — the record the UI session
+    adapter maps to a user_message bubble in the transcript."""
+    from primer.model.workspace_session import SessionStatus
+    from primer.session.enqueue import SessionWakeDeps, wake_session
+
+    await _seed_session(fake_storage_provider, "s-wake", SessionStatus.CREATED)
+    ws = _FakeWorkspace()
+
+    async def _get(wid):
+        return ws if wid == "ws-1" else None
+    app.state.workspace_registry.get_workspace = _get  # type: ignore[assignment]
+
+    # The unified invoke = steer = resume "send a message" path.
+    await wake_session(
+        workspace_id="ws-1",
+        session_id="s-wake",
+        instruction="do the thing",
+        deps=SessionWakeDeps(
+            storage_provider=fake_storage_provider,
+            scheduler=_NoopScheduler(),
+            claim_engine=None,
+            workspace_registry=app.state.workspace_registry,
+            event_bus=None,
+        ),
+    )
+
+    r = await client.get("/v1/sessions/s-wake/messages")
+    assert r.status_code == 200, r.text
+    items = r.json()["items"]
+    user_inputs = [it for it in items if it["kind"] == "user_input"]
+    assert len(user_inputs) == 1, f"expected exactly one USER_INPUT, got {items!r}"
+    assert user_inputs[0]["payload"]["text"] == "do the thing"

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -238,6 +238,12 @@ class _FakeWorkspace:
             raise BadRequestError("null byte in path")
         self._files[path] = content
 
+    async def append_message_line(self, session_id, line):
+        # WorkspaceIO write surface used by WorkspaceMessageWriter: wake_session
+        # persists a USER_INPUT record to messages.jsonl on steer/invoke.
+        path = f".state/sessions/{session_id}/messages.jsonl"
+        self._files[path] = self._files.get(path, b"") + line
+
     async def make_dir(self, path):
         if "\x00" in path:
             raise BadRequestError("null byte in path")

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -1004,3 +1004,301 @@ async def test_turn_start_consumes_claimable_and_mid_turn_steer_survives(
         "a steer landing mid-turn must survive to release so the pool's "
         "re-arm can see it"
     )
+
+
+# ---------------------------------------------------------------------------
+# Per-session seq monotonicity across turns (invoke + follow-up steer)
+# ---------------------------------------------------------------------------
+#
+# Regression for the HIGH-severity per-session seq bug: dispatch created the
+# per-turn WorkspaceMessageWriter with NO start_seq (each turn restarted at
+# seq=1) and never persisted the advancing seq back to the row. That collided
+# every turn's records with wake_session's USER_INPUT seqs and with the prior
+# turn's records, so the seq-filtered tap path silently dropped physically
+# later records whose seq <= a previously-seen value.
+
+
+class _SeqFakeSlot:
+    """On-disk slot stub: records the FIFO instructions wake_session appends."""
+
+    def __init__(self) -> None:
+        self.appended: list[str] = []
+
+    async def append_instruction(self, content: str) -> None:
+        self.appended.append(content)
+
+
+class _BridgingWorkspaceIO:
+    """Workspace IO serving BOTH surfaces the seq path touches.
+
+    * ``append_message_line`` — used by the WorkspaceMessageWriter that both
+      ``wake_session`` (USER_INPUT rows) and ``dispatch`` (turn output) drive.
+    * ``read_file`` + ``state_path`` + ``get_session`` — the tap reader's
+      seq-filtered live path (``read_session_since``) and wake's slot lookup.
+
+    Both writers and the reader target the same ``messages.jsonl`` bytes so a
+    tap client sees exactly what the two turns persisted.
+    """
+
+    state_path = ".state"
+
+    def __init__(self) -> None:
+        self._files: dict[str, bytes] = {}
+        self._slot = _SeqFakeSlot()
+
+    def _path(self, session_id: str) -> str:
+        return f"{self.state_path}/sessions/{session_id}/messages.jsonl"
+
+    async def append_message_line(self, session_id: str, line: bytes) -> None:
+        p = self._path(session_id)
+        self._files[p] = self._files.get(p, b"") + line
+
+    async def read_file(self, path: str) -> bytes:
+        from primer.model.except_ import NotFoundError
+
+        if path not in self._files:
+            raise NotFoundError(f"{path!r} not found")
+        return self._files[path]
+
+    async def get_session(self, session_id: str) -> _SeqFakeSlot:
+        return self._slot
+
+    def read_records(self, session_id: str) -> list[dict[str, Any]]:
+        import json
+
+        raw = self._files.get(self._path(session_id), b"")
+        return [
+            json.loads(ln) for ln in raw.decode().splitlines() if ln.strip()
+        ]
+
+
+class _SeqFakeRegistry:
+    def __init__(self, ws: _BridgingWorkspaceIO) -> None:
+        self._ws = ws
+
+    async def get_workspace(self, workspace_id: str) -> _BridgingWorkspaceIO:
+        return self._ws
+
+
+class _SeqFakeScheduler:
+    def __init__(self) -> None:
+        self.enqueued: list[str] = []
+
+    async def enqueue(self, session_id: str) -> None:
+        self.enqueued.append(session_id)
+
+
+class _SeqFakeEngine:
+    async def upsert(self, kind, session_id, *, priority=100, next_attempt_at=None):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_seq_strictly_increases_across_invoke_and_steer(
+    fake_storage_provider,
+    fake_event_bus: InMemoryEventBus,
+) -> None:
+    """Two turns on ONE interactive session (first invoke + follow-up steer)
+    must persist strictly-increasing unique seqs, and a seq-filtered tap
+    reader that already consumed turn 1 must surface ALL of turn 2 (none
+    dropped).
+
+    FAILS before the dispatch seed+persist fix (turn writers restart at
+    seq=1, colliding with the USER_INPUT rows and each other, so the
+    ``after_seq`` reader drops turn 2 entirely).
+    """
+    from primer.session.enqueue import SessionWakeDeps, wake_session
+    from primer.tap.reader import read_session_since
+    from primer.tap.selector import TapSelector
+
+    io = _BridgingWorkspaceIO()
+    registry = _SeqFakeRegistry(io)
+    scheduler = _SeqFakeScheduler()
+    engine = _SeqFakeEngine()
+
+    session_id = "s-seq"
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(
+        WorkspaceSession(
+            id=session_id,
+            workspace_id="w1",
+            binding=AgentSessionBinding(agent_id="ag1"),
+            status=SessionStatus.CREATED,
+            # Interactive: stays WAITING after a clean turn so a follow-up
+            # steer (turn 2) can re-arm it instead of dead-ending at ENDED.
+            autonomous=False,
+            created_at=_now(),
+            turn_status="idle",
+        )
+    )
+
+    wake_deps = SessionWakeDeps(
+        storage_provider=fake_storage_provider,
+        scheduler=scheduler,
+        claim_engine=engine,
+        workspace_registry=registry,
+        event_bus=fake_event_bus,
+    )
+
+    def _dispatch_deps(events: list[Any]) -> SessionDispatchDeps:
+        async def _build(session: WorkspaceSession):
+            return FakeExecutor(events)
+
+        return SessionDispatchDeps(
+            storage_provider=fake_storage_provider,
+            workspace_io=io,
+            event_bus=fake_event_bus,
+            build_executor=_build,
+        )
+
+    # --- Turn 1: first invoke ---
+    await wake_session(
+        workspace_id="w1", session_id=session_id,
+        instruction="first", deps=wake_deps,
+    )
+    await run_one_session_turn(
+        _make_lease(session_id),
+        _dispatch_deps([
+            TextDelta(text="alpha", index=0),
+            Done(stop_reason="stop", raw_reason="stop"),
+        ]),
+    )
+    row = await storage.get(session_id)
+    assert row.status == SessionStatus.WAITING, (
+        "interactive session must stay alive after a clean turn so it can "
+        "be steered"
+    )
+
+    # --- Turn 2: follow-up steer on the same session ---
+    await wake_session(
+        workspace_id="w1", session_id=session_id,
+        instruction="second", deps=wake_deps,
+    )
+    await run_one_session_turn(
+        _make_lease(session_id),
+        _dispatch_deps([
+            TextDelta(text="beta", index=0),
+            Done(stop_reason="stop", raw_reason="stop"),
+        ]),
+    )
+
+    # --- All persisted records: strictly increasing, unique seqs ---
+    recs = io.read_records(session_id)
+    seqs = [r["seq"] for r in recs]
+    assert seqs == sorted(seqs), f"seqs not strictly increasing in file order: {seqs}"
+    assert len(seqs) == len(set(seqs)), f"duplicate seqs across turns: {seqs}"
+    # USER_INPUT(first), ASSISTANT_TOKEN, DONE, USER_INPUT(second), ASSISTANT_TOKEN, DONE
+    assert len(recs) == 6, f"expected 6 records, got {len(recs)}: {[r['kind'] for r in recs]}"
+    assert [r["kind"] for r in recs].count(SessionMessageKind.USER_INPUT) == 2
+
+    # --- Seq-filtered tap: a client that consumed turn 1 sees ALL of turn 2 ---
+    row = await storage.get(session_id)
+    turn1 = recs[:3]
+    high_water = max(r["seq"] for r in turn1)
+    events, _ = await read_session_since(
+        io,
+        workspace_id="w1",
+        session=row,
+        after_seq=high_water,
+        selector=TapSelector(),
+        from_offset=0,
+    )
+    surfaced = sorted(e.seq for e in events)
+    assert len(events) == 3, (
+        "seq-filtered tap dropped physically-later turn-2 records: "
+        f"surfaced {surfaced} after after_seq={high_water}"
+    )
+    assert min(surfaced) > high_water
+
+
+@pytest.mark.xfail(
+    strict=True,
+    reason=(
+        "Residual mid-turn concurrent-steer race: wake_session's USER_INPUT "
+        "writer and the in-flight turn writer own INDEPENDENT seq counters. A "
+        "steer landing DURING a running turn (before that turn persists its "
+        "advancing last_seq at turn end) reads a stale row.last_seq and its "
+        "USER_INPUT seq collides with the turn's still-buffered output. "
+        "Persisting the row per-flush does not help — the two counters can't "
+        "be reconciled without a single shared per-session seq source (both "
+        "writers incrementing row.last_seq under the lifecycle lock per "
+        "record), which is a WorkspaceMessageWriter redesign tracked as a "
+        "follow-up. This test marks that boundary and will flip to a failing "
+        "XPASS once the shared-seq-source fix lands."
+    ),
+)
+@pytest.mark.asyncio
+async def test_midturn_concurrent_steer_seq_collision_is_known_gap(
+    fake_storage_provider,
+    fake_event_bus: InMemoryEventBus,
+) -> None:
+    """Documents the residual mid-turn-concurrent-steer seq collision.
+
+    A steer that lands WHILE turn 1 is streaming (its writer counter still
+    mid-flight, last_seq not yet persisted) writes a USER_INPUT whose seq
+    collides with turn 1's output. Strictly-increasing unique seqs therefore
+    do NOT hold — the known gap the turn-boundary fix does not close.
+    """
+    from primer.session.enqueue import SessionWakeDeps, wake_session
+
+    io = _BridgingWorkspaceIO()
+    wake_deps = SessionWakeDeps(
+        storage_provider=fake_storage_provider,
+        scheduler=_SeqFakeScheduler(),
+        claim_engine=_SeqFakeEngine(),
+        workspace_registry=_SeqFakeRegistry(io),
+        event_bus=fake_event_bus,
+    )
+
+    session_id = "s-seq-mid"
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(
+        WorkspaceSession(
+            id=session_id,
+            workspace_id="w1",
+            binding=AgentSessionBinding(agent_id="ag1"),
+            status=SessionStatus.CREATED,
+            autonomous=False,
+            created_at=_now(),
+            turn_status="idle",
+        )
+    )
+
+    # Turn 1 invoke.
+    await wake_session(
+        workspace_id="w1", session_id=session_id,
+        instruction="first", deps=wake_deps,
+    )
+
+    async def _steer_mid_turn() -> None:
+        await wake_session(
+            workspace_id="w1", session_id=session_id,
+            instruction="steer-mid", deps=wake_deps,
+        )
+
+    class _MidTurnSteerExecutor:
+        async def invoke(self, messages: list[Any], **kwargs: Any):
+            yield TextDelta(text="x", index=0)
+            # A concurrent steer lands mid-turn: wake_session writes a
+            # USER_INPUT record now, while this turn's buffered text is not
+            # yet flushed and its writer counter has not advanced.
+            await _steer_mid_turn()
+            yield Done(stop_reason="stop", raw_reason="stop")
+
+    async def _build(session: WorkspaceSession):
+        return _MidTurnSteerExecutor()
+
+    await run_one_session_turn(
+        _make_lease(session_id),
+        SessionDispatchDeps(
+            storage_provider=fake_storage_provider,
+            workspace_io=io,
+            event_bus=fake_event_bus,
+            build_executor=_build,
+        ),
+    )
+
+    seqs = [r["seq"] for r in io.read_records(session_id)]
+    assert seqs == sorted(seqs) and len(seqs) == len(set(seqs)), (
+        f"mid-turn steer produced non-monotonic/duplicate seqs: {seqs}"
+    )

--- a/tests/session/test_enqueue.py
+++ b/tests/session/test_enqueue.py
@@ -43,9 +43,15 @@ class _FakeSlot:
 class _FakeWorkspace:
     def __init__(self, slot):
         self._slot = slot
+        # Captures messages.jsonl lines the WorkspaceMessageWriter appends
+        # (wake_session persists a USER_INPUT record via workspace_io).
+        self.message_lines: list[bytes] = []
 
     async def get_session(self, sid):
         return self._slot
+
+    async def append_message_line(self, session_id, line):
+        self.message_lines.append(line)
 
 
 class _FakeRegistry:

--- a/tests/ui/test_session_adapter.py
+++ b/tests/ui/test_session_adapter.py
@@ -1,0 +1,141 @@
+"""Task 11 of docs/superpowers/plans/2026-07-05-studio-agents-interact.md —
+session adapter mapping a workspace Session's message stream
+(SessionMessageKind / the tap's mirrored TapEventClass) onto the shape
+chat-refactor's `<Transcript>` renders, so a Session can be rendered
+through the reused chat UI instead of a second parallel renderer.
+
+Static-source + transpile-build checks only (the ui/ suite convention,
+e.g. test_conversation_extracted.py / test_session_live_history.py), plus
+one MiniRacer eval of the actual mapping function (mirrors
+test_chat_coalesce_forwards_agent_id_and_created_at_from_first_token) so
+the load-bearing kind table and divider labels are exercised for real
+rather than only substring-matched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+ADAPTER = UI / "components" / "session-adapter.jsx"
+INDEX = UI / "index.html"
+
+
+def _order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            start = line.index('src="') + len('src="')
+            end = line.index('"', start)
+            out.append(line[start:end])
+    return out
+
+
+def test_session_adapter_module_exists_and_exports() -> None:
+    assert ADAPTER.exists(), "ui/components/session-adapter.jsx is missing"
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "function SA_toTranscript(" in src
+    assert "window.SA_toTranscript = SA_toTranscript;" in src
+    assert "window.SA_KIND_TO_TRANSCRIPT = SA_KIND_TO_TRANSCRIPT;" in src
+    assert "function SA_useSessionConversation(" in src
+    assert "window.SA_useSessionConversation = SA_useSessionConversation;" in src
+
+
+def test_kind_mapping_table_matches_the_locked_contract() -> None:
+    # Load-bearing mapping (studio-agents-interact Task 11 + Global
+    # Constraints' "Transport rules (locked)"): every SessionMessageKind /
+    # TapEventClass value must appear with its documented transcript kind.
+    src = ADAPTER.read_text(encoding="utf-8")
+    expected = {
+        "user_input": "user_message",
+        "assistant_token": "assistant_message",
+        "tool_call": "tool_call",
+        "tool_result": "tool_result",
+        "graph_transition": "divider",
+        "invocation_divider": "divider",
+        "yielded": "interaction",
+        "resumed": "interaction",
+        "done": "lifecycle",
+        "cancelled": "lifecycle",
+        "error": "lifecycle",
+    }
+    for kind, transcript_kind in expected.items():
+        assert f'{kind}: "{transcript_kind}"' in src, (
+            f"SA_KIND_TO_TRANSCRIPT must map {kind!r} -> {transcript_kind!r}"
+        )
+
+
+def test_no_session_websocket_only_rest_and_tap_sse() -> None:
+    # Transport rule (locked): reuse the workspace tap SSE, never a
+    # dedicated session WebSocket.
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "new WebSocket(" not in src
+    assert "new EventSource(" in src
+    assert "/tap" in src
+    assert "/messages" in src
+
+
+def test_controls_hit_the_documented_endpoints() -> None:
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "/steer" in src
+    assert "/interrupt" in src
+    assert "/cancel" in src
+
+
+def test_session_scoped_tap_reuses_wtp_build_selector() -> None:
+    # Reuse components/workspace-tap.jsx's selector builder to scope the
+    # live tail to this one session, rather than re-deriving the
+    # TapSelector predicate shape here.
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "window.WTP_buildSelector" in src
+
+
+def test_session_adapter_registered_before_studio_center() -> None:
+    order = _order()
+    assert "components/session-adapter.jsx" in order
+    assert "components/studio-center.jsx" in order
+    assert order.index("components/session-adapter.jsx") < order.index("components/studio-center.jsx")
+
+
+def test_bundle_transpiles_with_session_adapter() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    text = body.decode("utf-8")
+    assert "/* === components/session-adapter.jsx === */" in text
+
+
+def test_sa_to_transcript_maps_records_via_mini_racer() -> None:
+    """Runs the real SA_toTranscript/SA_KIND_TO_TRANSCRIPT against a tiny
+    sample of SessionMessageRecord-shaped rows, mirroring
+    test_chat_coalesce_forwards_agent_id_and_created_at_from_first_token's
+    use of py_mini_racer instead of guessing at behavior from a substring
+    match.
+    """
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    ctx.eval(ADAPTER.read_text(encoding="utf-8"))
+    ctx.eval(
+        """
+        var records = [
+          {seq: 1, kind: "user_input", payload: {text: "hi"}, created_at: "t1", node_id: null},
+          {seq: 2, kind: "graph_transition",
+           payload: {node_id: "n1", phase: "enter"}, created_at: "t2", node_id: "n1"},
+          {seq: 3, kind: "invocation_divider", payload: {invocation: 3}, created_at: "t3", node_id: null},
+          {seq: 4, kind: "done", payload: {}, created_at: "t4", node_id: null},
+        ];
+        var out = window.SA_toTranscript(records, {id: "s1"});
+        """
+    )
+    assert ctx.eval("out.length") == 4
+    assert ctx.eval("out[0].kind") == "user_message"
+    assert ctx.eval("out[1].kind") == "divider"
+    assert ctx.eval("out[1].label") == "n1 · enter"
+    assert ctx.eval("out[1].nodeId") == "n1"
+    assert ctx.eval("out[2].kind") == "divider"
+    assert ctx.eval("out[2].label") == "— invocation 3 —"
+    assert ctx.eval("out[3].kind") == "lifecycle"

--- a/tests/ui/test_studio_center.py
+++ b/tests/ui/test_studio_center.py
@@ -2,7 +2,7 @@
 
 The center region is the tab bar + the active document panel. B3 builds:
   - CenterTabs        — tab bar over studio.state.openTabs
-  - SessionAgentPanel — agent transcript (reuses SessionLiveStream)
+  - SessionAgentPanel — agent transcript (session adapter + Transcript/Composer)
   - SessionGraphPanel — graph run-view (reuses SD_GraphRunView)
   - FilePanel         — file preview/edit + 412-conflict save flow
   - StudioCenter      — wires CenterTabs + the active panel into the shell
@@ -76,17 +76,23 @@ def test_center_defines_components() -> None:
 
 
 # ---------------------------------------------------------------------------
-# REUSE — the agent transcript + graph run-view are the production components
-# from session-detail.jsx, reached as window globals (NOT reimplemented).
+# REUSE — the graph run-view is the production component from session-detail.jsx;
+# the agent transcript is now chat-refactor's Transcript/Composer over the
+# session adapter (Task 12) — both reached as window globals (NOT reimplemented).
 # ---------------------------------------------------------------------------
 
 
-def test_reuses_session_live_stream() -> None:
+def test_agent_panel_uses_session_adapter_and_chat_primitives() -> None:
+    # Task 12 retired the pre-Task-12 SessionLiveStream reuse for the agent
+    # panel (it deliberately no longer reuses window.SessionLiveStream); the
+    # panel now composes the session adapter + the reused chat primitives.
+    # (The graph run-view still reuses SD_GraphRunView — see below.)
     src = _center_src()
-    assert "window.SessionLiveStream" in src, "must reuse SessionLiveStream, not rebuild it"
-    # Passed the props it already expects.
-    for prop in ("sid={sid}", "wid={wid}", "session={session}"):
-        assert prop in src, f"SessionLiveStream prop missing: {prop}"
+    assert "window.SessionLiveStream" not in src, "agent panel must NOT reuse SessionLiveStream"
+    assert "window.SA_useSessionConversation(" in src, "must drive the panel off the session adapter"
+    assert "window.SA_toTranscript(records, session)" in src, "transcript must be fed by SA_toTranscript"
+    assert "<window.Transcript" in src, "must reuse the chat <Transcript> primitive"
+    assert "<window.Composer" in src, "must reuse the chat <Composer> primitive"
 
 
 def test_reuses_sd_graph_run_view() -> None:
@@ -113,7 +119,8 @@ def test_does_not_reimplement_reused_components() -> None:
 
 
 # ---------------------------------------------------------------------------
-# Session panel routing: fetch the session, branch on binding.kind.
+# Session panel routing: fetch the session, branch on ST_isAutonomous
+# (explicit session.autonomous wins; else the binding kind).
 # ---------------------------------------------------------------------------
 
 
@@ -121,9 +128,66 @@ def test_session_panel_fetches_and_branches_on_binding_kind() -> None:
     src = _center_src()
     assert "/sessions/" in src, "must GET /v1/sessions/{ref}"
     assert "useResource" in src
-    # Branch agent vs graph off binding.kind (with the defensive binding_kind alias).
+    # Branch agent vs graph via ST_isAutonomous, which itself reads binding.kind
+    # (with the defensive binding_kind alias).
     assert "binding.kind" in src
     assert "graph" in src and "agent" in src
+
+
+def _session_panel_src() -> str:
+    """Just the ST_SessionPanel router body — scopes the routing assertions
+    to the resolver, not the whole file."""
+    src = _center_src()
+    start = src.index("function ST_SessionPanel(")
+    end = src.index("function ST_FilePreview(", start)
+    return src[start:end]
+
+
+def _is_autonomous_src() -> str:
+    """The pure ST_isAutonomous helper (no JSX) — directly MiniRacer-evaluable
+    like test_studio_run_view_interactive.py's `_pure_helpers_src`."""
+    src = _center_src()
+    start = src.index("function ST_isAutonomous(")
+    end = src.index("function ST_sessionRowToTranscript(", start)
+    return src[start:end]
+
+
+def test_session_panel_routes_through_st_is_autonomous() -> None:
+    # ST_isAutonomous is the byte-mirror of backend session_is_autonomous:
+    # an explicit `session.autonomous` flag wins over the binding kind. The
+    # router MUST gate agent-vs-graph on it (not the raw `binding.kind ===
+    # "graph"`), or an explicit override that contradicts the binding kind
+    # routes to the WRONG panel.
+    router = _session_panel_src()
+    assert "ST_isAutonomous(session)" in router, "router must branch on ST_isAutonomous"
+    # The old router re-derived `var kind = ... binding.kind ...` and branched
+    # on `kind === "graph"`; that derivation must be gone (the check lives in
+    # ST_isAutonomous now). Asserts on the removed code, not the prose comment.
+    assert "var kind =" not in router, "router must not re-derive the raw binding kind to branch on"
+    assert "<SessionGraphPanel" in router and "<SessionAgentPanel" in router
+
+
+def test_explicit_override_session_routes_per_st_is_autonomous() -> None:
+    # Prove the override semantics the router now delegates to: an explicit
+    # `autonomous` flag decides the panel regardless of binding.kind. The
+    # router (asserted above) renders the graph/autonomous panel iff
+    # ST_isAutonomous(session) is truthy, else SessionAgentPanel.
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    ctx.eval(_is_autonomous_src())
+
+    # agent binding + explicit autonomous:true -> ST_isAutonomous true ->
+    # SessionGraphPanel (override wins over binding.kind).
+    assert ctx.eval('ST_isAutonomous({binding: {kind: "agent"}, autonomous: true})') is True
+    # graph binding + explicit autonomous:false -> ST_isAutonomous false ->
+    # SessionAgentPanel (override wins over binding.kind).
+    assert ctx.eval('ST_isAutonomous({binding: {kind: "graph"}, autonomous: false})') is False
+    # No override: behaves exactly like the old `binding.kind === "graph"`
+    # branch, so non-override routing is unchanged.
+    assert ctx.eval('ST_isAutonomous({binding: {kind: "graph"}})') is True
+    assert ctx.eval('ST_isAutonomous({binding: {kind: "agent"}})') is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_studio_debug_sidebar.py
+++ b/tests/ui/test_studio_debug_sidebar.py
@@ -93,6 +93,15 @@ def test_debug_sidebar_body_hidden_while_collapsed() -> None:
     assert 'display: collapsed ? "none" : "flex"' in fn
 
 
+def test_debug_sidebar_toggle_has_aria_controls_matching_body_id() -> None:
+    # a11y: the toggle button announces which element it expands/collapses.
+    # aria-controls must reference the ACTUAL id on the body wrapper, not
+    # just a matching-looking string in isolation.
+    fn = _studio_activity_fn_src()
+    assert 'aria-controls="debug-sidebar-body"' in fn
+    assert 'id="debug-sidebar-body"' in fn
+
+
 def test_debug_sidebar_expands_to_action_required_and_workspace_tap() -> None:
     # The body wrapper (hidden while collapsed, per the test above) still
     # contains BOTH the global Action Required list and the reused
@@ -248,6 +257,81 @@ def test_inline_yields_reconciles_via_the_adapters_tap_tail_not_a_second_stream(
     assert "new EventSource" not in fn, "must reuse session-adapter.jsx's existing tap, not open a second one"
     assert 'last.kind !== "yielded" && last.kind !== "resumed"' in fn
     assert "resourceApi.findKeys(baseKey).forEach(function (key) { resourceApi.refetchKey(key); });" in fn
+
+
+# ---------------------------------------------------------------------------
+# The other half of the sync: GLOBAL Action Required (studio-activity.jsx)
+# responding to a yield must invalidate the session-scoped cache immediately
+# too, so the INLINE panel (above) doesn't wait out its 4s poll to notice the
+# yield the global sidebar just cleared.
+# ---------------------------------------------------------------------------
+
+
+def test_action_required_defines_a_session_pending_invalidation_helper() -> None:
+    src = _activity_src()
+    assert "function SA_invalidateSessionPending(sessionId)" in src
+    # Same findKeys/refetchKey primitive ST_yieldInvalidates' useMutation
+    # callers use (studio-center.jsx), not a bespoke mechanism.
+    helper = _fn_block(src, "function SA_invalidateSessionPending(", "function ActionRequired(")
+    assert "window.primerApi && window.primerApi._resource" in helper
+    assert "resourceApi.findKeys(baseKey).forEach(function(key) { resourceApi.refetchKey(key); });" in helper
+
+
+def test_all_four_global_yield_handlers_invalidate_session_scoped_pending() -> None:
+    # approve / reject / respond / cancel — none of them special-cases only
+    # the workspace-wide cache; every write path that clears a yield also
+    # nudges the session-scoped one the inline panel reads.
+    fn = _action_required_fn_src()
+    assert fn.count("SA_invalidateSessionPending(item.session_id);") == 4
+
+
+def test_sa_invalidate_session_pending_uses_the_exact_key_sa_useSessionConversation_registers() -> None:
+    # Load-bearing string match: SA_useSessionConversation (session-adapter.jsx)
+    # registers its pending resource under "session-adapter:pending:" + sid
+    # with useResource's own deps-suffix composition (":: " + JSON deps).
+    # findKeys() only matches on an EXACT key or a "<base>::"-prefixed key, so
+    # SA_invalidateSessionPending must pass that literal base string — a
+    # mismatched key (e.g. missing/extra text) would silently no-op.
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval(
+        """
+        var window = {
+          primerApi: {
+            _resource: {
+              findKeysCalls: [],
+              refetchCalls: [],
+              findKeys: function(base) {
+                window.primerApi._resource.findKeysCalls.push(base);
+                return [base + '::["sess1","ws1"]'];
+              },
+              refetchKey: function(key) {
+                window.primerApi._resource.refetchCalls.push(key);
+              }
+            }
+          }
+        };
+        """
+    )
+    fn_src = _fn_block(_activity_src(), "function SA_invalidateSessionPending(", "function ActionRequired(")
+    ctx.eval(fn_src)
+    ctx.eval('SA_invalidateSessionPending("sess1");')
+    assert ctx.eval("window.primerApi._resource.findKeysCalls[0]") == "session-adapter:pending:sess1"
+    assert ctx.eval("window.primerApi._resource.refetchCalls[0]") == 'session-adapter:pending:sess1::["sess1","ws1"]'
+
+
+def test_sa_invalidate_session_pending_is_a_no_op_without_resource_api_or_session_id() -> None:
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    fn_src = _fn_block(_activity_src(), "function SA_invalidateSessionPending(", "function ActionRequired(")
+    ctx.eval(fn_src)
+    # Must not throw when primerApi/_resource is missing (no window.primerApi
+    # configured yet) or sessionId is falsy.
+    ctx.eval('SA_invalidateSessionPending("sess1");')
+    ctx.eval('SA_invalidateSessionPending(null);')
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_studio_debug_sidebar.py
+++ b/tests/ui/test_studio_debug_sidebar.py
@@ -1,0 +1,285 @@
+"""Task 14 of docs/superpowers/plans/2026-07-05-studio-agents-interact.md —
+the right sidebar (`StudioActivity` in `ui/components/studio-activity.jsx`)
+collapses by default (still the GLOBAL debug tracker: Action Required across
+ALL sessions + the reused WorkspaceTap feed), and the ACTIVE session's own
+pending interaction now also renders INLINE in its stream
+(`ui/components/studio-center.jsx`), reusing the exact respond/approval
+endpoints the global list already hits so the two surfaces can never drift.
+
+Static-source + transpile-build checks only (the `tests/ui` suite
+convention — see test_studio_activity.py / test_studio_run_view_interactive.py
+/ test_session_adapter.py), plus one MiniRacer eval of the one new pure
+helper this task adds (`ST_yieldInvalidates`) so the load-bearing cache-key
+list is exercised for real rather than only substring-matched.
+
+No browser/live server: see test_studio_run_view_interactive.py's docstring
+for why <Transcript>'s live EventSource/poll effects aren't exercised
+end-to-end here (would need the heavier tests/ui_e2e Playwright harness).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+ACTIVITY = UI / "components" / "studio-activity.jsx"
+CENTER = UI / "components" / "studio-center.jsx"
+INDEX = UI / "index.html"
+
+
+def _activity_src() -> str:
+    return ACTIVITY.read_text(encoding="utf-8")
+
+
+def _center_src() -> str:
+    return CENTER.read_text(encoding="utf-8")
+
+
+def _fn_block(src: str, start_marker: str, end_marker: str) -> str:
+    """Slice `src` from `start_marker` up to (not including) `end_marker`."""
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+def _studio_activity_fn_src() -> str:
+    return _fn_block(_activity_src(), "function StudioActivity(", "window.StudioActivity = StudioActivity;")
+
+
+def _action_required_fn_src() -> str:
+    return _fn_block(_activity_src(), "function ActionRequired(", "function WorkspaceActivity(")
+
+
+def _session_agent_panel_src() -> str:
+    return _fn_block(_center_src(), "function SessionAgentPanel(", "function SessionGraphPanel(")
+
+
+def _session_graph_panel_src() -> str:
+    return _fn_block(_center_src(), "function SessionGraphPanel(", "function ST_SessionPanel(")
+
+
+def _inline_yields_fn_src() -> str:
+    # ST_InlineYields is defined AFTER SessionGraphPanel (not next to its
+    # sibling pure helpers ST_isAutonomous/ST_sessionTranscriptRows) —
+    # deliberately, so the JSX-free pure-helpers slice those two other test
+    # files py_mini_racer-eval stays JSX-free. See the component's own
+    # file-header comment in studio-center.jsx for the full rationale.
+    return _fn_block(_center_src(), "function ST_InlineYields(", "function ST_SessionPanel(")
+
+
+# ---------------------------------------------------------------------------
+# Right sidebar starts collapsed by default (studio-activity.jsx).
+# ---------------------------------------------------------------------------
+
+
+def test_debug_sidebar_starts_collapsed_by_default() -> None:
+    fn = _studio_activity_fn_src()
+    assert "var [collapsed, setCollapsed] = React.useState(true);" in fn
+
+
+def test_debug_sidebar_toggle_flips_collapsed_state() -> None:
+    fn = _studio_activity_fn_src()
+    assert 'data-testid="debug-sidebar-toggle"' in fn
+    assert "onClick={toggle}" in fn
+    assert "setCollapsed(function(c) { return !c; });" in fn
+    # a11y: expanded state reflected for assistive tech.
+    assert 'aria-expanded={collapsed ? "false" : "true"}' in fn
+
+
+def test_debug_sidebar_body_hidden_while_collapsed() -> None:
+    fn = _studio_activity_fn_src()
+    assert 'data-testid="debug-sidebar-body"' in fn
+    assert 'display: collapsed ? "none" : "flex"' in fn
+
+
+def test_debug_sidebar_expands_to_action_required_and_workspace_tap() -> None:
+    # The body wrapper (hidden while collapsed, per the test above) still
+    # contains BOTH the global Action Required list and the reused
+    # WorkspaceTap feed — expanding reveals exactly those two, nothing new.
+    fn = _studio_activity_fn_src()
+    body = _fn_block(fn, 'data-testid="debug-sidebar-body"', "</div>\n    </div>\n  );\n}")
+    assert "<ActionRequired wid={wid} studio={studio} onCountChange={setPendingCount} />" in body
+    assert "<WorkspaceActivity wid={wid} />" in body
+
+
+def test_action_required_and_workspace_activity_stay_mounted_when_collapsed() -> None:
+    # Collapsing must be a pure CSS/visual toggle, not an unmount — the
+    # poll + tap-reconcile subscriptions inside ActionRequired/WorkspaceTap
+    # need to stay warm so the collapsed rail's badge count is always live
+    # and re-expanding doesn't show a stale/cold panel. Guard against a
+    # regression to conditional-mount (`{!collapsed && <ActionRequired`).
+    fn = _studio_activity_fn_src()
+    assert "{!collapsed &&" not in fn
+    assert "{collapsed ? null :" not in fn
+
+
+def test_debug_sidebar_badge_shows_live_pending_count() -> None:
+    fn = _studio_activity_fn_src()
+    assert 'data-testid="debug-sidebar-badge"' in fn
+    assert "pendingCount > 0" in fn
+    assert "var [pendingCount, setPendingCount] = React.useState(0);" in fn
+
+
+def test_action_required_reports_its_count_up_to_the_shell() -> None:
+    ar = _action_required_fn_src()
+    assert "function ActionRequired({ wid, studio, onCountChange })" in _activity_src()
+    assert "if (typeof onCountChange === \"function\") onCountChange(count);" in ar
+
+
+# ---------------------------------------------------------------------------
+# Regression guard: existing global Action Required testids/endpoints
+# (test_studio_activity.py) must be untouched by this task's refactor.
+# ---------------------------------------------------------------------------
+
+
+def test_existing_action_required_surface_untouched() -> None:
+    src = _activity_src()
+    for testid in (
+        "action-required",
+        "action-required-list",
+        "action-required-count",
+        "action-item",
+        "action-session-link",
+        "approve",
+        "reject",
+        "respond",
+        "cancel-yield",
+        "workspace-activity",
+        "studio-activity-root",
+    ):
+        assert f'data-testid="{testid}"' in src, f"Missing data-testid: {testid}"
+    assert "tool_approval/respond" in src
+    assert "ask_user/respond" in src
+    assert "yields/pending" in src
+
+
+# ---------------------------------------------------------------------------
+# Inline session-yield affordances (studio-center.jsx) — the session-scoped
+# counterpart to the global list above.
+# ---------------------------------------------------------------------------
+
+
+def test_inline_yields_component_exists() -> None:
+    src = _center_src()
+    assert "function ST_yieldInvalidates(" in src
+    assert "function ST_InlineYields({ wid, sid, pending, messages, pushToast })" in src
+
+
+def test_inline_yields_renders_nothing_without_a_pending_item() -> None:
+    fn = _inline_yields_fn_src()
+    assert "if (!wid || !sid || !pending || !pending.length) return null;" in fn
+
+
+def test_inline_yields_mounted_in_both_agent_and_graph_panels() -> None:
+    src = _center_src()
+    assert src.count("<ST_InlineYields wid={wid} sid={sid} pending={conv.pending} messages={conv.messages} pushToast={pushToast} />") == 2
+
+    agent = _session_agent_panel_src()
+    graph = _session_graph_panel_src()
+    for panel in (agent, graph):
+        assert "<ST_InlineYields" in panel
+        # Positioned after <Transcript>, before the Composer footer — mirrors
+        # chat-refactor's CT_ApprovalGate ("right after the message list").
+        transcript_idx = panel.index("<window.Transcript")
+        inline_idx = panel.index("<ST_InlineYields")
+        composer_idx = panel.index("<window.Composer")
+        assert transcript_idx < inline_idx < composer_idx
+
+
+def test_inline_yields_backed_by_session_scoped_pending_from_the_adapter() -> None:
+    # conv.pending is session-adapter.jsx's own GET .../sessions/{sid}/
+    # yields/pending resource (Task 10/11) — no second fetch is introduced
+    # here, it's threaded straight through from SA_useSessionConversation.
+    agent = _session_agent_panel_src()
+    assert "var conv = window.SA_useSessionConversation({ sid: sid, wid: wid });" in agent
+    assert "pending={conv.pending}" in agent
+
+
+def test_inline_yields_hits_the_same_endpoints_as_the_global_list() -> None:
+    fn = _inline_yields_fn_src()
+    assert "tool_approval/respond" in fn
+    assert 'decision: "approved"' in fn
+    assert 'decision: "rejected"' in fn
+    assert "ask_user/respond" in fn
+    assert "/yields/" in fn and "/cancel" in fn
+
+
+def test_inline_yields_testids_present() -> None:
+    fn = _inline_yields_fn_src()
+    for testid in (
+        "session-inline-yields",
+        "session-yield-item",
+        "session-yield-approve",
+        "session-yield-deny",
+        "session-yield-respond",
+        "session-yield-cancel",
+    ):
+        assert f'data-testid="{testid}"' in fn
+
+
+def test_inline_yields_testids_are_distinct_from_global_action_required() -> None:
+    # The global sidebar's items may render on-screen at the same time as
+    # the active session's inline affordance (same underlying yield) — the
+    # testids must never collide so each surface stays independently
+    # locatable in a real DOM.
+    fn = _inline_yields_fn_src()
+    for global_testid in ("approve", "reject", "respond", "cancel-yield", "action-item"):
+        assert f'data-testid="{global_testid}"' not in fn
+
+
+# ---------------------------------------------------------------------------
+# Global <-> inline sync: both invalidate the SAME two caches on every
+# write, and reconcile off the session's own already-open tap tail (no
+# second EventSource) rather than a fresh poll-only guess.
+# ---------------------------------------------------------------------------
+
+
+def test_inline_yields_invalidates_both_global_and_session_scoped_caches() -> None:
+    fn = _inline_yields_fn_src()
+    assert 'return ["session-adapter:pending:" + sid, "studio-yields-pending:" + wid];' in _center_src()
+    # All four write paths (approve/reject/respond/cancel) share the same
+    # invalidates list — none of them special-cases only one cache.
+    assert fn.count("invalidates: invalidates") == 4
+
+
+def test_inline_yields_reconciles_via_the_adapters_tap_tail_not_a_second_stream() -> None:
+    fn = _inline_yields_fn_src()
+    assert "new EventSource" not in fn, "must reuse session-adapter.jsx's existing tap, not open a second one"
+    assert 'last.kind !== "yielded" && last.kind !== "resumed"' in fn
+    assert "resourceApi.findKeys(baseKey).forEach(function (key) { resourceApi.refetchKey(key); });" in fn
+
+
+# ---------------------------------------------------------------------------
+# Pure helper: ST_yieldInvalidates — exercised for real via MiniRacer
+# (mirrors ST_isAutonomous in test_studio_run_view_interactive.py).
+# ---------------------------------------------------------------------------
+
+
+def test_st_yield_invalidates_pure_helper_via_mini_racer() -> None:
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    fn_src = _fn_block(_center_src(), "function ST_yieldInvalidates(", "function ST_InlineYields(")
+    ctx.eval(fn_src)
+    ctx.eval('var out = ST_yieldInvalidates("ws1", "sess1");')
+    assert ctx.eval("out.length") == 2
+    assert ctx.eval("out[0]") == "session-adapter:pending:sess1"
+    assert ctx.eval("out[1]") == "studio-yields-pending:ws1"
+
+
+# ---------------------------------------------------------------------------
+# Bundle transpile gate (whole bundle must still parse cleanly).
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_transpiles_with_debug_sidebar_and_inline_yields() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    build_jsx_bundle.cache_clear()
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    text = body.decode("utf-8")
+    assert "/* === components/studio-activity.jsx === */" in text
+    assert "/* === components/studio-center.jsx === */" in text

--- a/tests/ui/test_studio_graph_run_view.py
+++ b/tests/ui/test_studio_graph_run_view.py
@@ -1,0 +1,269 @@
+"""Task 13 of docs/superpowers/plans/2026-07-05-studio-agents-interact.md —
+the graph run view (`SessionGraphPanel` in `ui/components/studio-center.jsx`)
+rebuilt as a toggleable `window.SD_GraphRunView` G6 canvas over the SAME
+session-backed `<Transcript>`/`<Composer>` the agent panel (Task 12) uses,
+with an AUTONOMOUS Pause/Cancel/Restart control set instead of Stop/End.
+
+Static-source + transpile-build checks only — same rationale
+test_studio_run_view_interactive.py documents for Task 12: `<Transcript>`/
+`<Composer>`/`SD_GraphRunView` are full React components with live
+EventSource/G6-canvas effects that only a real DOM could exercise, and
+driving those interactively needs the heavier tests/ui_e2e Playwright
+harness (a live server + PRIMER_RUN_UI_E2E=1), which this task's file path
++ run command (plain `pytest tests/ui/test_studio_graph_run_view.py -n0
+-p no:cacheprovider`) does not provision. The viz-toggle's show/hide
+behavior, the graph_transition->divider mapping, and the Pause/Cancel/
+Restart (not Stop/End) wiring are therefore asserted the same way
+test_studio_terminal.py/test_studio_run_view_interactive.py assert their
+protocols: substring + scoped-slice checks pinned to the exact source
+region that wires each control, plus two MiniRacer evals of the actual
+pure helper functions (`ST_sessionTranscriptRows` via `SA_toTranscript`)
+so the "graph-transition records render as dividers" acceptance criterion
+is exercised for real rather than only substring-matched.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+CENTER = UI / "components" / "studio-center.jsx"
+ADAPTER = UI / "components" / "session-adapter.jsx"
+INDEX = UI / "index.html"
+
+
+def _center_src() -> str:
+    return CENTER.read_text(encoding="utf-8")
+
+
+def _adapter_src() -> str:
+    return ADAPTER.read_text(encoding="utf-8")
+
+
+def _fn_block(src: str, start_marker: str, end_marker: str) -> str:
+    """Slice `src` from `start_marker` up to (not including) `end_marker`."""
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+def _session_graph_panel_src() -> str:
+    """Just the `SessionGraphPanel` function body — scopes assertions to
+    this panel without false-matching `SessionAgentPanel`'s Stop/End set or
+    the still-defined-but-unused `ST_SessionControls` (Pause/Resume/Steer/
+    Cancel, the pre-Task-13 graph cluster neither panel calls anymore)."""
+    return _fn_block(_center_src(), "function SessionGraphPanel(", "function ST_SessionPanel(")
+
+
+# ---------------------------------------------------------------------------
+# SessionGraphPanel composes the SAME reused chat-refactor primitives over
+# the session adapter that the agent panel (Task 12) uses — not a second
+# parallel transcript renderer.
+# ---------------------------------------------------------------------------
+
+
+def test_session_graph_panel_uses_session_adapter_and_transcript_composer() -> None:
+    panel = _session_graph_panel_src()
+    assert "window.SA_useSessionConversation(" in panel
+    assert "ST_sessionTranscriptRows(" in panel
+    assert "<window.Transcript" in panel
+    assert "<window.Composer" in panel
+    assert "function Transcript(" not in panel
+    assert "function Composer(" not in panel
+
+
+def test_session_graph_panel_still_reuses_sd_graph_run_view_not_reimplemented() -> None:
+    panel = _session_graph_panel_src()
+    assert "window.SD_GraphRunView" in panel
+    assert "function SD_GraphRunView(" not in panel
+    # gid from the binding, rid = the session id (a graph run IS the
+    # session) — pinned exactly like test_studio_center.py's
+    # test_reuses_sd_graph_run_view, scoped here to this panel alone.
+    assert "gid={gid}" in panel
+    assert "rid={sid}" in panel
+
+
+# ---------------------------------------------------------------------------
+# Viz toggle (S6): a <SD_GraphRunView> region gated on a showViz boolean
+# defaulting ON, with a dedicated toggle control — OFF collapses to chat
+# only, and the Transcript/Composer render regardless of the toggle state.
+# ---------------------------------------------------------------------------
+
+
+def test_viz_toggle_control_exists_and_defaults_on() -> None:
+    panel = _session_graph_panel_src()
+    assert 'data-testid="ctrl-toggle-viz"' in panel
+    assert "React.useState(true)" in panel
+    assert "[showViz, setShowViz]" in panel
+    assert "setShowViz(function (v) { return !v; })" in panel
+
+
+def test_viz_region_is_conditionally_rendered_but_chat_is_not() -> None:
+    panel = _session_graph_panel_src()
+    # The SD_GraphRunView region is gated behind `showViz &&`.
+    assert "{showViz && (" in panel
+    viz_block = _fn_block(panel, "{showViz && (", "<window.Transcript")
+    assert "window.SD_GraphRunView" in viz_block
+    assert 'data-testid="graph-viz-region"' in viz_block
+    # Toggling off must NOT also hide the chat: <Transcript>/<Composer> sit
+    # OUTSIDE the showViz-gated block entirely (after it in source order,
+    # with no dependency on `showViz` themselves).
+    after_viz_block = panel.split(viz_block, 1)[1]
+    assert "<window.Transcript" in after_viz_block
+    assert "<window.Composer" in after_viz_block
+
+
+# ---------------------------------------------------------------------------
+# graph_transition records render as node/phase dividers in the transcript
+# — SA_toTranscript (Task 11, untouched) already maps this; exercised for
+# real via MiniRacer through the SAME ST_sessionTranscriptRows pipeline the
+# graph panel feeds <Transcript> with.
+# ---------------------------------------------------------------------------
+
+
+def test_graph_transition_records_render_as_dividers_via_mini_racer() -> None:
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    ctx.eval(_adapter_src())  # defines window.SA_toTranscript
+    helpers = _fn_block(_center_src(), "function ST_isAutonomous(", "function SessionAgentPanel(")
+    ctx.eval(helpers)  # defines ST_sessionTranscriptRows + friends
+    ctx.eval(
+        """
+        var records = [
+          {seq: 1, kind: "graph_transition",
+           payload: {node_id: "drafter", node_kind: "agent", phase: "enter", status: "running"},
+           created_at: "t1", node_id: "drafter"},
+          {seq: 2, kind: "graph_transition",
+           payload: {node_id: "drafter", node_kind: "agent", phase: "exit", status: "ended"},
+           created_at: "t2", node_id: "drafter"},
+        ];
+        var out = ST_sessionTranscriptRows(records, {id: "s1", binding: {kind: "graph"}});
+        """
+    )
+    assert ctx.eval("out.length") == 2
+    assert ctx.eval("out[0].kind") == "divider"
+    assert ctx.eval("out[0].text") == "drafter · enter"
+    assert ctx.eval("out[0].nodeId") == "drafter"
+    assert ctx.eval("out[1].kind") == "divider"
+    assert ctx.eval("out[1].text") == "drafter · exit"
+
+
+# ---------------------------------------------------------------------------
+# Autonomous control set: Pause + Cancel, Restart once ended. NO Stop/End —
+# those are the interactive (agent) set's terms; this panel never calls
+# conv.stop()/interrupt.
+# ---------------------------------------------------------------------------
+
+
+def test_pause_control_wired_to_the_pause_endpoint() -> None:
+    panel = _session_graph_panel_src()
+    assert 'data-testid="ctrl-pause"' in panel
+    assert "onClick={function () { if (wid) pauseMut.mutate(); }}" in panel
+    assert '"/pause"' in panel
+
+
+def test_cancel_control_wired_to_adapter_end_which_hits_cancel() -> None:
+    panel = _session_graph_panel_src()
+    assert 'data-testid="ctrl-cancel"' in panel
+    assert "onClick={function () { if (wid) cancelMut.mutate(); }}" in panel
+    assert "function () { return conv.end(); }" in panel
+    assert "/cancel" in _adapter_src()
+
+
+def test_restart_control_gated_on_ended_status_and_hits_restart() -> None:
+    panel = _session_graph_panel_src()
+    assert 'data-testid="ctrl-restart"' in panel
+    restart_gate = _fn_block(panel, "{isEnded && (", 'data-testid="ctrl-restart"')
+    assert "Btn" in restart_gate
+    assert 'status === "ended"' in panel
+    assert "onClick={function () { if (wid) restartMut.mutate(); }}" in panel
+    assert "function () { return conv.restart(); }" in panel
+    assert "/restart" in _adapter_src()
+
+
+def test_no_stop_or_end_control_on_the_graph_panel() -> None:
+    panel = _session_graph_panel_src()
+    assert "ctrl-end" not in panel
+    assert "ctrl-stop" not in panel
+    assert ">Stop<" not in panel
+    assert ">End<" not in panel
+
+
+def test_composer_never_shows_stop_and_never_calls_interrupt() -> None:
+    panel = _session_graph_panel_src()
+    # running is hardcoded false, so <Composer> can never swap to its Stop
+    # affordance; the panel never references conv.stop() (the interactive
+    # Stop path) or a raw /interrupt call.
+    assert "running={false}" in panel
+    assert "conv.stop" not in panel
+    assert "/interrupt" not in panel
+
+
+def test_no_dedicated_steer_or_resume_button_on_the_graph_panel() -> None:
+    # ST_SessionControls (Steer/Resume/Pause/Cancel) is the pre-Task-13
+    # cluster; this panel no longer reuses it (its own Pause/Cancel/Restart
+    # set above is self-contained), but the function itself must survive
+    # untouched (test_studio_run_view_interactive.py's own sanity pin).
+    panel = _session_graph_panel_src()
+    assert "ctrl-steer" not in panel
+    assert "ctrl-resume" not in panel
+    assert "<ST_SessionControls" not in panel
+    src = _center_src()
+    assert src.count("function ST_SessionControls(") == 1
+    assert 'data-testid="ctrl-steer"' in src  # still defined elsewhere, just unused here
+
+
+# ---------------------------------------------------------------------------
+# S7: mounting the panel never fires pause/steer/interrupt — every mutate()
+# call is wired exclusively behind an onClick, never inside a bare/mount
+# effect. Each wiring string above is pinned as occurring exactly once, so
+# it cannot ALSO appear un-gated inside a React.useEffect body.
+# ---------------------------------------------------------------------------
+
+
+def test_mutations_only_fire_from_onclick_never_on_mount() -> None:
+    panel = _session_graph_panel_src()
+    for call, onclick in (
+        ("pauseMut.mutate()", "onClick={function () { if (wid) pauseMut.mutate(); }}"),
+        ("cancelMut.mutate()", "onClick={function () { if (wid) cancelMut.mutate(); }}"),
+        ("restartMut.mutate()", "onClick={function () { if (wid) restartMut.mutate(); }}"),
+    ):
+        assert panel.count(call) == 1, f"{call} should be wired exactly once (via its onClick)"
+        assert onclick in panel
+
+
+# ---------------------------------------------------------------------------
+# index.html load order — unchanged by this task, re-asserted for
+# self-containedness (mirrors test_studio_run_view_interactive.py).
+# ---------------------------------------------------------------------------
+
+
+def test_index_html_registers_chat_primitives_and_session_adapter() -> None:
+    text = INDEX.read_text(encoding="utf-8")
+    for src in (
+        "components/session-adapter.jsx",
+        "components/chat/transcript.jsx",
+        "components/chat/composer.jsx",
+        "components/studio-center.jsx",
+    ):
+        assert src in text, f"{src} missing from index.html"
+
+
+# ---------------------------------------------------------------------------
+# Bundle transpile (the hard gate: the whole bundle incl. studio-center.jsx
+# compiles).
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_transpiles_with_the_rebuilt_graph_run_view() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    build_jsx_bundle.cache_clear()
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    text = body.decode("utf-8")
+    assert "/* === components/studio-center.jsx === */" in text
+    assert "/* === components/session-adapter.jsx === */" in text

--- a/tests/ui/test_studio_run_view_interactive.py
+++ b/tests/ui/test_studio_run_view_interactive.py
@@ -1,0 +1,346 @@
+"""Task 12 of docs/superpowers/plans/2026-07-05-studio-agents-interact.md —
+the agent run view (`SessionAgentPanel` in `ui/components/studio-center.jsx`)
+rebuilt as a session-backed `<Conversation>`: the reused
+`window.Transcript`/`window.Composer` chat-refactor primitives fed by the
+session adapter (Task 11, `ui/components/session-adapter.jsx`), with a
+Stop/End/Restart control set instead of the graph panel's Pause/Steer/Cancel.
+
+Static-source + transpile-build checks only (the `tests/ui` harness
+convention — see test_studio_center.py / test_studio_terminal.py /
+test_session_adapter.py), plus two MiniRacer evals of the actual pure
+helper functions this task adds (`ST_isAutonomous`, `ST_sessionTranscriptRows`
++ friends) so the load-bearing control-set derivation and row-flattening
+logic are exercised for real rather than only substring-matched — mirroring
+test_session_adapter.py's `test_sa_to_transcript_maps_records_via_mini_racer`.
+
+No browser/live server: <Transcript>/<Composer> are full React components
+with live EventSource/WS-adjacent effects (session-adapter.jsx's tap SSE)
+that only a real DOM could exercise end-to-end; driving those interactively
+here would need the heavier tests/ui_e2e Playwright harness (a live server +
+PRIMER_RUN_UI_E2E=1), which this task's file path + run command
+(`tests/ui/test_studio_run_view_interactive.py`, plain
+`pytest ... -n0 -p no:cacheprovider`) does not provision. The control-set
+WIRING (Stop -> .../interrupt, End -> .../cancel, Restart -> .../restart) is
+therefore asserted the same way test_studio_terminal.py asserts its WS URL/
+control-frame protocol: substring checks scoped to the exact source region
+that wires each control, so a future edit that silently drops/rewires one of
+these three endpoints fails a specific, named assertion.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+CENTER = UI / "components" / "studio-center.jsx"
+ADAPTER = UI / "components" / "session-adapter.jsx"
+INDEX = UI / "index.html"
+
+
+def _center_src() -> str:
+    return CENTER.read_text(encoding="utf-8")
+
+
+def _adapter_src() -> str:
+    return ADAPTER.read_text(encoding="utf-8")
+
+
+def _fn_block(src: str, start_marker: str, end_marker: str) -> str:
+    """Slice `src` from `start_marker` up to (not including) `end_marker`."""
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+def _session_agent_panel_src() -> str:
+    """Just the `SessionAgentPanel` function body — scopes assertions (like
+    "no dedicated steer button") to this panel without false-matching
+    `SessionGraphPanel`'s still-inlined `ST_SessionControls` (which does have
+    a Steer button; the graph panel is untouched by this task)."""
+    return _fn_block(_center_src(), "function SessionAgentPanel(", "function SessionGraphPanel(")
+
+
+def _pure_helpers_src() -> str:
+    """The plain-JS helper functions this task adds ahead of
+    `SessionAgentPanel` itself (ST_isAutonomous, ST_sessionRowToTranscript,
+    ST_coalesceAssistantRows, ST_sessionTranscriptRows) — no JSX, so (like
+    session-adapter.jsx) this slice is directly `py_mini_racer`-evaluable
+    without a full Babel/React/DOM stack."""
+    return _fn_block(_center_src(), "function ST_isAutonomous(", "function SessionAgentPanel(")
+
+
+# ---------------------------------------------------------------------------
+# SessionAgentPanel now composes the reused chat-refactor primitives over
+# the session adapter — not SessionLiveStream.
+# ---------------------------------------------------------------------------
+
+
+def test_session_agent_panel_uses_session_adapter_and_transcript_composer() -> None:
+    panel = _session_agent_panel_src()
+    assert "window.SA_useSessionConversation(" in panel
+    assert "ST_sessionTranscriptRows(" in panel
+    assert "<window.Transcript" in panel
+    assert "<window.Composer" in panel
+    # No bespoke chat UI (per the brief) — Message rows + the input surface
+    # are the reused components, not a second parallel renderer.
+    assert "function Transcript(" not in panel
+    assert "function Composer(" not in panel
+
+
+def test_session_agent_panel_no_longer_reuses_session_live_stream() -> None:
+    # SessionLiveStream backed the OLD (pre-Task-11/12) agent panel; Task 12
+    # explicitly retires that reuse path for THIS panel (SessionGraphPanel /
+    # the graph run-view, Task 13, is untouched and reuses a different
+    # production component, SD_GraphRunView).
+    panel = _session_agent_panel_src()
+    assert "SessionLiveStream" not in panel
+
+
+def test_transcript_fed_by_sa_to_transcript_via_the_flattening_helper() -> None:
+    src = _center_src()
+    helpers = _pure_helpers_src()
+    # ST_sessionTranscriptRows is the "fed by SA_toTranscript" pipeline the
+    # brief describes: SA_toTranscript's rows (Task 11, payload stays
+    # nested there by design) flattened + assistant-token-coalesced into
+    # what <Transcript>'s Message() row renderer actually reads.
+    assert "window.SA_toTranscript(records, session)" in src
+    assert "function ST_sessionRowToTranscript(" in helpers
+    assert "function ST_coalesceAssistantRows(" in helpers
+    assert "function ST_sessionTranscriptRows(" in helpers
+
+
+# ---------------------------------------------------------------------------
+# No dedicated steer button — steering IS sending a message (brief §4.2).
+# ---------------------------------------------------------------------------
+
+
+def test_no_dedicated_steer_button_on_the_agent_panel() -> None:
+    panel = _session_agent_panel_src()
+    assert "ctrl-steer" not in panel
+    assert "ST_SessionControls" not in panel
+
+
+def test_session_graph_panel_steer_control_is_untouched() -> None:
+    # Sanity: the graph panel's existing Steer/Pause/Resume/Cancel cluster
+    # (ST_SessionControls) is unaffected by this task — it still exists
+    # exactly once elsewhere in the file.
+    src = _center_src()
+    assert src.count("function ST_SessionControls(") == 1
+    assert 'data-testid="ctrl-steer"' in src
+
+
+# ---------------------------------------------------------------------------
+# Interactive control set: Stop -> .../interrupt, End -> .../cancel,
+# Restart (status === "ended" only) -> .../restart.
+# ---------------------------------------------------------------------------
+
+
+def test_composer_stop_wired_to_adapter_stop_which_hits_interrupt() -> None:
+    panel = _session_agent_panel_src()
+    assert "onStop={onStop}" in panel
+    assert "conv.stop()" in panel
+    # The endpoint itself is session-adapter.jsx's contract (also covered by
+    # test_session_adapter.py::test_controls_hit_the_documented_endpoints);
+    # re-asserted here so this file alone documents the full Stop path.
+    assert "/interrupt" in _adapter_src()
+
+
+def test_end_control_wired_to_adapter_end_which_hits_cancel() -> None:
+    panel = _session_agent_panel_src()
+    assert 'data-testid="ctrl-end"' in panel
+    assert "endMut.mutate()" in panel
+    assert "conv.end()" in panel
+    # End disables once the session has already ended — nothing left to cancel.
+    assert "disabled={!wid || isEnded || endMut.loading}" in panel
+    assert "/cancel" in _adapter_src()
+
+
+def test_restart_control_gated_on_ended_status_and_hits_restart() -> None:
+    panel = _session_agent_panel_src()
+    assert 'data-testid="ctrl-restart"' in panel
+    # Gated behind the same `isEnded` used for the header + Composer's
+    # disabled prop, and `isEnded` is derived from `status === "ended"`
+    # exactly (per brief §Interface — not the broader SESSION_TERMINAL set).
+    restart_gate = _fn_block(panel, "{isEnded && (", 'data-testid="ctrl-restart"')
+    assert "Btn" in restart_gate
+    assert 'status === "ended"' in panel
+    assert "restartMut.mutate()" in panel
+    assert "conv.restart()" in panel
+    assert "/restart" in _adapter_src()
+
+
+def test_no_pause_control_on_the_agent_panel() -> None:
+    panel = _session_agent_panel_src()
+    assert "ctrl-pause" not in panel
+    assert "Pause" not in panel
+
+
+# ---------------------------------------------------------------------------
+# Adapter extension: restart() + wsState were not part of Task 11's original
+# interface — this task adds them (session-adapter.jsx), minimally.
+# ---------------------------------------------------------------------------
+
+
+def test_adapter_restart_extension() -> None:
+    src = _adapter_src()
+    assert "var restart = React.useCallback(" in src
+    assert '"/restart"' in src
+    assert "restart: restart," in src
+    # The locked Task 11 mapping/exports are untouched.
+    assert "window.SA_toTranscript = SA_toTranscript;" in src
+    assert "window.SA_KIND_TO_TRANSCRIPT = SA_KIND_TO_TRANSCRIPT;" in src
+    assert "window.SA_useSessionConversation = SA_useSessionConversation;" in src
+
+
+def test_adapter_wsstate_extension_for_transcript_connection_pill() -> None:
+    src = _adapter_src()
+    assert "wsState: wsState," in src
+    assert 'es.onopen = function () { setWsState("open"); };' in src
+
+
+# ---------------------------------------------------------------------------
+# Non-invoked (CREATED) session: empty stream + composer prompting for the
+# first input — no separate "invoke" affordance, first Send auto-wakes it.
+# ---------------------------------------------------------------------------
+
+
+def test_first_send_goes_through_sendmessage_no_separate_invoke_control() -> None:
+    panel = _session_agent_panel_src()
+    assert "conv.sendMessage(text)" in panel
+    assert "ctrl-invoke" not in panel
+    assert "onSend={onSend}" in panel
+
+
+# ---------------------------------------------------------------------------
+# ST_isAutonomous — mirrors primer/session/autonomy.py::session_is_autonomous
+# exactly: explicit `session.autonomous` wins; else binding kind.
+# ---------------------------------------------------------------------------
+
+
+def test_st_is_autonomous_mirrors_backend_derivation_via_mini_racer() -> None:
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    ctx.eval(_pure_helpers_src())
+
+    assert ctx.eval('ST_isAutonomous({binding: {kind: "graph"}})') is True
+    assert ctx.eval('ST_isAutonomous({binding: {kind: "agent"}})') is False
+    # Explicit flag wins over binding kind, either direction.
+    assert ctx.eval('ST_isAutonomous({binding: {kind: "agent"}, autonomous: true})') is True
+    assert ctx.eval('ST_isAutonomous({binding: {kind: "graph"}, autonomous: false})') is False
+    # Defensive: no session / no binding.
+    assert ctx.eval("ST_isAutonomous(null)") is False
+    assert ctx.eval("ST_isAutonomous({})") is False
+
+
+# ---------------------------------------------------------------------------
+# ST_sessionTranscriptRows — flattens SA_toTranscript's rows for <Message>
+# (tool_result call_id->id / output->result aliasing; per-token
+# assistant_message coalescing with startSeq/endSeq).
+# ---------------------------------------------------------------------------
+
+
+def test_session_transcript_rows_flattens_and_coalesces_via_mini_racer() -> None:
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    ctx.eval(_adapter_src())  # defines window.SA_toTranscript
+    ctx.eval(_pure_helpers_src())  # defines ST_sessionTranscriptRows + friends
+    ctx.eval(
+        """
+        var records = [
+          {seq: 1, kind: "user_input", payload: {text: "hi"}, created_at: "t1", node_id: null},
+          {seq: 2, kind: "assistant_token", payload: {text: "Hel"}, created_at: "t2", node_id: null},
+          {seq: 3, kind: "assistant_token", payload: {text: "lo!"}, created_at: "t3", node_id: null},
+          {seq: 4, kind: "tool_call",
+           payload: {id: "call-1", arguments: {path: "a.txt"}}, created_at: "t4", node_id: null},
+          {seq: 5, kind: "tool_result",
+           payload: {call_id: "call-1", output: "contents", error: null}, created_at: "t5", node_id: null},
+          {seq: 6, kind: "done", payload: {stop_reason: "end_turn"}, created_at: "t6", node_id: null},
+        ];
+        var out = ST_sessionTranscriptRows(records, {id: "s1"});
+        """
+    )
+    # Two per-token assistant_message rows (seq 2, 3) coalesce into one.
+    assert ctx.eval("out.length") == 5
+
+    assert ctx.eval("out[0].kind") == "user_message"
+    assert ctx.eval("out[0].text") == "hi"
+
+    assert ctx.eval("out[1].kind") == "assistant_message"
+    assert ctx.eval("out[1].text") == "Hello!"
+    assert ctx.eval("out[1].startSeq") == 2
+    assert ctx.eval("out[1].endSeq") == 3
+
+    assert ctx.eval("out[2].kind") == "tool_call"
+    assert ctx.eval("out[2].id") == "call-1"
+
+    assert ctx.eval("out[3].kind") == "tool_result"
+    # Aliased so <Transcript> pairs tool_call<->tool_result by `.id`.
+    assert ctx.eval("out[3].id") == "call-1"
+    # Aliased from the session payload's `output` -> Message()'s `.result`.
+    assert ctx.eval("out[3].result") == "contents"
+
+    assert ctx.eval("out[4].kind") == "lifecycle"
+    # No dedicated Message() branch for a collapsed "lifecycle" row; falls
+    # back to a payload field instead of rendering a blank bubble.
+    assert ctx.eval("out[4].text") == "end_turn"
+
+
+def test_divider_rows_seed_text_from_the_divider_label() -> None:
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    ctx.eval(_adapter_src())
+    ctx.eval(_pure_helpers_src())
+    ctx.eval(
+        """
+        var records = [
+          {seq: 1, kind: "invocation_divider", payload: {invocation: 3}, created_at: "t1", node_id: null},
+        ];
+        var out = ST_sessionTranscriptRows(records, {id: "s1"});
+        """
+    )
+    assert ctx.eval("out[0].kind") == "divider"
+    assert ctx.eval("out[0].text") == "— invocation 3 —"
+
+
+# ---------------------------------------------------------------------------
+# index.html load order: session-adapter.jsx (window.SA_* / SA_useSession-
+# Conversation) and the chat-refactor primitives must both be registered —
+# already true (Task 11 + chat-refactor); re-asserted here since Task 12 is
+# the first file to actually reference window.Transcript/window.Composer
+# from studio-center.jsx.
+# ---------------------------------------------------------------------------
+
+
+def test_index_html_registers_chat_primitives_and_session_adapter() -> None:
+    text = INDEX.read_text(encoding="utf-8")
+    for src in (
+        "components/session-adapter.jsx",
+        "components/chat/transcript.jsx",
+        "components/chat/composer.jsx",
+        "components/studio-center.jsx",
+    ):
+        assert src in text, f"{src} missing from index.html"
+
+
+# ---------------------------------------------------------------------------
+# Bundle transpile (the hard gate: the whole bundle incl. studio-center.jsx
+# and the extended session-adapter.jsx compiles).
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_transpiles_with_the_rebuilt_agent_run_view() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    build_jsx_bundle.cache_clear()
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    text = body.decode("utf-8")
+    assert "/* === components/studio-center.jsx === */" in text
+    assert "/* === components/session-adapter.jsx === */" in text

--- a/tests/ui_e2e/test_panel_polling_and_signals.py
+++ b/tests/ui_e2e/test_panel_polling_and_signals.py
@@ -113,6 +113,60 @@ def _seed_ladder(base_url: str, unique_suffix: str, tmp_path):
     return wid, sid, cleanup_urls
 
 
+def _seed_graph(base_url: str, gid: str, agent_id: str) -> None:
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        r = c.post("/v1/graphs", json={
+            "id": gid, "description": "pause-disabled probe",
+            "nodes": [
+                {"kind": "begin", "id": "begin"},
+                {"kind": "agent", "id": "drafter", "agent_id": agent_id},
+                {"kind": "end", "id": "end", "output_template": ""},
+            ],
+            "edges": [
+                {"kind": "static", "from_node": "begin", "to_node": "drafter"},
+                {"kind": "static", "from_node": "drafter", "to_node": "end"},
+            ],
+        })
+        assert r.status_code == 201, f"seed graph failed: {r.text}"
+
+
+def _seed_graph_session(base_url: str, workspace_id: str, gid: str) -> str:
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        r = c.post(
+            f"/v1/workspaces/{workspace_id}/sessions",
+            json={"binding": {"kind": "graph", "graph_id": gid}, "auto_start": False},
+        )
+        assert r.status_code == 201, f"seed graph session failed: {r.text}"
+        return r.json()["id"]
+
+
+def _seed_graph_ladder(base_url: str, unique_suffix: str, tmp_path):
+    """Same ladder as ``_seed_ladder`` but binds the session to a graph —
+    Task 13 moved Pause off the agent panel onto the graph panel, so a
+    Pause-control pin now needs a graph-bound session rather than an
+    agent-bound one."""
+    pid = f"llm-psg-{unique_suffix}"
+    aid = f"ag-psg-{unique_suffix}"
+    gid = f"gr-psg-{unique_suffix}"
+    wp_id = f"wp-psg-{unique_suffix}"
+    tpl_id = f"tpl-psg-{unique_suffix}"
+    _seed_llm_provider(base_url, pid)
+    _seed_agent(base_url, aid, pid)
+    _seed_graph(base_url, gid, aid)
+    wid = _seed_workspace(base_url, wp_id, tpl_id, tmp_path)
+    sid = _seed_graph_session(base_url, wid, gid)
+    cleanup_urls = [
+        f"/v1/workspaces/{wid}/sessions/{sid}/cancel",
+        f"/v1/workspaces/{wid}",
+        f"/v1/workspace_templates/{tpl_id}",
+        f"/v1/workspace_providers/{wp_id}",
+        f"/v1/graphs/{gid}",
+        f"/v1/agents/{aid}",
+        f"/v1/llm_providers/{pid}",
+    ]
+    return wid, sid, cleanup_urls
+
+
 def _ask_item(sid, *, tool_call_id, prompt):
     return {"kind": "ask_user", "session_id": sid, "tool_call_id": tool_call_id, "prompt": prompt}
 
@@ -243,15 +297,20 @@ def test_u0060_respond_500_renders_inline_error_not_toast(
 def test_u0070_pause_button_disabled_when_status_not_running(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0070 — Re-pointed to the Studio's ``ctrl-pause``. Per
-    studio-center.jsx ``ST_SessionControls`` the Pause button is
+    """U0070 — Re-pointed to the Studio's ``ctrl-pause`` on the GRAPH
+    panel. Task 13 moved Pause (and Cancel) off the agent panel onto
+    SessionGraphPanel — the agent panel (SessionAgentPanel) has no Pause
+    control at all now (Stop/End/Restart only). Per studio-center.jsx
+    SessionGraphPanel the Pause button is still
     ``disabled={!wid || status !== "running" || pauseMut.loading}`` with
     a title "Enabled only when running" for a non-running (CREATED)
-    session. Pins both the disabled attr AND the title affordance.
+    session — same logic as the retired ST_SessionControls cluster, now
+    pinned against a graph-bound session. Pins both the disabled attr AND
+    the title affordance.
     """
-    wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
+    wid, sid, cleanup_urls = _seed_graph_ladder(base_url, unique_suffix, tmp_path)
     try:
-        open_session_in_studio(page, console_url, wid, sid, kind="agent")
+        open_session_in_studio(page, console_url, wid, sid, kind="graph")
 
         pause = page.locator("[data-testid='ctrl-pause']").first
         expect(pause).to_be_visible(timeout=10_000)
@@ -273,47 +332,50 @@ def test_u0070_pause_button_disabled_when_status_not_running(
 def test_u0067_resume_re_toasts_on_repeat_click(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0067 — Clicking Resume on a CREATED session emits a
-    "Resume signal sent" toast each time (the primer POST is
-    idempotent — 2xx no-op if already running). The UI's onResume
-    handler shows a toast on each click without an error toast,
-    even if the row was already running by the time the second
-    click landed.
+    """U0067 — Re-pointed: the Studio's agent panel has no dedicated
+    Resume control anymore (studio-center.jsx's retired
+    ST_SessionControls cluster is defined but never mounted by
+    SessionAgentPanel). Per session-adapter.jsx's SA_useSessionConversation
+    comment, "one input, three behaviours": a Composer send to a CREATED
+    session invokes it, to RUNNING/WAITING it steers, and to PAUSED it
+    resumes — always the SAME idempotent POST .../steer call
+    (session/enqueue.py's wake_session). Sending a message now covers
+    what a Resume click used to gate: repeating the (idempotent) send
+    must never surface an error toast even as the session's status moves
+    out from under it.
     """
     wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
         open_session_in_studio(page, console_url, wid, sid, kind="agent")
-        resume = page.locator("[data-testid='ctrl-resume']").first
-        resume.wait_for(state="visible", timeout=10_000)
 
-        # First click → toast.
-        resume.click()
+        composer = page.locator("textarea[placeholder='Send a message…']")
+        composer.wait_for(state="visible", timeout=10_000)
+        send_btn = page.locator("[data-testid='chat-send-btn']")
+
+        # First send — invokes the CREATED session (steer semantics). The
+        # persisted USER_INPUT is the surviving positive signal (no
+        # "Resume signal sent" toast exists anymore for a Composer send).
+        composer.fill("resume probe one")
+        send_btn.click()
         expect(
-            page.get_by_text("Resume signal sent", exact=False).first
-        ).to_be_visible(timeout=5_000)
+            page.get_by_text("resume probe one", exact=False).first
+        ).to_be_visible(timeout=10_000)
 
-        # Second click — even if status is mid-transition, the toast
-        # should appear again (the UI doesn't gate on status before
-        # calling resume). No error toast should fire.
-        # Wait briefly so the first toast doesn't mask the second.
+        # Second send — same idempotent call while the session may
+        # already be transitioning off CREATED. Tolerate the Composer
+        # swapping to its Stop affordance (turn in flight) by only
+        # retrying while Send is still the visible control.
         page.wait_for_timeout(500)
-        # The Resume button may or may not still be visible depending
-        # on the polled session state. If it's gone (status changed),
-        # treat the first click + toast as the contract pin and stop.
-        if resume.is_visible():
-            resume.click()
-            # Either the toast appears again OR (if the row terminated
-            # before the second click landed) the cancel/error path
-            # surfaces. Tolerate both — the negative contract is
-            # "no /errors/internal-style toast".
+        if send_btn.is_visible():
+            composer.fill("resume probe two")
+            send_btn.click()
             page.wait_for_timeout(1_500)
 
-        # No error-toast leak ("failed" appearing as a toast title).
-        # The toast container uses kind="error" for failures; assert
-        # we never see the standard "Resume failed" copy from the
-        # onError handler.
-        assert page.get_by_text("Resume failed", exact=False).count() == 0, (
-            "Resume click produced an error toast"
+        # No error-toast leak — the negative contract survives verbatim:
+        # a repeated idempotent send must never surface the generic
+        # "Send failed" error-toast copy from the onSend catch handler.
+        assert page.get_by_text("Send failed", exact=False).count() == 0, (
+            "repeated composer send produced an error toast"
         )
     finally:
         _cleanup(base_url, cleanup_urls)

--- a/tests/ui_e2e/test_session_lifecycle_journey.py
+++ b/tests/ui_e2e/test_session_lifecycle_journey.py
@@ -4,11 +4,11 @@ Two complex multi-page journeys that traverse 3-4 console pages each,
 mimicking a realistic operator workflow:
 
 * U0103 — Sessions full-lifecycle journey: seed agent + workspace + session
-  via API; user lands on /sessions, sees the row, drills into detail,
-  clicks Cancel, confirms in the modal, observes the "Cancel signal
-  sent" toast, watches the status caption poll to a terminal value,
-  navigates back to the list via the breadcrumb, sees the row with a
-  non-CREATED status pill.
+  via API; user opens the workspace's Studio, clicks the sidebar row to
+  open the agent panel, clicks End (fires directly, no confirm modal),
+  observes the "Session ended" toast, watches the status pill poll to a
+  terminal value, and confirms the sidebar still lists the row with a
+  non-CREATED status.
 
 * U0104 — Workspace detail Sessions tab reflects API-seeded session within
   the polling cadence: user lands on /workspaces/{wid}, clicks the
@@ -146,25 +146,30 @@ def test_u0103_sessions_full_lifecycle_journey(
     console_messages: list[dict],
     failed_requests: list[dict],
 ) -> None:
-    """U0103 — Multi-page session-lifecycle journey.
+    """U0103 — Studio session-lifecycle journey.
+
+    Re-pointed to the Studio (the retired /sessions list + /sessions/{id}
+    detail page + breadcrumb nav no longer exist): a session opens as a
+    center tab inside its workspace's single-page Studio.
 
     Steps:
       1. Seed agent + workspace + session via API.
-      2. Navigate to /sessions list — assert seeded session row visible.
-      3. Click the row → land on /sessions/{id}.
-      4. Click the Cancel button → confirmation modal opens.
-      5. Click the "Cancel session" confirm button.
-      6. Assert "Cancel signal sent" toast appears.
-      7. Watch the status pill poll OFF of CREATED within the
-         polling cadence (the API mutation flips the row to
-         cancelled/ending; UI polls /v1/sessions/{id} every 2 s).
-      8. Click the "Sessions" breadcrumb to navigate back to /sessions.
-      9. Assert the row is still listed with a non-CREATED status.
+      2. Enter the workspace's Studio — assert the seeded session row is
+         visible in the sidebar.
+      3. Click the row → center tab + agent panel (panel-agent) open.
+      4. Click ctrl-end (fires directly, no confirm modal — the agent
+         panel's End control is SessionAgentPanel's own, distinct from
+         the retired Cancel-with-confirmation flow).
+      5. Assert the "Session ended" toast appears.
+      6. Watch the panel header's status pill poll OFF of CREATED within
+         the polling cadence (ST_SessionPanel polls /v1/sessions/{id}
+         every 2 s while non-terminal).
+      7. Assert the session is still listed as a sidebar row with a
+         non-CREATED status.
 
-    Pages traversed: /console/ → /sessions → /sessions/{id} → /sessions.
-    Signals fired: cancel via UI.
-    Observed: list-row visibility, detail polling, terminal status pill,
-    breadcrumb navigation.
+    Signals fired: End (POST .../cancel) via the Studio agent panel.
+    Observed: sidebar row visibility, panel-header polling, terminal
+    status pill, sidebar row persistence post-end.
     """
     ids = _seed_session_ladder(base_url, unique_suffix)
     wid = ids["workspace"]
@@ -186,14 +191,18 @@ def test_u0103_sessions_full_lifecycle_journey(
             timeout=15_000,
         )
 
-        # Sanity: the ctrl-cancel control is enabled (session non-terminal).
-        cancel_btn = page.locator('[data-testid="ctrl-cancel"]').first
-        expect(cancel_btn).to_be_enabled(timeout=10_000)
+        # Sanity: the ctrl-end control is enabled (session non-terminal).
+        # Re-pointed: the agent panel's cancel affordance is now ``ctrl-end``
+        # (SessionAgentPanel's End button, POST .../cancel via
+        # SA_useSessionConversation's end()) — ``ctrl-cancel`` no longer
+        # exists on the agent panel (Task 13 moved it to the graph panel).
+        end_btn = page.locator('[data-testid="ctrl-end"]').first
+        expect(end_btn).to_be_enabled(timeout=10_000)
 
-        # --- 3. Click ctrl-cancel (fires directly, no confirm modal) --------
-        cancel_btn.click()
-        # Toast from ST_SessionControls has title "Cancel signal sent".
-        expect(page.get_by_text("Cancel signal sent")).to_be_visible(
+        # --- 3. Click ctrl-end (fires directly, no confirm modal) -----------
+        end_btn.click()
+        # Toast from SessionAgentPanel's endMut has title "Session ended".
+        expect(page.get_by_text("Session ended")).to_be_visible(
             timeout=10_000,
         )
 

--- a/tests/ui_e2e/test_session_panel_signals.py
+++ b/tests/ui_e2e/test_session_panel_signals.py
@@ -4,7 +4,7 @@ Covers:
 * U0052 — AskUserPanel does NOT render on a terminal session
   (the panel's polling stops on TERMINAL_STATUSES per
   ui/components/session-detail.jsx).
-* U0031 — Session pause + resume buttons toggle visible status.
+* U0031 — Composer send (invoke/steer/resume) toggles visible status.
 * U0027 — Empty per-collection search renders "No matches" cleanly.
 """
 
@@ -158,21 +158,25 @@ def test_u0052_ask_user_panel_hidden_on_terminal_session(
 def test_u0031_session_pause_resume_buttons_toggle_status(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0031 — Seed a CREATED session, click Resume on the detail page
+    """U0031 — Seed a CREATED session, send a message via the Composer
     (CREATED → WAITING / RUNNING since the worker pool will pick it up
     even though no real LLM is configured, the placeholder Ollama
     provider triggers a fatal which transitions the session toward
-    terminal). Then click Pause. Assert each click produces visible
-    status text changes within polling cadence.
+    terminal). Assert the send produces a visible status-pill change
+    within the polling cadence.
 
-    Priority area 2 — mutation feedback. Re-pointed to the Studio's
-    ``session-controls`` (``ctrl-resume``) in the center agent panel
-    (studio-center.jsx ``ST_SessionControls``).
+    Priority area 2 — mutation feedback. Re-pointed: the Studio's agent
+    panel has no Pause/Resume controls anymore (studio-center.jsx's
+    ST_SessionControls cluster is defined but never mounted by
+    SessionAgentPanel). Per session-adapter.jsx, resuming a CREATED
+    session is now "send a message via the Composer" — the SAME
+    POST .../steer call auto-wakes a CREATED/PAUSED/WAITING session
+    (session/enqueue.py's wake_session, "one input, three behaviours").
 
     We tolerate the session reaching terminal (ended/failed) at any
     point — the LLM provider points at a closed port so the worker's
-    LLM call will fail. The CONTRACT under test is that the BUTTONS
-    transition the visible UI state, not that the session actually
+    LLM call will fail. The CONTRACT under test is that the Composer
+    send transitions the visible UI state, not that the session actually
     runs to completion.
     """
     pid = f"llm-u31-{unique_suffix}"
@@ -192,21 +196,19 @@ def test_u0031_session_pause_resume_buttons_toggle_status(
         f"/v1/llm_providers/{pid}",
     ]
     try:
-        # Open the session in the Studio — the agent panel + controls mount.
+        # Open the session in the Studio — the agent panel + Composer mount.
         open_session_in_studio(page, console_url, wid, sid, kind="agent")
-        resume_btn = page.locator("[data-testid='ctrl-resume']").first
-        resume_btn.wait_for(state="visible", timeout=10_000)
+        composer = page.locator("textarea[placeholder='Send a message…']")
+        composer.wait_for(state="visible", timeout=10_000)
 
         # The panel header StatusPill reads "created" initially.
         body_initial = (page.locator("body").text_content() or "").lower()
         assert "created" in body_initial, "expected initial 'created' status"
 
-        # Click Resume — should send the signal + show a toast.
-        resume_btn.click()
-        # Toast confirms the signal was sent.
-        page.get_by_text("Resume signal sent", exact=False).first.wait_for(
-            state="visible", timeout=10_000,
-        )
+        # Send a message via the Composer — this is the resume/steer/invoke
+        # signal now (POST .../steer, session-adapter.jsx sendMessage).
+        composer.fill("please resume")
+        page.locator("[data-testid='chat-send-btn']").click()
 
         # Status moves off CREATED within ~12s (poll cadence 2s + worker
         # claim cycle + LLM fail path). Accept any non-CREATED status.

--- a/tests/ui_e2e/test_signals_files_workers.py
+++ b/tests/ui_e2e/test_signals_files_workers.py
@@ -1,8 +1,8 @@
 """Session signals + workspace files + sidebar workers UI tests.
 
 Covers backlog items:
-* U0068 — Session detail Steer queue renders submitted instruction in
-  "Queued this session" panel + success toast.
+* U0068 — Steering a session (Composer send) renders the submitted
+  instruction inline in the session transcript.
 * U0072 — Workspace detail Files tab lists a file written via API.
 * U0073 — Sidebar worker-pill text reflects /v1/workers count after
   POSTing a drain signal (activeWorkers drops to 0/1).
@@ -109,16 +109,17 @@ def _cleanup(base_url: str, urls: list[str]) -> None:
 def test_u0068_steer_queue_renders_submitted_instruction(
     page, base_url, console_url, unique_suffix, tmp_path,
 ) -> None:
-    """U0068 — Re-pointed to the Studio's steer control. Open the session
-    in the Studio (agent panel), click ``ctrl-steer`` to reveal the
-    ``steer-popover``, type an instruction into its textarea, click Queue.
-    Assert the "Steer queued" success toast appears and the popover
-    closes (studio-center.jsx ``ST_SessionControls`` steerMut onSuccess).
-
-    (The retired session-detail rendered a "Queued this session (N)" panel
-    that echoed each submitted instruction; the Studio's steer is a
-    fire-and-forget popover with no queued-echo panel, so that assertion
-    is dropped — the toast + popover-close is the surviving contract.)
+    """U0068 — Re-pointed to the Studio's Composer send. The retired
+    ``ctrl-steer``/``steer-popover`` cluster (studio-center.jsx's
+    ST_SessionControls) is no longer mounted by the agent panel — per
+    the studio-agents-interact brief, steering IS sending a message via
+    the Composer (SessionAgentPanel's onSend -> session-adapter.jsx's
+    sendMessage -> POST .../steer). There is no popover and no success
+    toast surviving from either the pre-Task-13 OR the retired
+    session-detail "Queued this session (N)" surface; the transcript
+    itself is the surviving contract — wake_session persists the steered
+    instruction as a USER_INPUT record (primer/session/enqueue.py), which
+    the session adapter renders inline as a user_message bubble.
     """
     pid = f"llm-st-{unique_suffix}"
     aid = f"ag-st-{unique_suffix}"
@@ -140,22 +141,21 @@ def test_u0068_steer_queue_renders_submitted_instruction(
     try:
         open_session_in_studio(page, console_url, wid, sid, kind="agent")
 
-        # Click ctrl-steer → the steer popover opens with its textarea.
-        steer_btn = page.locator("[data-testid='ctrl-steer']").first
-        steer_btn.wait_for(state="visible", timeout=10_000)
-        steer_btn.click()
+        # Send the instruction via the Composer — this IS steering now
+        # (no dedicated steer button/popover survives on the agent panel).
+        composer = page.locator("textarea[placeholder='Send a message…']")
+        expect(composer).to_be_visible(timeout=10_000)
+        composer.fill(instruction)
+        page.locator("[data-testid='chat-send-btn']").click()
 
-        popover = page.locator("[data-testid='steer-popover']")
-        expect(popover).to_be_visible(timeout=5_000)
-        popover.locator("textarea").fill(instruction)
-        # The Queue button submits (POST .../steer).
-        popover.get_by_role("button", name="Queue", exact=True).click()
-
-        # Success toast, and the popover closes on success.
+        # The steered instruction renders inline in the session transcript
+        # (persisted USER_INPUT on wake) — the surviving positive signal
+        # now that the popover + toast are both retired.
         expect(
-            page.get_by_text("Steer queued", exact=False).first
-        ).to_be_visible(timeout=5_000)
-        expect(popover).to_have_count(0, timeout=5_000)
+            page.get_by_text(instruction, exact=False).first
+        ).to_be_visible(timeout=10_000)
+        # No error toast leak from the send.
+        assert page.get_by_text("Send failed", exact=False).count() == 0
     finally:
         _cleanup(base_url, cleanup_urls)
 

--- a/ui/components/session-adapter.jsx
+++ b/ui/components/session-adapter.jsx
@@ -1,0 +1,290 @@
+/* global React */
+// Session adapter (Task 11, studio-agents-interact) — maps a workspace
+// Session's message stream onto the shape chat-refactor's `<Transcript>`
+// already knows how to render, so a Session can be rendered through the
+// reused chat UI without a second parallel renderer.
+//
+// SA_ = Session Adapter. No-build scope rule: top-level `var`/`function`
+// declarations (mirrors ui/components/chat/transcript.jsx's own top-level
+// style, not the IIFE-wrapped helper style of use-transcript.js) with
+// every exported symbol assigned to `window.X` at file end.
+//
+// Transport rule (locked, studio-agents-interact Global Constraints): NO
+// session WebSocket. History is `GET /v1/sessions/{sid}/messages`; live
+// updates are the workspace tap SSE `GET /v1/workspaces/{wid}/tap`,
+// scoped to this session via the same `window.WTP_buildSelector` helper
+// components/workspace-tap.jsx already exports (session-scoped selector +
+// TapCursor resume so the history<->live seam has no gap and no replay —
+// same pattern as SessionLiveStream in components/session-detail.jsx).
+//
+// Two symbols are produced:
+//   - SA_toTranscript(records, session): pure mapping, SessionMessageKind
+//     (or the tap's mirrored TapEventClass, once normalised to the same
+//     {seq, kind, payload, created_at, node_id} shape) -> the transcript
+//     row shape.
+//   - SA_useSessionConversation({ sid, wid }): the data hook. Its
+//     `messages` field is the normalised/merged *record* stream (history
+//     + live tap, deduped+sorted by seq) — callers apply SA_toTranscript
+//     themselves once they also have the `session` row in hand (Task 12's
+//     SessionAgentPanel renders `<Transcript>` "fed by SA_toTranscript").
+
+// ---------------------------------------------------------------------------
+// Pure mapping: SessionMessageKind -> transcript row kind
+// ---------------------------------------------------------------------------
+
+var SA_KIND_TO_TRANSCRIPT = {
+  user_input: "user_message",
+  assistant_token: "assistant_message",
+  tool_call: "tool_call",
+  tool_result: "tool_result",
+  graph_transition: "divider",
+  invocation_divider: "divider",
+  yielded: "interaction",
+  resumed: "interaction",
+  done: "lifecycle",
+  cancelled: "lifecycle",
+  error: "lifecycle",
+};
+
+// Divider label for the two kinds SA_KIND_TO_TRANSCRIPT maps to "divider".
+// invocation_divider (written by reset_session on ENDED->CREATED re-open,
+// payload: {invocation: N}) renders "— invocation N —"; graph_transition
+// (node ENTER/EXIT, payload: {node_id, node_kind, phase, status}) renders
+// "<node_id> · <phase>".
+function SA_dividerLabel(rec) {
+  if (rec.kind === "invocation_divider") {
+    var n = (rec.payload && rec.payload.invocation) || 1;
+    return "— invocation " + n + " —";
+  }
+  var p = rec.payload || {};
+  return (p.node_id || "node") + " · " + (p.phase || "");
+}
+
+// records: SessionMessageRecord-shaped rows — {seq, kind, payload,
+// created_at, node_id}, whether loaded from the REST history endpoint or
+// normalised from a live TapEvent (see SA_useSessionConversation below).
+// session: the WorkspaceSession row (reserved for session-aware rendering
+// decisions a future task may need — not read here yet).
+function SA_toTranscript(records, session) {
+  var out = [];
+  for (var i = 0; i < records.length; i++) {
+    var rec = records[i];
+    var kind = SA_KIND_TO_TRANSCRIPT[rec.kind] || "lifecycle";
+    out.push({
+      seq: rec.seq,
+      kind: kind,
+      nodeId: rec.node_id || null,
+      label: kind === "divider" ? SA_dividerLabel(rec) : undefined,
+      payload: rec.payload || {},
+      createdAt: rec.created_at,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Cursor encode — scopes the tap's resume cursor to this one session so the
+// live tail picks up exactly where the REST history left off. Same shape as
+// components/session-detail.jsx's private _slsEncodeCursor (TapCursor's
+// {known_as_of, seqs: {sid: seq}} wire form); duplicated locally (SA_-
+// prefixed) since that one isn't exported to `window`.
+// ---------------------------------------------------------------------------
+
+function SA_encodeCursor(sid, seq) {
+  var payload = { known_as_of: "1970-01-01T00:00:00+00:00", seqs: {} };
+  payload.seqs[sid] = seq;
+  var json = JSON.stringify(payload);
+  var b64;
+  try {
+    b64 = btoa(unescape(encodeURIComponent(json)));
+  } catch (_e) {
+    return null;
+  }
+  return b64.replace(/\+/g, "-").replace(/\//g, "_").replace(/=+$/, "");
+}
+
+// ---------------------------------------------------------------------------
+// SA_useSessionConversation — data hook backing a Session's live view.
+// ---------------------------------------------------------------------------
+
+function SA_useSessionConversation(opts) {
+  var sid = opts && opts.sid;
+  var wid = opts && opts.wid;
+  var primerApi = window.primerApi || {};
+  var apiFetch = primerApi.apiFetch;
+  var useResource = primerApi.useResource;
+
+  // Session row (status + turn_status) — light poll; the tap effect below
+  // stops opening new connections once it reports ENDED.
+  var detail = useResource(
+    "session-adapter:row:" + sid,
+    function (signal) {
+      return apiFetch("GET", "/sessions/" + encodeURIComponent(sid), null, { signal: signal });
+    },
+    { pollMs: 3000, deps: [sid] }
+  );
+  var sessionRow = detail.data;
+  var status = sessionRow ? sessionRow.status : null;
+  var turnStatus = sessionRow ? sessionRow.turn_status : "idle";
+
+  // Pending yield(s) for this session — inline interaction affordances
+  // (studio-agents-interact §5.4 / §4.5's session-scoped read).
+  var pendingRes = useResource(
+    "session-adapter:pending:" + sid,
+    function (signal) {
+      if (!wid) return Promise.resolve({ items: [] });
+      return apiFetch(
+        "GET",
+        "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/yields/pending",
+        null,
+        { signal: signal }
+      );
+    },
+    { pollMs: 4000, deps: [sid, wid] }
+  );
+  var pending = (pendingRes.data && pendingRes.data.items) || [];
+
+  // Raw normalised message-log records — REST history seed + live tap,
+  // merged/deduped/sorted by seq. SA_toTranscript is applied by callers
+  // (they also hold the `session` row for the mapping's second argument).
+  var recordsState = React.useState([]);
+  var records = recordsState[0];
+  var setRecords = recordsState[1];
+  var historyLoadedState = React.useState(false);
+  var historyLoaded = historyLoadedState[0];
+  var setHistoryLoaded = historyLoadedState[1];
+  var historyCursorRef = React.useRef(0);
+
+  // History load — GET /sessions/{sid}/messages (paginated; the server
+  // caps a single page at 1000, comfortably above one session's log in
+  // the common case). Best-effort: a failed history fetch still lets the
+  // live tap populate the stream from here on.
+  React.useEffect(function () {
+    var alive = true;
+    setRecords([]);
+    setHistoryLoaded(false);
+    historyCursorRef.current = 0;
+    if (!sid) return undefined;
+    (function () {
+      return apiFetch("GET", "/sessions/" + encodeURIComponent(sid) + "/messages?limit=1000")
+        .then(function (res) {
+          if (!alive) return;
+          var items = (res && res.items) || [];
+          var maxSeq = 0;
+          for (var i = 0; i < items.length; i++) {
+            if (typeof items[i].seq === "number" && items[i].seq > maxSeq) maxSeq = items[i].seq;
+          }
+          historyCursorRef.current = maxSeq;
+          if (items.length > 0) {
+            setRecords(function (prev) {
+              var seen = {};
+              for (var j = 0; j < prev.length; j++) seen[prev[j].seq] = true;
+              var merged = prev.concat(items.filter(function (it) { return !seen[it.seq]; }));
+              merged.sort(function (a, b) { return (a.seq || 0) - (b.seq || 0); });
+              return merged;
+            });
+          }
+        })
+        .catch(function () { /* history is best-effort; the live tap still tails */ })
+        .then(function () { if (alive) setHistoryLoaded(true); });
+    })();
+    return function () { alive = false; };
+  }, [sid]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Live tail — the session-scoped workspace tap (no session WebSocket).
+  // Opens only once history has loaded so the resume cursor carries
+  // history's high-water seq (no gap, no replay at the seam); skipped
+  // once the session is ENDED (a terminal session has nothing left to
+  // tail — the REST history above is already the full transcript).
+  React.useEffect(function () {
+    if (!wid || !sid || !historyLoaded) return undefined;
+    if (status === "ended") return undefined;
+
+    var selector = window.WTP_buildSelector ? window.WTP_buildSelector(null, sid) : null;
+    var highWater = historyCursorRef.current || 0;
+    var cursorToken = highWater > 0 ? SA_encodeCursor(sid, highWater) : null;
+
+    var url = "/v1/workspaces/" + encodeURIComponent(wid) + "/tap";
+    var params = [];
+    if (selector) params.push("selector=" + encodeURIComponent(JSON.stringify(selector)));
+    if (cursorToken) params.push("cursor=" + encodeURIComponent(cursorToken));
+    if (params.length > 0) url += "?" + params.join("&");
+
+    var es;
+    try {
+      es = new EventSource(url, { withCredentials: true });
+    } catch (_e) {
+      return undefined;
+    }
+
+    es.onmessage = function (ev) {
+      var tev;
+      try { tev = JSON.parse(ev.data); } catch (_e) { return; }
+      if (!tev || typeof tev.seq !== "number") return;
+      // Normalise the TapEvent (class/ts) onto the SessionMessageRecord
+      // shape (kind/created_at) records already carry from REST history.
+      var rec = {
+        seq: tev.seq,
+        kind: tev.class,
+        payload: (tev.payload && typeof tev.payload === "object") ? tev.payload : {},
+        created_at: tev.ts,
+        node_id: tev.node_id != null ? tev.node_id : null,
+      };
+      setRecords(function (prev) {
+        for (var i = 0; i < prev.length; i++) {
+          if (prev[i].seq === rec.seq) return prev;
+        }
+        var next = prev.concat([rec]);
+        next.sort(function (a, b) { return (a.seq || 0) - (b.seq || 0); });
+        return next;
+      });
+    };
+
+    es.onerror = function () { /* EventSource reconnects natively via Last-Event-ID */ };
+
+    return function () { try { es.close(); } catch (_e) { /* no-op */ } };
+  }, [wid, sid, historyLoaded, status]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // sendMessage/stop/end — one input, three behaviours (§5.1): a message
+  // to a CREATED session invokes it, to RUNNING/WAITING it steers, to
+  // PAUSED it resumes (all auto-wake, server-side). Stop preempts the
+  // turn but keeps the session alive; End hard-cancels it.
+  var sendMessage = React.useCallback(function (text) {
+    if (!wid || !sid) return Promise.reject(new Error("sendMessage: wid and sid are required"));
+    return apiFetch(
+      "POST",
+      "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/steer",
+      { instruction: text }
+    );
+  }, [apiFetch, wid, sid]);
+
+  var stop = React.useCallback(function () {
+    if (!wid || !sid) return Promise.resolve();
+    return apiFetch(
+      "POST",
+      "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/interrupt"
+    );
+  }, [apiFetch, wid, sid]);
+
+  var end = React.useCallback(function () {
+    if (!wid || !sid) return Promise.resolve();
+    return apiFetch(
+      "POST",
+      "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/cancel"
+    );
+  }, [apiFetch, wid, sid]);
+
+  return {
+    messages: records,
+    status: status,
+    turnStatus: turnStatus,
+    sendMessage: sendMessage,
+    stop: stop,
+    end: end,
+    pending: pending,
+  };
+}
+
+window.SA_toTranscript = SA_toTranscript;
+window.SA_KIND_TO_TRANSCRIPT = SA_KIND_TO_TRANSCRIPT;
+window.SA_useSessionConversation = SA_useSessionConversation;

--- a/ui/components/session-adapter.jsx
+++ b/ui/components/session-adapter.jsx
@@ -27,6 +27,11 @@
 //     + live tap, deduped+sorted by seq) — callers apply SA_toTranscript
 //     themselves once they also have the `session` row in hand (Task 12's
 //     SessionAgentPanel renders `<Transcript>` "fed by SA_toTranscript").
+//     Also returns `wsState` ("connecting"/"open"/"closed", the tap SSE's
+//     connection legibility — feeds <Transcript> the same way a chat's
+//     WebSocket wsState does) and `restart()` (POST .../restart — a Task 12
+//     addition; Task 11's original interface only needed sendMessage/
+//     stop/end).
 
 // ---------------------------------------------------------------------------
 // Pure mapping: SessionMessageKind -> transcript row kind
@@ -154,6 +159,15 @@ function SA_useSessionConversation(opts) {
   var historyLoaded = historyLoadedState[0];
   var setHistoryLoaded = historyLoadedState[1];
   var historyCursorRef = React.useRef(0);
+  // Connection legibility for the live tail (Task 12 addition — Task 11's
+  // original interface didn't need it, since nothing consumed it yet).
+  // Mirrors <Conversation>'s wsState ("connecting"/"open"/"closed") so a
+  // caller can feed it straight into <Transcript>'s CT_ConnectionStatus
+  // pill, even though the transport here is the tap SSE (EventSource), not
+  // a WebSocket.
+  var wsStateState = React.useState("connecting");
+  var wsState = wsStateState[0];
+  var setWsState = wsStateState[1];
 
   // History load — GET /sessions/{sid}/messages (paginated; the server
   // caps a single page at 1000, comfortably above one session's log in
@@ -198,7 +212,12 @@ function SA_useSessionConversation(opts) {
   // tail — the REST history above is already the full transcript).
   React.useEffect(function () {
     if (!wid || !sid || !historyLoaded) return undefined;
-    if (status === "ended") return undefined;
+    if (status === "ended") {
+      // Nothing left to tail on a terminal session — reflect that instead
+      // of leaving a stale "connecting" pill from before it ended.
+      setWsState("closed");
+      return undefined;
+    }
 
     var selector = window.WTP_buildSelector ? window.WTP_buildSelector(null, sid) : null;
     var highWater = historyCursorRef.current || 0;
@@ -214,8 +233,11 @@ function SA_useSessionConversation(opts) {
     try {
       es = new EventSource(url, { withCredentials: true });
     } catch (_e) {
+      setWsState("closed");
       return undefined;
     }
+
+    es.onopen = function () { setWsState("open"); };
 
     es.onmessage = function (ev) {
       var tev;
@@ -240,15 +262,22 @@ function SA_useSessionConversation(opts) {
       });
     };
 
-    es.onerror = function () { /* EventSource reconnects natively via Last-Event-ID */ };
+    es.onerror = function () {
+      // EventSource reconnects natively via Last-Event-ID; the browser
+      // flips readyState back to CONNECTING for us, so mirror that here
+      // rather than parking on a stale "open" pill.
+      setWsState("connecting");
+    };
 
     return function () { try { es.close(); } catch (_e) { /* no-op */ } };
   }, [wid, sid, historyLoaded, status]); // eslint-disable-line react-hooks/exhaustive-deps
 
-  // sendMessage/stop/end — one input, three behaviours (§5.1): a message
-  // to a CREATED session invokes it, to RUNNING/WAITING it steers, to
-  // PAUSED it resumes (all auto-wake, server-side). Stop preempts the
-  // turn but keeps the session alive; End hard-cancels it.
+  // sendMessage/stop/end/restart — one input, three behaviours (§5.1): a
+  // message to a CREATED session invokes it, to RUNNING/WAITING it steers,
+  // to PAUSED it resumes (all auto-wake, server-side). Stop preempts the
+  // turn but keeps the session alive; End hard-cancels it. Restart (Task
+  // 12 addition — not part of Task 11's original interface) re-opens an
+  // ENDED session and invokes it (studio-agents-interact §5.3).
   var sendMessage = React.useCallback(function (text) {
     if (!wid || !sid) return Promise.reject(new Error("sendMessage: wid and sid are required"));
     return apiFetch(
@@ -274,13 +303,24 @@ function SA_useSessionConversation(opts) {
     );
   }, [apiFetch, wid, sid]);
 
+  var restart = React.useCallback(function () {
+    if (!wid || !sid) return Promise.resolve();
+    return apiFetch(
+      "POST",
+      "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/restart",
+      {}
+    );
+  }, [apiFetch, wid, sid]);
+
   return {
     messages: records,
     status: status,
     turnStatus: turnStatus,
+    wsState: wsState,
     sendMessage: sendMessage,
     stop: stop,
     end: end,
+    restart: restart,
     pending: pending,
   };
 }

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -39,6 +39,23 @@ function SA_short(sid) {
   return sid.slice(0, 10) + "…" + sid.slice(-6);
 }
 
+// Global (this file) -> inline (studio-center.jsx's ST_InlineYields) sync.
+// The four raw-apiFetch handlers below aren't wired through useMutation's
+// `invalidates` option, so a successful respond here only ever refreshed
+// THIS component's own "studio-yields-pending:{wid}" resource (via hide()'s
+// delayed pending.refetch()) — the session-scoped "session-adapter:pending:
+// {sid}" cache SA_useSessionConversation polls for the inline panel was left
+// to catch up on its own 4s poll. Force it immediately, using the exact same
+// findKeys/refetchKey primitive ST_yieldInvalidates' callers (useMutation)
+// use, and the exact same key string SA_useSessionConversation registers
+// (session-adapter.jsx's `"session-adapter:pending:" + sid` resource key).
+function SA_invalidateSessionPending(sessionId) {
+  var resourceApi = window.primerApi && window.primerApi._resource;
+  if (!resourceApi || !sessionId) return;
+  var baseKey = "session-adapter:pending:" + sessionId;
+  resourceApi.findKeys(baseKey).forEach(function(key) { resourceApi.refetchKey(key); });
+}
+
 // ---------------------------------------------------------------------------
 // ActionRequired
 // ---------------------------------------------------------------------------
@@ -135,6 +152,7 @@ function ActionRequired({ wid, studio, onCountChange }) {
       { tool_call_id: item.tool_call_id, decision: "approved" }
     ).then(function() {
       hide(item.tool_call_id);
+      SA_invalidateSessionPending(item.session_id);
     }).catch(function(err) {
       // Surface error inline — stay visible so user can retry
       patchRespond(item.tool_call_id, { error: (err && (err.detail || err.title || err.message)) || "Approve failed" });
@@ -149,6 +167,7 @@ function ActionRequired({ wid, studio, onCountChange }) {
       { tool_call_id: item.tool_call_id, decision: "rejected", reason: "" }
     ).then(function() {
       hide(item.tool_call_id);
+      SA_invalidateSessionPending(item.session_id);
     }).catch(function(err) {
       patchRespond(item.tool_call_id, { error: (err && (err.detail || err.title || err.message)) || "Reject failed" });
     });
@@ -165,6 +184,7 @@ function ActionRequired({ wid, studio, onCountChange }) {
       { tool_call_id: item.tool_call_id, response: rs.draft.trim() }
     ).then(function() {
       hide(item.tool_call_id);
+      SA_invalidateSessionPending(item.session_id);
     }).catch(function(err) {
       patchRespond(item.tool_call_id, { submitting: false, error: (err && (err.detail || err.title || err.message)) || "Respond failed" });
     });
@@ -185,6 +205,7 @@ function ActionRequired({ wid, studio, onCountChange }) {
       { reason: "operator cancelled" }
     ).then(function() {
       hide(item.tool_call_id);
+      SA_invalidateSessionPending(item.session_id);
     }).catch(function(err) {
       patchRespond(item.tool_call_id, { error: (err && (err.detail || err.title || err.message)) || "Cancel failed" });
     });
@@ -585,6 +606,7 @@ function StudioActivity({ wid, studio }) {
         type="button"
         data-testid="debug-sidebar-toggle"
         aria-expanded={collapsed ? "false" : "true"}
+        aria-controls="debug-sidebar-body"
         aria-label={collapsed ? "Expand debug panel" : "Collapse debug panel"}
         title={collapsed ? "Expand debug panel (Action Required + Activity)" : "Collapse debug panel"}
         onClick={toggle}
@@ -629,6 +651,7 @@ function StudioActivity({ wid, studio }) {
       </button>
 
       <div
+        id="debug-sidebar-body"
         data-testid="debug-sidebar-body"
         style={{
           display: collapsed ? "none" : "flex",

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -43,7 +43,7 @@ function SA_short(sid) {
 // ActionRequired
 // ---------------------------------------------------------------------------
 
-function ActionRequired({ wid, studio }) {
+function ActionRequired({ wid, studio, onCountChange }) {
   var apiFetch = window.primerApi.apiFetch;
   var useResource = window.primerApi.useResource;
 
@@ -202,6 +202,13 @@ function ActionRequired({ wid, studio }) {
 
   var visibleItems = items.filter(function(it) { return !hidden[it.tool_call_id]; });
   var count = visibleItems.length;
+
+  // Task 14: report the live count up to StudioActivity so the collapsed
+  // rail can show a badge without a second fetch — ActionRequired stays the
+  // single source of truth for "how many pending yields right now".
+  React.useEffect(function() {
+    if (typeof onCountChange === "function") onCountChange(count);
+  }, [count, onCountChange]);
 
   return (
     <div
@@ -540,14 +547,32 @@ function WorkspaceActivity({ wid }) {
 }
 
 // ---------------------------------------------------------------------------
-// StudioActivity — right sidebar shell (B4)
+// StudioActivity — right sidebar shell (B4 -> Task 14 collapsed debug view)
 // Replaces <ST_RegionPlaceholder testid="region-activity" /> in studio.jsx
+//
+// Task 14: this column is the GLOBAL debug tracker (Action Required across
+// ALL sessions + the workspace-wide WorkspaceTap feed) — but it starts
+// COLLAPSED so an operator who isn't actively debugging doesn't lose the
+// screen real estate. Collapsing is purely a visual toggle: ActionRequired
+// and WorkspaceActivity stay MOUNTED at all times (only the wrapping
+// `debug-sidebar-body` div's display flips), so their poll timers + tap
+// EventSources never tear down/reconnect on every expand — the badge count
+// on the collapsed rail is always live, and re-expanding shows already-warm
+// data instead of a cold fetch.
 // ---------------------------------------------------------------------------
 
 function StudioActivity({ wid, studio }) {
+  var [collapsed, setCollapsed] = React.useState(true);
+  var [pendingCount, setPendingCount] = React.useState(0);
+
+  function toggle() {
+    setCollapsed(function(c) { return !c; });
+  }
+
   return (
     <div
       data-testid="studio-activity-root"
+      className={collapsed ? "is-collapsed" : ""}
       style={{
         display: "flex",
         flexDirection: "column",
@@ -556,8 +581,66 @@ function StudioActivity({ wid, studio }) {
         borderLeft: "1px solid var(--border)",
       }}
     >
-      <ActionRequired wid={wid} studio={studio} />
-      <WorkspaceActivity wid={wid} />
+      <button
+        type="button"
+        data-testid="debug-sidebar-toggle"
+        aria-expanded={collapsed ? "false" : "true"}
+        aria-label={collapsed ? "Expand debug panel" : "Collapse debug panel"}
+        title={collapsed ? "Expand debug panel (Action Required + Activity)" : "Collapse debug panel"}
+        onClick={toggle}
+        style={{
+          flexShrink: 0,
+          display: "flex",
+          alignItems: "center",
+          gap: 8,
+          height: 34,
+          padding: "0 12px",
+          border: "none",
+          borderBottom: collapsed ? "none" : "1px solid var(--border)",
+          background: "transparent",
+          color: "var(--text-2)",
+          cursor: "pointer",
+          fontSize: 10.5,
+          textTransform: "uppercase",
+          letterSpacing: "0.06em",
+          fontWeight: 600,
+          font: "inherit",
+        }}
+      >
+        <Icon name={collapsed ? "chevron-left" : "chevron-right"} size={13} style={{ flexShrink: 0, color: "var(--text-3)" }} />
+        <Icon name="bell" size={13} style={{ flexShrink: 0 }} />
+        <span style={{ flex: 1, textAlign: "left" }}>Debug</span>
+        {pendingCount > 0 && (
+          <span
+            data-testid="debug-sidebar-badge"
+            style={{
+              background: "var(--amber-dim)",
+              color: "var(--amber)",
+              borderRadius: 999,
+              padding: "1px 7px",
+              fontSize: 10.5,
+              fontWeight: 700,
+              fontFamily: "IBM Plex Mono, monospace",
+            }}
+          >
+            {pendingCount}
+          </span>
+        )}
+      </button>
+
+      <div
+        data-testid="debug-sidebar-body"
+        style={{
+          display: collapsed ? "none" : "flex",
+          flexDirection: "column",
+          flex: 1,
+          minHeight: 0,
+          overflow: "hidden",
+        }}
+      >
+        <ActionRequired wid={wid} studio={studio} onCountChange={setPendingCount} />
+        <WorkspaceActivity wid={wid} />
+      </div>
     </div>
   );
 }

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -7,14 +7,17 @@
 //                        dirty dot, close ×; horizontal overflow; empty state).
 //   the active panel  — chosen by the active tab's kind:
 //     session(agent) → SessionAgentPanel  (header + End/Restart + Transcript/Composer)
-//     session(graph) → SessionGraphPanel  (header + SD_GraphRunView)
+//     session(graph) → SessionGraphPanel  (header + Pause/Cancel/Restart +
+//                       a toggleable SD_GraphRunView over the SAME
+//                       session-backed Transcript/Composer, Task 13)
 //     file           → FilePanel          (preview/edit toggle + Save + 412 flow)
 //
 // REUSE (do NOT rebuild): the graph run-view is still the production
 // component from session-detail.jsx; the agent transcript (Task 12,
-// studio-agents-interact plan) is now chat-refactor's own reused primitives
-// over the session adapter instead — all reached across files as the
-// no-build window globals:
+// studio-agents-interact plan) and the graph panel's bottom transcript
+// (Task 13, this file) are both chat-refactor's own reused primitives over
+// the session adapter — all reached across files as the no-build window
+// globals:
 //   window.SD_GraphRunView        ({ gid, rid, wid, session, pushToast })
 //   window.SA_useSessionConversation ({ sid, wid })  — session-adapter.jsx
 //   window.SA_toTranscript           (records, session)
@@ -22,16 +25,23 @@
 // Markdown preview reuses window.renderMarkdown; code highlight reuses
 // window.primerVendor.highlightPython.
 //
-// REUSE FRICTION (noted for B6): the GRAPH panel's per-session control
-// mutations (pause/resume/steer/cancel) still live *inlined* here
-// (ST_SessionControls below) against the same workspace-scoped endpoints
-// (POST .../sessions/{sid}/{pause|resume|cancel|steer}) — they were never
-// exported as standalone helpers/hooks from session-detail.jsx. The AGENT
-// panel (SessionAgentPanel) no longer has this friction: Stop/End route
-// through SA_useSessionConversation's own stop()/end() (POST
-// .../interrupt / .../cancel), and Restart through a small `restart()`
-// this task added to that same hook (POST .../restart — Task 11's original
-// interface didn't need it; session-adapter.jsx is otherwise untouched).
+// REUSE FRICTION (noted for B6, updated by Task 13): `ST_SessionControls`
+// below (Pause/Resume/Steer/Cancel against the workspace-scoped
+// POST .../sessions/{sid}/{pause|resume|cancel|steer} endpoints) was the
+// pre-Task-13 GRAPH panel's control cluster. Neither run-view panel calls
+// it anymore: the AGENT panel (SessionAgentPanel, Task 12) has its own
+// Stop/End/Restart set over SA_useSessionConversation's stop()/end()/
+// restart(), and the GRAPH panel (SessionGraphPanel, Task 13) now has its
+// own minimal Pause/Cancel/Restart set — Cancel and Restart reuse that
+// SAME adapter's end()/restart() (identical POST .../cancel and
+// .../restart calls the agent panel makes), and Pause is one fresh
+// mutation against the pre-existing POST .../pause endpoint
+// (ST_SessionControls's own pauseMut, copied rather than shared since it
+// was never factored out as a standalone hook). `ST_SessionControls` is
+// left defined-but-unused rather than deleted: it is still exercised by
+// tests/ui/test_studio_run_view_interactive.py's sanity pin (Task 12
+// deliberately asserted the pre-Task-13 graph cluster was untouched by
+// its own change), and by any not-yet-repointed tests/ui_e2e journeys.
 //
 // No-build rules: top-level declarations use `var`; helpers prefixed ST_;
 // every exported symbol is assigned to window.X at the bottom.
@@ -173,8 +183,11 @@ function CenterTabs({ openTabs, activeTabId, onFocus, onClose }) {
 // ---------------------------------------------------------------------------
 // ST_SessionControls — pause/resume · steer · cancel inline control cluster.
 // Re-creates SessionDetail's signal mutations against the same workspace-scoped
-// endpoints (see REUSE FRICTION note at top). Shared by the agent + graph
-// header rows.
+// endpoints (see REUSE FRICTION note at top). Pre-Task-13 this was the graph
+// panel's header cluster; SessionGraphPanel now has its own minimal
+// Pause/Cancel/Restart set instead (see that function), so nothing in this
+// file calls ST_SessionControls anymore — left defined for the reasons in
+// the REUSE FRICTION note (not deleted).
 // ---------------------------------------------------------------------------
 
 function ST_SessionControls({ wid, sid, session, pushToast }) {
@@ -322,8 +335,9 @@ function ST_TokenMeterInline({ session }) {
 // ST_isAutonomous — mirrors primer/session/autonomy.py::session_is_autonomous
 // exactly: an explicit `session.autonomous` flag wins; otherwise derive from
 // the binding kind (graph ⇒ autonomous, agent ⇒ interactive). Gates the
-// agent run view's Stop/End/Restart control set (interactive, this panel)
-// vs. the graph panel's Pause/Steer/Cancel (autonomous, ST_SessionControls).
+// agent run view's Stop/End/Restart control set (interactive,
+// SessionAgentPanel) vs. the graph run view's Pause/Cancel/Restart control
+// set (autonomous, SessionGraphPanel).
 // ---------------------------------------------------------------------------
 
 function ST_isAutonomous(session) {
@@ -584,24 +598,119 @@ function SessionAgentPanel({ wid, sid, session, pushToast }) {
 }
 
 // ---------------------------------------------------------------------------
-// SessionGraphPanel — graph run-view panel.
-//   header: name · status · progress (superstep N · X/Y · current)
-//   body  : the reused SD_GraphRunView (graph canvas + node inspector)
+// SessionGraphPanel — graph run view (Task 13).
+//   header: name · status · progress (superstep N · X/Y · current) + the
+//           toggle-viz control + the AUTONOMOUS control set (pause + cancel,
+//           restart once ended — NO Stop/End, those are the INTERACTIVE
+//           (agent) set's terms; this panel never calls /interrupt).
+//   top   : the reused SD_GraphRunView (graph canvas + node inspector),
+//           shown/hidden by the viz toggle (S6 — OFF collapses to chat only).
+//   bottom: the SAME session-backed <Transcript>/<Composer> the agent panel
+//           uses (SA_useSessionConversation) — graph_transition records
+//           SA_toTranscript already maps to divider rows
+//           (SA_KIND_TO_TRANSCRIPT), so node/phase transitions render
+//           inline with no extra plumbing here.
+//   S7: mounting this panel never fires a control — SD_GraphRunView's own
+//       effects only GET/poll/tail, SA_useSessionConversation's effects
+//       only fetch history + tail the tap, and the three mutations below
+//       are wired exclusively to onClick handlers. Opening the panel on an
+//       already-running auto_start graph therefore never pauses/steers it.
 // ---------------------------------------------------------------------------
 
-function SessionGraphPanel({ wid, sid, session, pushToast }) {
+function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
   var StatusPill = window.StatusPill;
-  var gid = session && session.binding && session.binding.graph_id
+  var { useMutation, apiFetch } = window.primerApi;
+
+  // gid: accept an explicit prop (this task's interface) but fall back to
+  // deriving it from the session binding exactly like the pre-Task-13
+  // panel did — ST_SessionPanel (the only caller today) doesn't pass
+  // gid/rid, so this keeps that call site working unchanged.
+  gid = gid || (session && session.binding && session.binding.graph_id
     ? session.binding.graph_id
-    : (session && session.graph_id) || null;
+    : (session && session.graph_id) || null);
+  // rid: for a graph-bound session the run IS the session, so the run id
+  // passed to SD_GraphRunView below is always `sid` (matching its
+  // pre-existing rid={sid} call in session-detail.jsx and the
+  // test_reuses_sd_graph_run_view pin) — `rid` is accepted here only for
+  // interface parity with SD_GraphRunView's own prop name.
+
   var title = (session && (session.name || session.id)) || sid;
   var superstep = (session && (session.turn_no != null ? session.turn_no : session.turn_count)) || 0;
+  var status = session && session.status;
+  var isTerminal = !!(session && window.SESSION_TERMINAL && window.SESSION_TERMINAL.has(status));
+  var isEnded = status === "ended";
 
   // Progress summary if the row carries node counts (best-effort; the
   // run-view itself owns the authoritative per-node state).
   var done = session && (session.nodes_done != null ? session.nodes_done : null);
   var total = session && (session.nodes_total != null ? session.nodes_total : null);
   var current = session && (session.current_node || session.active_node) || null;
+
+  // Viz toggle (S6) — a pure render toggle, no network effect either way.
+  // Defaults ON so opening the panel shows the live run exactly like the
+  // pre-Task-13 panel did.
+  var [showViz, setShowViz] = React.useState(true);
+
+  // The SAME session-backed conversation hook the agent panel uses.
+  var conv = window.SA_useSessionConversation({ sid: sid, wid: wid });
+  var [composerText, setComposerText] = React.useState("");
+  var scrollRef = React.useRef(null);
+
+  function toastErr(t) {
+    return function (err) {
+      if (typeof pushToast !== "function") return;
+      pushToast({
+        kind: "error",
+        title: (err && err.title) || t,
+        detail: (err && err.detail) || (err && err.message),
+        requestId: err && err.requestId,
+      });
+    };
+  }
+
+  var invalidates = ["studio-session:" + sid, "session-adapter:row:" + sid, "sessions:list"];
+
+  // Autonomous control set (brief §Interface): Pause + Cancel, Restart once
+  // ended. Cancel/Restart reuse the session adapter's own end()/restart()
+  // — the identical POST .../cancel and .../restart calls the agent
+  // panel's End/Restart hit — so the network wiring isn't duplicated.
+  // Pause has no adapter equivalent (its interface is Stop/End/Restart
+  // only), so it is the one fresh mutation here, against the same
+  // workspace-scoped POST .../pause the pre-Task-13 ST_SessionControls
+  // used (reused endpoint, not a new one).
+  var pauseMut = useMutation(
+    function () { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/pause"); },
+    { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Session paused" }); }, onError: toastErr("Pause failed") }
+  );
+  var cancelMut = useMutation(
+    function () { return conv.end(); },
+    { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "warning", title: "Cancel signal sent" }); }, onError: toastErr("Cancel failed") }
+  );
+  var restartMut = useMutation(
+    function () { return conv.restart(); },
+    { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Session restarted" }); }, onError: toastErr("Restart failed") }
+  );
+
+  var rows = React.useMemo(
+    function () { return ST_sessionTranscriptRows(conv.messages, session); },
+    [conv.messages, session]
+  );
+
+  // Stick-to-bottom — same rationale as the agent panel.
+  React.useEffect(function () {
+    var el = scrollRef.current;
+    if (!el) return undefined;
+    var raf = requestAnimationFrame(function () { el.scrollTop = el.scrollHeight; });
+    return function () { cancelAnimationFrame(raf); };
+  }, [rows.length]);
+
+  function onSend() {
+    var text = composerText.trim();
+    if (!text) return;
+    var p = conv.sendMessage(text);
+    setComposerText("");
+    if (p && typeof p.catch === "function") p.catch(toastErr("Send failed"));
+  }
 
   return (
     <div
@@ -624,16 +733,103 @@ function SessionGraphPanel({ wid, sid, session, pushToast }) {
           {current ? " · " + current : ""}
         </span>
         <div style={{ flex: 1 }} />
-        <ST_SessionControls wid={wid} sid={sid} session={session} pushToast={pushToast} />
+        <Btn
+          size="sm"
+          kind={showViz ? "primary" : "ghost"}
+          icon="graph"
+          onClick={function () { setShowViz(function (v) { return !v; }); }}
+          data-testid="ctrl-toggle-viz"
+          title={showViz ? "Hide the run-view canvas — chat only" : "Show the run-view canvas"}
+        >{showViz ? "Hide viz" : "Show viz"}</Btn>
+        <Btn
+          size="sm"
+          icon="pause"
+          disabled={!wid || status !== "running" || pauseMut.loading}
+          onClick={function () { if (wid) pauseMut.mutate(); }}
+          data-testid="ctrl-pause"
+          title={status !== "running" ? "Enabled only when running" : "Pause after current turn"}
+        >Pause</Btn>
+        <Btn
+          size="sm"
+          kind="danger"
+          icon="stop"
+          disabled={!wid || isTerminal || cancelMut.loading}
+          onClick={function () { if (wid) cancelMut.mutate(); }}
+          data-testid="ctrl-cancel"
+          title="Cancel the run"
+        >Cancel</Btn>
+        {isEnded && (
+          <Btn
+            size="sm"
+            kind="primary"
+            icon="refresh"
+            disabled={!wid || restartMut.loading}
+            onClick={function () { if (wid) restartMut.mutate(); }}
+            data-testid="ctrl-restart"
+            title="Re-open this ended run and invoke it"
+          >Restart</Btn>
+        )}
       </div>
-      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
-        {wid && gid && window.SD_GraphRunView
-          ? <window.SD_GraphRunView gid={gid} rid={sid} wid={wid} session={session} pushToast={pushToast} />
-          : (
-            <div className="muted text-sm" style={{ padding: 20, textAlign: "center", color: "var(--text-4)" }}>
-              Run view unavailable — graph binding or workspace missing.
-            </div>
-          )}
+
+      {showViz && (
+        <div
+          data-testid="graph-viz-region"
+          style={{ flex: "0 0 auto", height: 360, minHeight: 0, overflow: "auto", borderBottom: "1px solid var(--border)" }}
+        >
+          {wid && gid && window.SD_GraphRunView
+            ? <window.SD_GraphRunView gid={gid} rid={sid} wid={wid} session={session} pushToast={pushToast} />
+            : (
+              <div className="muted text-sm" style={{ padding: 20, textAlign: "center", color: "var(--text-4)" }}>
+                Run view unavailable — graph binding or workspace missing.
+              </div>
+            )}
+        </div>
+      )}
+
+      <window.Transcript
+        messages={rows}
+        chatId={sid}
+        agentId={null}
+        wsState={conv.wsState}
+        waitingForReply={false}
+        turnStatus={conv.turnStatus}
+        pendingToolCall={null}
+        sendMessage={conv.sendMessage}
+        onRewind={null}
+        // Same rationale as the agent panel: no compaction concept for a
+        // session transcript, and no per-message rewind endpoint here either.
+        compactionBoundarySeq={Number.MAX_SAFE_INTEGER}
+        scrollRef={scrollRef}
+        onScroll={function () {}}
+        loadingOlder={false}
+        hasMoreOlder={false}
+      />
+      <div
+        style={{
+          borderTop: "1px solid var(--border)", padding: 14,
+          display: "flex", gap: 8, alignItems: "stretch", flex: "0 0 auto",
+        }}
+      >
+        <window.Composer
+          value={composerText}
+          onChange={setComposerText}
+          onSend={onSend}
+          // NO Stop affordance on the autonomous set (brief §Interface) —
+          // running is always false so <Composer> never swaps to its Stop
+          // control (which is reserved for the agent panel's interactive
+          // hard-preempt call; this panel must never trigger it). Steering
+          // IS sending a message here too, same as the agent panel.
+          onStop={function () {}}
+          running={false}
+          disabled={isEnded}
+          attachments={[]}
+          onAttach={function () {}}
+          onRemoveAttachment={function () {}}
+          slashCommands={[]}
+          mentionSources={[]}
+          schemaInvalid={false}
+          wsState={conv.wsState}
+        />
       </div>
     </div>
   );

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -6,25 +6,32 @@
 //   CenterTabs        — the tab bar over studio.state.openTabs (glyph/title,
 //                        dirty dot, close ×; horizontal overflow; empty state).
 //   the active panel  — chosen by the active tab's kind:
-//     session(agent) → SessionAgentPanel  (header + controls + SessionLiveStream)
+//     session(agent) → SessionAgentPanel  (header + End/Restart + Transcript/Composer)
 //     session(graph) → SessionGraphPanel  (header + SD_GraphRunView)
 //     file           → FilePanel          (preview/edit toggle + Save + 412 flow)
 //
-// REUSE (do NOT rebuild): the agent transcript and the graph run-view are the
-// production components from session-detail.jsx, reached across files as the
+// REUSE (do NOT rebuild): the graph run-view is still the production
+// component from session-detail.jsx; the agent transcript (Task 12,
+// studio-agents-interact plan) is now chat-refactor's own reused primitives
+// over the session adapter instead — all reached across files as the
 // no-build window globals:
-//   window.SessionLiveStream  ({ sid, wid, session, pushToast })
-//   window.SD_GraphRunView    ({ gid, rid, wid, session, pushToast })
+//   window.SD_GraphRunView        ({ gid, rid, wid, session, pushToast })
+//   window.SA_useSessionConversation ({ sid, wid })  — session-adapter.jsx
+//   window.SA_toTranscript           (records, session)
+//   window.Transcript / window.Composer              — chat-refactor
 // Markdown preview reuses window.renderMarkdown; code highlight reuses
 // window.primerVendor.highlightPython.
 //
-// REUSE FRICTION (noted for B6): the per-session control mutations
-// (pause/resume/steer/cancel) live *inlined* inside SessionDetail in
-// session-detail.jsx — they are NOT exported as standalone helpers/hooks.
-// Rather than touch session-detail.jsx (out of scope for B3), this file
-// re-creates those mutations against the SAME workspace-scoped endpoints
-// (POST .../sessions/{sid}/{pause|resume|cancel|steer}). B6 will extract the
-// shared control surface and this panel can swap to it.
+// REUSE FRICTION (noted for B6): the GRAPH panel's per-session control
+// mutations (pause/resume/steer/cancel) still live *inlined* here
+// (ST_SessionControls below) against the same workspace-scoped endpoints
+// (POST .../sessions/{sid}/{pause|resume|cancel|steer}) — they were never
+// exported as standalone helpers/hooks from session-detail.jsx. The AGENT
+// panel (SessionAgentPanel) no longer has this friction: Stop/End route
+// through SA_useSessionConversation's own stop()/end() (POST
+// .../interrupt / .../cancel), and Restart through a small `restart()`
+// this task added to that same hook (POST .../restart — Task 11's original
+// interface didn't need it; session-adapter.jsx is otherwise untouched).
 //
 // No-build rules: top-level declarations use `var`; helpers prefixed ST_;
 // every exported symbol is assigned to window.X at the bottom.
@@ -312,15 +319,183 @@ function ST_TokenMeterInline({ session }) {
 }
 
 // ---------------------------------------------------------------------------
-// SessionAgentPanel — agent transcript panel.
-//   header: title · status pill · turn · token meter + inline controls
-//   body  : the reused SessionLiveStream (session-scoped tap + history)
+// ST_isAutonomous — mirrors primer/session/autonomy.py::session_is_autonomous
+// exactly: an explicit `session.autonomous` flag wins; otherwise derive from
+// the binding kind (graph ⇒ autonomous, agent ⇒ interactive). Gates the
+// agent run view's Stop/End/Restart control set (interactive, this panel)
+// vs. the graph panel's Pause/Steer/Cancel (autonomous, ST_SessionControls).
+// ---------------------------------------------------------------------------
+
+function ST_isAutonomous(session) {
+  if (!session) return false;
+  if (session.autonomous != null) return !!session.autonomous;
+  var kind = (session.binding && session.binding.kind) || session.binding_kind || null;
+  return kind === "graph";
+}
+
+// ---------------------------------------------------------------------------
+// ST_sessionRowToTranscript / ST_coalesceAssistantRows / ST_sessionTranscriptRows
+//   — adapt SA_toTranscript's rows (Task 11) to what chat-refactor's
+//   <Transcript>/<Message> row renderer (ui/components/chat/transcript.jsx)
+//   actually reads off the top level of each row (m.text, m.arguments,
+//   m.result, m.id, ...) — mirroring window.chatFlatten's `{...payload,
+//   ...row}` spread for a ChatMessage. SA_toTranscript deliberately keeps
+//   `payload` NESTED (locked contract, tests/ui/test_session_adapter.py), so
+//   this spreads it back out here rather than changing that file.
+//
+//   A couple of field names differ between a SessionMessageRecord's payload
+//   (primer/session/persistence.py) and the ChatMessage wire shape Message()
+//   was built against: a tool_result's pairing key is `call_id`
+//   (<Transcript> pairs tool_call<->tool_result by `.id`) and its output
+//   lives under `output` (Message() reads `.result`) — aliased below.
+//   Divider/lifecycle/interaction rows (graph_transition/invocation_divider/
+//   yielded/resumed/done/cancelled/error) have no dedicated Message() branch
+//   for these collapsed kinds, so they fall through to the generic bubble;
+//   seeding `.text` from the divider label (or the nearest payload field)
+//   keeps that bubble from rendering blank.
+// ---------------------------------------------------------------------------
+
+function ST_sessionRowToTranscript(row) {
+  var payload = row.payload || {};
+  var flat = Object.assign({}, payload, {
+    seq: row.seq,
+    kind: row.kind,
+    nodeId: row.nodeId,
+    created_at: row.createdAt,
+  });
+  if (row.kind === "tool_result") {
+    if (flat.id == null && payload.call_id != null) flat.id = payload.call_id;
+    if (flat.result === undefined && payload.output !== undefined) flat.result = payload.output;
+  }
+  if (flat.text == null && flat.content == null) {
+    flat.text = row.label || payload.message || payload.reason || payload.stop_reason || payload.tool_name || "";
+  }
+  return flat;
+}
+
+// Merges a run of consecutive per-token "assistant_message" rows (each
+// SA_toTranscript's 1:1 mapping of one ASSISTANT_TOKEN SessionMessageRecord)
+// into a single bubble — same idea as window.chatCoalesce
+// (ui/components/chat/use-transcript.js), but keyed off `text` (the
+// session's own payload field, primer/session/persistence.py) rather than
+// `delta` (the chat WS frame's field), and stamping startSeq/endSeq the same
+// way — <Transcript>'s row key (`am-${startSeq}-${endSeq}`) needs them, or
+// every assistant bubble in a session collides on the same React key.
+function ST_coalesceAssistantRows(rows) {
+  var out = [];
+  var buffer = null;
+  function flush() {
+    if (buffer && buffer.text.trim().length > 0) out.push(buffer);
+    buffer = null;
+  }
+  for (var i = 0; i < rows.length; i++) {
+    var m = rows[i];
+    if (m.kind === "assistant_message") {
+      var delta = typeof m.text === "string" ? m.text : "";
+      if (!buffer) {
+        buffer = Object.assign({}, m, { text: delta, startSeq: m.seq, endSeq: m.seq });
+      } else {
+        buffer.text += delta;
+        buffer.endSeq = m.seq;
+      }
+      continue;
+    }
+    flush();
+    out.push(m);
+  }
+  flush();
+  return out;
+}
+
+function ST_sessionTranscriptRows(records, session) {
+  var mapped = window.SA_toTranscript(records, session).map(ST_sessionRowToTranscript);
+  return ST_coalesceAssistantRows(mapped);
+}
+
+// ---------------------------------------------------------------------------
+// SessionAgentPanel — agent run view = a session-backed <Conversation>.
+//   header: title · status pill · turn · token meter + End/Restart
+//   body  : <Transcript> fed by SA_toTranscript (Task 11) + <Composer>
+//           docked at the bottom — no dedicated steer button (steering IS
+//           sending a message, studio-agents-interact §4.2). Composer's own
+//           Stop affordance maps to the adapter's stop() (POST .../interrupt);
+//           End/Restart are the two extra header controls this panel adds
+//           (POST .../cancel and .../restart respectively) since the brief's
+//           interactive control set (§Interface) has no Pause.
 // ---------------------------------------------------------------------------
 
 function SessionAgentPanel({ wid, sid, session, pushToast }) {
   var StatusPill = window.StatusPill;
+  var { useMutation } = window.primerApi;
+  var conv = window.SA_useSessionConversation({ sid: sid, wid: wid });
+  var [composerText, setComposerText] = React.useState("");
+  var scrollRef = React.useRef(null);
+
   var title = (session && (session.name || session.id)) || sid;
   var turnNo = (session && (session.turn_no != null ? session.turn_no : session.turn_count)) || 0;
+  var status = (session && session.status) || conv.status;
+  var isEnded = status === "ended";
+  var turnInFlight = conv.turnStatus === "claimable" || conv.turnStatus === "running";
+  var agentId = (session && session.binding && session.binding.agent_id) || null;
+
+  function toastErr(title) {
+    return function (err) {
+      if (typeof pushToast !== "function") return;
+      pushToast({
+        kind: "error",
+        title: (err && err.title) || title,
+        detail: (err && err.detail) || (err && err.message),
+        requestId: err && err.requestId,
+      });
+    };
+  }
+
+  var invalidates = ["studio-session:" + sid, "session-adapter:row:" + sid, "sessions:list"];
+
+  var endMut = useMutation(
+    function () { return conv.end(); },
+    {
+      invalidates: invalidates,
+      onSuccess: function () { pushToast && pushToast({ kind: "warning", title: "Session ended" }); },
+      onError: toastErr("End failed"),
+    }
+  );
+  var restartMut = useMutation(
+    function () { return conv.restart(); },
+    {
+      invalidates: invalidates,
+      onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Session restarted" }); },
+      onError: toastErr("Restart failed"),
+    }
+  );
+
+  function onSend() {
+    var text = composerText.trim();
+    if (!text) return;
+    var p = conv.sendMessage(text);
+    setComposerText("");
+    if (p && typeof p.catch === "function") p.catch(toastErr("Send failed"));
+  }
+
+  function onStop() {
+    var p = conv.stop();
+    if (p && typeof p.catch === "function") p.catch(toastErr("Stop failed"));
+  }
+
+  var rows = React.useMemo(
+    function () { return ST_sessionTranscriptRows(conv.messages, session); },
+    [conv.messages, session]
+  );
+
+  // Stick-to-bottom: a session transcript has no lazy-load-older (history is
+  // a single bounded fetch, session-adapter.jsx), so unlike <Conversation>
+  // this only ever needs to follow the tail as new rows arrive.
+  React.useEffect(function () {
+    var el = scrollRef.current;
+    if (!el) return undefined;
+    var raf = requestAnimationFrame(function () { el.scrollTop = el.scrollHeight; });
+    return function () { cancelAnimationFrame(raf); };
+  }, [rows.length]);
 
   return (
     <div
@@ -340,16 +515,69 @@ function SessionAgentPanel({ wid, sid, session, pushToast }) {
         <span className="mono" style={{ fontSize: 11, color: "var(--text-4)" }}>turn {turnNo}</span>
         <div style={{ flex: 1 }} />
         <ST_TokenMeterInline session={session} />
-        <ST_SessionControls wid={wid} sid={sid} session={session} pushToast={pushToast} />
+        <Btn
+          size="sm"
+          kind="danger"
+          icon="x-circle"
+          disabled={!wid || isEnded || endMut.loading}
+          onClick={function () { if (wid) endMut.mutate(); }}
+          data-testid="ctrl-end"
+          title="End this session (cancel — hard stop)"
+        >End</Btn>
+        {isEnded && (
+          <Btn
+            size="sm"
+            kind="primary"
+            icon="refresh"
+            disabled={!wid || restartMut.loading}
+            onClick={function () { if (wid) restartMut.mutate(); }}
+            data-testid="ctrl-restart"
+            title="Re-open this ended session and invoke it"
+          >Restart</Btn>
+        )}
       </div>
-      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
-        {wid && window.SessionLiveStream
-          ? <window.SessionLiveStream sid={sid} wid={wid} session={session} pushToast={pushToast} />
-          : (
-            <div className="muted text-sm" style={{ padding: 20, textAlign: "center", color: "var(--text-4)" }}>
-              Live stream unavailable — session has no workspace.
-            </div>
-          )}
+      <window.Transcript
+        messages={rows}
+        chatId={sid}
+        agentId={agentId}
+        wsState={conv.wsState}
+        waitingForReply={false}
+        turnStatus={conv.turnStatus}
+        pendingToolCall={null}
+        sendMessage={conv.sendMessage}
+        onRewind={null}
+        // No compaction concept for a session transcript — a boundary of
+        // +Infinity means "nothing is ever past it", which keeps
+        // <Transcript>'s per-message rewind icon (a chat-only affordance,
+        // Task F3) from rendering on every user row for a surface that has
+        // no POST /rewind endpoint to back it.
+        compactionBoundarySeq={Number.MAX_SAFE_INTEGER}
+        scrollRef={scrollRef}
+        onScroll={function () {}}
+        loadingOlder={false}
+        hasMoreOlder={false}
+      />
+      <div
+        style={{
+          borderTop: "1px solid var(--border)", padding: 14,
+          display: "flex", gap: 8, alignItems: "stretch", flex: "0 0 auto",
+        }}
+      >
+        <window.Composer
+          value={composerText}
+          onChange={setComposerText}
+          onSend={onSend}
+          onStop={onStop}
+          running={turnInFlight}
+          disabled={isEnded}
+          attachments={[]}
+          onAttach={function () {}}
+          onRemoveAttachment={function () {}}
+          slashCommands={[]}
+          mentionSources={[]}
+          schemaInvalid={false}
+          wsState={conv.wsState}
+        />
       </div>
     </div>
   );
@@ -880,6 +1108,8 @@ function StudioCenter({ wid, studio }) {
 // ---------------------------------------------------------------------------
 window.StudioCenter = StudioCenter;
 window.CenterTabs = CenterTabs;
+window.ST_isAutonomous = ST_isAutonomous;
+window.ST_sessionTranscriptRows = ST_sessionTranscriptRows;
 window.SessionAgentPanel = SessionAgentPanel;
 window.SessionGraphPanel = SessionGraphPanel;
 window.FilePanel = FilePanel;

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -684,13 +684,17 @@ function ST_SessionPanel({ wid, sid, pushToast }) {
   }
   if (!session) return null;
 
-  // Resolve binding kind; mirror SessionLiveStream/SD_GraphRunView's defensive
-  // reads (binding.kind || binding_kind).
-  var kind = (session.binding && session.binding.kind) || session.binding_kind || "agent";
+  // Route through ST_isAutonomous (the byte-mirror of backend
+  // session_is_autonomous): an explicit `session.autonomous` flag wins,
+  // else derive from the binding kind (graph ⇒ autonomous). Branching on
+  // the raw binding.kind instead would send an explicit-override session
+  // (autonomous flag contradicting binding.kind) to the wrong panel. For a
+  // session WITHOUT an explicit override this is identical to the old
+  // `binding.kind === "graph"` branch (agent/missing ⇒ agent panel).
   // The session's own workspace_id is authoritative; fall back to the route wid.
   var effWid = session.workspace_id || wid;
 
-  if (kind === "graph") {
+  if (ST_isAutonomous(session)) {
     return <SessionGraphPanel wid={effWid} sid={sid} session={session} pushToast={pushToast} />;
   }
   return <SessionAgentPanel wid={effWid} sid={sid} session={session} pushToast={pushToast} />;

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -426,6 +426,7 @@ function ST_sessionTranscriptRows(records, session) {
   return ST_coalesceAssistantRows(mapped);
 }
 
+
 // ---------------------------------------------------------------------------
 // SessionAgentPanel — agent run view = a session-backed <Conversation>.
 //   header: title · status pill · turn · token meter + End/Restart
@@ -571,6 +572,11 @@ function SessionAgentPanel({ wid, sid, session, pushToast }) {
         loadingOlder={false}
         hasMoreOlder={false}
       />
+      {/* Task 14: this session's own pending interaction, inline — the
+          session-scoped counterpart to the global right-sidebar Action
+          Required list (studio-activity.jsx). Renders nothing when there's
+          nothing parked. */}
+      <ST_InlineYields wid={wid} sid={sid} pending={conv.pending} messages={conv.messages} pushToast={pushToast} />
       <div
         style={{
           borderTop: "1px solid var(--border)", padding: 14,
@@ -804,6 +810,11 @@ function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
         loadingOlder={false}
         hasMoreOlder={false}
       />
+      {/* Task 14: same inline pending-interaction affordance as the agent
+          panel — a graph-bound session parks on a yield exactly the same
+          way (studio-agents-interact §5.4), so it needs the same inline
+          Approve/Deny/respond surface over its own chat stream. */}
+      <ST_InlineYields wid={wid} sid={sid} pending={conv.pending} messages={conv.messages} pushToast={pushToast} />
       <div
         style={{
           borderTop: "1px solid var(--border)", padding: 14,
@@ -834,6 +845,225 @@ function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
     </div>
   );
 }
+
+// ---------------------------------------------------------------------------
+// ST_InlineYields — Task 14: the ACTIVE session's own pending interaction(s)
+// rendered INLINE in its stream (right after <Transcript>, before the
+// Composer) — the session-scoped counterpart to studio-activity.jsx's
+// GLOBAL "Action Required" list. Both surfaces hit the exact same
+// endpoints (tool_approval/respond, ask_user/respond, yields/{id}/cancel)
+// so responding here clears the identical server-side yield the global
+// sidebar is tracking — there is no separate "inline" state to drift.
+//
+// Data: `pending` is session-adapter.jsx's own `conv.pending`
+// (GET .../workspaces/{wid}/sessions/{sid}/yields/pending, Task 10, polled
+// every 4s) — passed down from the panel, no second fetch here.
+//
+// Reconcile: rather than opening a SECOND EventSource onto the session-
+// scoped tap (the adapter already tails it into `conv.messages`), this
+// watches the tail of `messages` for a fresh "yielded"/"resumed" record and
+// force-refetches both the session-scoped AND workspace-wide pending
+// caches via window.primerApi._resource — the same findKeys/refetchKey
+// primitive useMutation's own `invalidates` list uses (use-mutation.js).
+// One live connection (the adapter's), two caches kept in sync.
+//
+// Placed AFTER SessionGraphPanel (below) rather than up here next to its
+// sibling pure helpers (ST_isAutonomous / ST_sessionTranscriptRows) — those
+// are deliberately JSX-free so tests/ui/test_studio_run_view_interactive.py
+// + test_studio_graph_run_view.py can `py_mini_racer`-eval that exact slice
+// of the file; this component (JSX-bearing) would break that eval if it
+// sat inside the same gap.
+// ---------------------------------------------------------------------------
+
+function ST_yieldInvalidates(wid, sid) {
+  return ["session-adapter:pending:" + sid, "studio-yields-pending:" + wid];
+}
+
+function ST_InlineYields({ wid, sid, pending, messages, pushToast }) {
+  var apiFetch = window.primerApi.apiFetch;
+  var useMutation = window.primerApi.useMutation;
+  var invalidates = ST_yieldInvalidates(wid, sid);
+
+  function toastErr(title) {
+    return function (err) {
+      if (typeof pushToast !== "function") return;
+      pushToast({
+        kind: "error",
+        title: (err && err.title) || title,
+        detail: (err && err.detail) || (err && err.message),
+        requestId: err && err.requestId,
+      });
+    };
+  }
+
+  var approveMut = useMutation(
+    function (item) {
+      return apiFetch(
+        "POST",
+        "/sessions/" + encodeURIComponent(item.session_id) + "/tool_approval/respond",
+        { tool_call_id: item.tool_call_id, decision: "approved" }
+      );
+    },
+    { invalidates: invalidates, onError: toastErr("Approve failed") }
+  );
+  var rejectMut = useMutation(
+    function (item) {
+      return apiFetch(
+        "POST",
+        "/sessions/" + encodeURIComponent(item.session_id) + "/tool_approval/respond",
+        { tool_call_id: item.tool_call_id, decision: "rejected", reason: "" }
+      );
+    },
+    { invalidates: invalidates, onError: toastErr("Reject failed") }
+  );
+  var respondMut = useMutation(
+    function (payload) {
+      return apiFetch(
+        "POST",
+        "/sessions/" + encodeURIComponent(payload.item.session_id) + "/ask_user/respond",
+        { tool_call_id: payload.item.tool_call_id, response: payload.text }
+      );
+    },
+    { invalidates: invalidates, onError: toastErr("Respond failed") }
+  );
+  var cancelMut = useMutation(
+    function (item) {
+      return apiFetch(
+        "POST",
+        "/sessions/" + encodeURIComponent(item.session_id) + "/yields/" + encodeURIComponent(item.tool_call_id) + "/cancel",
+        { reason: "operator cancelled" }
+      );
+    },
+    { invalidates: invalidates, onError: toastErr("Cancel failed") }
+  );
+
+  // Tap-tail reconcile — see file-header comment above. Only reacts to a
+  // NEW last record (guarded by seq) so this doesn't refetch on every
+  // unrelated render (assistant tokens streaming in, etc).
+  var lastSeqRef = React.useRef(null);
+  React.useEffect(function () {
+    if (!messages || !messages.length) return;
+    var last = messages[messages.length - 1];
+    if (last.seq === lastSeqRef.current) return;
+    lastSeqRef.current = last.seq;
+    if (last.kind !== "yielded" && last.kind !== "resumed") return;
+    var resourceApi = window.primerApi._resource;
+    if (!resourceApi) return;
+    invalidates.forEach(function (baseKey) {
+      resourceApi.findKeys(baseKey).forEach(function (key) { resourceApi.refetchKey(key); });
+    });
+  }, [messages]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  var [drafts, setDrafts] = React.useState({});
+  function getDraft(id) { return drafts[id] || ""; }
+  function setDraft(id, text) {
+    setDrafts(function (prev) {
+      var next = Object.assign({}, prev);
+      next[id] = text;
+      return next;
+    });
+  }
+
+  if (!wid || !sid || !pending || !pending.length) return null;
+
+  var busy = approveMut.loading || rejectMut.loading || respondMut.loading || cancelMut.loading;
+
+  return (
+    <div
+      data-testid="session-inline-yields"
+      style={{ borderTop: "1px solid var(--border)", background: "var(--bg-2)", flex: "0 0 auto" }}
+    >
+      {pending.map(function (item, idx) {
+        var isApproval = item.kind === "approval";
+        var isAsk = item.kind === "ask_user";
+        var isCancelable = item.kind === "watch_files" || item.kind === "sleep";
+        var actionable = !!item.tool_call_id;
+        var draft = getDraft(item.tool_call_id || String(idx));
+
+        return (
+          <div
+            key={item.tool_call_id || idx}
+            data-testid="session-yield-item"
+            style={{ padding: "10px 14px", display: "flex", flexDirection: "column", gap: 8 }}
+          >
+            <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+              <span style={{ color: "var(--amber)", fontSize: 12 }}>⚠</span>
+              <span
+                style={{
+                  fontSize: 10.5, textTransform: "uppercase", letterSpacing: "0.05em",
+                  fontWeight: 600, color: "var(--amber)",
+                }}
+              >
+                Waiting on you — {item.kind}
+              </span>
+            </div>
+
+            {item.prompt && (
+              <div style={{ fontSize: 12.5, lineHeight: 1.5, color: "var(--text-2)", whiteSpace: "pre-wrap" }}>
+                {item.prompt}
+              </div>
+            )}
+
+            {isApproval && (
+              <div style={{ display: "flex", gap: 8 }}>
+                <Btn
+                  size="sm" kind="primary" icon="check"
+                  disabled={!actionable || busy}
+                  data-testid="session-yield-approve"
+                  onClick={function () { approveMut.mutate(item); }}
+                >Approve</Btn>
+                <Btn
+                  size="sm" kind="danger" icon="x"
+                  disabled={!actionable || busy}
+                  data-testid="session-yield-deny"
+                  onClick={function () { rejectMut.mutate(item); }}
+                >Deny</Btn>
+              </div>
+            )}
+
+            {isAsk && (
+              <div style={{ display: "flex", gap: 8 }}>
+                <input
+                  type="text"
+                  data-testid="session-yield-respond"
+                  placeholder="Type a response… Enter to send"
+                  value={draft}
+                  disabled={busy || !actionable}
+                  onChange={function (e) { setDraft(item.tool_call_id || String(idx), e.target.value); }}
+                  onKeyDown={function (e) {
+                    if (e.key !== "Enter" || e.shiftKey) return;
+                    e.preventDefault();
+                    var text = draft.trim();
+                    if (!text) return;
+                    respondMut.mutate({ item: item, text: text });
+                    setDraft(item.tool_call_id || String(idx), "");
+                  }}
+                  style={{
+                    flex: 1, background: "var(--bg-0)", border: "1px solid var(--border)",
+                    borderRadius: 6, padding: "5px 10px", fontSize: 12.5, color: "var(--text)",
+                    fontFamily: "inherit", outline: "none",
+                  }}
+                />
+              </div>
+            )}
+
+            {isCancelable && (
+              <div>
+                <Btn
+                  size="sm" kind="ghost" icon="x-circle"
+                  disabled={!actionable || busy}
+                  data-testid="session-yield-cancel"
+                  onClick={function () { cancelMut.mutate(item); }}
+                >Cancel</Btn>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
 
 // ---------------------------------------------------------------------------
 // ST_SessionPanel — resolves a session tab to the agent or graph panel.

--- a/ui/index.html
+++ b/ui/index.html
@@ -101,6 +101,7 @@
 <script type="text/babel" src="components/workspaces/providers.jsx"></script>
 <script type="text/babel" src="components/workspaces/templates.jsx"></script>
 <script type="text/babel" src="components/workspace-tap.jsx"></script>
+<script type="text/babel" src="components/session-adapter.jsx"></script>
 <script type="text/babel" src="components/studio-sidebar.jsx"></script>
 <script type="text/babel" src="components/studio-center.jsx"></script>
 <script type="text/babel" src="components/studio-activity.jsx"></script>


### PR DESCRIPTION
The **UI** half of studio-agents-interact — the session-backed Studio center + right sidebar — plus two backend session fixes the UI surfaced. Completes the studio line.

## Status — rebased onto merged base (clean, conflict-free)
#104 and #105 are now **merged** into `feat/studio-terminal-backend`. This branch was rebased onto the updated base (they were rebase-merged, so the base carried the same content under new SHAs and the old integration merges conflicted). It now contains **only** the studio-UI increment — 10 commits: the studio UI files + the backend session fixes below. Post-rebase tests re-run green FOREGROUND: **62 backend session (+1 xfail)**, **183 studio UI**. Mergeable, no conflicts.

## Session-backed chat (S1–S3)
- `ui/components/session-adapter.jsx` — maps session records + workspace `/tap` to the transcript shape; seeds history via `GET /sessions/{sid}/messages`, tails via session-scoped `GET /workspaces/{wid}/tap` (no session WebSocket), wires send→`/steer`, stop→`/interrupt`, end→`/cancel`, restart→`/restart`. `graph_transition` → node/phase dividers.
- Steering = sending a message (invoke = steer = resume), reusing the chat-refactor `<Transcript>`/`<Composer>`.

## Control model (S4) — routed via `ST_isAutonomous` (byte-mirror of backend `session_is_autonomous`)
- **Agent/interactive panel:** Stop / End / Restart (no Pause).
- **Graph/autonomous panel:** Pause / Cancel / Restart + a G6 viz toggle (no Stop; `<Composer running={false}>` structurally prevents the Stop control).

## Agent + graph run views (S6, S7)
- `SessionAgentPanel` — session-backed `<Conversation>` over the adapter.
- `SessionGraphPanel` — toggleable `SD_GraphRunView` G6 canvas on top + the same chat below; opening an autonomous run does **not** interrupt it (mount fires zero control mutations).

## Debug sidebar + inline yields (S5)
- `ui/components/studio-activity.jsx` — collapsed-by-default right sidebar; global **Action Required** (aggregated `/yields/pending` + tap) + WorkspaceTap.
- `ST_InlineYields` — the active session's pending interactions render inline in its stream (`tool_approval/respond` + `ask_user/respond` + `yields/{id}/cancel`); global and inline stay in sync (bidirectional-immediate cache invalidation).

## Backend session fixes (new here — not in #104)
- `primer/session/enqueue.py` — **persist `USER_INPUT` on wake** so a steered/invoked message appears in the transcript (was invisible).
- `primer/session/dispatch.py` + `persistence.py` — **per-session seq-monotonicity**: seed the per-turn writer with `start_seq=last_seq` (fresh under the lifecycle lock) and persist it back advance-only at every turn-exit path. Without this, multi-turn interactive sessions reused seqs across turns and the `seq <= after_seq` tap filter / JS seq-dedup silently dropped records.

## Review + tests
Whole-plan review: **Ready** (no Critical/High; reviewer ran the suites). `tests/ui` green (677); backend session suites green (29 + 1 xfail), independently reproduced by a verifier pass.

**CI status:** `ci.yml`/`e2e.yml` trigger only on PRs targeting `main` (or pushes to `main`), so they have **not** run on this PR — it targets the `feat/studio-terminal-backend` integration branch. The `tests/ui_e2e` control-model re-alignment was verified against a **live DOM** (register/login + Playwright), not via CI. **Before the final merge to `main`, run `e2e.yml` (and `ci.yml`) via `workflow_dispatch`** — or let them fire naturally once this stack rebases onto `main`.

## Follow-ups (non-blocking; tracked)
- Mid-turn concurrent-steer seq collision — captured as `xfail(strict=True)` `tests/session/test_dispatch.py::test_midturn_concurrent_steer_seq_collision_is_known_gap`; needs a shared per-session seq source (writer redesign).
- `ST_SessionControls` is now dead weight (kept for a sanity-pin test) — cleanup once ui_e2e journeys fully repoint.
- Tool-call rows render name "tool" (backend TOOL_CALL payload carries no name); session lifecycle rows use the generic bubble (shared `chat/transcript.jsx`); `session-adapter` `wsState` has no terminal error state.
- `tests/ui_e2e` needs an opt-in auth-disable knob in the docker bringup (or real-login in shared helpers) for local runs; CI (`e2e.yml`) runs it via `PRIMER_E2E_AUTH_DISABLED=1 bringup.sh` + `PRIMER_RUN_UI_E2E=1`.