### PR TITLE
fix(ui): make the Studio debug rail actually collapse

### DIFF
--- a/tests/ui/test_studio_debug_sidebar.py
+++ b/tests/ui/test_studio_debug_sidebar.py
@@ -396,6 +396,21 @@ def test_st_body_grid_shrinks_the_right_track_when_the_rail_is_collapsed() -> No
     assert '.studio-activity-root.is-collapsed { width: 40px; min-width: 40px; }' in css
 
 
+def test_activity_root_actually_carries_the_class_the_collapse_css_targets() -> None:
+    # THE linchpin (regression that shipped): the collapse CSS above keys off the
+    # `studio-activity-root` CLASS. For a long time `studio-activity-root` was
+    # ONLY a data-testid and the root's className was `{collapsed ? "is-collapsed"
+    # : ""}` — so `.studio-activity-root.is-collapsed` matched NO element and the
+    # rail silently never collapsed even though the CSS strings above all existed.
+    # The root MUST apply the class as a real className (and still toggle
+    # is-collapsed) so the :has() + width selectors engage.
+    fn = _studio_activity_fn_src()
+    assert (
+        'className={"studio-activity-root" + (collapsed ? " is-collapsed" : "")}'
+        in fn
+    )
+
+
 def test_collapsed_rail_grid_override_hides_the_right_resize_handle() -> None:
     css = _styles_src()
     assert '[data-testid="studio-resize-right"]' in css

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -725,7 +725,13 @@ function StudioActivity({ wid, studio }) {
   return (
     <div
       data-testid="studio-activity-root"
-      className={collapsed ? "is-collapsed" : ""}
+      // The collapse CSS keys off the `studio-activity-root` CLASS
+      // (`.st-body:has(.studio-activity-root.is-collapsed)` shrinks the grid
+      // track; `.studio-activity-root.is-collapsed { width: 40px }` shrinks the
+      // rail). `studio-activity-root` was previously ONLY a data-testid, so
+      // neither selector ever matched and the rail never actually collapsed —
+      // it MUST be a real className for the rules to engage.
+      className={"studio-activity-root" + (collapsed ? " is-collapsed" : "")}
       style={{
         display: "flex",
         flexDirection: "column",


### PR DESCRIPTION
Follow-up to the merged studio-UX PRs (#114/#115). The debug rail's collapse never worked in the browser despite the CSS and green tests.

## Root cause
The collapse CSS keys off a **class** — `.st-body:has(.studio-activity-root.is-collapsed)` shrinks the grid track and `.studio-activity-root.is-collapsed { width: 40px }` shrinks the rail. But `studio-activity-root` was only a **`data-testid`**; the element's `className` was just `"is-collapsed"`. So `.studio-activity-root.is-collapsed` matched no element, the `:has()` rule never fired, and the rail stayed full-width.

The existing tests only asserted the CSS *strings exist in the source* — not that the selector matches a real element — so the suite stayed green while the feature was dead.

## Fix
- Apply `studio-activity-root` as a real `className` (keeping the data-testid) so both selectors engage; the rail collapses to a 40px strip and the center reclaims the width.
- Add a linchpin test asserting the element actually carries the class — closing the gap that let this ship.

`tests/ui/` (studio debug-sidebar / activity / center) pass.