### PR TITLE
Studio non-blocking follow-ups (tool names, lifecycle styling, wsState, dead-code, e2e auth knob)

### DIFF
--- a/primer/session/persistence.py
+++ b/primer/session/persistence.py
@@ -35,6 +35,7 @@ from primer.model.chat import (
     StreamEvent,
     TextDelta,
     ToolCallEnd,
+    ToolCallStart,
     Usage,
     _ExecutorToolResult,
     _GraphNodeEvent,
@@ -215,6 +216,12 @@ class _CoalesceState:
 
     text_buffers: dict[str | None, str] = field(default_factory=dict)
     last_usage_by: dict[str | None, Usage] = field(default_factory=dict)
+    # Tool name carried from ToolCallStart (which has it) to the paired
+    # ToolCallEnd (same id, but no name field), keyed by tool_call id — so the
+    # TOOL_CALL record can persist the real name instead of the UI's generic
+    # "tool" fallback. Popped on ToolCallEnd; keyed by id (globally unique)
+    # rather than node_id so concurrent fan-out siblings never collide.
+    tool_names: dict[str, str] = field(default_factory=dict)
 
 
 def translate_stream_event(
@@ -228,6 +235,7 @@ def translate_stream_event(
     |----------------------|-------------------------------------------------|
     | TextDelta            | None (coalesces into state.text_buffers[node])  |
     | Usage                | None (accumulated in state.last_usage_by[node]) |
+    | ToolCallStart        | None (records tool name in state.tool_names[id])|
     | ToolCallEnd          | flush text buffer (if any), then TOOL_CALL      |
     | ExtendedEvent(_ExecutorToolResult) | TOOL_RESULT                    |
     | ExtendedEvent(_GraphNodeEvent) | reconstruct inner StreamEvent and    |
@@ -347,6 +355,13 @@ def translate_stream_event(
         state.text_buffers[node_id] = state.text_buffers.get(node_id, "") + event.text
         return None
 
+    if isinstance(event, ToolCallStart):
+        # ToolCallStart carries the tool name; the paired ToolCallEnd (same
+        # id) does not. Stash it so the TOOL_CALL record below can persist the
+        # real name. Produces no record itself (the call is persisted on End).
+        state.tool_names[event.id] = event.name
+        return None
+
     if isinstance(event, ToolCallEnd):
         records: list[SessionMessageRecord] = []
         buffered = state.text_buffers.get(node_id, "")
@@ -365,7 +380,11 @@ def translate_stream_event(
             SessionMessageRecord(
                 seq=1,
                 kind=SessionMessageKind.TOOL_CALL,
-                payload={"id": event.id, "arguments": event.arguments},
+                payload={
+                    "id": event.id,
+                    "name": state.tool_names.pop(event.id, None),
+                    "arguments": event.arguments,
+                },
                 node_id=node_id,
                 created_at=now,
             )
@@ -443,9 +462,9 @@ def translate_stream_event(
             created_at=now,
         )
 
-    # All other events (StreamStart, ReasoningDelta, ToolCallStart, ToolCallDelta,
-    # MediaDelta, ExtendedEvent without _ExecutorToolResult / _GraphNodeEvent) —
-    # silently dropped.
+    # All other events (StreamStart, ReasoningDelta, ToolCallDelta, MediaDelta,
+    # ExtendedEvent without _ExecutorToolResult / _GraphNodeEvent) — silently
+    # dropped. (ToolCallStart is handled above: it records the tool name.)
     return None
 
 

--- a/primer/session/persistence.py
+++ b/primer/session/persistence.py
@@ -217,11 +217,17 @@ class _CoalesceState:
     text_buffers: dict[str | None, str] = field(default_factory=dict)
     last_usage_by: dict[str | None, Usage] = field(default_factory=dict)
     # Tool name carried from ToolCallStart (which has it) to the paired
-    # ToolCallEnd (same id, but no name field), keyed by tool_call id — so the
-    # TOOL_CALL record can persist the real name instead of the UI's generic
-    # "tool" fallback. Popped on ToolCallEnd; keyed by id (globally unique)
-    # rather than node_id so concurrent fan-out siblings never collide.
-    tool_names: dict[str, str] = field(default_factory=dict)
+    # ToolCallEnd (same id, but no name field), keyed by (node_id, tool_call
+    # id) — so the TOOL_CALL record can persist the real name instead of the
+    # UI's generic "tool" fallback. Popped on ToolCallEnd. The LLM adapters
+    # synthesize call ids from a per-stream counter (e.g. "call_0"), so bare
+    # ids restart at the same value on every stream — concurrent graph
+    # fan-out siblings can legitimately share an id. Keying by node_id too
+    # (mirroring text_buffers/last_usage_by above) keeps siblings isolated.
+    # An unmatched ToolCallStart (turn cancelled before its ToolCallEnd)
+    # leaves a dangling entry, but it's bounded to this _CoalesceState's
+    # lifetime (one run) — not worth cleanup machinery.
+    tool_names: dict[tuple[str | None, str], str] = field(default_factory=dict)
 
 
 def translate_stream_event(
@@ -235,7 +241,7 @@ def translate_stream_event(
     |----------------------|-------------------------------------------------|
     | TextDelta            | None (coalesces into state.text_buffers[node])  |
     | Usage                | None (accumulated in state.last_usage_by[node]) |
-    | ToolCallStart        | None (records tool name in state.tool_names[id])|
+    | ToolCallStart        | None (records name in state.tool_names[node,id])|
     | ToolCallEnd          | flush text buffer (if any), then TOOL_CALL      |
     | ExtendedEvent(_ExecutorToolResult) | TOOL_RESULT                    |
     | ExtendedEvent(_GraphNodeEvent) | reconstruct inner StreamEvent and    |
@@ -359,7 +365,9 @@ def translate_stream_event(
         # ToolCallStart carries the tool name; the paired ToolCallEnd (same
         # id) does not. Stash it so the TOOL_CALL record below can persist the
         # real name. Produces no record itself (the call is persisted on End).
-        state.tool_names[event.id] = event.name
+        # Keyed by (node_id, id): synthesized ids can collide across
+        # concurrent fan-out siblings, so node_id disambiguates.
+        state.tool_names[(node_id, event.id)] = event.name
         return None
 
     if isinstance(event, ToolCallEnd):
@@ -382,7 +390,7 @@ def translate_stream_event(
                 kind=SessionMessageKind.TOOL_CALL,
                 payload={
                     "id": event.id,
-                    "name": state.tool_names.pop(event.id, None),
+                    "name": state.tool_names.pop((node_id, event.id), None),
                     "arguments": event.arguments,
                 },
                 node_id=node_id,

--- a/scripts/e2e/ui-bringup.sh
+++ b/scripts/e2e/ui-bringup.sh
@@ -58,8 +58,29 @@ fi
 
 # ---- 1. Compose stack ------------------------------------------------------
 
+# Optionally disable auth for the test container. Mirrors the opt-in knob in
+# scripts/e2e/bringup.sh: some suites (tests/ui_e2e) seed fixtures over plain
+# httpx with no login and 401 when auth is on. Opt in with
+# PRIMER_E2E_AUTH_DISABLED=1; unset (the default) keeps auth enabled — the
+# production default. The container is env-driven (see docker-compose.yml), so
+# we inject PRIMER_AUTH__ENABLED=false via a compose override file rather than
+# editing docker-compose.yml (which must keep auth on by default).
+COMPOSE_UP=(up -d)
+if [[ "${PRIMER_E2E_AUTH_DISABLED:-0}" == "1" ]]; then
+    AUTH_OVERRIDE="$(mktemp)"
+    trap 'rm -f "$AUTH_OVERRIDE"' EXIT
+    cat > "$AUTH_OVERRIDE" <<'EOF'
+services:
+  primer:
+    environment:
+      PRIMER_AUTH__ENABLED: "false"
+EOF
+    COMPOSE_UP=(-f docker-compose.yml -f "$AUTH_OVERRIDE" up -d)
+    echo "[ui-bringup] auth disabled (PRIMER_E2E_AUTH_DISABLED=1)" >&2
+fi
+
 echo "[ui-bringup] ensuring primer-app + postgres are up..." >&2
-"${COMPOSE[@]}" up -d >&2
+"${COMPOSE[@]}" "${COMPOSE_UP[@]}" >&2
 
 # ---- 2. Wait for /v1/health and /console/ to respond -----------------------
 

--- a/tests/session/test_persistence.py
+++ b/tests/session/test_persistence.py
@@ -246,6 +246,48 @@ def test_translate_tool_call_end_flushes_text_buffer() -> None:
     assert result[1].kind == SessionMessageKind.TOOL_CALL
 
 
+def test_translate_tool_call_carries_name_from_start() -> None:
+    """ToolCallStart records the tool name (which ToolCallEnd lacks) so the
+    paired TOOL_CALL record persists it, id-keyed, instead of leaving the UI
+    to fall back to the generic "tool" label."""
+    from primer.model.chat import ToolCallEnd, ToolCallStart
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+    # Start carries the name but produces no record of its own.
+    assert (
+        translate_stream_event(
+            ToolCallStart(id="tc9", name="fs__write", index=0), state
+        )
+        is None
+    )
+    rec = translate_stream_event(
+        ToolCallEnd(id="tc9", arguments={"path": "x"}, index=0), state
+    )
+    assert isinstance(rec, SessionMessageRecord)
+    assert rec.kind == SessionMessageKind.TOOL_CALL
+    assert rec.payload.get("id") == "tc9"
+    assert rec.payload.get("name") == "fs__write"
+    assert rec.payload.get("arguments") == {"path": "x"}
+    # Consumed on End — the map doesn't accumulate dead keys.
+    assert "tc9" not in state.tool_names
+
+
+def test_translate_tool_call_end_without_start_has_null_name() -> None:
+    """A ToolCallEnd with no preceding ToolCallStart (name unknown) still
+    emits a TOOL_CALL record; name is None and the UI falls back to "tool"."""
+    from primer.model.chat import ToolCallEnd
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+    rec = translate_stream_event(
+        ToolCallEnd(id="tc-orphan", arguments={}, index=0), state
+    )
+    assert isinstance(rec, SessionMessageRecord)
+    assert rec.kind == SessionMessageKind.TOOL_CALL
+    assert rec.payload.get("name") is None
+
+
 def test_translate_executor_tool_result() -> None:
     """ExtendedEvent wrapping _ExecutorToolResult emits a TOOL_RESULT record."""
     from primer.model.chat import ExtendedEvent, _ExecutorToolResult

--- a/tests/session/test_persistence.py
+++ b/tests/session/test_persistence.py
@@ -270,7 +270,7 @@ def test_translate_tool_call_carries_name_from_start() -> None:
     assert rec.payload.get("name") == "fs__write"
     assert rec.payload.get("arguments") == {"path": "x"}
     # Consumed on End — the map doesn't accumulate dead keys.
-    assert "tc9" not in state.tool_names
+    assert (None, "tc9") not in state.tool_names
 
 
 def test_translate_tool_call_end_without_start_has_null_name() -> None:
@@ -556,6 +556,40 @@ def test_concurrent_nodes_usage_does_not_mix() -> None:
     assert isinstance(rb, SessionMessageRecord)
     assert ra.payload["usage"]["input_tokens"] == 10
     assert rb.payload["usage"]["input_tokens"] == 99
+
+
+def test_concurrent_nodes_tool_name_does_not_mix() -> None:
+    """Two fan-out siblings whose tool-call ids collide (LLM adapters
+    synthesize ids like "call_0" from a fresh per-stream counter, so two
+    concurrent nodes legitimately emit the same id) must not clobber each
+    other's stashed tool name. Interleaved A-start, B-start, A-end, B-end —
+    each TOOL_CALL record must carry its OWN node's tool name."""
+    from primer.model.chat import ToolCallEnd, ToolCallStart
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+    same_id = "call_0"
+    translate_stream_event(
+        _wrap_node("a", ToolCallStart(id=same_id, name="fs__write", index=0)), state
+    )
+    translate_stream_event(
+        _wrap_node("b", ToolCallStart(id=same_id, name="fs__read", index=0)), state
+    )
+    rec_a = translate_stream_event(
+        _wrap_node("a", ToolCallEnd(id=same_id, arguments={"path": "a.txt"}, index=0)),
+        state,
+    )
+    rec_b = translate_stream_event(
+        _wrap_node("b", ToolCallEnd(id=same_id, arguments={"path": "b.txt"}, index=0)),
+        state,
+    )
+
+    assert isinstance(rec_a, SessionMessageRecord)
+    assert isinstance(rec_b, SessionMessageRecord)
+    assert rec_a.node_id == "a"
+    assert rec_a.payload["name"] == "fs__write"
+    assert rec_b.node_id == "b"
+    assert rec_b.payload["name"] == "fs__read"
 
 
 def test_agent_only_path_unchanged_node_id_none() -> None:

--- a/tests/ui/test_session_adapter.py
+++ b/tests/ui/test_session_adapter.py
@@ -76,6 +76,18 @@ def test_no_session_websocket_only_rest_and_tap_sse() -> None:
     assert "/messages" in src
 
 
+def test_ws_state_reaches_terminal_closed_when_eventsource_gives_up() -> None:
+    # Connection legibility: es.onerror mirrors the browser's native retry
+    # (readyState CONNECTING) as "connecting", but once EventSource gives up
+    # for good (readyState === 2 / CLOSED) it must flip to a terminal
+    # "closed" so <Transcript>'s pill shows a non-transient failure rather
+    # than parking on "connecting" forever. CT_ConnectionStatus already
+    # renders any non-open/non-connecting value as the offline pill.
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "es.onerror = function" in src
+    assert 'es.readyState === 2 ? "closed" : "connecting"' in src
+
+
 def test_controls_hit_the_documented_endpoints() -> None:
     src = ADAPTER.read_text(encoding="utf-8")
     assert "/steer" in src

--- a/tests/ui/test_session_adapter.py
+++ b/tests/ui/test_session_adapter.py
@@ -54,11 +54,14 @@ def test_kind_mapping_table_matches_the_locked_contract() -> None:
         "tool_result": "tool_result",
         "graph_transition": "divider",
         "invocation_divider": "divider",
-        "yielded": "interaction",
-        "resumed": "interaction",
-        "done": "lifecycle",
-        "cancelled": "lifecycle",
-        "error": "lifecycle",
+        # Lifecycle rows map to the same-named kinds Message() styles directly
+        # (not a collapsed "lifecycle"/"interaction" bucket, which has no
+        # Message() branch and renders as a generic agent bubble).
+        "yielded": "yielded",
+        "resumed": "resumed",
+        "done": "done",
+        "cancelled": "cancelled",
+        "error": "error",
     }
     for kind, transcript_kind in expected.items():
         assert f'{kind}: "{transcript_kind}"' in src, (
@@ -150,4 +153,6 @@ def test_sa_to_transcript_maps_records_via_mini_racer() -> None:
     assert ctx.eval("out[1].nodeId") == "n1"
     assert ctx.eval("out[2].kind") == "divider"
     assert ctx.eval("out[2].label") == "— invocation 3 —"
-    assert ctx.eval("out[3].kind") == "lifecycle"
+    # A DONE record maps to Message()'s own "done" kind (muted "· done" row),
+    # not a generic "lifecycle" bucket.
+    assert ctx.eval("out[3].kind") == "done"

--- a/tests/ui/test_studio_graph_run_view.py
+++ b/tests/ui/test_studio_graph_run_view.py
@@ -50,9 +50,7 @@ def _fn_block(src: str, start_marker: str, end_marker: str) -> str:
 
 def _session_graph_panel_src() -> str:
     """Just the `SessionGraphPanel` function body — scopes assertions to
-    this panel without false-matching `SessionAgentPanel`'s Stop/End set or
-    the still-defined-but-unused `ST_SessionControls` (Pause/Resume/Steer/
-    Cancel, the pre-Task-13 graph cluster neither panel calls anymore)."""
+    this panel without false-matching `SessionAgentPanel`'s Stop/End set."""
     return _fn_block(_center_src(), "function SessionGraphPanel(", "function ST_SessionPanel(")
 
 
@@ -203,17 +201,12 @@ def test_composer_never_shows_stop_and_never_calls_interrupt() -> None:
 
 
 def test_no_dedicated_steer_or_resume_button_on_the_graph_panel() -> None:
-    # ST_SessionControls (Steer/Resume/Pause/Cancel) is the pre-Task-13
-    # cluster; this panel no longer reuses it (its own Pause/Cancel/Restart
-    # set above is self-contained), but the function itself must survive
-    # untouched (test_studio_run_view_interactive.py's own sanity pin).
+    # The graph panel's own Pause/Cancel/Restart set is self-contained; it
+    # has no Steer or Resume control (those lived on the pre-Task-13 cluster,
+    # since removed).
     panel = _session_graph_panel_src()
     assert "ctrl-steer" not in panel
     assert "ctrl-resume" not in panel
-    assert "<ST_SessionControls" not in panel
-    src = _center_src()
-    assert src.count("function ST_SessionControls(") == 1
-    assert 'data-testid="ctrl-steer"' in src  # still defined elsewhere, just unused here
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_studio_run_view_interactive.py
+++ b/tests/ui/test_studio_run_view_interactive.py
@@ -56,8 +56,7 @@ def _fn_block(src: str, start_marker: str, end_marker: str) -> str:
 def _session_agent_panel_src() -> str:
     """Just the `SessionAgentPanel` function body — scopes assertions (like
     "no dedicated steer button") to this panel without false-matching
-    `SessionGraphPanel`'s still-inlined `ST_SessionControls` (which does have
-    a Steer button; the graph panel is untouched by this task)."""
+    `SessionGraphPanel`'s own control cluster."""
     return _fn_block(_center_src(), "function SessionAgentPanel(", "function SessionGraphPanel(")
 
 
@@ -119,15 +118,6 @@ def test_no_dedicated_steer_button_on_the_agent_panel() -> None:
     panel = _session_agent_panel_src()
     assert "ctrl-steer" not in panel
     assert "ST_SessionControls" not in panel
-
-
-def test_session_graph_panel_steer_control_is_untouched() -> None:
-    # Sanity: the graph panel's existing Steer/Pause/Resume/Cancel cluster
-    # (ST_SessionControls) is unaffected by this task — it still exists
-    # exactly once elsewhere in the file.
-    src = _center_src()
-    assert src.count("function ST_SessionControls(") == 1
-    assert 'data-testid="ctrl-steer"' in src
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_studio_run_view_interactive.py
+++ b/tests/ui/test_studio_run_view_interactive.py
@@ -279,9 +279,11 @@ def test_session_transcript_rows_flattens_and_coalesces_via_mini_racer() -> None
     # Aliased from the session payload's `output` -> Message()'s `.result`.
     assert ctx.eval("out[3].result") == "contents"
 
-    assert ctx.eval("out[4].kind") == "lifecycle"
-    # No dedicated Message() branch for a collapsed "lifecycle" row; falls
-    # back to a payload field instead of rendering a blank bubble.
+    # A DONE record maps to Message()'s dedicated "done" kind (a muted
+    # "· done" row), not a generic "lifecycle" bubble.
+    assert ctx.eval("out[4].kind") == "done"
+    # The flatten still seeds text from the payload (stop_reason); the "done"
+    # branch renders "· done" and ignores it, so this is harmless.
     assert ctx.eval("out[4].text") == "end_turn"
 
 

--- a/tests/ui/test_studio_run_view_interactive.py
+++ b/tests/ui/test_studio_run_view_interactive.py
@@ -246,7 +246,8 @@ def test_session_transcript_rows_flattens_and_coalesces_via_mini_racer() -> None
           {seq: 2, kind: "assistant_token", payload: {text: "Hel"}, created_at: "t2", node_id: null},
           {seq: 3, kind: "assistant_token", payload: {text: "lo!"}, created_at: "t3", node_id: null},
           {seq: 4, kind: "tool_call",
-           payload: {id: "call-1", arguments: {path: "a.txt"}}, created_at: "t4", node_id: null},
+           payload: {id: "call-1", name: "fs__write", arguments: {path: "a.txt"}},
+           created_at: "t4", node_id: null},
           {seq: 5, kind: "tool_result",
            payload: {call_id: "call-1", output: "contents", error: null}, created_at: "t5", node_id: null},
           {seq: 6, kind: "done", payload: {stop_reason: "end_turn"}, created_at: "t6", node_id: null},
@@ -267,6 +268,10 @@ def test_session_transcript_rows_flattens_and_coalesces_via_mini_racer() -> None
 
     assert ctx.eval("out[2].kind") == "tool_call"
     assert ctx.eval("out[2].id") == "call-1"
+    # The persisted tool name (primer/session/persistence.py TOOL_CALL payload)
+    # flattens onto the top-level `name` Message() reads (m.name || m.tool_name
+    # || "tool"), so the row shows the real tool instead of the generic "tool".
+    assert ctx.eval("out[2].name") == "fs__write"
 
     assert ctx.eval("out[3].kind") == "tool_result"
     # Aliased so <Transcript> pairs tool_call<->tool_result by `.id`.

--- a/ui/components/session-adapter.jsx
+++ b/ui/components/session-adapter.jsx
@@ -44,11 +44,17 @@ var SA_KIND_TO_TRANSCRIPT = {
   tool_result: "tool_result",
   graph_transition: "divider",
   invocation_divider: "divider",
-  yielded: "interaction",
-  resumed: "interaction",
-  done: "lifecycle",
-  cancelled: "lifecycle",
-  error: "lifecycle",
+  // Lifecycle rows map to the SAME-named kinds <Transcript>'s Message()
+  // already renders with dedicated styling: yielded/resumed/done as a muted
+  // "· kind" dot, cancelled as a red "■ cancelled" marker, error as an error
+  // banner. Collapsing them into a generic "lifecycle"/"interaction" bucket
+  // (which Message() has no branch for) fell through to the plain agent
+  // bubble and lost that styling.
+  yielded: "yielded",
+  resumed: "resumed",
+  done: "done",
+  cancelled: "cancelled",
+  error: "error",
 };
 
 // Divider label for the two kinds SA_KIND_TO_TRANSCRIPT maps to "divider".

--- a/ui/components/session-adapter.jsx
+++ b/ui/components/session-adapter.jsx
@@ -263,10 +263,13 @@ function SA_useSessionConversation(opts) {
     };
 
     es.onerror = function () {
-      // EventSource reconnects natively via Last-Event-ID; the browser
-      // flips readyState back to CONNECTING for us, so mirror that here
-      // rather than parking on a stale "open" pill.
-      setWsState("connecting");
+      // EventSource reconnects natively via Last-Event-ID; while it is
+      // retrying the browser holds readyState at CONNECTING, so mirror that
+      // rather than parking on a stale "open" pill. But once it gives up for
+      // good (readyState === 2 / CLOSED) no reconnect is coming — surface a
+      // terminal "closed" state so <Transcript>'s pill shows a non-transient
+      // failure ("offline") instead of an indefinite "connecting".
+      setWsState(es.readyState === 2 ? "closed" : "connecting");
     };
 
     return function () { try { es.close(); } catch (_e) { /* no-op */ } };

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -24,25 +24,6 @@
 //   window.Transcript / window.Composer              — chat-refactor
 // Markdown preview reuses window.renderMarkdown; code highlight reuses
 // window.primerVendor.highlightPython.
-//
-// REUSE FRICTION (noted for B6, updated by Task 13): `ST_SessionControls`
-// below (Pause/Resume/Steer/Cancel against the workspace-scoped
-// POST .../sessions/{sid}/{pause|resume|cancel|steer} endpoints) was the
-// pre-Task-13 GRAPH panel's control cluster. Neither run-view panel calls
-// it anymore: the AGENT panel (SessionAgentPanel, Task 12) has its own
-// Stop/End/Restart set over SA_useSessionConversation's stop()/end()/
-// restart(), and the GRAPH panel (SessionGraphPanel, Task 13) now has its
-// own minimal Pause/Cancel/Restart set — Cancel and Restart reuse that
-// SAME adapter's end()/restart() (identical POST .../cancel and
-// .../restart calls the agent panel makes), and Pause is one fresh
-// mutation against the pre-existing POST .../pause endpoint
-// (ST_SessionControls's own pauseMut, copied rather than shared since it
-// was never factored out as a standalone hook). `ST_SessionControls` is
-// left defined-but-unused rather than deleted: it is still exercised by
-// tests/ui/test_studio_run_view_interactive.py's sanity pin (Task 12
-// deliberately asserted the pre-Task-13 graph cluster was untouched by
-// its own change), and by any not-yet-repointed tests/ui_e2e journeys.
-//
 // No-build rules: top-level declarations use `var`; helpers prefixed ST_;
 // every exported symbol is assigned to window.X at the bottom.
 
@@ -176,139 +157,6 @@ function CenterTabs({ openTabs, activeTabId, onFocus, onClose }) {
           </div>
         );
       })}
-    </div>
-  );
-}
-
-// ---------------------------------------------------------------------------
-// ST_SessionControls — pause/resume · steer · cancel inline control cluster.
-// Re-creates SessionDetail's signal mutations against the same workspace-scoped
-// endpoints (see REUSE FRICTION note at top). Pre-Task-13 this was the graph
-// panel's header cluster; SessionGraphPanel now has its own minimal
-// Pause/Cancel/Restart set instead (see that function), so nothing in this
-// file calls ST_SessionControls anymore — left defined for the reasons in
-// the REUSE FRICTION note (not deleted).
-// ---------------------------------------------------------------------------
-
-function ST_SessionControls({ wid, sid, session, pushToast }) {
-  var { useMutation, apiFetch } = window.primerApi;
-  var [steerOpen, setSteerOpen] = React.useState(false);
-  var [steerText, setSteerText] = React.useState("");
-
-  var status = session && session.status;
-  var isTerminal = !!(session && window.SESSION_TERMINAL && window.SESSION_TERMINAL.has(status));
-
-  function toastErr(title) {
-    return function (err) {
-      if (typeof pushToast !== "function") return;
-      pushToast({
-        kind: "error",
-        title: (err && err.title) || title,
-        detail: (err && err.detail) || (err && err.message),
-        requestId: err && err.requestId,
-      });
-    };
-  }
-
-  var invalidates = ["studio-session:" + sid, "session-detail:" + sid, "sessions:list"];
-
-  var pauseMut = useMutation(
-    function () { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/pause"); },
-    { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Session paused" }); }, onError: toastErr("Pause failed") }
-  );
-  var resumeMut = useMutation(
-    function () { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/resume"); },
-    { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Resume signal sent" }); }, onError: toastErr("Resume failed") }
-  );
-  var cancelMut = useMutation(
-    function () { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/cancel"); },
-    { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "warning", title: "Cancel signal sent" }); }, onError: toastErr("Cancel failed") }
-  );
-  var steerMut = useMutation(
-    function (instruction) { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/steer", { instruction: instruction }); },
-    {
-      invalidates: invalidates,
-      onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Steer queued" }); setSteerText(""); setSteerOpen(false); },
-      onError: toastErr("Steer failed"),
-    }
-  );
-
-  function submitSteer() {
-    var text = steerText.trim();
-    if (!text || !wid) return;
-    steerMut.mutate(text);
-  }
-
-  return (
-    <div style={{ display: "flex", alignItems: "center", gap: 6, position: "relative" }} data-testid="session-controls">
-      <Btn
-        size="sm"
-        icon="pause"
-        disabled={!wid || status !== "running" || pauseMut.loading}
-        onClick={function () { if (wid) pauseMut.mutate(); }}
-        data-testid="ctrl-pause"
-        title={status !== "running" ? "Enabled only when running" : "Pause after current turn"}
-      >Pause</Btn>
-      <Btn
-        size="sm"
-        icon="play"
-        disabled={!wid || isTerminal || resumeMut.loading}
-        onClick={function () { if (wid) resumeMut.mutate(); }}
-        data-testid="ctrl-resume"
-        title="Resume (idempotent)"
-      >Resume</Btn>
-      <Btn
-        size="sm"
-        icon="send"
-        disabled={!wid || isTerminal}
-        onClick={function () { setSteerOpen(function (o) { return !o; }); }}
-        data-testid="ctrl-steer"
-        title="Queue a steer instruction"
-      >Steer</Btn>
-      <Btn
-        size="sm"
-        kind="danger"
-        icon="stop"
-        disabled={!wid || isTerminal || cancelMut.loading}
-        onClick={function () { if (wid) cancelMut.mutate(); }}
-        data-testid="ctrl-cancel"
-        title="Cancel the run"
-      >Cancel</Btn>
-
-      {steerOpen && (
-        <div
-          style={{
-            position: "absolute",
-            top: 30,
-            right: 0,
-            zIndex: 30,
-            width: 320,
-            background: "var(--bg-elev)",
-            border: "1px solid var(--border-strong)",
-            borderRadius: 9,
-            boxShadow: "var(--shadow)",
-            padding: 10,
-          }}
-          data-testid="steer-popover"
-        >
-          <textarea
-            placeholder="Drop a hint or directive for the next turn…"
-            value={steerText}
-            onChange={function (e) { setSteerText(e.target.value); }}
-            rows={3}
-            autoFocus
-            style={{
-              width: "100%", padding: "6px 8px", fontSize: 12, background: "var(--bg-2)",
-              border: "1px solid var(--border)", borderRadius: 6, color: "var(--text)",
-              resize: "none", fontFamily: "IBM Plex Mono, monospace", outline: "none", marginBottom: 8,
-            }}
-          />
-          <div style={{ display: "flex", gap: 6, justifyContent: "flex-end" }}>
-            <Btn size="sm" kind="ghost" onClick={function () { setSteerOpen(false); }}>Cancel</Btn>
-            <Btn size="sm" kind="primary" icon="send" disabled={!steerText.trim() || steerMut.loading} onClick={submitSteer}>Queue</Btn>
-          </div>
-        </div>
-      )}
     </div>
   );
 }
@@ -682,7 +530,7 @@ function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
   // panel's End/Restart hit — so the network wiring isn't duplicated.
   // Pause has no adapter equivalent (its interface is Stop/End/Restart
   // only), so it is the one fresh mutation here, against the same
-  // workspace-scoped POST .../pause the pre-Task-13 ST_SessionControls
+  // workspace-scoped POST .../pause the pre-Task-13 graph cluster
   // used (reused endpoint, not a new one).
   var pauseMut = useMutation(
     function () { return apiFetch("POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/" + encodeURIComponent(sid) + "/pause"); },


### PR DESCRIPTION
The five non-blocking follow-ups called out in the studio-UI review (#106), each its own commit. All FOREGROUND-tested; a review of the increment caught one real concurrency bug (fixed below).

- **`3171f87e` + `719d8dd2` — tool names on session `TOOL_CALL` rows.** Rows previously rendered the generic name "tool" because the backend `TOOL_CALL` payload carried no name. Now the name is threaded from `ToolCallStart`→`ToolCallEnd` (real backend value, not derived) into the persisted payload and onto the field `<Message>` reads. **Review-caught fix:** `tool_names` must be keyed by `(node_id, id)` — Ollama/Gemini synthesize `id="call_{idx}"` from a fresh per-stream counter, so concurrent graph-fan-out nodes both emit `call_0` and would clobber each other's tool name (permanently corrupting persisted history). Now matches the `(node_id, …)` keying of the sibling coalesce maps. Regression test with two nodes sharing a colliding id.
- **`cc9a8278` — session lifecycle rows get their own styling.** `SA_KIND_TO_TRANSCRIPT` now maps done/cancelled/error/yielded/resumed to the kinds `Message()` already styles, instead of the generic "agent" bubble. **Adapter-only** — the shared `chat/transcript.jsx` is untouched, so the /chats lane can't regress.
- **`ba29933c` — `wsState` terminal state.** The session-adapter no longer sticks on "connecting" forever; a closed `EventSource` (`readyState===2`) reports `"closed"`, which the connection pill renders as offline.
- **`08b8ecc0` — drop dead `ST_SessionControls`.** No live caller (the panels built their own control clusters); no e2e journey locates its exclusive controls (`ctrl-steer`/`ctrl-resume`). Verified zero live references.
- **`9d1a691e` — opt-in `PRIMER_E2E_AUTH_DISABLED` in `ui-bringup.sh`.** Mirrors the existing host-bringup opt-in so local `tests/ui_e2e` can run without 401s. **Default unchanged (auth ON)** — the flag only injects an ephemeral compose override; `docker-compose.yml` is not touched.

## Tests
FOREGROUND, CPU-safe. Backend session/tap: 71 passed +1 xfail. Studio UI + adapter: 25–69 passed across the touched suites. (The auth-knob docker path + ui_e2e journeys are CI-validated, not run locally.)

Base `feat/studio-terminal-backend` (same integration branch the studio line merged into).