### PR TITLE
Studio UX round 2: run-view event-stream drop, one-row chat header + agent-picker overlay, table styling consistency

### DIFF
--- a/tests/ui/test_admin_users_page.py
+++ b/tests/ui/test_admin_users_page.py
@@ -40,6 +40,18 @@ def test_table_testid() -> None:
     assert "admin-users-table" in _src()
 
 
+def test_tables_use_shared_tbl_class() -> None:
+    """The Users list + per-user keys tables render with the shared console
+    table styling (`.tbl` inside `.tbl-wrap`, as agents.jsx and peers do),
+    not the old hand-rolled `className="table"` with per-cell inline
+    padding."""
+    src = _src()
+    assert 'className="tbl-wrap"' in src
+    assert 'className="tbl"' in src
+    assert 'className="table"' not in src
+    assert 'padding: "8px 12px"' not in src
+
+
 def test_create_and_delete_present() -> None:
     src = _src()
     assert "create-user-submit" in src

--- a/tests/ui/test_agent_selector_top_right.py
+++ b/tests/ui/test_agent_selector_top_right.py
@@ -3,17 +3,19 @@ relocate the agent selector (<CT_AgentSwitcher>, ui/components/chats.jsx)
 out of the bottom-left composer row to the top-right, next to the
 back/title chrome.
 
-Architecture (R1/§3/§5 of docs/superpowers/reqs/chat-refactor.md):
-ChatDetail (chats.jsx) — the host — builds the <CT_AgentSwitcher> node
-and hands it to <Conversation> (chat/conversation.jsx) via the
-`rightChromeSlot` prop that Task B2 already exposed. <Conversation>
-renders it in a top-of-panel chrome row (alongside `headerSlot`) rather
-than inline in the composer's flex row, so:
-  * conversation.jsx no longer references <CT_AgentSwitcher> at all —
-    it only knows about the opaque `rightChromeSlot` node.
-  * chats.jsx now wires a real node into `rightChromeSlot` (no longer
-    `null`), with `placement="down"` (was "up" for the old
-    bottom-composer popover).
+conversation.jsx side (still current): <Conversation> owns nothing about
+the agent selector — it only knows about the opaque `headerSlot` /
+`rightChromeSlot` nodes and renders them in a top-of-panel chrome row
+(never inline in the composer's flex row). Those slot tests below still
+hold.
+
+SUPERSEDED for ChatDetail by C1 (fix/studio-ux, PR #114): the desktop
+ChatDetail header is now a SINGLE row. The agent selector + schema toggle
++ TokenMeter moved OUT of <Conversation>'s `rightChromeSlot` and INTO
+ChatDetail's own `panel-h .right` cluster, so ChatDetail now passes BOTH
+slots as `null` and <Conversation>'s second chrome row no longer renders.
+The overlay + ⌘/Ctrl+Shift+A shortcut behavior lives in
+test_agent_switch_overlay.py.
 
 Static-source + transpile-build checks only (the ui/ suite convention,
 e.g. test_conversation_extracted.py / test_composer_schema_shells.py) —
@@ -102,35 +104,52 @@ def test_composer_row_no_longer_has_agent_switcher_placement_up() -> None:
 
 
 # ---------------------------------------------------------------------------
-# chats.jsx (ChatDetail, the host) — wires a real <CT_AgentSwitcher> into
-# `rightChromeSlot`, "down" now that it's in a top chrome row.
+# chats.jsx (ChatDetail, the host) — C1: the desktop header is ONE row now.
+# The agent selector lives in ChatDetail's own `panel-h .right` cluster, so
+# BOTH of <Conversation>'s opaque chrome slots are `null` (its second header
+# row no longer renders).
 # ---------------------------------------------------------------------------
 
 
-def test_chat_detail_no_longer_passes_a_null_right_chrome_slot() -> None:
+def test_chat_detail_passes_null_chrome_slots_for_one_row_header() -> None:
+    # C1: with the switcher moved into ChatDetail's own header row, both
+    # opaque slots must be null so <Conversation> renders no second row.
     src = _chats_src()
-    assert "rightChromeSlot={null}" not in src, (
-        "ChatDetail must fill `rightChromeSlot` with the agent switcher now"
-    )
-
-
-def test_chat_detail_wires_agent_switcher_into_right_chrome_slot() -> None:
-    src = _chats_src()
-    # `<Conversation` (no trailing `>`) also appears in prose comments
-    # earlier in the file — anchor on the real JSX mount, which has a
-    # newline immediately after the tag name.
     assert "<Conversation\n" in src
     start = src.index("<Conversation\n")
     end = src.index("/>", start)
     block = src[start:end]
-    assert "rightChromeSlot=" in block
-    assert "<CT_AgentSwitcher" in block, (
-        "the <CT_AgentSwitcher> node passed to <Conversation> must live "
-        "inside the `rightChromeSlot` prop wiring"
+    assert "rightChromeSlot={null}" in block, (
+        "C1: ChatDetail must pass `rightChromeSlot={null}` — the agent "
+        "selector moved into its own one-row header cluster"
     )
-    assert 'placement="down"' in block, (
-        'the relocated switcher opens downward now that it sits in a '
-        'top chrome row (was placement="up" in the old bottom composer)'
+    assert "headerSlot={null}" in block, (
+        "C1: ChatDetail must pass `headerSlot={null}` so <Conversation>'s "
+        "second chrome row no longer renders"
+    )
+
+
+def test_chat_detail_agent_switcher_lives_in_the_one_row_header_cluster() -> None:
+    # C1/C2: <CT_AgentSwitcher> is grouped with the schema toggle + TokenMeter
+    # inside ChatDetail's `chat-header-cluster`, ABOVE the <Conversation>
+    # mount — no longer inside <Conversation>'s `rightChromeSlot`.
+    src = _chats_src()
+    conv_start = src.index("<Conversation\n")
+    conv_end = src.index("/>", conv_start)
+    conv_block = src[conv_start:conv_end]
+    assert "<CT_AgentSwitcher" not in conv_block, (
+        "C1: the agent switcher must NOT be wired into <Conversation> "
+        "anymore — it lives in ChatDetail's own header cluster"
+    )
+    cluster = src.index('data-testid="chat-header-cluster"')
+    switcher = src.index("<CT_AgentSwitcher")
+    schema = src.index('data-testid="chat-schema-panel-toggle"')
+    token = src.index("<window.TokenMeter")
+    # The cluster opens first, then the three grouped controls, all before
+    # the <Conversation> mount further down the file.
+    assert cluster < switcher < schema < token < conv_start, (
+        "C1/C2: agent selector + schema toggle + TokenMeter must be grouped "
+        "in that order inside the `chat-header-cluster`, above <Conversation>"
     )
 
 

--- a/tests/ui/test_agent_switch_overlay.py
+++ b/tests/ui/test_agent_switch_overlay.py
@@ -1,0 +1,209 @@
+"""C3/C4 (fix/studio-ux, PR #114) — the /chats agent selector overlay.
+
+Replaces <CT_AgentSwitcher>'s old cramped inline `.popover` (a 300px
+absolutely-positioned box with a paged Prev/Next list) with a centered,
+command-palette-style modal modelled on StudioCommandPalette / QuickOpen
+(ui/components/studio-palette.jsx):
+
+  C3 — dimmed backdrop, ~520px card, large autofocused search, a
+        scrollable id+description results list with a "current" marker,
+        ↑/↓/Enter/Esc keyboard nav, click-backdrop-to-close. The header
+        trigger button stays (shows the current agent) but now OPENS the
+        overlay. The switch mutation (POST /chats/{id}/agent) + its
+        success/error toasts, the search filter, `disabled` when the chat
+        is ended, and the current-agent guard are all preserved.
+  C4 — a ⌘/Ctrl+Shift+A shortcut (⌘K is the global search — no collision)
+        opens the overlay with the search focused while a chat is open.
+        Listener added on mount / removed on unmount, preventDefault on
+        match, single `open` source of truth, shortcut shown in the
+        trigger's title.
+
+Static-source + transpile-build checks only (the ui/ suite convention,
+e.g. test_studio_palette.py / test_agent_selector_top_right.py) — no
+DOM/browser harness.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+CHATS = UI / "components" / "chats.jsx"
+STYLES = UI / "styles.css"
+
+
+def _chats_src() -> str:
+    return CHATS.read_text(encoding="utf-8")
+
+
+def _styles_src() -> str:
+    return STYLES.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# The old inline popover is gone; a centered overlay replaces it.
+# ---------------------------------------------------------------------------
+
+
+def test_old_inline_paged_popover_is_gone() -> None:
+    src = _chats_src()
+    # The old popover paged its list with Prev/Next + a `page + 1 / pages`
+    # counter. None of that survives the overlay rewrite.
+    assert "Prev" not in src
+    assert "page + 1" not in src
+    # The old absolutely-positioned box carried the literal `popover` class;
+    # only the prose comment describing what it *replaced* may mention it.
+    assert 'className="popover"' not in src
+
+
+def test_overlay_backdrop_and_card_present() -> None:
+    src = _chats_src()
+    assert 'data-testid="agent-overlay"' in src
+    assert "agent-overlay-backdrop" in src
+    assert "agent-overlay-card" in src
+
+
+def test_overlay_search_input_autofocused() -> None:
+    src = _chats_src()
+    assert 'data-testid="agent-overlay-search"' in src
+    # autofocus: a ref on the input + a focus() call when the overlay opens.
+    assert "inputRef" in src
+    assert "inputRef.current.focus()" in src
+
+
+def test_overlay_close_control_and_backdrop_click_closes() -> None:
+    src = _chats_src()
+    assert 'data-testid="agent-overlay-close"' in src
+    # Clicking the backdrop closes; clicking the card does not bubble to it.
+    assert 'className="agent-overlay-backdrop" data-testid="agent-overlay" onClick={closeOverlay}' in src
+    assert "onClick={(e) => e.stopPropagation()}" in src
+
+
+def test_overlay_list_shows_id_and_description_with_current_marker() -> None:
+    src = _chats_src()
+    assert 'data-testid="agent-overlay-item"' in src
+    assert "agent-overlay-item-id" in src
+    assert "agent-overlay-item-desc" in src
+    # a.description drives the secondary line; a "current" marker flags the
+    # active agent.
+    assert "a.description" in src
+    assert "agent-overlay-current" in src
+
+
+# ---------------------------------------------------------------------------
+# Keyboard navigation inside the overlay (↑/↓/Enter/Esc).
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_keyboard_navigation() -> None:
+    src = _chats_src()
+    assert 'e.key === "ArrowDown"' in src
+    assert 'e.key === "ArrowUp"' in src
+    assert 'e.key === "Enter"' in src
+    assert 'e.key === "Escape"' in src
+
+
+# ---------------------------------------------------------------------------
+# C4 — ⌘/Ctrl+Shift+A global shortcut.
+# ---------------------------------------------------------------------------
+
+
+def test_shortcut_combo_is_cmd_ctrl_shift_a() -> None:
+    src = _chats_src()
+    # metaKey || ctrlKey, plus shiftKey, plus the "A" key — and NOT ⌘K
+    # (⌘K is the global search; the combo must not fire on a bare cmd+a).
+    assert "(e.metaKey || e.ctrlKey) && e.shiftKey" in src
+    assert 'e.code === "KeyA"' in src
+
+
+def test_shortcut_listener_added_on_mount_removed_on_unmount() -> None:
+    src = _chats_src()
+    assert 'window.addEventListener("keydown", onKey)' in src
+    assert 'window.removeEventListener("keydown", onKey)' in src
+
+
+def test_shortcut_prevent_defaults_on_match() -> None:
+    src = _chats_src()
+    # The matched combo must preventDefault so the browser doesn't select-all.
+    assert "e.preventDefault();" in src
+
+
+def test_shortcut_shown_in_trigger_title() -> None:
+    src = _chats_src()
+    assert "Switch agent" in src
+    assert "Shift + A" in src
+
+
+def test_open_is_single_source_of_truth() -> None:
+    src = _chats_src()
+    # One `open` state drives both the trigger button and the shortcut.
+    assert "const [open, setOpen] = React.useState(false);" in src
+    # Trigger opens it; the shortcut sets the same state.
+    assert "const openOverlay = () => { if (!disabled) setOpen(true); };" in src
+
+
+# ---------------------------------------------------------------------------
+# Preserved behavior: search filter, switch mutation + toasts, guards.
+# ---------------------------------------------------------------------------
+
+
+def test_search_filter_preserved() -> None:
+    src = _chats_src()
+    # Filters over id + description, case-insensitively.
+    assert "a.id" in src and "a.description" in src
+    assert "toLowerCase().includes(q.toLowerCase())" in src
+
+
+def test_switch_mutation_and_toasts_preserved() -> None:
+    src = _chats_src()
+    assert 'apiFetch("POST", `/chats/${chatId}/agent`, { agent_id: agentId })' in src
+    assert 'title: "Agent switched"' in src
+    assert '"Switch failed"' in src
+
+
+def test_current_agent_guard_preserved() -> None:
+    src = _chats_src()
+    # choose() no-ops on the current agent (and while a switch is in flight).
+    assert "a.id === currentAgentId" in src
+
+
+def test_disabled_when_chat_ended() -> None:
+    src = _chats_src()
+    # The trigger is disabled and the open helper is guarded when the chat
+    # is ended; ChatDetail passes disabled={chatStatus === "ended"}.
+    assert "disabled={disabled}" in src
+    assert "if (!disabled) setOpen(true)" in src
+    assert 'disabled={chatStatus === "ended"}' in src
+
+
+# ---------------------------------------------------------------------------
+# CSS: the overlay + cluster styles live at the end of ui/styles.css.
+# ---------------------------------------------------------------------------
+
+
+def test_overlay_and_cluster_css_present() -> None:
+    css = _styles_src()
+    for selector in (
+        ".chat-header-cluster",
+        ".agent-overlay-backdrop",
+        ".agent-overlay-card",
+        ".agent-overlay-input",
+        ".agent-overlay-item",
+        ".agent-overlay-current",
+    ):
+        assert selector in css, f"missing CSS for `{selector}`"
+
+
+# ---------------------------------------------------------------------------
+# Transpile.
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_still_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    text = body.decode("utf-8")
+    assert "/* === components/chats.jsx === */" in text

--- a/tests/ui/test_api_tokens_page.py
+++ b/tests/ui/test_api_tokens_page.py
@@ -34,6 +34,17 @@ def test_table_testid():
     assert "api-tokens-table" in _src()
 
 
+def test_table_uses_shared_tbl_class():
+    # Consistency sweep: the tokens table uses the console-wide shared .tbl /
+    # .tbl-wrap styling (like agents/channels/…), not the old hand-rolled
+    # className="table" + inline per-cell padding.
+    src = _src()
+    assert 'className="tbl-wrap"' in src
+    assert 'className="tbl"' in src
+    assert 'className="table"' not in src
+    assert '"8px 12px"' not in src
+
+
 def test_sidebar_has_tokens_entry():
     src = CHROME.read_text()
     assert "tokens" in src.lower() or "API tokens" in src or "api_tokens" in src.lower()

--- a/tests/ui/test_linked_accounts_page.py
+++ b/tests/ui/test_linked_accounts_page.py
@@ -52,6 +52,17 @@ def test_table_testid_and_columns() -> None:
     assert "created_at" in src
 
 
+def test_table_uses_shared_tbl_class() -> None:
+    """The linked-identities table renders with the shared console table
+    styling (`.tbl` inside `.tbl-wrap`, as agents.jsx and peers do), not
+    the old hand-rolled `className="table"` with per-cell inline padding."""
+    src = _src()
+    assert 'className="tbl-wrap"' in src
+    assert 'className="tbl"' in src
+    assert 'className="table"' not in src
+    assert 'padding: "8px 12px"' not in src
+
+
 def test_unlink_confirm_dialog_present() -> None:
     src = _src()
     assert "function LA_UnlinkConfirmDialog" in src

--- a/tests/ui/test_sso_admin_page.py
+++ b/tests/ui/test_sso_admin_page.py
@@ -48,6 +48,17 @@ def test_table_testid() -> None:
     assert "sso-providers-table" in _src()
 
 
+def test_table_uses_shared_tbl_class() -> None:
+    """The OIDC-providers table renders with the shared console table
+    styling (`.tbl` inside `.tbl-wrap`, as agents.jsx and peers do), not
+    the old hand-rolled `className="table"` with per-cell inline padding."""
+    src = _src()
+    assert 'className="tbl-wrap"' in src
+    assert 'className="tbl"' in src
+    assert 'className="table"' not in src
+    assert 'padding: "8px 12px"' not in src
+
+
 def test_create_edit_delete_present() -> None:
     src = _src()
     assert "create-sso-provider-submit" in src

--- a/tests/ui/test_studio_center.py
+++ b/tests/ui/test_studio_center.py
@@ -106,10 +106,12 @@ def test_reuses_sd_graph_run_view() -> None:
 def test_graph_panel_converges_node_turn_log_into_transcript() -> None:
     # fix #9: the studio graph panel opts SD_GraphRunView into convergence —
     # selecting a node filters the shared transcript (ST_filterRecordsByNode)
-    # instead of opening a separate per-node turn-log panel (hidden here).
+    # instead of opening a separate per-node panel. R1 extends this: the whole
+    # 360px node-event-stream inspector is dropped (hideInspector), so the graph
+    # canvas fills the run view and its content lives in the converged transcript.
     src = _center_src()
     assert "onNodeSelect={setSelectedNode}" in src
-    assert "hideNodeTurnLog={true}" in src
+    assert "hideInspector={true}" in src
     assert "function ST_filterRecordsByNode(" in src
     assert "ST_filterRecordsByNode(conv.messages, selectedNode)" in src
 

--- a/tests/ui/test_studio_graph_run_view.py
+++ b/tests/ui/test_studio_graph_run_view.py
@@ -321,9 +321,10 @@ def test_graph_panel_filters_transcript_by_selected_node() -> None:
 
 def test_graph_panel_hides_separate_node_turn_log() -> None:
     panel = _session_graph_panel_src()
-    # The studio panel opts SD_GraphRunView into hiding the per-node turn-log
-    # (it lives in the converged transcript now) …
-    assert "hideNodeTurnLog={true}" in panel
+    # R1: the studio panel opts SD_GraphRunView into dropping the whole 360px
+    # node-event-stream inspector (hideInspector) — the per-node turn-log AND
+    # the event stream both live in the converged transcript now …
+    assert "hideInspector={true}" in panel
     # … and never renders a second per-node turn-log panel of its own.
     assert "SD_NodeTurnLog" not in panel
     assert "run-node-turnlog" not in panel
@@ -366,7 +367,7 @@ def test_sd_graph_run_view_opt_in_prop_keeps_old_page_turn_log() -> None:
     # callback), so a caller that omits them renders SD_NodeTurnLog as before.
     detail = _detail_src()
     assert (
-        "function SD_GraphRunView({ gid, rid, wid, session, pushToast, onNodeSelect, hideNodeTurnLog })"
+        "function SD_GraphRunView({ gid, rid, wid, session, pushToast, onNodeSelect, hideNodeTurnLog, hideInspector })"
         in detail
     )
     # onNodeSelect only fires when supplied (typeof guard) — omitting it keeps
@@ -378,6 +379,11 @@ def test_sd_graph_run_view_opt_in_prop_keeps_old_page_turn_log() -> None:
         "<SD_NodeTurnLog gid={gid} rid={rid} nodeId={node.node_id} nodeStatus={node.status} />"
         in detail
     )
+    # R1: the whole inspector is gated on !hideInspector (default falsy -> still
+    # shown), so the standalone /sessions run view keeps the node inspector while
+    # the Studio panel (hideInspector={true}) renders the canvas alone.
+    assert "{!hideInspector && (" in detail
+    assert 'gridTemplateColumns: hideInspector ? "minmax(0, 1fr)" : "minmax(0, 1fr) 360px"' in detail
 
 
 # ---------------------------------------------------------------------------

--- a/ui/components/admin_users.jsx
+++ b/ui/components/admin_users.jsx
@@ -116,19 +116,15 @@ function ADM_AdminUsersPage() {
       )}
 
       {items.length > 0 && (
-        <div
-          data-testid="admin-users-table"
-          className="panel"
-          style={{ padding: 0, overflow: "hidden" }}
-        >
-          <table className="table" style={{ width: "100%", fontSize: 12 }}>
+        <div data-testid="admin-users-table" className="tbl-wrap">
+          <table className="tbl">
             <thead>
               <tr>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Username</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Email</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Role</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Status</th>
-                <th style={{ textAlign: "right", padding: "8px 12px" }}>Actions</th>
+                <th>Username</th>
+                <th>Email</th>
+                <th>Role</th>
+                <th>Status</th>
+                <th style={{ textAlign: "right" }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -182,30 +178,25 @@ function ADM_AdminUsersPage() {
 
 function ADM_UserRow({ user, onEdit, onDelete, onKeys }) {
   return (
-    <tr
-      data-testid={`admin-user-row-${user.id}`}
-      style={{ borderTop: "1px solid var(--border)" }}
-    >
-      <td style={{ padding: "8px 12px", fontWeight: 600 }}>
-        <span className="mono">{user.username}</span>
-      </td>
-      <td style={{ padding: "8px 12px" }}>
+    <tr data-testid={`admin-user-row-${user.id}`}>
+      <td className="mono">{user.username}</td>
+      <td>
         {user.email ? user.email : <span className="muted">—</span>}
       </td>
-      <td style={{ padding: "8px 12px" }}>
-        <span className={`pill ${ADM_roleClass(user.role)}`} style={{ fontSize: 10.5 }}>
+      <td>
+        <span className={`pill ${ADM_roleClass(user.role)}`}>
           {user.role}
         </span>
       </td>
-      <td style={{ padding: "8px 12px" }}>
+      <td>
         {user.disabled
-          ? <span className="pill pill-failed" style={{ fontSize: 10.5 }}>disabled</span>
-          : <span className="pill pill-claimed" style={{ fontSize: 10.5 }}>enabled</span>}
+          ? <span className="pill pill-failed">disabled</span>
+          : <span className="pill pill-claimed">enabled</span>}
         {user.must_change_password && (
-          <span className="pill pill-paused" style={{ fontSize: 10.5, marginLeft: 4 }}>must change pw</span>
+          <span className="pill pill-paused" style={{ marginLeft: 4 }}>must change pw</span>
         )}
       </td>
-      <td style={{ padding: "8px 12px", textAlign: "right", whiteSpace: "nowrap" }}>
+      <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
         <Btn
           size="sm"
           kind="ghost"
@@ -638,21 +629,17 @@ function ADM_UserKeysDialog({ user, onClose }) {
           <div className="muted text-sm" style={{ padding: "20px 0" }}>No API keys for this user.</div>
         )}
         {items.length > 0 && (
-          <div
-            data-testid="adm-user-keys-table"
-            className="panel"
-            style={{ padding: 0, overflow: "hidden" }}
-          >
-            <table className="table" style={{ width: "100%", fontSize: 12 }}>
+          <div data-testid="adm-user-keys-table" className="tbl-wrap">
+            <table className="tbl">
               <thead>
                 <tr>
-                  <th style={{ textAlign: "left", padding: "8px 12px" }}>Name</th>
-                  <th style={{ textAlign: "left", padding: "8px 12px" }}>Prefix</th>
-                  <th style={{ textAlign: "left", padding: "8px 12px" }}>Scopes</th>
-                  <th style={{ textAlign: "left", padding: "8px 12px" }}>Created</th>
-                  <th style={{ textAlign: "left", padding: "8px 12px" }}>Last used</th>
-                  <th style={{ textAlign: "left", padding: "8px 12px" }}>Status</th>
-                  <th style={{ textAlign: "right", padding: "8px 12px" }}>Actions</th>
+                  <th>Name</th>
+                  <th>Prefix</th>
+                  <th>Scopes</th>
+                  <th>Created</th>
+                  <th>Last used</th>
+                  <th>Status</th>
+                  <th style={{ textAlign: "right" }}>Actions</th>
                 </tr>
               </thead>
               <tbody>
@@ -714,37 +701,28 @@ function ADM_UserKeyRow({ user, token, onRevoked, onConfirmStart, onConfirmEnd }
 
   return (
     <React.Fragment>
-      <tr
-        data-testid={`adm-user-key-row-${token.id}`}
-        style={{ borderTop: "1px solid var(--border)" }}
-      >
-        <td style={{ padding: "8px 12px", fontWeight: 600 }}>{token.name}</td>
-        <td style={{ padding: "8px 12px" }}>
-          <span className="mono" style={{ fontSize: 11 }}>{token.prefix}…</span>
-        </td>
-        <td style={{ padding: "8px 12px" }}>
+      <tr data-testid={`adm-user-key-row-${token.id}`}>
+        <td>{token.name}</td>
+        <td className="mono">{token.prefix}…</td>
+        <td>
           {Array.isArray(token.scopes) && token.scopes.length > 0 ? (
             <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
               {token.scopes.map((s) => (
-                <span key={s} className="pill pill-paused" style={{ fontSize: 10.5 }}>{s}</span>
+                <span key={s} className="pill pill-paused">{s}</span>
               ))}
             </div>
           ) : (
             <span className="muted text-sm">—</span>
           )}
         </td>
-        <td style={{ padding: "8px 12px" }} title={token.created_at || ""}>
-          <span className="mono">{token.created_at || "—"}</span>
-        </td>
-        <td style={{ padding: "8px 12px" }} title={token.last_used_at || ""}>
-          <span className="mono">{token.last_used_at || "—"}</span>
-        </td>
-        <td style={{ padding: "8px 12px" }}>
+        <td className="mono" title={token.created_at || ""}>{token.created_at || "—"}</td>
+        <td className="mono" title={token.last_used_at || ""}>{token.last_used_at || "—"}</td>
+        <td>
           {isRevoked
-            ? <span className="pill pill-failed" style={{ fontSize: 10.5 }}>revoked</span>
+            ? <span className="pill pill-failed">revoked</span>
             : <span className="muted text-sm">—</span>}
         </td>
-        <td style={{ padding: "8px 12px", textAlign: "right", whiteSpace: "nowrap" }}>
+        <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
           <Btn
             size="sm"
             kind="danger"

--- a/ui/components/api_tokens.jsx
+++ b/ui/components/api_tokens.jsx
@@ -139,21 +139,17 @@ function AT_ApiTokensPage() {
       )}
 
       {items.length > 0 && (
-        <div
-          data-testid="api-tokens-table"
-          className="panel"
-          style={{ padding: 0, overflow: "hidden" }}
-        >
-          <table className="table" style={{ width: "100%", fontSize: 12 }}>
+        <div data-testid="api-tokens-table" className="tbl-wrap">
+          <table className="tbl">
             <thead>
               <tr>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Name</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Prefix</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Scopes</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Last used</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Expires</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Status</th>
-                <th style={{ textAlign: "right", padding: "8px 12px" }}>Actions</th>
+                <th>Name</th>
+                <th>Prefix</th>
+                <th>Scopes</th>
+                <th>Last used</th>
+                <th>Expires</th>
+                <th>Status</th>
+                <th style={{ textAlign: "right" }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -215,23 +211,14 @@ function AT_TokenRow({ token, onRevoke }) {
       : "pill-ended";
   const isRevoked = status === "revoked";
   return (
-    <tr
-      data-testid={`api-token-row-${token.id}`}
-      style={{ borderTop: "1px solid var(--border)" }}
-    >
-      <td style={{ padding: "8px 12px", fontWeight: 600 }}>{token.name}</td>
-      <td style={{ padding: "8px 12px" }}>
-        <span className="mono" style={{ fontSize: 11 }}>{token.prefix}…</span>
-      </td>
-      <td style={{ padding: "8px 12px" }}>
+    <tr data-testid={`api-token-row-${token.id}`}>
+      <td>{token.name}</td>
+      <td className="mono">{token.prefix}…</td>
+      <td>
         {Array.isArray(token.scopes) && token.scopes.length > 0 ? (
           <div style={{ display: "flex", gap: 4, flexWrap: "wrap" }}>
             {token.scopes.map((s) => (
-              <span
-                key={s}
-                className="pill pill-paused"
-                style={{ fontSize: 10.5 }}
-              >
+              <span key={s} className="pill pill-paused">
                 {s}
               </span>
             ))}
@@ -240,20 +227,20 @@ function AT_TokenRow({ token, onRevoke }) {
           <span className="muted text-sm">—</span>
         )}
       </td>
-      <td style={{ padding: "8px 12px" }} title={token.last_used_at || ""}>
+      <td title={token.last_used_at || ""}>
         <span className="mono">{AT_relTime(token.last_used_at)}</span>
       </td>
-      <td style={{ padding: "8px 12px" }} title={token.expires_at || ""}>
+      <td title={token.expires_at || ""}>
         {token.expires_at
           ? <span className="mono">{AT_relTime(token.expires_at)}</span>
           : <span className="muted">never</span>}
       </td>
-      <td style={{ padding: "8px 12px" }}>
-        <span className={`pill ${statusClass}`} style={{ fontSize: 10.5 }}>
+      <td>
+        <span className={`pill ${statusClass}`}>
           {status}
         </span>
       </td>
-      <td style={{ padding: "8px 12px", textAlign: "right", whiteSpace: "nowrap" }}>
+      <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
         <Btn
           size="sm"
           kind="danger"

--- a/ui/components/chats.jsx
+++ b/ui/components/chats.jsx
@@ -397,14 +397,24 @@ function CT_NewChatModal({ onClose, pushToast }) {
 }
 
 // ============================================================================
-// CT_AgentSwitcher - clickable header dropdown to switch a chat's agent
-// (POST /v1/chats/{id}/agent), paginated + searchable picker.
+// CT_AgentSwitcher - header trigger button + centered command-palette-style
+// modal overlay to switch a chat's agent (POST /v1/chats/{id}/agent).
+//
+// C3: the old cramped inline `.popover` is replaced by a dimmed-backdrop
+// centered card modelled on StudioCommandPalette/QuickOpen (studio-palette.jsx)
+// — large autofocused search, scrollable id+description list with a "current"
+// marker, ↑/↓/Enter/Esc keyboard nav, click-backdrop-to-close.
+// C4: a ⌘/Ctrl+Shift+A shortcut (⌘K is the global search — no collision) opens
+// the same overlay with the search focused while a chat is open. `open` is the
+// single source of truth shared by the trigger button and the shortcut.
 // ============================================================================
 
-function CT_AgentSwitcher({ chatId, currentAgentId, pushToast, placement = "down", disabled = false, triggerStyle = null }) {
+function CT_AgentSwitcher({ chatId, currentAgentId, pushToast, disabled = false, triggerStyle = null }) {
   const { useResource, useMutation, apiFetch } = window.primerApi;
   const [open, setOpen] = React.useState(false);
   const [q, setQ] = React.useState("");
+  const [cursor, setCursor] = React.useState(0);
+  const inputRef = React.useRef(null);
   const agents = useResource(
     "agent-switcher:agents",
     (s) => apiFetch("GET", "/agents?limit=200", null, { signal: s }),
@@ -415,11 +425,6 @@ function CT_AgentSwitcher({ chatId, currentAgentId, pushToast, placement = "down
     ? items.filter((a) =>
         (a.id + " " + (a.description || "")).toLowerCase().includes(q.toLowerCase()))
     : items;
-  const PAGE = 8;
-  const [page, setPage] = React.useState(0);
-  React.useEffect(() => setPage(0), [q]);
-  const shown = filtered.slice(page * PAGE, page * PAGE + PAGE);
-  const pages = Math.max(1, Math.ceil(filtered.length / PAGE));
 
   const switchAgent = useMutation(
     (agentId) => apiFetch("POST", `/chats/${chatId}/agent`, { agent_id: agentId }),
@@ -438,48 +443,130 @@ function CT_AgentSwitcher({ chatId, currentAgentId, pushToast, placement = "down
     }
   );
 
+  const openOverlay = () => { if (!disabled) setOpen(true); };
+  const closeOverlay = () => { setOpen(false); setQ(""); };
+
+  // C4 — global keydown shortcut, added on mount / removed on unmount. Refs
+  // hold the latest open+disabled so the listener stays registered once. When
+  // the overlay is already open we let ⇧A type into the search (no
+  // preventDefault); when the chat is ended (disabled) the shortcut is a no-op.
+  const stateRef = React.useRef({ open, disabled });
+  stateRef.current = { open, disabled };
+  React.useEffect(() => {
+    function onKey(e) {
+      const combo = (e.metaKey || e.ctrlKey) && e.shiftKey && !e.altKey &&
+        (e.code === "KeyA" || (e.key || "").toLowerCase() === "a");
+      if (!combo) return;
+      if (stateRef.current.open || stateRef.current.disabled) return;
+      e.preventDefault();
+      setOpen(true);
+    }
+    window.addEventListener("keydown", onKey);
+    return () => window.removeEventListener("keydown", onKey);
+  }, []);
+
+  // Autofocus the search + reset query/cursor whenever the overlay opens.
+  React.useEffect(() => {
+    if (!open) return undefined;
+    setQ(""); setCursor(0);
+    const t = setTimeout(() => { if (inputRef.current) inputRef.current.focus(); }, 30);
+    return () => clearTimeout(t);
+  }, [open]);
+
+  React.useEffect(() => setCursor(0), [q]);
+  // Clamp the highlight when the filtered list shrinks.
+  React.useEffect(() => {
+    setCursor((c) => Math.min(c, Math.max(0, filtered.length - 1)));
+  }, [filtered.length]);
+
+  const choose = (a) => {
+    if (!a || a.id === currentAgentId || switchAgent.loading) return;
+    switchAgent.mutate(a.id);
+  };
+
+  function onKeyDown(e) {
+    if (e.key === "ArrowDown") {
+      e.preventDefault();
+      setCursor((c) => Math.min(c + 1, filtered.length - 1));
+    } else if (e.key === "ArrowUp") {
+      e.preventDefault();
+      setCursor((c) => Math.max(c - 1, 0));
+    } else if (e.key === "Enter") {
+      e.preventDefault();
+      if (filtered[cursor]) choose(filtered[cursor]);
+    } else if (e.key === "Escape") {
+      e.stopPropagation();
+      closeOverlay();
+    }
+  }
+
   return (
-    <span className="agent-switcher" style={{ position: "relative", display: "inline-flex", alignItems: "stretch" }}>
+    <>
       <button
         className="chip"
-        onClick={() => !disabled && setOpen((v) => !v)}
-        title="Switch agent"
+        onClick={openOverlay}
+        title="Switch agent  (⌘/Ctrl + Shift + A)"
         disabled={disabled}
         style={{ display: "inline-flex", alignItems: "center", gap: 4, whiteSpace: "nowrap", ...(triggerStyle || {}) }}
       >
         agent <span className="mono">{currentAgentId}</span>
-        <Icon name={placement === "up" ? "chevron-up" : "chevron-down"} size={11} />
+        <Icon name="chevron-down" size={11} />
       </button>
       {open && (
-        <div className="popover" style={{ position: "absolute",
-              ...(placement === "up" ? { bottom: "100%", marginBottom: 6 } : { top: "100%", marginTop: 6 }),
-              left: 0, zIndex: 50,
-              width: 300, background: "var(--bg-1)", border: "1px solid var(--border)",
-              borderRadius: 8, padding: 8, boxShadow: "0 6px 24px rgba(0,0,0,.3)" }}>
-          <input className="input" placeholder="Search agents…" value={q}
-                 onChange={(e) => setQ(e.target.value)} style={{ width: "100%", marginBottom: 6 }} />
-          <div style={{ display: "flex", flexDirection: "column", gap: 2, maxHeight: 260, overflow: "auto" }}>
-            {shown.map((a) => (
-              <button key={a.id} className="menu-item"
-                      disabled={a.id === currentAgentId || switchAgent.loading}
-                      onClick={() => switchAgent.mutate(a.id)}
-                      style={{ textAlign: "left", padding: "6px 8px", borderRadius: 6 }}>
-                <div className="mono">{a.id}{a.id === currentAgentId ? " (current)" : ""}</div>
-                {a.description ? <div className="muted text-sm">{a.description}</div> : null}
+        <div className="agent-overlay-backdrop" data-testid="agent-overlay" onClick={closeOverlay}>
+          <div className="agent-overlay-card" onClick={(e) => e.stopPropagation()}>
+            <div className="agent-overlay-head">
+              <Icon name="search" size={14} className="agent-overlay-search-icon" />
+              <input
+                ref={inputRef}
+                className="agent-overlay-input"
+                data-testid="agent-overlay-search"
+                placeholder="Switch agent…"
+                value={q}
+                onChange={(e) => { setQ(e.target.value); setCursor(0); }}
+                onKeyDown={onKeyDown}
+              />
+              <button
+                type="button"
+                className="agent-overlay-close"
+                data-testid="agent-overlay-close"
+                onClick={closeOverlay}
+                title="Close (Esc)"
+                aria-label="Close"
+              >
+                <kbd>esc</kbd>
               </button>
-            ))}
-            {shown.length === 0 ? <div className="muted text-sm">No agents match.</div> : null}
-          </div>
-          {pages > 1 && (
-            <div style={{ display: "flex", justifyContent: "space-between", marginTop: 6 }}>
-              <button className="chip" disabled={page === 0} onClick={() => setPage((p) => p - 1)}>Prev</button>
-              <span className="muted text-sm">{page + 1}/{pages}</span>
-              <button className="chip" disabled={page >= pages - 1} onClick={() => setPage((p) => p + 1)}>Next</button>
             </div>
-          )}
+            <div className="agent-overlay-list">
+              {filtered.length === 0 ? (
+                <div className="agent-overlay-empty">No agents match.</div>
+              ) : filtered.map((a, idx) => {
+                const active = idx === cursor;
+                const isCurrent = a.id === currentAgentId;
+                return (
+                  <div
+                    key={a.id}
+                    data-testid="agent-overlay-item"
+                    className={"agent-overlay-item" + (active ? " active" : "")}
+                    aria-disabled={isCurrent || switchAgent.loading}
+                    onMouseEnter={() => setCursor(idx)}
+                    onClick={() => choose(a)}
+                  >
+                    <span className="agent-overlay-item-main">
+                      <span className="mono agent-overlay-item-id">{a.id}</span>
+                      {a.description ? <span className="agent-overlay-item-desc">{a.description}</span> : null}
+                    </span>
+                    {isCurrent ? (
+                      <span className="agent-overlay-current"><Icon name="check" size={12} />current</span>
+                    ) : null}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
         </div>
       )}
-    </span>
+    </>
   );
 }
 
@@ -606,44 +693,17 @@ function ChatDetail({ chatId, onBack, pushToast }) {
             <span className="mono">{cid}</span>
           )}
           <div className="right" style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            <window.TokenMeter
-              inputTokens={convStatus.usage.input_tokens}
-              contextLength={convStatus.usage.context_length}
-              onCompact={chatStatus === "ended" ? null : convStatus.requestCompact}
-              compactDisabled={convStatus.compactInFlight || convStatus.wsState !== "open"}
-              compactTooltip={
-                convStatus.compactInFlight
-                  ? "Compaction in progress…"
-                  : convStatus.wsState !== "open"
-                    ? "WebSocket offline"
-                    : ""
-              }
-            />
-            {wsBadge}
-            <span className={chatStatus === "active" ? "pill pill-running" : "pill pill-ended"}>
-              <span className="dot"></span>{chatStatus}
-            </span>
-          </div>
-        </div>
-        )}
-        <Conversation
-          chatId={cid}
-          pushToast={pushToast}
-          onStatus={setConvStatus}
-          headerSlot={null}
-          // R1: the agent selector lives in the host's top-right chrome
-          // slot now, next to the back/title chrome above, instead of
-          // the composer row — <Conversation> just renders whatever
-          // node this host hands it (see conversation.jsx). `placement`
-          // flips to "down" (was "up" in the old bottom-composer spot)
-          // since the popover now opens below the trigger.
-          rightChromeSlot={
-            <>
+            {/* C1/C2: one consolidated header row. The agent selector +
+                schema toggle + TokenMeter (token pill + compact) are grouped
+                into a single subtle cluster; the connection badge + chat
+                status pill trail it. This is what pulls the compact button
+                "down with the agent selector and schema" — they used to sit
+                in <Conversation>'s own second chrome row (now null). */}
+            <span className="chat-header-cluster" data-testid="chat-header-cluster">
               <CT_AgentSwitcher
                 chatId={cid}
                 currentAgentId={chatAgent}
                 pushToast={pushToast}
-                placement="down"
                 disabled={chatStatus === "ended"}
               />
               <button
@@ -657,8 +717,37 @@ function ChatDetail({ chatId, onBack, pushToast }) {
                 <Icon name="settings" size={12} />
                 schema
               </button>
-            </>
-          }
+              <window.TokenMeter
+                inputTokens={convStatus.usage.input_tokens}
+                contextLength={convStatus.usage.context_length}
+                onCompact={chatStatus === "ended" ? null : convStatus.requestCompact}
+                compactDisabled={convStatus.compactInFlight || convStatus.wsState !== "open"}
+                compactTooltip={
+                  convStatus.compactInFlight
+                    ? "Compaction in progress…"
+                    : convStatus.wsState !== "open"
+                      ? "WebSocket offline"
+                      : ""
+                }
+              />
+            </span>
+            {wsBadge}
+            <span className={chatStatus === "active" ? "pill pill-running" : "pill pill-ended"}>
+              <span className="dot"></span>{chatStatus}
+            </span>
+          </div>
+        </div>
+        )}
+        <Conversation
+          chatId={cid}
+          pushToast={pushToast}
+          onStatus={setConvStatus}
+          // C1: the whole desktop control cluster (agent selector, schema
+          // toggle, TokenMeter + compact) now lives in this host's single
+          // `panel-h .right` row above — so both of <Conversation>'s opaque
+          // chrome slots are null and its second header row no longer renders.
+          headerSlot={null}
+          rightChromeSlot={null}
           showSchemaPanel={showSchemaPanel}
           onCloseSchemaPanel={() => setShowSchemaPanel(false)}
         />

--- a/ui/components/linked_accounts.jsx
+++ b/ui/components/linked_accounts.jsx
@@ -114,19 +114,15 @@ function LA_LinkedAccountsPage() {
       )}
 
       {items.length > 0 && (
-        <div
-          data-testid="linked-accounts-table"
-          className="panel"
-          style={{ padding: 0, overflow: "hidden" }}
-        >
-          <table className="table" style={{ width: "100%", fontSize: 12 }}>
+        <div data-testid="linked-accounts-table" className="tbl-wrap">
+          <table className="tbl">
             <thead>
               <tr>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Provider</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Subject</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Email</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Linked</th>
-                <th style={{ textAlign: "right", padding: "8px 12px" }}>Actions</th>
+                <th>Provider</th>
+                <th>Subject</th>
+                <th>Email</th>
+                <th>Linked</th>
+                <th style={{ textAlign: "right" }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -186,21 +182,14 @@ function LA_LinkedAccountsPage() {
 
 function LA_IdentityRow({ identity, onUnlink }) {
   return (
-    <tr
-      data-testid={`linked-account-row-${identity.id}`}
-      style={{ borderTop: "1px solid var(--border)" }}
-    >
-      <td style={{ padding: "8px 12px", fontWeight: 600 }}>{identity.provider_name}</td>
-      <td style={{ padding: "8px 12px" }}>
-        <span className="mono" style={{ fontSize: 11 }}>{identity.subject}</span>
-      </td>
-      <td style={{ padding: "8px 12px" }}>
+    <tr data-testid={`linked-account-row-${identity.id}`}>
+      <td>{identity.provider_name}</td>
+      <td className="mono">{identity.subject}</td>
+      <td>
         {identity.email ? identity.email : <span className="muted text-sm">—</span>}
       </td>
-      <td style={{ padding: "8px 12px" }} title={identity.created_at || ""}>
-        <span className="mono">{LA_fmtDate(identity.created_at)}</span>
-      </td>
-      <td style={{ padding: "8px 12px", textAlign: "right", whiteSpace: "nowrap" }}>
+      <td className="mono" title={identity.created_at || ""}>{LA_fmtDate(identity.created_at)}</td>
+      <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
         <Btn
           size="sm"
           kind="danger"

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -436,7 +436,7 @@ function SD_StatusCanvas({ graph, statusByNode, metaByNode, selectedNodeId, onSe
   );
 }
 
-function SD_GraphRunView({ gid, rid, wid, session, pushToast, onNodeSelect, hideNodeTurnLog }) {
+function SD_GraphRunView({ gid, rid, wid, session, pushToast, onNodeSelect, hideNodeTurnLog, hideInspector }) {
   const { useResource, apiFetch } = window.primerApi;
   const isTerminal = session && window.SESSION_TERMINAL.has(session.status);
   const [selectedNodeId, setSelectedNodeId] = React.useState(null);
@@ -519,7 +519,13 @@ function SD_GraphRunView({ gid, rid, wid, session, pushToast, onNodeSelect, hide
           </span>
         </div>
       </div>
-      <div style={{ display: "grid", gridTemplateColumns: "minmax(0, 1fr) 360px" }}>
+      {/* fix #9 (studio): when hideInspector is set, the run view is the graph
+          canvas alone at full width — the 360px node-event-stream inspector is
+          dropped entirely (its content is redundant with the converged session
+          transcript the Studio renders below, which filters to the selected
+          node via onNodeSelect). The standalone /sessions run view omits the
+          prop and keeps the inspector. */}
+      <div style={{ display: "grid", gridTemplateColumns: hideInspector ? "minmax(0, 1fr)" : "minmax(0, 1fr) 360px" }}>
         <SD_StatusCanvas
           graph={graph.data}
           statusByNode={statusByNode}
@@ -527,16 +533,18 @@ function SD_GraphRunView({ gid, rid, wid, session, pushToast, onNodeSelect, hide
           selectedNodeId={selectedNodeId}
           onSelectNode={selectNode}
         />
-        <SD_NodeInspector
-          gid={gid}
-          rid={rid}
-          wid={wid}
-          session={session}
-          node={selectedItem}
-          graph={graph.data}
-          pushToast={pushToast}
-          hideNodeTurnLog={hideNodeTurnLog}
-        />
+        {!hideInspector && (
+          <SD_NodeInspector
+            gid={gid}
+            rid={rid}
+            wid={wid}
+            session={session}
+            node={selectedItem}
+            graph={graph.data}
+            pushToast={pushToast}
+            hideNodeTurnLog={hideNodeTurnLog}
+          />
+        )}
       </div>
     </div>
   );

--- a/ui/components/sso_admin.jsx
+++ b/ui/components/sso_admin.jsx
@@ -154,20 +154,16 @@ function SSO_ProvidersPage() {
       )}
 
       {items.length > 0 && (
-        <div
-          data-testid="sso-providers-table"
-          className="panel"
-          style={{ padding: 0, overflow: "hidden" }}
-        >
-          <table className="table" style={{ width: "100%", fontSize: 12 }}>
+        <div data-testid="sso-providers-table" className="tbl-wrap">
+          <table className="tbl">
             <thead>
               <tr>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Name</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Client ID</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Secret</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Scopes</th>
-                <th style={{ textAlign: "left", padding: "8px 12px" }}>Status</th>
-                <th style={{ textAlign: "right", padding: "8px 12px" }}>Actions</th>
+                <th>Name</th>
+                <th>Client ID</th>
+                <th>Secret</th>
+                <th>Scopes</th>
+                <th>Status</th>
+                <th style={{ textAlign: "right" }}>Actions</th>
               </tr>
             </thead>
             <tbody>
@@ -215,28 +211,23 @@ function SSO_ProvidersPage() {
 function SSO_ProviderRow({ provider, onEdit, onDelete }) {
   const hasSecret = !!provider.client_secret;
   return (
-    <tr
-      data-testid={`sso-provider-row-${provider.id}`}
-      style={{ borderTop: "1px solid var(--border)" }}
-    >
-      <td style={{ padding: "8px 12px", fontWeight: 600 }}>{provider.name}</td>
-      <td style={{ padding: "8px 12px" }}>
-        <span className="mono">{provider.client_id}</span>
-      </td>
-      <td style={{ padding: "8px 12px" }}>
+    <tr data-testid={`sso-provider-row-${provider.id}`}>
+      <td>{provider.name}</td>
+      <td className="mono">{provider.client_id}</td>
+      <td>
         {hasSecret
-          ? <span className="pill pill-claimed" style={{ fontSize: 10.5 }}>configured</span>
+          ? <span className="pill pill-claimed">configured</span>
           : <span className="muted text-sm">not set</span>}
       </td>
-      <td style={{ padding: "8px 12px" }}>
+      <td>
         <span className="mono muted text-sm">{(provider.scopes || []).join(", ")}</span>
       </td>
-      <td style={{ padding: "8px 12px" }}>
+      <td>
         {provider.enabled
-          ? <span className="pill pill-claimed" style={{ fontSize: 10.5 }}>enabled</span>
-          : <span className="pill pill-failed" style={{ fontSize: 10.5 }}>disabled</span>}
+          ? <span className="pill pill-claimed">enabled</span>
+          : <span className="pill pill-failed">disabled</span>}
       </td>
-      <td style={{ padding: "8px 12px", textAlign: "right", whiteSpace: "nowrap" }}>
+      <td style={{ textAlign: "right", whiteSpace: "nowrap" }}>
         <Btn
           size="sm"
           kind="ghost"

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -799,9 +799,11 @@ function SessionGraphPanel({ wid, sid, gid, rid, session, pushToast }) {
                 pushToast={pushToast}
                 // fix #9: opt into convergence — selecting a node filters the
                 // shared transcript (below) instead of opening a per-node
-                // turn-log panel, which we hide here.
+                // panel. hideInspector drops the 360px node-event-stream
+                // inspector entirely so the graph canvas fills the run view;
+                // its content is redundant with the converged transcript below.
                 onNodeSelect={setSelectedNode}
-                hideNodeTurnLog={true}
+                hideInspector={true}
               />
             : (
               <div className="muted text-sm" style={{ padding: 20, textAlign: "center", color: "var(--text-4)" }}>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -2429,3 +2429,135 @@ input, textarea, select { font: inherit; color: inherit; }
   .mobile-only { display: none !important; }
   .desktop-only { display: revert; }
 }
+
+/* ============================================================================
+   Chat header control cluster + agent-switch overlay (fix/studio-ux, PR #114)
+   ----------------------------------------------------------------------------
+   C1/C2: the /chats desktop ChatDetail header is one row now. The agent
+   selector, the schema toggle, and the TokenMeter (token pill + compact
+   button) are grouped into a single subtle bordered cluster inside
+   `.panel-h .right`; the connection badge + status pill trail it.
+
+   C3: the agent selector's old cramped inline `.popover` is replaced by a
+   centered, command-palette-style modal (mirrors StudioCommandPalette /
+   QuickOpen in studio-palette.jsx) — dimmed backdrop, ~520px card, large
+   autofocused search, a scrollable id+description results list with a
+   "current" marker and ↑/↓/Enter/Esc keyboard nav. Opened by the trigger
+   button or the ⌘/Ctrl+Shift+A shortcut (C4).
+   ========================================================================== */
+
+.chat-header-cluster {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 3px 5px;
+  border: 1px solid var(--border);
+  border-radius: 8px;
+  background: var(--bg-1);
+}
+.chat-header-cluster:hover { border-color: var(--border-strong); }
+/* Keep every grouped control the same visual height + baseline. */
+.chat-header-cluster > * { flex: 0 0 auto; }
+.chat-header-cluster .chip { padding: 3px 8px; }
+
+/* --- centered agent-switch overlay (command-palette style) --- */
+.agent-overlay-backdrop {
+  position: fixed;
+  inset: 0;
+  background: oklch(0 0 0 / 0.5);
+  z-index: 60;
+  display: flex;
+  justify-content: center;
+  padding-top: 12vh;
+}
+.agent-overlay-card {
+  width: 520px;
+  max-width: calc(100vw - 32px);
+  height: max-content;
+  max-height: 64vh;
+  background: var(--bg-1);
+  border: 1px solid var(--border-strong);
+  border-radius: 12px;
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+  overflow: hidden;
+}
+.agent-overlay-head {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 12px 14px;
+  border-bottom: 1px solid var(--border);
+}
+.agent-overlay-search-icon { color: var(--text-3); flex: 0 0 auto; }
+.agent-overlay-input {
+  flex: 1;
+  min-width: 0;
+  background: transparent;
+  border: 0;
+  outline: none;
+  color: var(--text);
+  font-size: 14px;
+}
+.agent-overlay-input::placeholder { color: var(--text-4); }
+.agent-overlay-close {
+  flex: 0 0 auto;
+  background: var(--bg-2);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 1px 6px;
+  color: var(--text-3);
+  cursor: pointer;
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 11px;
+  line-height: 1.5;
+}
+.agent-overlay-close:hover { color: var(--text); border-color: var(--border-strong); }
+.agent-overlay-list {
+  overflow: auto;
+  padding: 6px;
+  min-height: 0;
+}
+.agent-overlay-empty {
+  padding: 20px;
+  text-align: center;
+  color: var(--text-4);
+  font-size: 12px;
+}
+.agent-overlay-item {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  padding: 8px 10px;
+  border-radius: 7px;
+  cursor: pointer;
+}
+.agent-overlay-item.active { background: var(--bg-active); }
+.agent-overlay-item[aria-disabled="true"] { cursor: default; opacity: 0.75; }
+.agent-overlay-item-main {
+  flex: 1;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+.agent-overlay-item-id { color: var(--text); font-size: 13px; }
+.agent-overlay-item-desc {
+  color: var(--text-3);
+  font-size: 11.5px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+.agent-overlay-current {
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
+  color: var(--accent);
+  font-family: "IBM Plex Mono", monospace;
+  font-size: 10.5px;
+  text-transform: uppercase;
+  letter-spacing: 0.4px;
+}


### PR DESCRIPTION
Second batch of Studio/console UX fixes from real-usage feedback (follow-up to #114, which is merged). Four focused commits.

## Run view
- **Drop the node-event-stream inspector** from the Studio graph run view — the graph canvas now fills the full width; selecting a node filters the converged transcript below (the 360px inspector duplicated it). The standalone `/sessions` run view keeps its inspector (opt-in `hideInspector`).

## Chat header (/chats)
- **One row:** agent selector + schema + token meter/compact + live/status pills consolidated into a single header row (removes the old second row).
- **Command-palette agent picker:** the cramped inline dropdown is replaced by a centered overlay (backdrop, autofocused search, id+description list, current marker, ↑/↓/Enter/Esc, click-out).
- **Shortcut:** ⌘/Ctrl+Shift+A opens it (avoids the ⌘K global search).

## Table styling consistency
- Users, SSO, Linked Accounts, and API tokens tables converted from a hand-rolled `className="table"` + inline per-cell padding to the shared **`.tbl`/`.tbl-wrap`** styling used by Agents and ~16 other console pages.

## Tests
- `tests/ui/` full suite: **1031 passed, 1 skipped**. Static + Babel-transpile + MiniRacer checks updated/added for each change (incl. new `test_agent_switch_overlay.py`).

Note: the debug-rail collapse reported alongside these was already correct on the merged #114 branch (the `:has()` rule shrinks the rail; the resize handler writes CSS vars that don't override it) — no code change needed here.