### PR TITLE
fix(ui): larger composer attach control + discoverable collapsed-rail expand handle

### DIFF
--- a/tests/ui/test_studio_debug_sidebar.py
+++ b/tests/ui/test_studio_debug_sidebar.py
@@ -371,8 +371,10 @@ def _styles_src() -> str:
 def test_collapsed_rail_hides_bell_and_label_but_keeps_chevron_and_badge() -> None:
     fn = _studio_activity_fn_src()
     assert "var expanded = !collapsed;" in fn
-    # Chevron (the toggle indicator) and the badge are unconditional; only
-    # the bell icon + "Debug" text retract into the collapsed rail.
+    # Chevron (the toggle indicator) and the badge are unconditional; the bell
+    # icon + the HORIZONTAL "Debug" text retract when collapsed (the collapsed
+    # rail instead shows a compact VERTICAL Debug label — see the rail-label
+    # test below).
     assert '{expanded && <Icon name="bell" size={13} style={{ flexShrink: 0 }} />}' in fn
     assert '{expanded && <span style={{ flex: 1, textAlign: "left" }}>Debug</span>}' in fn
     assert 'Icon name={collapsed ? "chevron-left" : "chevron-right"}' in fn
@@ -384,6 +386,16 @@ def test_collapsed_toggle_button_restyles_into_a_narrow_column() -> None:
     assert 'flexDirection: collapsed ? "column" : "row"' in fn
     assert 'height: collapsed ? "auto" : 34' in fn
     assert 'padding: collapsed ? "10px 4px" : "0 12px"' in fn
+
+
+def test_collapsed_rail_shows_a_vertical_debug_label_as_the_expand_handle() -> None:
+    # Discoverability: collapsed, the rail is a thin strip. A vertical "Debug"
+    # label (writing-mode) makes it legibly the expand handle instead of a bare,
+    # easily-missed chevron — operators kept asking how to re-open the panel.
+    fn = _studio_activity_fn_src()
+    assert "{collapsed && (" in fn
+    assert 'data-testid="debug-sidebar-rail-label"' in fn
+    assert 'writingMode: "vertical-rl"' in fn
 
 
 def test_st_body_grid_shrinks_the_right_track_when_the_rail_is_collapsed() -> None:

--- a/ui/components/chat/composer.jsx
+++ b/ui/components/chat/composer.jsx
@@ -363,7 +363,7 @@ function Composer({
             }}
             placeholder={disabled ? "This chat has ended." : "Send a message…"}
             rows={2}
-            style={{ flex: 1, resize: "none", paddingRight: 34 }}
+            style={{ flex: 1, resize: "none", paddingRight: 44 }}
             disabled={disabled}
             onKeyDown={handleComposerKeyDown}
             onKeyUp={updateCursorFromEvent}
@@ -379,22 +379,27 @@ function Composer({
             data-testid="chat-attach-btn"
             onClick={() => fileInputRef.current && fileInputRef.current.click()}
             disabled={disabled}
+            // Full-height attach affordance: spans the textarea box top-to-bottom
+            // (anchored right) with the icon vertically centered, so it reads as
+            // proportional to the chat box instead of a tiny bottom-corner glyph.
             style={{
               position: "absolute",
-              right: 6,
-              bottom: 6,
+              right: 4,
+              top: 0,
+              bottom: 0,
               background: "transparent",
               border: "none",
               borderRadius: 6,
-              padding: 4,
+              padding: "0 8px",
               color: "var(--text-2)",
               cursor: disabled ? "not-allowed" : "pointer",
               display: "flex",
               alignItems: "center",
+              justifyContent: "center",
               opacity: disabled ? 0.5 : 1,
             }}
           >
-            <Icon name="paperclip" size={14} />
+            <Icon name="paperclip" size={18} />
           </button>
           <input
             ref={fileInputRef}

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -773,6 +773,17 @@ function StudioActivity({ wid, studio }) {
         <Icon name={collapsed ? "chevron-left" : "chevron-right"} size={13} style={{ flexShrink: 0, color: "var(--text-3)" }} />
         {expanded && <Icon name="bell" size={13} style={{ flexShrink: 0 }} />}
         {expanded && <span style={{ flex: 1, textAlign: "left" }}>Debug</span>}
+        {/* Collapsed: a vertical "Debug" label so the thin rail is legibly the
+            expand handle. The chevron alone was too subtle — operators couldn't
+            tell the strip was clickable (or that it was the debug panel). */}
+        {collapsed && (
+          <span
+            data-testid="debug-sidebar-rail-label"
+            style={{ writingMode: "vertical-rl", letterSpacing: "0.12em", color: "var(--text-3)" }}
+          >
+            Debug
+          </span>
+        )}
         {pendingCount > 0 && (
           <span
             data-testid="debug-sidebar-badge"


### PR DESCRIPTION
Two small UX follow-ups from real usage.

## Composer attach control
The paperclip was a 14px glyph tucked in the bottom-right corner of the (2-row) chat box, next to a full-height Send button — visually undersized. Now it spans the box height (anchored right, vertically centered) with an 18px icon, so it reads proportional to the composer. Applies to both the /chats composer and the Studio session composer (same shared `<Composer>`).

## Collapsed debug-rail expand handle
After the rail-collapse fix (#116), the collapsed rail showed only a bare `chevron-left` — operators couldn't tell the thin strip was the expand handle ("how do I expand it?"). Added a vertical "Debug" label so the collapsed rail is legibly the handle.

## Tests
`tests/ui/` full suite: 1033 passed, 1 skipped. Added a rail-label test and updated the collapsed-rail test's comment; the composer-attach tests don't pin the old size/position.