### PR TITLE
Studio UX fixes: collapsible debug rail, 1-click schema, tools filter, live-stream self-heal, graph queued-row + converged turn-log

### DIFF
--- a/tests/ui/test_agents_tools_selected_filter.py
+++ b/tests/ui/test_agents_tools_selected_filter.py
@@ -1,0 +1,86 @@
+"""studio-ux fix 4 — the Edit/New-agent modal's Tools tab
+(`AG_NewAgentModal` in ui/components/agents.jsx) had a text filter but no
+way to see WHICH tools are currently ticked across all toolsets/pages. A
+"Selected" filter chip now ANDs with the text filter, reusing the existing
+`selectedScopedIds` state the "N of 172 selected" counter already reads.
+
+Static-source checks only (the tests/ui suite convention — no DOM/browser
+harness; see test_studio_activity.py's docstring for the rationale).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+AGENTS = UI / "components" / "agents.jsx"
+
+
+def _src() -> str:
+    return AGENTS.read_text(encoding="utf-8")
+
+
+def _fn_block(src: str, start_marker: str, end_marker: str) -> str:
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+def _modal_src() -> str:
+    return _fn_block(_src(), "function AG_NewAgentModal(", "function AgentDetail(")
+
+
+def test_selected_only_state_exists() -> None:
+    modal = _modal_src()
+    assert "const [showSelectedOnly, setShowSelectedOnly] = React.useState(false);" in modal
+
+
+def test_filtered_toolset_entries_composes_selected_filter_with_text_filter() -> None:
+    modal = _modal_src()
+    assert "if (showSelectedOnly) {" in modal
+    assert "ts.tools.filter((t) => selectedScopedIds.has(t.scoped_id))" in modal
+    # Both filters can be active together — selected-only doesn't replace
+    # the text-filter branch, it narrows its result further.
+    assert "}, [toolsetEntries, toolFilter, showSelectedOnly, selectedScopedIds]);" in modal
+
+
+def test_toggling_selected_only_resets_to_first_page() -> None:
+    modal = _modal_src()
+    assert "React.useEffect(() => { setToolPage(1); }, [toolFilter, showSelectedOnly]);" in modal
+
+
+def test_selected_filter_chip_rendered_next_to_the_search_input() -> None:
+    modal = _modal_src()
+    assert 'data-testid="agent-tool-filter-selected"' in modal
+    assert 'data-testid="agent-tool-filter"' in modal
+    search_idx = modal.index('data-testid="agent-tool-filter"')
+    chip_idx = modal.index('data-testid="agent-tool-filter-selected"')
+    counter_idx = modal.index("{selectedCount} of {totalAvailable} selected")
+    # Chip sits between the search box and the "N of M selected" counter.
+    assert search_idx < chip_idx < counter_idx
+    assert "onClick={() => setShowSelectedOnly((v) => !v)}" in modal
+    assert 'aria-pressed={showSelectedOnly}' in modal
+
+
+def test_selected_filter_chip_reuses_the_existing_selection_counter_state() -> None:
+    # No new selection-tracking state — the chip reads/derives from the
+    # SAME selectedScopedIds Set the "N of 172 selected" counter uses.
+    modal = _modal_src()
+    assert "const selectedCount = selectedScopedIds.size;" in modal
+
+
+def test_empty_state_message_covers_the_selected_only_case() -> None:
+    modal = _modal_src()
+    assert 'data-testid="agent-tool-empty"' in modal
+    assert "No selected tools" in modal
+
+
+def test_bundle_transpiles_with_the_tools_selected_filter() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    build_jsx_bundle.cache_clear()
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    text = body.decode("utf-8")
+    assert "/* === components/agents.jsx === */" in text

--- a/tests/ui/test_new_session_modal_graph_form.py
+++ b/tests/ui/test_new_session_modal_graph_form.py
@@ -28,3 +28,47 @@ def test_modal_packages_into_graph_input_field() -> None:
 def test_modal_falls_back_to_textarea_without_schema() -> None:
     src = _src()
     assert "initial_instructions" in src
+
+
+# ---------------------------------------------------------------------------
+# studio-ux fix 6: a graph's dynamic Begin.input_schema string field (e.g. a
+# real-world "question" property declared as `{"type": "string"}` with no
+# maxLength — see tests/ui_e2e/test_graph_builder_feedback_loop.py) used to
+# render as a cramped single-line <input>. Plain string fields now default to
+# a resizable multi-line <textarea>; only an EXPLICIT short maxLength keeps a
+# field single-line.
+# ---------------------------------------------------------------------------
+
+
+def _schema_field_fn_src() -> str:
+    src = _src()
+    start = src.index("function SharedNewSessionSchemaField(")
+    end = src.index("// Read a File as raw base64")
+    return src[start:end]
+
+
+def test_plain_string_field_without_maxlength_defaults_to_a_textarea() -> None:
+    fn = _schema_field_fn_src()
+    assert (
+        "var long = !schema || typeof schema.maxLength !== \"number\" || schema.maxLength >= 120;"
+        in fn
+    )
+
+
+def test_long_branch_still_renders_the_resizable_textarea() -> None:
+    fn = _schema_field_fn_src()
+    # The (renamed-in-spirit, same-shaped) "long" branch is unchanged — a
+    # plain textarea using the shared .textarea class, which already carries
+    # resize:vertical (ui/styles.css), so a "question"-like field is both
+    # multi-line AND resizable out of the box.
+    assert 'control = long ? (\n      <textarea' in fn
+    assert 'className="textarea"' in fn
+    assert "rows={4}" in fn
+
+
+def test_a_short_explicit_maxlength_still_renders_a_single_line_input() -> None:
+    # An author who WANTS a short single-line field (e.g. a "name"/"id"
+    # property) signals it with an explicit small maxLength; that path is
+    # preserved as the `<input type="text">` branch.
+    fn = _schema_field_fn_src()
+    assert '<input\n        type="text"' in fn

--- a/tests/ui/test_schema_panel.py
+++ b/tests/ui/test_schema_panel.py
@@ -185,6 +185,94 @@ def test_schema_panel_still_pure_no_data_fetching_or_ws() -> None:
     assert "apiFetch" not in src
 
 
+# ---------------------------------------------------------------------------
+# studio-ux fix 2: the "⚙ schema" chip (chats.jsx) toggles the panel OPEN in
+# ONE click — no more internal collapsed-rail intermediate step between the
+# chip mounting <SchemaPanel> and the operator seeing the Builder/JSON tabs.
+# ---------------------------------------------------------------------------
+
+
+def test_conversation_always_mounts_schema_panel_fully_open() -> None:
+    src = _conv_src()
+    assert "collapsed={false}" in src
+    # The old double-gating internal state is gone — mounting IS visible now.
+    assert "schemaCollapsed" not in src
+
+
+def test_conversation_wires_its_own_toggle_chevron_to_fully_close_the_panel() -> None:
+    src = _conv_src()
+    assert "onToggle={onCloseSchemaPanel}" in src
+    assert "onCloseSchemaPanel" in src
+
+
+def test_chats_jsx_closes_the_panel_via_the_same_state_the_chip_toggles() -> None:
+    chats_src = (CHAT_DIR.parent / "chats.jsx").read_text(encoding="utf-8")
+    assert "onCloseSchemaPanel={() => setShowSchemaPanel(false)}" in chats_src
+
+
+# ---------------------------------------------------------------------------
+# studio-ux fix 3: a chat with no response_format override of its own still
+# shows the EFFECTIVE (agent build-time) schema, labeled as inherited and
+# read-only until the operator explicitly starts an override.
+# ---------------------------------------------------------------------------
+
+
+def test_schema_panel_accepts_inherited_schema_prop() -> None:
+    src = _panel_src()
+    assert "inheritedSchema = null," in src
+
+
+def test_conversation_fetches_the_bound_agents_response_format() -> None:
+    src = _conv_src()
+    assert "const agentIdForSchema = chatRow?.agent_id || null;" in src
+    assert "apiFetch(\"GET\", `/agents/${encodeURIComponent(agentIdForSchema)}`" in src
+    assert "inheritedSchema={agentResponseFormat}" in src
+
+
+def test_conversation_only_fetches_agent_detail_while_schema_panel_is_open() -> None:
+    # Guarded exactly like agents.jsx's AG_ReferencesPanel (cache key AND
+    # fetcher both gate on the condition) so a hidden panel never fires an
+    # extra GET on every chat.
+    src = _conv_src()
+    assert 'showSchemaPanel && agentIdForSchema ? `agent-detail:${agentIdForSchema}` : "agent-detail:none"' in src
+    assert "deps: [showSchemaPanel, agentIdForSchema]" in src
+
+
+def test_schema_panel_shows_inherited_only_without_a_chat_override() -> None:
+    src = _panel_src()
+    assert "const hasOwnValue = value !== null && value !== undefined;" in src
+    assert "const showingInherited = !hasOwnValue && inheritedSchema != null && !overriding;" in src
+
+
+def test_schema_panel_inherited_view_is_labeled_and_read_only() -> None:
+    src = _panel_src()
+    assert 'data-testid="schema-inherited-banner"' in src
+    assert "Inherited from agent" in src
+    assert 'data-testid="schema-inherited-preview"' in src
+    assert "readOnly" in src
+    assert 'data-testid="schema-inherited-edit"' in src
+
+
+def test_schema_panel_inherited_seed_effect_never_emits_before_an_edit() -> None:
+    # The seeding effect's CODE (not its explanatory comment, which
+    # discusses emit()/onChange by name) must only set local display state
+    # (setJsonText/setBuilderFields) — never actually call emit() or
+    # onChange — so opening the panel on an agent with a default schema
+    # can't silently create a per-chat override.
+    src = _panel_src()
+    start = src.index("React.useEffect(() => {\n    if (hasOwnValue || overriding || inheritedSchema == null) return;")
+    end = src.index("const emit = (schema) => {")
+    seed_effect = src[start:end]
+    assert "emit(" not in seed_effect
+    assert "onChange(" not in seed_effect
+    assert "setJsonText(JSON.stringify(inheritedSchema, null, 2));" in seed_effect
+
+
+def test_schema_panel_edit_override_button_unlocks_editing() -> None:
+    src = _panel_src()
+    assert "onClick={() => setOverriding(true)}" in src
+
+
 def test_bundle_transpiles_with_schema_panel_f2_changes() -> None:
     from primer.api._jsx_bundle import build_jsx_bundle
 

--- a/tests/ui/test_session_adapter.py
+++ b/tests/ui/test_session_adapter.py
@@ -98,6 +98,40 @@ def test_controls_hit_the_documented_endpoints() -> None:
     assert "/cancel" in src
 
 
+def test_catch_up_refetches_messages_after_known_seq() -> None:
+    # Bug fix: a fresh/slow-starting session's live tap can miss events
+    # emitted right before it subscribes (highWater 0 -> live-only tail),
+    # leaving the transcript stuck "waiting for events" until a full page
+    # refresh. The adapter must self-heal by re-fetching /messages after
+    # its current max known seq and merging the result in (deduped by seq,
+    # never resetting `records`).
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "function" in src and "catchUp" in src
+    assert "/messages?after_seq=" in src
+    assert "catchUpInFlightRef" in src, "catch-up must guard against overlapping fetches"
+
+
+def test_catch_up_triggered_by_polled_last_seq_outrunning_known_seq() -> None:
+    # The session row is already light-polled every 3s and carries the
+    # authoritative high-water `last_seq` (WorkspaceSession.last_seq) — the
+    # adapter must compare that against its own max known record seq
+    # (historyCursorRef) and only re-fetch when actually behind, so it
+    # never issues a superfluous request once caught up.
+    src = ADAPTER.read_text(encoding="utf-8")
+    assert "polledLastSeq" in src
+    assert "sessionRow.last_seq" in src
+    assert "polledLastSeq > (historyCursorRef.current || 0)" in src
+
+
+def test_catch_up_also_triggered_on_tap_reconnect() -> None:
+    # A tap that attaches even a moment late — or reconnects after a drop —
+    # must also re-sync, not rely solely on the next poll tick.
+    src = ADAPTER.read_text(encoding="utf-8")
+    onopen_start = src.index("es.onopen = function")
+    onopen_body = src[onopen_start:src.index("es.onmessage = function")]
+    assert "catchUp()" in onopen_body
+
+
 def test_session_scoped_tap_reuses_wtp_build_selector() -> None:
     # Reuse components/workspace-tap.jsx's selector builder to scope the
     # live tail to this one session, rather than re-deriving the

--- a/tests/ui/test_studio_center.py
+++ b/tests/ui/test_studio_center.py
@@ -103,6 +103,26 @@ def test_reuses_sd_graph_run_view() -> None:
     assert "rid={sid}" in src
 
 
+def test_graph_panel_converges_node_turn_log_into_transcript() -> None:
+    # fix #9: the studio graph panel opts SD_GraphRunView into convergence —
+    # selecting a node filters the shared transcript (ST_filterRecordsByNode)
+    # instead of opening a separate per-node turn-log panel (hidden here).
+    src = _center_src()
+    assert "onNodeSelect={setSelectedNode}" in src
+    assert "hideNodeTurnLog={true}" in src
+    assert "function ST_filterRecordsByNode(" in src
+    assert "ST_filterRecordsByNode(conv.messages, selectedNode)" in src
+
+
+def test_graph_panel_optimistic_queued_send_helpers_present() -> None:
+    # fix #8: pure, JSX-free helpers back the optimistic "(queued)" row so the
+    # send/reconcile logic is unit-testable via MiniRacer.
+    src = _center_src()
+    assert "function ST_queuedTranscriptRow(" in src
+    assert "function ST_reconcileQueued(" in src
+    assert "(queued)" in src
+
+
 def test_reuses_markdown_and_highlighter() -> None:
     src = _center_src()
     assert "window.renderMarkdown" in src, "markdown preview must reuse vendor renderMarkdown"

--- a/tests/ui/test_studio_debug_sidebar.py
+++ b/tests/ui/test_studio_debug_sidebar.py
@@ -26,6 +26,7 @@ UI = ROOT / "ui"
 ACTIVITY = UI / "components" / "studio-activity.jsx"
 CENTER = UI / "components" / "studio-center.jsx"
 INDEX = UI / "index.html"
+STYLES = UI / "styles.css"
 
 
 def _activity_src() -> str:
@@ -351,6 +352,79 @@ def test_st_yield_invalidates_pure_helper_via_mini_racer() -> None:
     assert ctx.eval("out.length") == 2
     assert ctx.eval("out[0]") == "session-adapter:pending:sess1"
     assert ctx.eval("out[1]") == "studio-yields-pending:ws1"
+
+
+# ---------------------------------------------------------------------------
+# studio-ux fix 1: collapsed = an actual thin rail (~40px), not just an
+# internal display:none — the OUTER .st-col-right grid TRACK must shrink too
+# so the center column reflows wider. See ui/styles.css's :has() rule next to
+# .st-col-right and the collapsed-branching inline style on the toggle
+# button below (both scoped desktop-only; the mobile off-canvas drawer is
+# untouched — see test_studio_mobile_panel_toggles_and_drawers).
+# ---------------------------------------------------------------------------
+
+
+def _styles_src() -> str:
+    return STYLES.read_text(encoding="utf-8")
+
+
+def test_collapsed_rail_hides_bell_and_label_but_keeps_chevron_and_badge() -> None:
+    fn = _studio_activity_fn_src()
+    assert "var expanded = !collapsed;" in fn
+    # Chevron (the toggle indicator) and the badge are unconditional; only
+    # the bell icon + "Debug" text retract into the collapsed rail.
+    assert '{expanded && <Icon name="bell" size={13} style={{ flexShrink: 0 }} />}' in fn
+    assert '{expanded && <span style={{ flex: 1, textAlign: "left" }}>Debug</span>}' in fn
+    assert 'Icon name={collapsed ? "chevron-left" : "chevron-right"}' in fn
+    assert '{pendingCount > 0 && (' in fn
+
+
+def test_collapsed_toggle_button_restyles_into_a_narrow_column() -> None:
+    fn = _studio_activity_fn_src()
+    assert 'flexDirection: collapsed ? "column" : "row"' in fn
+    assert 'height: collapsed ? "auto" : 34' in fn
+    assert 'padding: collapsed ? "10px 4px" : "0 12px"' in fn
+
+
+def test_st_body_grid_shrinks_the_right_track_when_the_rail_is_collapsed() -> None:
+    css = _styles_src()
+    assert ".st-body:has(.studio-activity-root.is-collapsed)" in css
+    assert (
+        "grid-template-columns: var(--st-left-w, 248px) 5px minmax(0, 1fr) 5px 40px;"
+        in css
+    )
+    assert '.studio-activity-root.is-collapsed { width: 40px; min-width: 40px; }' in css
+
+
+def test_collapsed_rail_grid_override_hides_the_right_resize_handle() -> None:
+    css = _styles_src()
+    assert '[data-testid="studio-resize-right"]' in css
+
+
+def test_collapsed_rail_grid_override_is_desktop_only() -> None:
+    # The mobile breakpoint renders .st-col-right as an off-canvas fixed
+    # drawer (see the max-width:639px block) — this override's higher
+    # specificity must not leak into that layout, so it's gated behind a
+    # min-width media query rather than left unscoped.
+    css = _styles_src()
+    idx = css.index(".st-body:has(.studio-activity-root.is-collapsed)")
+    preceding = css[:idx]
+    media_idx = preceding.rfind("@media (min-width: 640px)")
+    assert media_idx != -1, "the collapsed-rail grid override must sit inside a min-width media query"
+    # No closing brace for that media block between its opening and our rule
+    # (i.e. the rule is actually INSIDE it, not just preceded by it earlier
+    # in the file).
+    between = css[media_idx:idx]
+    assert between.count("{") > between.count("}")
+
+
+def test_action_required_and_workspace_activity_still_stay_mounted_when_collapsed() -> None:
+    # Regression guard alongside the existing mount-guard test above: the
+    # new `expanded` flag must not have been used to sneak a conditional
+    # mount back in for the two subscription-owning children.
+    fn = _studio_activity_fn_src()
+    assert "{expanded && <ActionRequired" not in fn
+    assert "{expanded && <WorkspaceActivity" not in fn
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_studio_graph_run_view.py
+++ b/tests/ui/test_studio_graph_run_view.py
@@ -30,6 +30,7 @@ ROOT = Path(__file__).resolve().parents[2]
 UI = ROOT / "ui"
 CENTER = UI / "components" / "studio-center.jsx"
 ADAPTER = UI / "components" / "session-adapter.jsx"
+DETAIL = UI / "components" / "session-detail.jsx"
 INDEX = UI / "index.html"
 
 
@@ -39,6 +40,17 @@ def _center_src() -> str:
 
 def _adapter_src() -> str:
     return ADAPTER.read_text(encoding="utf-8")
+
+
+def _detail_src() -> str:
+    return DETAIL.read_text(encoding="utf-8")
+
+
+def _center_helpers_src() -> str:
+    """The JSX-free ST_ pure-helper slice (ST_isAutonomous .. just before
+    SessionAgentPanel) — MiniRacer-evaluable, mirrors the slice the existing
+    divider test evals."""
+    return _fn_block(_center_src(), "function ST_isAutonomous(", "function SessionAgentPanel(")
 
 
 def _fn_block(src: str, start_marker: str, end_marker: str) -> str:
@@ -226,6 +238,146 @@ def test_mutations_only_fire_from_onclick_never_on_mount() -> None:
     ):
         assert panel.count(call) == 1, f"{call} should be wired exactly once (via its onClick)"
         assert onclick in panel
+
+
+# ---------------------------------------------------------------------------
+# fix #8 — optimistic "queued" row when steering a busy (non-idle) session.
+# Sending to a RUNNING/WAITING session queues the steer as the next turn; the
+# persisted USER_INPUT only surfaces via the tap once the running turn yields.
+# The panel appends a local "(queued)" placeholder immediately and drops it
+# when the real record lands.
+# ---------------------------------------------------------------------------
+
+
+def test_optimistic_queued_row_is_wired_into_the_graph_panel() -> None:
+    panel = _session_graph_panel_src()
+    # Local optimistic-send state + a busy gate (only non-idle sessions queue).
+    assert "[pendingSends, setPendingSends]" in panel
+    assert "if (isBusy) {" in panel
+    # busy = running/waiting/turn-in-flight (mirrors the brief's non-idle set).
+    assert 'liveStatus === "running"' in panel
+    assert 'liveStatus === "waiting"' in panel
+    assert "turnInFlight" in panel
+    # The queued placeholder is appended to the transcript rows and reconciled
+    # against the real record stream.
+    assert "ST_queuedTranscriptRow" in panel
+    assert "ST_reconcileQueued(prev, conv.messages)" in panel
+
+
+def test_optimistic_queued_row_reconciles_via_mini_racer() -> None:
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    ctx.eval(_adapter_src())  # window.SA_toTranscript (for the shared slice)
+    ctx.eval(_center_helpers_src())  # ST_queuedTranscriptRow / ST_reconcileQueued / ...
+
+    # A queued send renders as a user_message row, clearly marked "(queued)",
+    # keyed off clientId so it can't collide with a real seq'd row.
+    ctx.eval('var qr = ST_queuedTranscriptRow({ id: "c1", text: "retry the build" });')
+    assert ctx.eval("qr.kind") == "user_message"
+    assert ctx.eval("qr.text") == "retry the build (queued)"
+    assert ctx.eval("qr.clientId") == "c1"
+    assert ctx.eval("qr.queued") is True
+
+    # Before the real USER_INPUT lands, the pending send survives (an unrelated
+    # assistant token must NOT reconcile it) — same array reference back.
+    ctx.eval('var pend = [{ id: "c1", text: "retry the build" }];')
+    ctx.eval('var kept = ST_reconcileQueued(pend, [{seq:1, kind:"assistant_token", payload:{text:"..."}}]);')
+    assert ctx.eval("kept.length") == 1
+    assert ctx.eval("kept === pend") is True
+
+    # Once the persisted USER_INPUT record (same text) arrives, it drops.
+    ctx.eval('var gone = ST_reconcileQueued(pend, [{seq:5, kind:"user_input", payload:{text:"retry the build"}}]);')
+    assert ctx.eval("gone.length") == 0
+
+    # Two identical queued sends reconcile ONE-TO-ONE against one real record,
+    # not both at once.
+    ctx.eval('var two = [{id:"a",text:"go"},{id:"b",text:"go"}];')
+    ctx.eval('var one = ST_reconcileQueued(two, [{seq:9, kind:"user_input", payload:{text:"go"}}]);')
+    assert ctx.eval("one.length") == 1
+
+
+# ---------------------------------------------------------------------------
+# fix #9 — converge the per-node SD_NodeTurnLog into the shared transcript.
+# Selecting a node in the run-view filters the session <Transcript> to that
+# node's records (node_id === selectedNode); the separate turn-log panel is
+# suppressed via SD_GraphRunView's opt-in hideNodeTurnLog flag.
+# ---------------------------------------------------------------------------
+
+
+def test_graph_panel_filters_transcript_by_selected_node() -> None:
+    panel = _session_graph_panel_src()
+    # Node-selection state driven by the run-view's opt-in callback.
+    assert "[selectedNode, setSelectedNode]" in panel
+    assert "onNodeSelect={setSelectedNode}" in panel
+    # The transcript is fed the node-filtered record set (node_id === selection).
+    assert "ST_filterRecordsByNode(conv.messages, selectedNode)" in panel
+    # A clear-filter affordance returns to the full (all-nodes) transcript.
+    assert 'data-testid="graph-node-filter"' in panel
+    assert 'data-testid="graph-node-filter-clear"' in panel
+    assert "setSelectedNode(null)" in panel
+
+
+def test_graph_panel_hides_separate_node_turn_log() -> None:
+    panel = _session_graph_panel_src()
+    # The studio panel opts SD_GraphRunView into hiding the per-node turn-log
+    # (it lives in the converged transcript now) …
+    assert "hideNodeTurnLog={true}" in panel
+    # … and never renders a second per-node turn-log panel of its own.
+    assert "SD_NodeTurnLog" not in panel
+    assert "run-node-turnlog" not in panel
+    assert "/turn_log" not in panel
+
+
+def test_node_filter_narrows_records_via_mini_racer() -> None:
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = {};")
+    ctx.eval(_adapter_src())
+    ctx.eval(_center_helpers_src())
+    ctx.eval(
+        """
+        var recs = [
+          {seq:1, kind:"user_input", payload:{text:"hi"}, node_id: null},
+          {seq:2, kind:"assistant_token", payload:{text:"a"}, node_id:"drafter"},
+          {seq:3, kind:"assistant_token", payload:{text:"b"}, node_id:"reviewer"},
+          {seq:4, kind:"tool_call", payload:{name:"run"}, node_id:"drafter"},
+        ];
+        """
+    )
+    # No node selected -> the full stream (unfiltered).
+    assert ctx.eval("ST_filterRecordsByNode(recs, null).length") == 4
+    # A node selected -> only that node's records, in order.
+    ctx.eval('var dr = ST_filterRecordsByNode(recs, "drafter");')
+    assert ctx.eval("dr.length") == 2
+    assert ctx.eval("dr[0].seq") == 2
+    assert ctx.eval("dr[1].seq") == 4
+    # The filtered set still flows through the SAME transcript pipeline (one
+    # coalesced assistant bubble + the tool_call row).
+    ctx.eval('var out = ST_sessionTranscriptRows(dr, {id:"s1", binding:{kind:"graph"}});')
+    assert ctx.eval("out.length") == 2
+
+
+def test_sd_graph_run_view_opt_in_prop_keeps_old_page_turn_log() -> None:
+    # fix #9 must NOT regress the shared SD_GraphRunView export: the opt-in
+    # props default to today's behavior (turn-log shown, no selection
+    # callback), so a caller that omits them renders SD_NodeTurnLog as before.
+    detail = _detail_src()
+    assert (
+        "function SD_GraphRunView({ gid, rid, wid, session, pushToast, onNodeSelect, hideNodeTurnLog })"
+        in detail
+    )
+    # onNodeSelect only fires when supplied (typeof guard) — omitting it keeps
+    # local-only node selection.
+    assert 'typeof onNodeSelect === "function"' in detail
+    # The turn-log is gated on !hideNodeTurnLog (default falsy -> still shown).
+    assert "{!hideNodeTurnLog && (" in detail
+    assert (
+        "<SD_NodeTurnLog gid={gid} rid={rid} nodeId={node.node_id} nodeStatus={node.status} />"
+        in detail
+    )
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_studio_run_view_interactive.py
+++ b/tests/ui/test_studio_run_view_interactive.py
@@ -186,7 +186,12 @@ def test_adapter_restart_extension() -> None:
 def test_adapter_wsstate_extension_for_transcript_connection_pill() -> None:
     src = _adapter_src()
     assert "wsState: wsState," in src
-    assert 'es.onopen = function () { setWsState("open"); };' in src
+    # Scoped to the onopen source region (not an exact one-liner match) since
+    # a later fix taught onopen to also trigger a catch-up re-fetch
+    # (fix/studio-live-stream) alongside setting wsState to "open".
+    onopen_start = src.index("es.onopen = function")
+    onopen_body = src[onopen_start:src.index("es.onmessage = function")]
+    assert 'setWsState("open");' in onopen_body
 
 
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_workspace_create_loading_state.py
+++ b/tests/ui/test_workspace_create_loading_state.py
@@ -1,0 +1,72 @@
+"""studio-ux fix 5 — the "New workspace" modal's Create button
+(`WS_NewWorkspaceModal` in ui/components/workspaces.jsx) gave no feedback
+while the POST + (slow, k8s) provisioning ran: it was already disabled
+in-flight (`disabled={!templateId || create.loading}`), but with no visual
+loading affordance an operator could easily read the button as inert/broken
+and click again or bail out. It now shows an inline spinner + "Creating…"
+label while `create.loading` (the existing useMutation() state) is true.
+
+Static-source checks only (the tests/ui suite convention).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+WORKSPACES = UI / "components" / "workspaces.jsx"
+STYLES = UI / "styles.css"
+
+
+def _fn_block(src: str, start_marker: str, end_marker: str) -> str:
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+def _modal_src() -> str:
+    src = WORKSPACES.read_text(encoding="utf-8")
+    return _fn_block(src, "function WS_NewWorkspaceModal(", "function WorkspaceDetail(")
+
+
+def test_create_button_stays_disabled_while_the_mutation_is_in_flight() -> None:
+    modal = _modal_src()
+    assert "disabled={!templateId || create.loading}" in modal
+
+
+def test_create_button_shows_a_spinner_and_creating_label_while_loading() -> None:
+    modal = _modal_src()
+    assert 'data-testid="workspace-create-submit"' in modal
+    assert '{create.loading ? (<><span className="spinner" /><span>Creating…</span></>) : "Create"}' in modal
+
+
+def test_create_button_swaps_its_icon_out_for_the_spinner_while_loading() -> None:
+    # The Btn shell always renders `icon` as a leading <Icon>; passing
+    # icon={undefined} while loading avoids a duplicate plus-icon sitting
+    # next to the spinner.
+    modal = _modal_src()
+    assert 'icon={create.loading ? undefined : "plus"}' in modal
+
+
+def test_create_uses_the_existing_use_mutation_loading_state() -> None:
+    # No new bespoke "submitting" state — reuses useMutation()'s own
+    # .loading, exactly as instructed.
+    modal = _modal_src()
+    assert "const create = useMutation(" in modal
+    assert "create.loading" in modal
+
+
+def test_spinner_css_is_shared_beyond_the_auth_submit_button() -> None:
+    css = STYLES.read_text(encoding="utf-8")
+    assert ".auth-submit .spinner,\n.btn .spinner {" in css
+
+
+def test_bundle_transpiles_with_workspace_create_loading_state() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    build_jsx_bundle.cache_clear()
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    text = body.decode("utf-8")
+    assert "/* === components/workspaces.jsx === */" in text

--- a/tests/ui_e2e/test_graph_run_view_journey.py
+++ b/tests/ui_e2e/test_graph_run_view_journey.py
@@ -125,11 +125,14 @@ def test_graph_run_view_journey(base_url, console_url, page, tmp_path) -> None:
     # the chain lands at the canvas center once layout finishes.
     page.wait_for_timeout(2000)
     # The agent node sits at the center of a begin->agent->end chain (dagre
-    # LR + autoFit). Click center -> inspector shows the Turn log section.
+    # LR + autoFit). Click center -> node-select filters the transcript to that
+    # node. Converged (#9): the separate per-node "Turn log" panel was removed
+    # in favour of a node-filtered transcript; the graph-node-filter banner
+    # (with its "All nodes" clear affordance) surfaces the active node filter.
     box = canvas.bounding_box()
     assert box is not None
     page.mouse.click(box["x"] + box["width"] / 2, box["y"] + box["height"] / 2)
-    expect(page.get_by_text("Turn log", exact=False)).to_be_visible()
+    expect(page.locator("[data-testid='graph-node-filter']")).to_be_visible()
 
 
 # test_graph_health_issue_journey REMOVED (no Studio equivalent) — it asserted

--- a/ui/components/agents.jsx
+++ b/ui/components/agents.jsx
@@ -355,6 +355,11 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
   const [fieldErrors, setFieldErrors] = React.useState({});
   const [activeTab, setActiveTab] = React.useState("basic");
   const [toolFilter, setToolFilter] = React.useState("");
+  // "Selected" filter chip (studio-ux fix 4): the Tools tab's search had no
+  // way to see WHICH tools are ticked across all toolsets/pages — this ANDs
+  // with the text filter, reusing the same selectedScopedIds set the
+  // "N of 172 selected" counter already tracks.
+  const [showSelectedOnly, setShowSelectedOnly] = React.useState(false);
   const [toolPage, setToolPage] = React.useState(1);
 
   React.useEffect(() => {
@@ -377,20 +382,31 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
 
   const filteredToolsetEntries = React.useMemo(() => {
     const q = toolFilter.trim().toLowerCase();
-    if (!q) return toolsetEntries;
-    return toolsetEntries
-      .map((ts) => ({
-        ...ts,
-        tools: ts.tools.filter(
-          (t) =>
-            t.id.toLowerCase().includes(q) ||
-            t.scoped_id.toLowerCase().includes(q) ||
-            (t.description || "").toLowerCase().includes(q) ||
-            ts.id.toLowerCase().includes(q),
-        ),
-      }))
-      .filter((ts) => ts.tools.length > 0 || ts.id.toLowerCase().includes(q));
-  }, [toolsetEntries, toolFilter]);
+    let entries = toolsetEntries;
+    if (q) {
+      entries = entries
+        .map((ts) => ({
+          ...ts,
+          tools: ts.tools.filter(
+            (t) =>
+              t.id.toLowerCase().includes(q) ||
+              t.scoped_id.toLowerCase().includes(q) ||
+              (t.description || "").toLowerCase().includes(q) ||
+              ts.id.toLowerCase().includes(q),
+          ),
+        }))
+        .filter((ts) => ts.tools.length > 0 || ts.id.toLowerCase().includes(q));
+    }
+    // "Selected" filter chip: restrict to tools currently in
+    // selectedScopedIds, across every toolset/page (not just the visible
+    // slice), so it composes cleanly with the text filter above.
+    if (showSelectedOnly) {
+      entries = entries
+        .map((ts) => ({ ...ts, tools: ts.tools.filter((t) => selectedScopedIds.has(t.scoped_id)) }))
+        .filter((ts) => ts.tools.length > 0);
+    }
+    return entries;
+  }, [toolsetEntries, toolFilter, showSelectedOnly, selectedScopedIds]);
 
   const totalAvailable = React.useMemo(
     () => toolsetEntries.reduce((acc, ts) => acc + ts.tools.length, 0),
@@ -423,7 +439,7 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
   const toolTotalPages = Math.max(1, Math.ceil(flatTools.length / AGENT_TOOL_PAGE_SIZE));
   // Snap to first page whenever the filter narrows the result set,
   // and clamp the current page if the page count shrinks below it.
-  React.useEffect(() => { setToolPage(1); }, [toolFilter]);
+  React.useEffect(() => { setToolPage(1); }, [toolFilter, showSelectedOnly]);
   React.useEffect(() => {
     if (toolPage > toolTotalPages) setToolPage(toolTotalPages);
   }, [toolPage, toolTotalPages]);
@@ -651,6 +667,17 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
                 style={{ width: "100%" }}
               />
             </div>
+            <button
+              type="button"
+              data-testid="agent-tool-filter-selected"
+              className={"chip" + (showSelectedOnly ? " active" : "")}
+              aria-pressed={showSelectedOnly}
+              onClick={() => setShowSelectedOnly((v) => !v)}
+              title={showSelectedOnly ? "Show all tools" : "Show only selected tools"}
+              style={{ whiteSpace: "nowrap" }}
+            >
+              Selected
+            </button>
             <span className="muted text-sm" style={{ whiteSpace: "nowrap" }}>
               {selectedCount} of {totalAvailable} selected
             </span>
@@ -661,8 +688,10 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
             </div>
           )}
           {!toolsCatalogue.loading && filteredToolsetEntries.length === 0 && (
-            <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }}>
-              {toolFilter ? "No tools match the filter." : "No toolsets available."}
+            <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }} data-testid="agent-tool-empty">
+              {showSelectedOnly
+                ? `No selected tools${toolFilter ? " match the filter." : "."}`
+                : toolFilter ? "No tools match the filter." : "No toolsets available."}
             </div>
           )}
           {/* Unavailable toolsets stay visible outside the paginated

--- a/ui/components/chat/conversation.jsx
+++ b/ui/components/chat/conversation.jsx
@@ -42,7 +42,7 @@
 // component fills its flex parent (height:100%/flex:1); the host owns
 // viewport-relative sizing.
 
-function Conversation({ chatId, headerSlot, rightChromeSlot, showSchemaPanel, onStatus, pushToast }) {
+function Conversation({ chatId, headerSlot, rightChromeSlot, showSchemaPanel, onCloseSchemaPanel, onStatus, pushToast }) {
   const { useResource, useViewport, apiFetch, useRouter } = window.primerApi;
   const { isMobile } = useViewport();
   const { navigate } = useRouter();
@@ -65,6 +65,27 @@ function Conversation({ chatId, headerSlot, rightChromeSlot, showSchemaPanel, on
   // <Transcript>'s own turnInFlight calc (turn_status claimable/running)
   // since both need the same "a turn is in flight" signal.
   const turnInFlight = chatRow?.turn_status === "claimable" || chatRow?.turn_status === "running";
+
+  // studio-ux fix 3: a chat with no `response_format` of its own still
+  // effectively runs under the AGENT's build-time response_format (per-turn
+  // precedence is agent default -> chat override -> ephemeral send-frame).
+  // Fetched only while the schema panel is open and the chat is bound to a
+  // real agent id, mirroring the guarded-useResource convention in
+  // agents.jsx's AG_ReferencesPanel (cache key/fetcher both fall back to a
+  // no-op "none" entry rather than skipping the hook). SchemaPanel decides
+  // whether to actually SHOW this — it only applies while the chat has no
+  // override of its own (`schemaValue == null`).
+  const agentIdForSchema = chatRow?.agent_id || null;
+  const agentDetail = useResource(
+    showSchemaPanel && agentIdForSchema ? `agent-detail:${agentIdForSchema}` : "agent-detail:none",
+    (s) =>
+      showSchemaPanel && agentIdForSchema
+        ? apiFetch("GET", `/agents/${encodeURIComponent(agentIdForSchema)}`, null, { signal: s })
+        : Promise.resolve(null),
+    { deps: [showSchemaPanel, agentIdForSchema] }
+  );
+  const agentResponseFormat =
+    agentDetail.data && agentDetail.data.response_format != null ? agentDetail.data.response_format : null;
 
   const [messages, setMessages] = React.useState([]);
   const [lastSeq, setLastSeq] = React.useState(0);
@@ -112,7 +133,12 @@ function Conversation({ chatId, headerSlot, rightChromeSlot, showSchemaPanel, on
   const [schemaValue, setSchemaValue] = React.useState(null);
   const [schemaPersistent, setSchemaPersistent] = React.useState(false);
   const [schemaValid, setSchemaValid] = React.useState(true);
-  const [schemaCollapsed, setSchemaCollapsed] = React.useState(true);
+  // studio-ux fix 2: the panel used to ALSO start collapsed internally
+  // (a second, redundant expand step behind the "⚙ schema" chip's own
+  // mount/unmount toggle — see showSchemaPanel above). <SchemaPanel> is now
+  // always rendered fully open the moment it's mounted; its own header
+  // chevron (still useful as a quick "hide" control) closes the panel
+  // outright via onCloseSchemaPanel instead of re-collapsing in place.
 
   // One-time hydration: once the chat row's own fetch resolves, seed
   // the panel from any existing per-chat persistent schema (A1's
@@ -1092,12 +1118,19 @@ function Conversation({ chatId, headerSlot, rightChromeSlot, showSchemaPanel, on
         </div>
       </div>
 
-      {/* <SchemaPanel> (R3) — collapsible right-hand sibling of the
-          timeline + composer column, per §3's layout. Builder/JSON
-          bodies + persistent/ephemeral application (Task F2) are wired
-          above (handleSchemaPersistentChange, the debounced persist
-          effect, sendMessage's ephemeral frame.response_format, and the
-          one-time chatRow.response_format hydration). */}
+      {/* <SchemaPanel> (R3) — right-hand sibling of the timeline + composer
+          column, per §3's layout. Builder/JSON bodies + persistent/ephemeral
+          application (Task F2) are wired above (handleSchemaPersistentChange,
+          the debounced persist effect, sendMessage's ephemeral
+          frame.response_format, and the one-time chatRow.response_format
+          hydration). studio-ux fix 2: always mounted fully OPEN (never the
+          internal collapsed-rail state) — the "⚙ schema" chip is now the
+          single toggle for the whole panel (mount === visible); its own
+          header chevron closes it outright via onCloseSchemaPanel instead of
+          re-collapsing in place. studio-ux fix 3: inheritedSchema hands it
+          the agent's build-time response_format so a chat with no override
+          of its own still shows the EFFECTIVE schema instead of looking
+          schema-less. */}
       {showSchemaPanel && (
         <SchemaPanel
           value={schemaValue}
@@ -1106,8 +1139,9 @@ function Conversation({ chatId, headerSlot, rightChromeSlot, showSchemaPanel, on
           onPersistentChange={handleSchemaPersistentChange}
           valid={schemaValid}
           onValidityChange={setSchemaValid}
-          collapsed={schemaCollapsed}
-          onToggle={() => setSchemaCollapsed((c) => !c)}
+          collapsed={false}
+          onToggle={onCloseSchemaPanel}
+          inheritedSchema={agentResponseFormat}
         />
       )}
     </div>

--- a/ui/components/chat/schema-panel.jsx
+++ b/ui/components/chat/schema-panel.jsx
@@ -414,12 +414,24 @@ function SchemaPanel({
   onValidityChange,
   collapsed = true,
   onToggle,
+  inheritedSchema = null,
 }) {
   const [tab, setTab] = React.useState("builder"); // "builder" | "json"
   const [builderFields, setBuilderFields] = React.useState(() => (SP_isRepresentableSchema(value) ? SP_schemaToFields(value) : []));
   const [builderEscape, setBuilderEscape] = React.useState(() => !SP_isRepresentableSchema(value));
   const [jsonText, setJsonText] = React.useState(() => (value ? JSON.stringify(value, null, 2) : ""));
   const [jsonError, setJsonError] = React.useState(null);
+
+  // studio-ux fix 3: the chat has no `response_format` override of its own
+  // (`value` is null/undefined) but the agent it's bound to may have a
+  // build-time one — `inheritedSchema` carries that down from <Conversation>.
+  // Shown read-only + labeled "inherited from agent" until the operator
+  // explicitly starts an override; nothing is emitted upward (no onChange
+  // call) while merely displaying it, so opening the panel never silently
+  // creates a per-chat override.
+  const hasOwnValue = value !== null && value !== undefined;
+  const [overriding, setOverriding] = React.useState(false);
+  const showingInherited = !hasOwnValue && inheritedSchema != null && !overriding;
 
   // Tracks the last schema THIS component pushed via onChange (as its
   // JSON string) so the hydration effect below can tell "the parent
@@ -442,6 +454,28 @@ function SchemaPanel({
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [value]);
+
+  // studio-ux fix 3: while showing the inherited (read-only) schema, seed
+  // the SAME jsonText/builderFields display state from it — DISPLAY only,
+  // via setState directly rather than emit(), so `value`/onChange never
+  // fire from merely looking at what the agent would apply. The moment the
+  // operator clicks "Edit override" (setOverriding(true) below), this
+  // pre-seeded state becomes the starting point for a real edit — the very
+  // next keystroke/field change runs through handleJsonTextChange /
+  // handleBuilderFieldsChange as normal, which DO emit(), promoting it to a
+  // genuine per-chat override.
+  React.useEffect(() => {
+    if (hasOwnValue || overriding || inheritedSchema == null) return;
+    setJsonText(JSON.stringify(inheritedSchema, null, 2));
+    if (SP_isRepresentableSchema(inheritedSchema)) {
+      setBuilderFields(SP_schemaToFields(inheritedSchema));
+      setBuilderEscape(false);
+    } else {
+      setBuilderFields([]);
+      setBuilderEscape(true);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [inheritedSchema, hasOwnValue, overriding]);
 
   const emit = (schema) => {
     lastEmittedRef.current = JSON.stringify(schema === undefined ? null : schema);
@@ -583,30 +617,57 @@ function SchemaPanel({
         </button>
       </div>
 
-      <div style={{ padding: "8px 10px", borderBottom: "1px solid var(--border)" }}>
-        <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--text-2)" }}>
-          <input
-            type="checkbox"
-            data-testid="schema-persistent-toggle"
-            checked={!!persistent}
-            onChange={(e) => typeof onPersistentChange === "function" && onPersistentChange(e.target.checked)}
-          />
-          Persistent
-        </label>
-        <div style={{ marginTop: 2, fontSize: 10, color: "var(--text-3)" }}>
-          {persistent
-            ? "Applies to every message in this chat."
-            : "Applies to the next message only."}
-        </div>
-        {valid === false && (
-          <div data-testid="schema-invalid-banner" style={{ marginTop: 6, fontSize: 11, color: "var(--red, #c33)" }}>
-            <Icon name="warn-circle" size={11} /> {jsonError || "schema invalid"} — send disabled
+      {showingInherited ? (
+        <div data-testid="schema-inherited-banner" style={{ padding: "8px 10px", borderBottom: "1px solid var(--border)" }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--text-2)" }}>
+            <Icon name="info" size={12} />
+            Inherited from agent
           </div>
-        )}
-      </div>
+          <div style={{ marginTop: 2, fontSize: 10, color: "var(--text-3)" }}>
+            This chat has no schema override of its own — every turn already runs under the agent's own response_format below.
+          </div>
+          <button
+            type="button"
+            data-testid="schema-inherited-edit"
+            className="btn btn-sm"
+            style={{ marginTop: 6 }}
+            onClick={() => setOverriding(true)}
+          >Edit override for this chat</button>
+        </div>
+      ) : (
+        <div style={{ padding: "8px 10px", borderBottom: "1px solid var(--border)" }}>
+          <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12, color: "var(--text-2)" }}>
+            <input
+              type="checkbox"
+              data-testid="schema-persistent-toggle"
+              checked={!!persistent}
+              onChange={(e) => typeof onPersistentChange === "function" && onPersistentChange(e.target.checked)}
+            />
+            Persistent
+          </label>
+          <div style={{ marginTop: 2, fontSize: 10, color: "var(--text-3)" }}>
+            {persistent
+              ? "Applies to every message in this chat."
+              : "Applies to the next message only."}
+          </div>
+          {valid === false && (
+            <div data-testid="schema-invalid-banner" style={{ marginTop: 6, fontSize: 11, color: "var(--red, #c33)" }}>
+              <Icon name="warn-circle" size={11} /> {jsonError || "schema invalid"} — send disabled
+            </div>
+          )}
+        </div>
+      )}
 
       <div style={{ flex: 1, minHeight: 0, overflow: "auto", padding: 10, color: "var(--text-3)", fontSize: 12 }}>
-        {tab === "builder" ? (
+        {showingInherited ? (
+          <textarea
+            data-testid="schema-inherited-preview"
+            className="textarea mono"
+            value={jsonText}
+            readOnly
+            style={{ width: "100%", height: "100%", minHeight: 160, resize: "none", background: "var(--bg-2)", color: "var(--text-2)" }}
+          />
+        ) : tab === "builder" ? (
           <div data-testid="schema-builder-body">
             {builderEscape ? (
               <div data-testid="schema-builder-escape" style={{ display: "flex", flexDirection: "column", gap: 6 }}>

--- a/ui/components/chats.jsx
+++ b/ui/components/chats.jsx
@@ -660,6 +660,7 @@ function ChatDetail({ chatId, onBack, pushToast }) {
             </>
           }
           showSchemaPanel={showSchemaPanel}
+          onCloseSchemaPanel={() => setShowSchemaPanel(false)}
         />
       </div>
 

--- a/ui/components/new-session-form.jsx
+++ b/ui/components/new-session-form.jsx
@@ -102,7 +102,14 @@ function SharedNewSessionSchemaField({ propKey, schema, value, onChange }) {
       />
     );
   } else {
-    var long = schema && typeof schema.maxLength === "number" && schema.maxLength >= 200;
+    // Plain string fields default to a resizable multi-line textarea — an
+    // uncapped (or generously capped) string schema property (e.g. a
+    // graph's freeform "question" field, which typically has NO maxLength
+    // at all) is often long, and a single-line <input> for unbounded text
+    // is a poor fit regardless of the property's name. Only an EXPLICIT
+    // short maxLength signals a genuinely short field (e.g. a "name"/"id"
+    // property capped well under this threshold).
+    var long = !schema || typeof schema.maxLength !== "number" || schema.maxLength >= 120;
     control = long ? (
       <textarea
         className="textarea"

--- a/ui/components/session-adapter.jsx
+++ b/ui/components/session-adapter.jsx
@@ -137,6 +137,12 @@ function SA_useSessionConversation(opts) {
   var sessionRow = detail.data;
   var status = sessionRow ? sessionRow.status : null;
   var turnStatus = sessionRow ? sessionRow.turn_status : "idle";
+  // Polled high-water seq (the row's authoritative last_seq) — compared
+  // below against the adapter's own max known record seq to detect when
+  // the live tap missed persisted events (e.g. a fresh/slow-starting
+  // workspace where events land just before the tap subscribes) so the
+  // gap can be closed with a catch-up re-fetch instead of a page refresh.
+  var polledLastSeq = sessionRow && typeof sessionRow.last_seq === "number" ? sessionRow.last_seq : null;
 
   // Pending yield(s) for this session — inline interaction affordances
   // (studio-agents-interact §5.4 / §4.5's session-scoped read).
@@ -174,6 +180,47 @@ function SA_useSessionConversation(opts) {
   var wsStateState = React.useState("connecting");
   var wsState = wsStateState[0];
   var setWsState = wsStateState[1];
+
+  // Guards the catch-up re-fetch below from overlapping itself — the poll
+  // tick and a tap (re)connect can fire close together, and this keeps
+  // either trigger from double-fetching or thrashing the endpoint.
+  var catchUpInFlightRef = React.useRef(false);
+
+  // Catch-up re-fetch — re-reads GET /messages for rows after the
+  // adapter's current max known seq (historyCursorRef, which both the
+  // history seed below and every tap-delivered record keep advanced) and
+  // merges in anything the live tap missed. Triggered when the polled
+  // session row's last_seq outruns historyCursorRef (effect further down)
+  // and on every tap (re)connect (es.onopen below), since a tap that
+  // attaches even a moment late — the common case on a freshly-created or
+  // still-spinning-up k8s workspace — would otherwise never backfill the
+  // gap short of a full page refresh.
+  var catchUp = React.useCallback(function () {
+    if (!sid || catchUpInFlightRef.current) return;
+    catchUpInFlightRef.current = true;
+    var afterSeq = historyCursorRef.current || 0;
+    apiFetch(
+      "GET",
+      "/sessions/" + encodeURIComponent(sid) + "/messages?after_seq=" + afterSeq + "&limit=1000"
+    )
+      .then(function (res) {
+        var items = (res && res.items) || [];
+        if (items.length === 0) return;
+        setRecords(function (prev) {
+          var seen = {};
+          for (var j = 0; j < prev.length; j++) seen[prev[j].seq] = true;
+          var fresh = items.filter(function (it) { return !seen[it.seq]; });
+          if (fresh.length === 0) return prev;
+          var merged = prev.concat(fresh);
+          merged.sort(function (a, b) { return (a.seq || 0) - (b.seq || 0); });
+          var maxSeq = merged.length > 0 ? merged[merged.length - 1].seq : 0;
+          if (maxSeq > historyCursorRef.current) historyCursorRef.current = maxSeq;
+          return merged;
+        });
+      })
+      .catch(function () { /* best-effort; next poll tick or tap reconnect retries */ })
+      .then(function () { catchUpInFlightRef.current = false; });
+  }, [apiFetch, sid]);
 
   // History load — GET /sessions/{sid}/messages (paginated; the server
   // caps a single page at 1000, comfortably above one session's log in
@@ -243,7 +290,14 @@ function SA_useSessionConversation(opts) {
       return undefined;
     }
 
-    es.onopen = function () { setWsState("open"); };
+    es.onopen = function () {
+      setWsState("open");
+      // Re-sync on every (re)connect: a tap that attaches even a moment
+      // late — or reconnects after a drop — can otherwise miss events that
+      // were already persisted, leaving the transcript stuck until a page
+      // refresh. This costs one extra no-op request when already caught up.
+      catchUp();
+    };
 
     es.onmessage = function (ev) {
       var tev;
@@ -258,6 +312,7 @@ function SA_useSessionConversation(opts) {
         created_at: tev.ts,
         node_id: tev.node_id != null ? tev.node_id : null,
       };
+      if (rec.seq > historyCursorRef.current) historyCursorRef.current = rec.seq;
       setRecords(function (prev) {
         for (var i = 0; i < prev.length; i++) {
           if (prev[i].seq === rec.seq) return prev;
@@ -279,7 +334,24 @@ function SA_useSessionConversation(opts) {
     };
 
     return function () { try { es.close(); } catch (_e) { /* no-op */ } };
-  }, [wid, sid, historyLoaded, status]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [wid, sid, historyLoaded, status, catchUp]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Poll-triggered catch-up — the session row above is light-polled every
+  // 3s and carries the authoritative high-water last_seq. If it has moved
+  // past the adapter's own max known record seq (historyCursorRef), the
+  // persisted log has rows the live tap never delivered — the "stuck
+  // waiting for events" symptom on a session whose tap subscribed a beat
+  // late (e.g. a freshly-created/slow k8s workspace). Re-fetch and merge
+  // them in. Gated on actually being behind, so once caught up this never
+  // issues an extra request on the 3s cadence.
+  React.useEffect(function () {
+    if (!sid || !historyLoaded) return undefined;
+    if (typeof polledLastSeq !== "number") return undefined;
+    if (polledLastSeq > (historyCursorRef.current || 0)) {
+      catchUp();
+    }
+    return undefined;
+  }, [sid, historyLoaded, polledLastSeq, catchUp]); // eslint-disable-line react-hooks/exhaustive-deps
 
   // sendMessage/stop/end/restart — one input, four behaviours (§5.1): a
   // message to a CREATED session invokes it, to RUNNING/WAITING it steers,

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -436,10 +436,22 @@ function SD_StatusCanvas({ graph, statusByNode, metaByNode, selectedNodeId, onSe
   );
 }
 
-function SD_GraphRunView({ gid, rid, wid, session, pushToast }) {
+function SD_GraphRunView({ gid, rid, wid, session, pushToast, onNodeSelect, hideNodeTurnLog }) {
   const { useResource, apiFetch } = window.primerApi;
   const isTerminal = session && window.SESSION_TERMINAL.has(session.status);
   const [selectedNodeId, setSelectedNodeId] = React.useState(null);
+
+  // Node selection keeps its own state (drives the canvas highlight + the
+  // inspector) AND, when the OPT-IN onNodeSelect callback is supplied,
+  // notifies the caller so it can react to the selection — the Studio graph
+  // panel uses this to filter its converged session <Transcript> to the
+  // selected node (fix #9). Defaults to today's behavior: no callback ->
+  // local-only selection, so the shared export is unaffected when mounted
+  // without the opt-in prop.
+  const selectNode = React.useCallback((id) => {
+    setSelectedNodeId(id);
+    if (typeof onNodeSelect === "function") onNodeSelect(id);
+  }, [onNodeSelect]);
 
   const graph = useResource(
     `run-graph-def:${gid}`,
@@ -513,7 +525,7 @@ function SD_GraphRunView({ gid, rid, wid, session, pushToast }) {
           statusByNode={statusByNode}
           metaByNode={metaByNode}
           selectedNodeId={selectedNodeId}
-          onSelectNode={setSelectedNodeId}
+          onSelectNode={selectNode}
         />
         <SD_NodeInspector
           gid={gid}
@@ -523,6 +535,7 @@ function SD_GraphRunView({ gid, rid, wid, session, pushToast }) {
           node={selectedItem}
           graph={graph.data}
           pushToast={pushToast}
+          hideNodeTurnLog={hideNodeTurnLog}
         />
       </div>
     </div>
@@ -571,7 +584,7 @@ function SD_NodeTurnLog({ gid, rid, nodeId, nodeStatus }) {
   );
 }
 
-function SD_NodeInspector({ gid, rid, wid, session, node, graph, pushToast }) {
+function SD_NodeInspector({ gid, rid, wid, session, node, graph, pushToast, hideNodeTurnLog }) {
   const { useRouter } = window.primerApi;
   const { navigate } = useRouter();
   const nodeId = node && node.node_id;
@@ -739,13 +752,19 @@ function SD_NodeInspector({ gid, rid, wid, session, node, graph, pushToast }) {
             ))}
           </div>
         )}
-        {/* Per-node turn-log below the stream. */}
-        <div style={{ borderTop: "1px solid var(--border)" }}>
-          <div className="muted text-sm" style={{ padding: "8px 12px 0", textTransform: "uppercase", letterSpacing: "0.05em", fontSize: 10.5 }}>
-            Turn log
+        {/* Per-node turn-log below the stream. Suppressed when the caller
+            opts into hideNodeTurnLog (the Studio graph panel, which converges
+            per-node detail into its filtered session <Transcript> instead —
+            fix #9). Defaults to shown, so the standalone run-view export is
+            unaffected. */}
+        {!hideNodeTurnLog && (
+          <div style={{ borderTop: "1px solid var(--border)" }}>
+            <div className="muted text-sm" style={{ padding: "8px 12px 0", textTransform: "uppercase", letterSpacing: "0.05em", fontSize: 10.5 }}>
+              Turn log
+            </div>
+            <SD_NodeTurnLog gid={gid} rid={rid} nodeId={node.node_id} nodeStatus={node.status} />
           </div>
-          <SD_NodeTurnLog gid={gid} rid={rid} nodeId={node.node_id} nodeStatus={node.status} />
-        </div>
+        )}
       </div>
     </div>
   );

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -709,6 +709,14 @@ function WorkspaceActivity({ wid }) {
 function StudioActivity({ wid, studio }) {
   var [collapsed, setCollapsed] = React.useState(true);
   var [pendingCount, setPendingCount] = React.useState(0);
+  // Task (studio-ux fix 1): only the bell+"Debug" label retract into the
+  // thin rail — the chevron (the toggle affordance itself) and the pending
+  // badge stay visible in both states. A separate, positively-named flag
+  // (rather than negating `collapsed` inline at each call site) keeps this
+  // JSX visibly distinct from the ActionRequired/WorkspaceActivity
+  // conditional-mount anti-pattern the sibling mount-guard test forbids
+  // (see test_action_required_and_workspace_activity_stay_mounted_when_collapsed).
+  var expanded = !collapsed;
 
   function toggle() {
     setCollapsed(function(c) { return !c; });
@@ -737,10 +745,13 @@ function StudioActivity({ wid, studio }) {
         style={{
           flexShrink: 0,
           display: "flex",
+          flexDirection: collapsed ? "column" : "row",
           alignItems: "center",
-          gap: 8,
-          height: 34,
-          padding: "0 12px",
+          justifyContent: "center",
+          gap: collapsed ? 6 : 8,
+          height: collapsed ? "auto" : 34,
+          minHeight: collapsed ? 64 : "auto",
+          padding: collapsed ? "10px 4px" : "0 12px",
           border: "none",
           borderBottom: collapsed ? "none" : "1px solid var(--border)",
           background: "transparent",
@@ -754,8 +765,8 @@ function StudioActivity({ wid, studio }) {
         }}
       >
         <Icon name={collapsed ? "chevron-left" : "chevron-right"} size={13} style={{ flexShrink: 0, color: "var(--text-3)" }} />
-        <Icon name="bell" size={13} style={{ flexShrink: 0 }} />
-        <span style={{ flex: 1, textAlign: "left" }}>Debug</span>
+        {expanded && <Icon name="bell" size={13} style={{ flexShrink: 0 }} />}
+        {expanded && <span style={{ flex: 1, textAlign: "left" }}>Debug</span>}
         {pendingCount > 0 && (
           <span
             data-testid="debug-sidebar-badge"

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -310,6 +310,78 @@ function ST_sessionTranscriptRows(records, session) {
   return ST_coalesceAssistantRows(mapped);
 }
 
+// ---------------------------------------------------------------------------
+// ST_filterRecordsByNode — narrow the raw session record stream to a single
+// node's records (record.node_id === nodeId). A null/empty nodeId means
+// "all nodes" (no filter, the full transcript). Used by SessionGraphPanel to
+// converge the per-node SD_NodeTurnLog into the shared session <Transcript>
+// (fix #9): selecting a node in the run-view filters the transcript instead
+// of opening a second per-node panel.
+// ---------------------------------------------------------------------------
+
+function ST_filterRecordsByNode(records, nodeId) {
+  if (!nodeId) return records || [];
+  var out = [];
+  var list = records || [];
+  for (var i = 0; i < list.length; i++) {
+    if (list[i] && list[i].node_id === nodeId) out.push(list[i]);
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Optimistic "queued" send rows (fix #8). Steering a RUNNING/WAITING graph
+// session queues the message as the next turn server-side; the persisted
+// USER_INPUT record only surfaces via the adapter tap once the running turn
+// yields. Until then nothing renders and it looks like nothing happened, so
+// the panel appends a LOCAL placeholder row immediately on send and drops it
+// once the real record lands.
+//
+// ST_queuedTranscriptRow — shape one local pending send as a user_message
+// transcript row, clearly marked "(queued)" and carrying `clientId` so
+// <Transcript> keys it off `pending-${clientId}` (no collision with a real
+// seq'd row) and `queued`/`pending` flags for any styling.
+// ---------------------------------------------------------------------------
+
+function ST_queuedTranscriptRow(pendingSend) {
+  return {
+    kind: "user_message",
+    text: pendingSend.text + " (queued)",
+    clientId: pendingSend.id,
+    queued: true,
+    pending: true,
+    nodeId: null,
+  };
+}
+
+// ST_reconcileQueued — drop any local pending send whose text now appears as
+// a persisted USER_INPUT record in the real stream (the running turn yielded
+// and the steer landed via the adapter tap). Matches one-to-one on the
+// trimmed text so two identical queued sends reconcile against two real
+// records, not one. Returns the SAME array reference when nothing reconciles
+// so a caller's setState no-ops (no render churn / effect loop).
+function ST_reconcileQueued(pendingSends, records) {
+  var prev = pendingSends || [];
+  if (!prev.length) return prev;
+  var realTexts = [];
+  var list = records || [];
+  for (var i = 0; i < list.length; i++) {
+    var m = list[i];
+    if (!m || m.kind !== "user_input") continue;
+    var pl = m.payload || {};
+    var t = pl.text != null ? pl.text : (pl.message != null ? pl.message : (pl.instruction != null ? pl.instruction : ""));
+    realTexts.push(String(t).trim());
+  }
+  if (!realTexts.length) return prev;
+  var next = [];
+  for (var k = 0; k < prev.length; k++) {
+    var idx = realTexts.indexOf(prev[k].text);
+    if (idx >= 0) { realTexts.splice(idx, 1); continue; }
+    next.push(prev[k]);
+  }
+  return next.length === prev.length ? prev : next;
+}
+
 
 // ---------------------------------------------------------------------------
 // SessionAgentPanel — agent run view = a session-backed <Conversation>.
@@ -552,6 +624,23 @@ function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
   var [composerText, setComposerText] = React.useState("");
   var scrollRef = React.useRef(null);
 
+  // fix #9: selected node from the run-view. null = all nodes (full
+  // transcript). Driven by SD_GraphRunView's opt-in onNodeSelect below;
+  // filters the shared <Transcript> to that node's records.
+  var [selectedNode, setSelectedNode] = React.useState(null);
+
+  // fix #8: local optimistic "queued" sends — [{ id, text }] — appended to
+  // the transcript the instant the operator steers a busy (non-idle) session,
+  // reconciled away once the real USER_INPUT record arrives via the adapter.
+  var [pendingSends, setPendingSends] = React.useState([]);
+
+  // Non-idle = a turn is in flight or the session is actively running/waiting,
+  // so a steer queues behind it rather than surfacing immediately. Reads both
+  // the polled session row and the adapter's live turn_status.
+  var turnInFlight = conv.turnStatus === "claimable" || conv.turnStatus === "running";
+  var liveStatus = conv.status || status;
+  var isBusy = liveStatus === "running" || liveStatus === "waiting" || turnInFlight;
+
   function toastErr(t) {
     return function (err) {
       if (typeof pushToast !== "function") return;
@@ -587,10 +676,24 @@ function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
     { invalidates: invalidates, onSuccess: function () { pushToast && pushToast({ kind: "success", title: "Session restarted" }); }, onError: toastErr("Restart failed") }
   );
 
+  // fix #9: when a node is selected, filter the record stream to that node's
+  // records (node_id === selectedNode) BEFORE mapping — coalescing then runs
+  // scoped to the node. fix #8: append the local optimistic queued rows after
+  // the real rows so a just-steered message shows immediately.
   var rows = React.useMemo(
-    function () { return ST_sessionTranscriptRows(conv.messages, session); },
-    [conv.messages, session]
+    function () {
+      var base = ST_sessionTranscriptRows(ST_filterRecordsByNode(conv.messages, selectedNode), session);
+      if (!pendingSends.length) return base;
+      return base.concat(pendingSends.map(ST_queuedTranscriptRow));
+    },
+    [conv.messages, session, selectedNode, pendingSends]
   );
+
+  // fix #8: reconcile — drop any optimistic queued send once its persisted
+  // USER_INPUT record lands in the real stream (via the adapter tap).
+  React.useEffect(function () {
+    setPendingSends(function (prev) { return ST_reconcileQueued(prev, conv.messages); });
+  }, [conv.messages]);
 
   // Stick-to-bottom — same rationale as the agent panel.
   React.useEffect(function () {
@@ -605,7 +708,22 @@ function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
     if (!text) return;
     var p = conv.sendMessage(text);
     setComposerText("");
-    if (p && typeof p.catch === "function") p.catch(toastErr("Send failed"));
+    // fix #8: on a non-idle session the steer queues behind the running turn,
+    // so show a local "(queued)" placeholder immediately. Reconciled by the
+    // effect above when the real record arrives; removed here if the send
+    // itself fails so a rejected steer doesn't leave a stuck placeholder.
+    if (isBusy) {
+      var localId = "queued-" + Date.now() + "-" + Math.random().toString(36).slice(2, 8);
+      setPendingSends(function (prev) { return prev.concat([{ id: localId, text: text }]); });
+      if (p && typeof p.catch === "function") {
+        p.catch(function (err) {
+          setPendingSends(function (prev) { return prev.filter(function (x) { return x.id !== localId; }); });
+          toastErr("Send failed")(err);
+        });
+      }
+    } else if (p && typeof p.catch === "function") {
+      p.catch(toastErr("Send failed"));
+    }
   }
 
   return (
@@ -673,7 +791,18 @@ function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
           style={{ flex: "0 0 auto", height: 360, minHeight: 0, overflow: "auto", borderBottom: "1px solid var(--border)" }}
         >
           {wid && gid && window.SD_GraphRunView
-            ? <window.SD_GraphRunView gid={gid} rid={sid} wid={wid} session={session} pushToast={pushToast} />
+            ? <window.SD_GraphRunView
+                gid={gid}
+                rid={sid}
+                wid={wid}
+                session={session}
+                pushToast={pushToast}
+                // fix #9: opt into convergence — selecting a node filters the
+                // shared transcript (below) instead of opening a per-node
+                // turn-log panel, which we hide here.
+                onNodeSelect={setSelectedNode}
+                hideNodeTurnLog={true}
+              />
             : (
               <div className="muted text-sm" style={{ padding: 20, textAlign: "center", color: "var(--text-4)" }}>
                 Run view unavailable — graph binding or workspace missing.
@@ -682,6 +811,33 @@ function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
         </div>
       )}
 
+      {/* fix #9: active node filter banner — shown only when a node is
+          selected. Names the node the transcript is scoped to and offers a
+          one-click return to the full (all-nodes) transcript. */}
+      {selectedNode && (
+        <div
+          data-testid="graph-node-filter"
+          style={{
+            display: "flex", alignItems: "center", gap: 8, padding: "6px 14px",
+            borderBottom: "1px solid var(--border)", background: "var(--bg-2)",
+            flex: "0 0 auto", fontSize: 11.5, color: "var(--text-3)",
+          }}
+        >
+          <span style={{ color: "var(--violet)", flexShrink: 0 }}>◈</span>
+          <span>
+            Showing <span className="mono" style={{ color: "var(--text)", fontWeight: 600 }}>{selectedNode}</span> only
+          </span>
+          <div style={{ flex: 1 }} />
+          <Btn
+            size="sm"
+            kind="ghost"
+            icon="x"
+            data-testid="graph-node-filter-clear"
+            title="Show the full transcript (all nodes)"
+            onClick={function () { setSelectedNode(null); }}
+          >All nodes</Btn>
+        </div>
+      )}
       <window.Transcript
         messages={rows}
         chatId={sid}

--- a/ui/components/workspaces.jsx
+++ b/ui/components/workspaces.jsx
@@ -367,10 +367,13 @@ function WS_NewWorkspaceModal({ onClose, pushToast }) {
           <Btn kind="ghost" onClick={onClose}>Cancel</Btn>
           <Btn
             kind="primary"
-            icon="plus"
+            icon={create.loading ? undefined : "plus"}
             disabled={!templateId || create.loading}
             onClick={onCreate}
-          >Create</Btn>
+            data-testid="workspace-create-submit"
+          >
+            {create.loading ? (<><span className="spinner" /><span>Creating…</span></>) : "Create"}
+          </Btn>
         </>
       }
     >

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -265,6 +265,28 @@
 .st-col-center { background: var(--bg); }
 .st-col-right { background: var(--bg-1); border-left: 1px solid var(--border); }
 
+/* Task (studio-ux fix 1): the debug sidebar's "collapsed" state used to
+   only hide the inner debug-sidebar-body — the OUTER .st-col-right grid
+   TRACK stayed at the full --st-right-w, so the center column never
+   reclaimed the space. Collapsed now renders as a thin ~40px rail (icon +
+   badge only — see studio-activity.jsx); the grid container's own
+   template must shrink the right track to match. The collapsed class
+   lives on the CHILD (.studio-activity-root), not on .st-body itself,
+   hence :has(). Desktop-only: below 640px .st-col-right is an off-canvas
+   fixed drawer (see the max-width:639px block) where this override's
+   higher specificity would otherwise squeeze the mobile single-column
+   body's grid-template-columns even though the drawer itself is
+   invisible there. */
+@media (min-width: 640px) {
+  .st-body:has(.studio-activity-root.is-collapsed) {
+    grid-template-columns: var(--st-left-w, 248px) 5px minmax(0, 1fr) 5px 40px;
+  }
+  .st-body:has(.studio-activity-root.is-collapsed) [data-testid="studio-resize-right"] {
+    display: none;
+  }
+  .studio-activity-root.is-collapsed { width: 40px; min-width: 40px; }
+}
+
 /* Column resize handles (left/right). 5px hit area straddling the border. */
 .st-resize {
   position: relative;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -2037,7 +2037,10 @@ input, textarea, select { font: inherit; color: inherit; }
 .auth-submit:hover { background: var(--accent-2); border-color: var(--accent-2); }
 .auth-submit:active { transform: translateY(1px); }
 .auth-submit:disabled { opacity: 0.6; cursor: not-allowed; }
-.auth-submit .spinner {
+/* Shared beyond auth: the workspaces "New workspace" Create button (studio-ux
+   fix 5) reuses this same inline spinner + keyframe for its in-flight state. */
+.auth-submit .spinner,
+.btn .spinner {
   width: 12px;
   height: 12px;
   border: 1.5px solid currentColor;


### PR DESCRIPTION
Nine UX/functional fixes from real Studio usage. All `tests/ui` green (**1010 passed, 1 skipped**); linear history (rebase-mergeable). `ui_e2e`/`e2e` CI-verified on this PR.

## UI fixes
1. **Debug sidebar actually collapses.** It now shrinks to a thin rail (reclaiming center-column width) instead of just hiding the events body at full width; ActionRequired/WorkspaceActivity stay mounted (streams don't tear down), badge stays live on the rail. (`studio-activity.jsx` + `styles.css` `:has()` desktop-scoped)
2. **Chat schema panel opens in one click** — the "⚙ schema" chip directly toggles the panel (was two clicks). (`chats.jsx`/`conversation.jsx`/`schema-panel.jsx`)
3. **Chat schema panel shows the agent's inherited schema.** When a chat has no override, the agent's build-time `response_format` is shown as **inherited** (read-only until edited). *Answering your question:* a sidebar schema **overrides** the agent default (per-chat persistent, or ephemeral this-send); editing the inherited one creates the chat override — nothing is silently persisted.
4. **"Selected" filter in the agent Tools picker** — a chip that shows only the ticked tools (across pages/toolsets). (`agents.jsx`)
5. **Workspace Create shows a loader** — the button disables + spins while the (slow, k8s) provisioning runs. (`workspaces.jsx`)
6. **New-session "question" field is now a multiline textarea.** (`new-session-form.jsx`)

## Functional bugs
7. **New session no longer stuck "waiting for events" until refresh.** Root cause: on a fresh/slow-provisioning workspace the tap opens with no cursor (empty history) and any events around subscription were never backfilled. Fix: the adapter **self-heals** — when the polled `session.last_seq` outruns the known max record seq (and on every tap (re)connect), it re-fetches `/messages?after_seq=` and merges (dedup-guarded, no thrash). No refresh needed. (`session-adapter.jsx`)
8. **Message to a running graph now shows an optimistic "(queued)" row.** Steering a busy session correctly queues server-side, but the user's message wasn't shown — now a local `(queued)` row appears immediately and reconciles 1:1 when the persisted `user_input` lands (removed on steer failure). (`studio-center.jsx`)
9. **Converged the per-node "TURN LOG" into the transcript.** Selecting a node now **filters the same session `<Transcript>`** by `node_id` (with an "All nodes" clear affordance) instead of a separate `SD_NodeTurnLog` panel. Done via opt-in `hideNodeTurnLog`/`onNodeSelect` props on the shared `SD_GraphRunView`, so the old `/sessions` detail page is unchanged. (`studio-center.jsx`/`session-detail.jsx`)

## Notes
- #8 applied to the graph panel (where you saw it); the queued-row helpers are reusable for the agent panel as a fast-follow.
- Fixes were built on three disjoint-file branches and consolidated linearly (no merge commits).