### PR TITLE
fix(ui): discoverable Studio Debug/events toggle in the header

### DIFF
--- a/tests/ui/test_studio_debug_sidebar.py
+++ b/tests/ui/test_studio_debug_sidebar.py
@@ -75,15 +75,21 @@ def _inline_yields_fn_src() -> str:
 
 
 def test_debug_sidebar_starts_collapsed_by_default() -> None:
+    # Collapsed state now lives in the studio store (studio.state.debugOpen);
+    # StudioActivity derives `collapsed` from it and the store default is
+    # collapsed (ST_defaultState sets debugOpen:false — asserted in the studio
+    # store test). Deriving from the store is what lets the header toggle reach
+    # the rail.
     fn = _studio_activity_fn_src()
-    assert "var [collapsed, setCollapsed] = React.useState(true);" in fn
+    assert "var collapsed = !(studio && studio.state && studio.state.debugOpen);" in fn
 
 
 def test_debug_sidebar_toggle_flips_collapsed_state() -> None:
     fn = _studio_activity_fn_src()
     assert 'data-testid="debug-sidebar-toggle"' in fn
     assert "onClick={toggle}" in fn
-    assert "setCollapsed(function(c) { return !c; });" in fn
+    # The rail's own handle flips the SHARED store state, not local state.
+    assert "studio.toggleDebug()" in fn
     # a11y: expanded state reflected for assistive tech.
     assert 'aria-expanded={collapsed ? "false" : "true"}' in fn
 

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -48,6 +48,34 @@ def test_studio_file_exists_and_exports() -> None:
     assert "window.useStudioState = useStudioState;" in src
 
 
+def test_debug_rail_open_state_lives_in_the_studio_store() -> None:
+    # The right debug/activity rail's open state is store-owned (persisted) so
+    # the header toggle and the rail's own handle share ONE source of truth —
+    # StudioActivity's old internal useState could never be reached from the
+    # header, which is why operators couldn't open the panel.
+    src = _studio_src()
+    assert '"debugOpen",' in src                     # persisted across reloads
+    assert "debugOpen: false," in src                # default collapsed
+    assert "debugOpen: !s.debugOpen" in src          # toggleDebug callback
+    assert "toggleDebug: toggleDebug," in src        # exposed on the store
+    # Column width is driven directly from state (bulletproof — not solely via
+    # the :has(.is-collapsed) CSS): 40px rail when closed, rightWidth when open.
+    assert '"--st-right-w": (s.debugOpen ? s.rightWidth : 40) + "px"' in src
+
+
+def test_studio_header_has_a_desktop_debug_toggle() -> None:
+    # A discoverable desktop control to open the events panel (the 40px edge
+    # rail was too easy to miss). Bell icon, active when open, desktop-only
+    # (mobile uses the drawer bell), wired from the store through header props.
+    src = _studio_src()
+    assert 'data-testid="studio-debug-toggle"' in src
+    assert "onClick={onToggleDebug}" in src
+    assert 'debugOpen ? " is-active"' in src
+    assert "desktop-only" in src
+    assert "onToggleDebug={studio.toggleDebug}" in src
+    assert "debugOpen={s.debugOpen}" in src
+
+
 def test_studio_shell_root_and_header_testids() -> None:
     src = _studio_src()
     assert 'data-testid="studio-root"' in src

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -707,7 +707,11 @@ function WorkspaceActivity({ wid }) {
 // ---------------------------------------------------------------------------
 
 function StudioActivity({ wid, studio }) {
-  var [collapsed, setCollapsed] = React.useState(true);
+  // Collapsed state is owned by the studio store (studio.state.debugOpen) so the
+  // header Debug toggle and this rail's own handle share ONE source of truth —
+  // the internal-only useState meant the header could never reach it. Default is
+  // collapsed (debugOpen:false in ST_defaultState).
+  var collapsed = !(studio && studio.state && studio.state.debugOpen);
   var [pendingCount, setPendingCount] = React.useState(0);
   // Task (studio-ux fix 1): only the bell+"Debug" label retract into the
   // thin rail — the chevron (the toggle affordance itself) and the pending
@@ -719,7 +723,7 @@ function StudioActivity({ wid, studio }) {
   var expanded = !collapsed;
 
   function toggle() {
-    setCollapsed(function(c) { return !c; });
+    if (studio && typeof studio.toggleDebug === "function") studio.toggleDebug();
   }
 
   return (

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -29,6 +29,7 @@ var ST_PERSIST_KEYS = [
   "expanded",
   "fileModes",
   "terminalOpen",
+  "debugOpen",
   "activeTermId",
   "termTabs",
   "density",
@@ -175,6 +176,10 @@ function ST_defaultState() {
     fileModes: {},
     // Terminal placeholders (P7)
     terminalOpen: false,
+    // Right debug/activity rail — open state (persisted). Default collapsed
+    // so an operator who isn't debugging keeps the screen width; the header
+    // Debug toggle + the rail's own handle both flip this.
+    debugOpen: false,
     terminalHeight: 240,
     termTabs: [{ id: "bash", title: "bash" }],
     activeTermId: "bash",
@@ -395,6 +400,11 @@ function useStudioState(wid, initialOpen) {
     setState(function (s) { return Object.assign({}, s, { terminalOpen: !s.terminalOpen }); });
   }, []);
 
+  // ---- right debug/activity rail (StudioActivity) open/collapsed ----
+  var toggleDebug = React.useCallback(function () {
+    setState(function (s) { return Object.assign({}, s, { debugOpen: !s.debugOpen }); });
+  }, []);
+
   // ---- command palette / quick-open (B5) ----
   var openPalette = React.useCallback(function (mode) {
     setState(function (s) { return Object.assign({}, s, { paletteOpen: true, paletteMode: mode || "command", paletteQuery: "" }); });
@@ -454,6 +464,7 @@ function useStudioState(wid, initialOpen) {
     toggleTheme: toggleTheme,
     toggleDensity: toggleDensity,
     toggleTerminal: toggleTerminal,
+    toggleDebug: toggleDebug,
     toggleChip: toggleChip,
     setLeftWidth: setLeftWidth,
     setRightWidth: setRightWidth,
@@ -481,7 +492,7 @@ function useStudioState(wid, initialOpen) {
 // collapse to a single document there.
 // ---------------------------------------------------------------------------
 
-function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, onToggleLeftPanel, onToggleRightPanel }) {
+function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, debugOpen, onToggleDebug, onToggleLeftPanel, onToggleRightPanel }) {
   var { useResource, apiFetch } = window.primerApi;
   var [menuOpen, setMenuOpen] = React.useState(false);
   // Workspace Settings overlay — restores the orphaned WorkspaceDetail tabs
@@ -609,6 +620,21 @@ function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, term
         onClick={onToggleTerminal}
       >
         <Icon name="code" size={15} />
+      </button>
+
+      {/* Desktop Debug/Activity rail toggle. On desktop the rail is a static
+          column (collapsed to a thin strip by default), and its own edge handle
+          proved too easy to miss — this gives an obvious, always-visible control
+          next to the terminal toggle. Mobile uses the drawer bell below. */}
+      <button
+        className={"st-hbtn touch-target desktop-only" + (debugOpen ? " is-active" : "")}
+        data-testid="studio-debug-toggle"
+        title="Toggle workspace events (Action Required + Activity)"
+        aria-label="Toggle debug and activity panel"
+        aria-pressed={debugOpen ? "true" : "false"}
+        onClick={onToggleDebug}
+      >
+        <Icon name="bell" size={15} />
       </button>
 
       {/* Mobile-only panel-drawer toggle (right: Action Required + Activity). */}
@@ -774,7 +800,10 @@ function Studio({ wid, pushToast, initialOpen }) {
       data-theme={s.theme}
       data-density={s.density}
       data-testid="studio-root"
-      style={{ "--st-left-w": s.leftWidth + "px", "--st-right-w": s.rightWidth + "px", "--st-term-h": s.terminalHeight + "px" }}
+      // --st-right-w collapses to the 40px rail directly from state (not only
+      // via the :has(.is-collapsed) CSS) so the debug rail width is bulletproof
+      // regardless of :has() support, and the header Debug toggle controls it.
+      style={{ "--st-left-w": s.leftWidth + "px", "--st-right-w": (s.debugOpen ? s.rightWidth : 40) + "px", "--st-term-h": s.terminalHeight + "px" }}
     >
       <StudioHeader
         wid={wid}
@@ -783,6 +812,8 @@ function Studio({ wid, pushToast, initialOpen }) {
         onSelectWorkspace={selectWorkspace}
         terminalOpen={s.terminalOpen}
         onToggleTerminal={studio.toggleTerminal}
+        debugOpen={s.debugOpen}
+        onToggleDebug={studio.toggleDebug}
         onToggleLeftPanel={function () { setRightPanelOpen(false); setLeftPanelOpen(function (o) { return !o; }); }}
         onToggleRightPanel={function () { setLeftPanelOpen(false); setRightPanelOpen(function (o) { return !o; }); }}
       />


### PR DESCRIPTION
The right debug/activity rail (workspace events) couldn't be re-opened. After the collapse fix (#116) and the vertical-label affordance (#117), operators still couldn't open it — the only desktop control was the 40px edge strip, which is too easy to miss, and the header's existing right-panel toggle only drives the *mobile* drawer.

## Root cause
StudioActivity owned its collapsed state in an internal `useState` — nothing outside the rail could reach it, so there was no way to add a header button.

## Fix
- Lift the rail's open state into the studio store as `debugOpen` (persisted; default collapsed). The rail's own handle and a new header button now share one source of truth.
- Add a discoverable **desktop Debug toggle** in the studio header, next to the terminal toggle (bell icon, active when open). Mobile keeps its existing drawer bell.
- Drive `--st-right-w` directly from `debugOpen` (40px rail when closed, `rightWidth` when open) so the collapse is bulletproof, not solely dependent on the `:has(.is-collapsed)` CSS.

## Tests
`tests/ui/` full suite: 1035 passed, 1 skipped. Added store + header-toggle coverage; updated the two studio-activity tests that pinned the old internal state.