### PR TITLE
fix(ui): Studio debug rail — << / >> handle (no bell) + Workspace Activity fills to the bottom

### DIFF
--- a/tests/ui/test_agent_selector_top_right.py
+++ b/tests/ui/test_agent_selector_top_right.py
@@ -130,9 +130,13 @@ def test_chat_detail_passes_null_chrome_slots_for_one_row_header() -> None:
 
 
 def test_chat_detail_agent_switcher_lives_in_the_one_row_header_cluster() -> None:
-    # C1/C2: <CT_AgentSwitcher> is grouped with the schema toggle + TokenMeter
-    # inside ChatDetail's `chat-header-cluster`, ABOVE the <Conversation>
-    # mount — no longer inside <Conversation>'s `rightChromeSlot`.
+    # C1/C2 + Fix 2: <CT_AgentSwitcher> is grouped with the schema toggle +
+    # the compact button inside ChatDetail's `chat-header-cluster`, ABOVE the
+    # <Conversation> mount — no longer inside <Conversation>'s
+    # `rightChromeSlot`. Fix 2 replaced the in-cluster <TokenMeter> with a
+    # purpose-built compact button (`chat-compact-btn`) that carries the token
+    # count; the shared <TokenMeter> now only appears in the mobile kebab
+    # sheet further down the file.
     src = _chats_src()
     conv_start = src.index("<Conversation\n")
     conv_end = src.index("/>", conv_start)
@@ -144,12 +148,13 @@ def test_chat_detail_agent_switcher_lives_in_the_one_row_header_cluster() -> Non
     cluster = src.index('data-testid="chat-header-cluster"')
     switcher = src.index("<CT_AgentSwitcher")
     schema = src.index('data-testid="chat-schema-panel-toggle"')
-    token = src.index("<window.TokenMeter")
+    compact = src.index('data-testid="chat-compact-btn"')
     # The cluster opens first, then the three grouped controls, all before
     # the <Conversation> mount further down the file.
-    assert cluster < switcher < schema < token < conv_start, (
-        "C1/C2: agent selector + schema toggle + TokenMeter must be grouped "
-        "in that order inside the `chat-header-cluster`, above <Conversation>"
+    assert cluster < switcher < schema < compact < conv_start, (
+        "C1/C2 + Fix 2: agent selector + schema toggle + compact button must "
+        "be grouped in that order inside the `chat-header-cluster`, above "
+        "<Conversation>"
     )
 
 

--- a/tests/ui/test_chat_a11y.py
+++ b/tests/ui/test_chat_a11y.py
@@ -64,9 +64,30 @@ def test_tool_rows_and_media_chips_are_keyboard_operable() -> None:
 def test_connection_status_indicator_exists_and_is_wired() -> None:
     src = _src(TRANSCRIPT)
     assert "function CT_ConnectionStatus(" in src
-    assert "<CT_ConnectionStatus wsState={wsState} turnStatus={turnStatus} />" in src
+    # Fix 1: the state pill also folds in the chat lifecycle, so <Transcript>
+    # forwards `chatStatus` alongside wsState/turnStatus.
+    assert (
+        "<CT_ConnectionStatus wsState={wsState} turnStatus={turnStatus} chatStatus={chatStatus} />"
+        in src
+    )
     assert 'data-testid="chat-connection-status"' in src
     assert 'data-testid="chat-turn-status"' in src
+
+
+def test_connection_status_state_pill_shows_ended_when_chat_ended() -> None:
+    # Fix 1: the single state pill reads "ended" (pill-ended) when the chat
+    # lifecycle is ended, otherwise the live turn status. `chatStatus` is an
+    # optional prop so a bare Studio embed (no chatStatus) still shows turn.
+    src = _src(TRANSCRIPT)
+    assert "function CT_ConnectionStatus({ wsState, turnStatus, chatStatus })" in src
+    assert 'const ended = chatStatus === "ended";' in src
+    assert 'const stateLabel = ended ? "ended" : turn;' in src
+    assert '"pill pill-ended"' in src
+
+
+def test_conversation_forwards_chat_status_to_transcript() -> None:
+    src = _src(CONVERSATION)
+    assert "chatStatus={chatStatus}" in src
 
 
 def test_connection_status_covers_every_turn_status_value() -> None:

--- a/tests/ui/test_chat_header_green_buttons.py
+++ b/tests/ui/test_chat_header_green_buttons.py
@@ -1,0 +1,156 @@
+"""Fix 1 + Fix 2 (fix/studio-debug-rail-polish, PR #119) — the /chats
+ChatDetail desktop header.
+
+  Fix 1 — all chat status (connection + turn/lifecycle) lives on the LEFT
+          CT_ConnectionStatus inside the transcript; the desktop header's
+          right side holds BUTTONS ONLY. The old right-side wsBadge + the
+          standalone active/ended lifecycle pill are gone from the desktop
+          header (they still render in the mobile kebab sheet — untouched).
+  Fix 2 — the three cluster controls are green: circular icon buttons for the
+          agent trigger + schema toggle, and a green pill for compact that
+          carries the live token count. The shared <TokenMeter> component is
+          NOT modified — the desktop cluster renders a purpose-built button.
+
+Static-source + transpile-build checks only (the ui/ suite convention) — no
+DOM/browser harness.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+CHATS = UI / "components" / "chats.jsx"
+STYLES = UI / "styles.css"
+
+
+def _chats() -> str:
+    return CHATS.read_text(encoding="utf-8")
+
+
+def _styles() -> str:
+    return STYLES.read_text(encoding="utf-8")
+
+
+def _desktop_header() -> str:
+    # The desktop header is the `else` branch of ChatDetail's isMobile
+    # ternary: `<div className="panel-h">` up to the <Conversation> mount.
+    src = _chats()
+    start = src.index('<div className="panel-h">')
+    end = src.index("<Conversation\n", start)
+    return src[start:end]
+
+
+def _after_conversation() -> str:
+    src = _chats()
+    return src[src.index("<Conversation\n"):]
+
+
+# ---------------------------------------------------------------------------
+# Fix 1 — the desktop header right side is buttons only.
+# ---------------------------------------------------------------------------
+
+
+def test_desktop_header_no_longer_renders_ws_badge() -> None:
+    assert "{wsBadge}" not in _desktop_header(), (
+        "Fix 1: the desktop header right side must not render the wsBadge — "
+        "connection status lives on the left CT_ConnectionStatus now"
+    )
+
+
+def test_desktop_header_no_longer_renders_lifecycle_status_pill() -> None:
+    # The standalone active/ended lifecycle pill folded into the left state
+    # pill; the desktop header must not render it anymore.
+    assert 'chatStatus === "active"' not in _desktop_header()
+
+
+def test_mobile_kebab_still_renders_ws_badge_and_lifecycle_pill() -> None:
+    # Mobile is untouched — the wsBadge + lifecycle pill still render in the
+    # BottomSheet kebab below the <Conversation> mount.
+    after = _after_conversation()
+    assert "{wsBadge}" in after
+    assert 'chatStatus === "active"' in after
+
+
+# ---------------------------------------------------------------------------
+# Fix 2 — three green cluster controls.
+# ---------------------------------------------------------------------------
+
+
+def test_agent_trigger_is_a_green_circular_icon_button() -> None:
+    src = _chats()
+    # The trigger converted from the old text chip to a `.chat-cbtn` circular
+    # icon button using the `agent` icon.
+    assert 'data-testid="chat-agent-trigger"' in src
+    assert 'className="chat-cbtn"' in src
+    assert '<Icon name="agent"' in src
+    # The old text-chip trigger ("agent <id> ▾") is gone.
+    assert 'agent <span className="mono">{currentAgentId}</span>' not in src
+
+
+def test_schema_toggle_is_a_green_circular_icon_button() -> None:
+    header = _desktop_header()
+    assert 'data-testid="chat-schema-panel-toggle"' in header
+    # Green circular button, pressed/active when the panel is showing.
+    assert '"chat-cbtn" + (showSchemaPanel ? " active" : "")' in header
+    assert '<Icon name="settings"' in header
+    # The old text chip label is gone from the toggle.
+    assert "schema\n" not in header
+
+
+def test_compact_button_is_a_green_pill_carrying_the_token_count() -> None:
+    src = _chats()
+    header = _desktop_header()
+    assert 'data-testid="chat-compact-btn"' in header
+    assert "chat-cbtn chat-cbtn-compact" in header
+    assert '<Icon name="compress"' in header
+    # The button carries the live token count: input / context (pct%).
+    assert "compactInput.toLocaleString()" in src
+    assert "compactCtx.toLocaleString()" in src
+    assert "compactPct" in src
+
+
+def test_compact_button_disable_and_action_logic_preserved() -> None:
+    src = _chats()
+    # Disabled when the chat is ended, a compaction is in flight, or the
+    # socket is not open (mirrors the old TokenMeter compactDisabled logic).
+    assert (
+        'chatStatus === "ended" || convStatus.compactInFlight'
+        ' || convStatus.wsState !== "open"'
+    ) in src
+    # Clicking triggers compaction.
+    assert "convStatus.requestCompact()" in src
+
+
+def test_shared_token_meter_component_untouched_and_still_used_by_mobile() -> None:
+    # Fix 2 must NOT change the shared <TokenMeter> — the mobile kebab sheet
+    # still renders it (only the desktop cluster swapped to a bespoke button).
+    assert "<window.TokenMeter" in _after_conversation()
+
+
+# ---------------------------------------------------------------------------
+# CSS — the green button styles live at the end of ui/styles.css.
+# ---------------------------------------------------------------------------
+
+
+def test_green_button_css_present() -> None:
+    css = _styles()
+    assert ".chat-cbtn {" in css
+    assert ".chat-cbtn-compact {" in css
+    # Circular icon buttons + green accent.
+    assert "border-radius: 50%" in css
+    assert "var(--green)" in css
+
+
+# ---------------------------------------------------------------------------
+# Transpile.
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_still_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    assert "/* === components/chats.jsx === */" in body.decode("utf-8")

--- a/tests/ui/test_studio_activity.py
+++ b/tests/ui/test_studio_activity.py
@@ -30,6 +30,35 @@ def _studio_src() -> str:
     return STUDIO.read_text(encoding="utf-8")
 
 
+TAP = UI / "components" / "workspace-tap.jsx"
+
+
+def _tap_src() -> str:
+    return TAP.read_text(encoding="utf-8")
+
+
+def test_workspace_activity_fills_height_via_tap_fillheight() -> None:
+    # Request: Workspace Activity should fill from its start to the bottom of the
+    # sidebar instead of leaving dead space below a short event list. It passes
+    # fillHeight to WorkspaceTap, which then drops the 520px cap and lets the
+    # event list grow (flex:1) to the bottom.
+    act = _activity_src()
+    assert "<window.WorkspaceTap wid={wid} fillHeight />" in act
+    tap = _tap_src()
+    assert "function WorkspaceTap({ wid, sessionId, fillHeight })" in tap
+    assert '{ overflowY: "auto", flex: 1, minHeight: 0, padding: "6px 0" }' in tap
+    # Standalone/page usages (e.g. the /workspaces events panel) keep the cap.
+    assert "maxHeight: 520" in tap
+
+
+def test_collapsed_rail_uses_double_chevron_handle() -> None:
+    # Per user request the rail's expand/collapse affordance is a << / >> double
+    # chevron (replaces the single chevron), flipping the shared store state.
+    act = _activity_src()
+    assert 'Icon name={collapsed ? "chevrons-left" : "chevrons-right"}' in act
+    assert "studio.toggleDebug()" in act
+
+
 def _index_order() -> list[str]:
     out: list[str] = []
     for line in INDEX.read_text(encoding="utf-8").splitlines():

--- a/tests/ui/test_studio_debug_sidebar.py
+++ b/tests/ui/test_studio_debug_sidebar.py
@@ -381,10 +381,13 @@ def test_collapsed_rail_hides_bell_and_label_but_keeps_chevron_and_badge() -> No
     # icon + the HORIZONTAL "Debug" text retract when collapsed (the collapsed
     # rail instead shows a compact VERTICAL Debug label — see the rail-label
     # test below).
-    assert '{expanded && <Icon name="bell" size={13} style={{ flexShrink: 0 }} />}' in fn
     assert '{expanded && <span style={{ flex: 1, textAlign: "left" }}>Debug</span>}' in fn
-    assert 'Icon name={collapsed ? "chevron-left" : "chevron-right"}' in fn
+    # The toggle indicator is a double chevron: << to expand the collapsed rail,
+    # >> to collapse the open panel (per user request — replaces the single ‹/›).
+    assert 'Icon name={collapsed ? "chevrons-left" : "chevrons-right"}' in fn
     assert '{pendingCount > 0 && (' in fn
+    # The decorative bell was removed from the rail (user disliked it).
+    assert 'name="bell"' not in fn
 
 
 def test_collapsed_toggle_button_restyles_into_a_narrow_column() -> None:

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -50,9 +50,9 @@ def test_studio_file_exists_and_exports() -> None:
 
 def test_debug_rail_open_state_lives_in_the_studio_store() -> None:
     # The right debug/activity rail's open state is store-owned (persisted) so
-    # the header toggle and the rail's own handle share ONE source of truth —
-    # StudioActivity's old internal useState could never be reached from the
-    # header, which is why operators couldn't open the panel.
+    # the rail's own << handle and the state-driven column width share ONE
+    # source of truth (StudioActivity's old internal useState left the width and
+    # the toggle out of sync, and nothing outside the rail could reach it).
     src = _studio_src()
     assert '"debugOpen",' in src                     # persisted across reloads
     assert "debugOpen: false," in src                # default collapsed
@@ -63,17 +63,13 @@ def test_debug_rail_open_state_lives_in_the_studio_store() -> None:
     assert '"--st-right-w": (s.debugOpen ? s.rightWidth : 40) + "px"' in src
 
 
-def test_studio_header_has_a_desktop_debug_toggle() -> None:
-    # A discoverable desktop control to open the events panel (the 40px edge
-    # rail was too easy to miss). Bell icon, active when open, desktop-only
-    # (mobile uses the drawer bell), wired from the store through header props.
+def test_no_header_debug_toggle_the_rail_owns_it() -> None:
+    # Per user preference the events panel is opened from the rail's own << handle
+    # (studio-activity.jsx), NOT a header button — the earlier header bell was
+    # removed. Guard against re-introducing header debug wiring.
     src = _studio_src()
-    assert 'data-testid="studio-debug-toggle"' in src
-    assert "onClick={onToggleDebug}" in src
-    assert 'debugOpen ? " is-active"' in src
-    assert "desktop-only" in src
-    assert "onToggleDebug={studio.toggleDebug}" in src
-    assert "debugOpen={s.debugOpen}" in src
+    assert 'data-testid="studio-debug-toggle"' not in src
+    assert "onToggleDebug" not in src
 
 
 def test_studio_shell_root_and_header_testids() -> None:

--- a/ui/components/chat/conversation.jsx
+++ b/ui/components/chat/conversation.jsx
@@ -1039,6 +1039,7 @@ function Conversation({ chatId, headerSlot, rightChromeSlot, showSchemaPanel, on
           wsState={wsState}
           waitingForReply={waitingForReply}
           turnStatus={chatRow?.turn_status}
+          chatStatus={chatStatus}
           pendingToolCall={chatRow?.pending_tool_call}
           sendMessage={sendMessage}
           onRewind={handleRewind}

--- a/ui/components/chat/transcript.jsx
+++ b/ui/components/chat/transcript.jsx
@@ -894,7 +894,7 @@ function CompactionMarker({ m }) {
 // ... as a real indicator alongside the WS badge" per the plan — so
 // connection + turn legibility travels with the component wherever it's
 // embedded, not just the /chats page's own header.
-function CT_ConnectionStatus({ wsState, turnStatus }) {
+function CT_ConnectionStatus({ wsState, turnStatus, chatStatus }) {
   const wsPillClass = wsState === "open"
     ? "pill pill-running"
     : wsState === "connecting"
@@ -902,11 +902,19 @@ function CT_ConnectionStatus({ wsState, turnStatus }) {
       : "pill pill-ended";
   const wsLabel = wsState === "open" ? "live" : wsState === "connecting" ? "connecting" : "offline";
   const turn = turnStatus || "idle";
-  const turnPillClass = turn === "running"
-    ? "pill pill-running"
-    : turn === "claimable"
-      ? "pill pill-claimed"
-      : "pill pill-created";
+  // Fix 1 (fix/studio-debug-rail-polish): all chat status lives on this left
+  // indicator now. The state pill folds the chat lifecycle into the turn
+  // pill's slot — "ended" when ended, else the live turn status as before.
+  // `chatStatus` is optional (a bare Studio embed passes none → turn status).
+  const ended = chatStatus === "ended";
+  const stateLabel = ended ? "ended" : turn;
+  const statePillClass = ended
+    ? "pill pill-ended"
+    : turn === "running"
+      ? "pill pill-running"
+      : turn === "claimable"
+        ? "pill pill-claimed"
+        : "pill pill-created";
   return (
     <div
       className="chat-connection-status"
@@ -920,8 +928,12 @@ function CT_ConnectionStatus({ wsState, turnStatus }) {
       <span className={wsPillClass} title={`WebSocket ${wsState}`}>
         <span className="dot"></span>{wsLabel}
       </span>
-      <span className={turnPillClass} data-testid="chat-turn-status" title={`Turn status: ${turn}`}>
-        <span className="dot"></span>{turn}
+      <span
+        className={statePillClass}
+        data-testid="chat-turn-status"
+        title={ended ? "Chat ended" : `Turn status: ${turn}`}
+      >
+        <span className="dot"></span>{stateLabel}
       </span>
     </div>
   );
@@ -950,7 +962,7 @@ const _QUIET_LAST_KINDS = new Set([
 ]);
 
 function Transcript({
-  messages, chatId, agentId, wsState, waitingForReply, turnStatus,
+  messages, chatId, agentId, wsState, waitingForReply, turnStatus, chatStatus,
   pendingToolCall, sendMessage, onRewind, compactionBoundarySeq,
   scrollRef, onScroll, loadingOlder, hasMoreOlder,
 }) {
@@ -994,7 +1006,7 @@ function Transcript({
       {/* Task G1 (§4.5): connection + turn-status legibility that travels
           with the component wherever it's embedded — see
           CT_ConnectionStatus above. */}
-      <CT_ConnectionStatus wsState={wsState} turnStatus={turnStatus} />
+      <CT_ConnectionStatus wsState={wsState} turnStatus={turnStatus} chatStatus={chatStatus} />
       <div
         ref={scrollRef}
         onScroll={onScroll}

--- a/ui/components/chats.jsx
+++ b/ui/components/chats.jsx
@@ -409,7 +409,7 @@ function CT_NewChatModal({ onClose, pushToast }) {
 // single source of truth shared by the trigger button and the shortcut.
 // ============================================================================
 
-function CT_AgentSwitcher({ chatId, currentAgentId, pushToast, disabled = false, triggerStyle = null }) {
+function CT_AgentSwitcher({ chatId, currentAgentId, pushToast, disabled = false }) {
   const { useResource, useMutation, apiFetch } = window.primerApi;
   const [open, setOpen] = React.useState(false);
   const [q, setQ] = React.useState("");
@@ -503,14 +503,15 @@ function CT_AgentSwitcher({ chatId, currentAgentId, pushToast, disabled = false,
   return (
     <>
       <button
-        className="chip"
+        type="button"
+        className="chat-cbtn"
         onClick={openOverlay}
-        title="Switch agent  (⌘/Ctrl + Shift + A)"
+        title={`Agent: ${currentAgentId} — switch  (⌘/Ctrl + Shift + A)`}
         disabled={disabled}
-        style={{ display: "inline-flex", alignItems: "center", gap: 4, whiteSpace: "nowrap", ...(triggerStyle || {}) }}
+        data-testid="chat-agent-trigger"
+        aria-label={`Switch agent (current: ${currentAgentId})`}
       >
-        agent <span className="mono">{currentAgentId}</span>
-        <Icon name="chevron-down" size={11} />
+        <Icon name="agent" size={15} />
       </button>
       {open && (
         <div className="agent-overlay-backdrop" data-testid="agent-overlay" onClick={closeOverlay}>
@@ -634,6 +635,26 @@ function ChatDetail({ chatId, onBack, pushToast }) {
   const chatAgent = chatRow?.agent_id || "—";
   const chatTitle = chatRow?.title || null;
 
+  // Fix 2 (fix/studio-debug-rail-polish): the desktop cluster's compact
+  // control is a green pill that carries the live token count on the button
+  // itself. Same disable/tooltip logic the shared <TokenMeter> used (ended
+  // chat, compaction in flight, or socket not open) — but rendered inline in
+  // the cluster below as a purpose-built button so the count reads inline.
+  // The shared <TokenMeter> (mobile kebab below + Studio) is left untouched.
+  const compactUsage = convStatus.usage || {};
+  const compactInput = compactUsage.input_tokens || 0;
+  const compactCtx = compactUsage.context_length || 0;
+  const compactPct = compactCtx > 0 ? Math.round((compactInput / compactCtx) * 100) : 0;
+  const compactDisabled =
+    chatStatus === "ended" || convStatus.compactInFlight || convStatus.wsState !== "open";
+  const compactTooltip = chatStatus === "ended"
+    ? "Chat ended"
+    : convStatus.compactInFlight
+      ? "Compaction in progress…"
+      : convStatus.wsState !== "open"
+        ? "WebSocket offline"
+        : "Compact conversation now";
+
   return (
     <div
       className="col"
@@ -693,12 +714,12 @@ function ChatDetail({ chatId, onBack, pushToast }) {
             <span className="mono">{cid}</span>
           )}
           <div className="right" style={{ display: "flex", gap: 8, alignItems: "center" }}>
-            {/* C1/C2: one consolidated header row. The agent selector +
-                schema toggle + TokenMeter (token pill + compact) are grouped
-                into a single subtle cluster; the connection badge + chat
-                status pill trail it. This is what pulls the compact button
-                "down with the agent selector and schema" — they used to sit
-                in <Conversation>'s own second chrome row (now null). */}
+            {/* Fix 1/Fix 2 (fix/studio-debug-rail-polish): the right side is
+                BUTTONS ONLY now — all status (connection + turn/lifecycle)
+                lives on the left CT_ConnectionStatus inside the transcript.
+                The three controls are green: circular icon buttons for agent
+                + schema and a green pill carrying the live token count for
+                compact. */}
             <span className="chat-header-cluster" data-testid="chat-header-cluster">
               <CT_AgentSwitcher
                 chatId={cid}
@@ -708,32 +729,26 @@ function ChatDetail({ chatId, onBack, pushToast }) {
               />
               <button
                 type="button"
-                className={"chip" + (showSchemaPanel ? " active" : "")}
+                className={"chat-cbtn" + (showSchemaPanel ? " active" : "")}
                 onClick={() => setShowSchemaPanel((v) => !v)}
                 title={showSchemaPanel ? "Hide structured output schema panel" : "Show structured output schema panel"}
                 data-testid="chat-schema-panel-toggle"
-                style={{ display: "inline-flex", alignItems: "center", gap: 4, whiteSpace: "nowrap" }}
+                aria-pressed={showSchemaPanel}
+                aria-label="Toggle structured output schema panel"
               >
-                <Icon name="settings" size={12} />
-                schema
+                <Icon name="settings" size={14} />
               </button>
-              <window.TokenMeter
-                inputTokens={convStatus.usage.input_tokens}
-                contextLength={convStatus.usage.context_length}
-                onCompact={chatStatus === "ended" ? null : convStatus.requestCompact}
-                compactDisabled={convStatus.compactInFlight || convStatus.wsState !== "open"}
-                compactTooltip={
-                  convStatus.compactInFlight
-                    ? "Compaction in progress…"
-                    : convStatus.wsState !== "open"
-                      ? "WebSocket offline"
-                      : ""
-                }
-              />
-            </span>
-            {wsBadge}
-            <span className={chatStatus === "active" ? "pill pill-running" : "pill pill-ended"}>
-              <span className="dot"></span>{chatStatus}
+              <button
+                type="button"
+                className="chat-cbtn chat-cbtn-compact"
+                onClick={() => { if (!compactDisabled && convStatus.requestCompact) convStatus.requestCompact(); }}
+                disabled={compactDisabled}
+                title={compactTooltip}
+                data-testid="chat-compact-btn"
+              >
+                <Icon name="compress" size={13} />
+                <span className="mono">{compactInput.toLocaleString()} / {compactCtx.toLocaleString()} ({compactPct}%)</span>
+              </button>
             </span>
           </div>
         </div>

--- a/ui/components/shared.jsx
+++ b/ui/components/shared.jsx
@@ -23,6 +23,8 @@ const Icon = ({ name, size = 14, ...rest }) => {
     case "chevron-down": return <svg {...props}><path d="M6 9l6 6 6-6" /></svg>;
     case "chevron-up": return <svg {...props}><path d="M6 15l6-6 6 6" /></svg>;
     case "chevron-left": return <svg {...props}><path d="M15 6l-6 6 6 6" /></svg>;
+    case "chevrons-left": return <svg {...props}><path d="M11 6l-6 6 6 6" /><path d="M18 6l-6 6 6 6" /></svg>;
+    case "chevrons-right": return <svg {...props}><path d="M13 6l6 6-6 6" /><path d="M6 6l6 6-6 6" /></svg>;
     case "plus": return <svg {...props}><path d="M12 5v14M5 12h14" /></svg>;
     case "minus": return <svg {...props}><path d="M5 12h14" /></svg>;
     case "x": return <svg {...props}><path d="M6 6l12 12M18 6l-12 12" /></svg>;

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -683,9 +683,12 @@ function WorkspaceActivity({ wid }) {
         </span>
       </div>
 
-      {/* WorkspaceTap owns its filter chips + SSE connection + auto-scroll */}
+      {/* WorkspaceTap owns its filter chips + SSE connection + auto-scroll.
+          fillHeight makes its event list grow to the bottom of the sidebar
+          (no 520px cap) so Workspace Activity fills the space below User
+          Interaction instead of leaving it empty. */}
       <div style={{ flex: 1, minHeight: 0, overflowY: "auto" }}>
-        <window.WorkspaceTap wid={wid} />
+        <window.WorkspaceTap wid={wid} fillHeight />
       </div>
     </div>
   );
@@ -774,8 +777,7 @@ function StudioActivity({ wid, studio }) {
           font: "inherit",
         }}
       >
-        <Icon name={collapsed ? "chevron-left" : "chevron-right"} size={13} style={{ flexShrink: 0, color: "var(--text-3)" }} />
-        {expanded && <Icon name="bell" size={13} style={{ flexShrink: 0 }} />}
+        <Icon name={collapsed ? "chevrons-left" : "chevrons-right"} size={15} style={{ flexShrink: 0, color: "var(--text-2)" }} />
         {expanded && <span style={{ flex: 1, textAlign: "left" }}>Debug</span>}
         {/* Collapsed: a vertical "Debug" label so the thin rail is legibly the
             expand handle. The chevron alone was too subtle — operators couldn't

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -492,7 +492,7 @@ function useStudioState(wid, initialOpen) {
 // collapse to a single document there.
 // ---------------------------------------------------------------------------
 
-function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, debugOpen, onToggleDebug, onToggleLeftPanel, onToggleRightPanel }) {
+function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, onToggleLeftPanel, onToggleRightPanel }) {
   var { useResource, apiFetch } = window.primerApi;
   var [menuOpen, setMenuOpen] = React.useState(false);
   // Workspace Settings overlay — restores the orphaned WorkspaceDetail tabs
@@ -620,21 +620,6 @@ function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, term
         onClick={onToggleTerminal}
       >
         <Icon name="code" size={15} />
-      </button>
-
-      {/* Desktop Debug/Activity rail toggle. On desktop the rail is a static
-          column (collapsed to a thin strip by default), and its own edge handle
-          proved too easy to miss — this gives an obvious, always-visible control
-          next to the terminal toggle. Mobile uses the drawer bell below. */}
-      <button
-        className={"st-hbtn touch-target desktop-only" + (debugOpen ? " is-active" : "")}
-        data-testid="studio-debug-toggle"
-        title="Toggle workspace events (Action Required + Activity)"
-        aria-label="Toggle debug and activity panel"
-        aria-pressed={debugOpen ? "true" : "false"}
-        onClick={onToggleDebug}
-      >
-        <Icon name="bell" size={15} />
       </button>
 
       {/* Mobile-only panel-drawer toggle (right: Action Required + Activity). */}
@@ -812,8 +797,6 @@ function Studio({ wid, pushToast, initialOpen }) {
         onSelectWorkspace={selectWorkspace}
         terminalOpen={s.terminalOpen}
         onToggleTerminal={studio.toggleTerminal}
-        debugOpen={s.debugOpen}
-        onToggleDebug={studio.toggleDebug}
         onToggleLeftPanel={function () { setRightPanelOpen(false); setLeftPanelOpen(function (o) { return !o; }); }}
         onToggleRightPanel={function () { setLeftPanelOpen(false); setRightPanelOpen(function (o) { return !o; }); }}
       />

--- a/ui/components/workspace-tap.jsx
+++ b/ui/components/workspace-tap.jsx
@@ -222,7 +222,7 @@ function WTP_eventKey(ev) {
 // server-selectored EventSource).
 // ---------------------------------------------------------------------------
 
-function WorkspaceTap({ wid, sessionId }) {
+function WorkspaceTap({ wid, sessionId, fillHeight }) {
   var tap = window.useWorkspaceTap(wid);
   var liveEvents = tap.events;
   var connState = tap.connState;
@@ -351,7 +351,13 @@ function WorkspaceTap({ wid, sessionId }) {
   var activeClasses = selectedClasses === null ? WTP_ALL_CLASSES : selectedClasses;
 
   return (
-    <div className="col" style={{ gap: 0 }} data-testid="workspace-tap-root">
+    <div
+      className="col"
+      style={fillHeight
+        ? { gap: 0, display: "flex", flexDirection: "column", height: "100%", minHeight: 0 }
+        : { gap: 0 }}
+      data-testid="workspace-tap-root"
+    >
       {/* Filter bar */}
       <div
         style={{
@@ -416,7 +422,12 @@ function WorkspaceTap({ wid, sessionId }) {
       <div
         ref={scrollRef}
         onScroll={onScroll}
-        style={{ overflowY: "auto", maxHeight: 520, minHeight: 120, padding: "6px 0" }}
+        // fillHeight (Studio Workspace Activity panel): grow to fill the column
+        // down to the bottom instead of the fixed 520px cap that left dead
+        // space below a short event list. Standalone/page usages keep the cap.
+        style={fillHeight
+          ? { overflowY: "auto", flex: 1, minHeight: 0, padding: "6px 0" }
+          : { overflowY: "auto", maxHeight: 520, minHeight: 120, padding: "6px 0" }}
         data-testid="tap-event-list"
       >
         {events.length === 0 && (

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -2561,3 +2561,56 @@ input, textarea, select { font: inherit; color: inherit; }
   text-transform: uppercase;
   letter-spacing: 0.4px;
 }
+
+/* ==========================================================================
+   Chat header cluster controls — green icon/compact buttons (Fix 2,
+   fix/studio-debug-rail-polish)
+   --------------------------------------------------------------------------
+   The /chats desktop header cluster's three controls (agent / schema /
+   compact) are green-accented: `.chat-cbtn` is a ~30px green-tinted circular
+   icon button (agent trigger + schema toggle); `.chat-cbtn-compact` extends
+   it into a rounded pill that carries the live token count. Green matches the
+   app accent (var(--green) / var(--green-dim), same as .pill-ended / the
+   composer Send accent). Height + baseline line up with the cluster's other
+   controls and the panel title.
+   ========================================================================== */
+.chat-cbtn {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 30px;
+  height: 30px;
+  padding: 0;
+  border-radius: 50%;
+  border: 1px solid var(--green-dim);
+  background: var(--green-dim);
+  color: var(--green);
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+}
+.chat-cbtn:hover:not(:disabled) {
+  background: var(--green);
+  border-color: var(--green);
+  color: #fff;
+}
+.chat-cbtn.active,
+.chat-cbtn[aria-pressed="true"] {
+  background: var(--green);
+  border-color: var(--green);
+  color: #fff;
+}
+.chat-cbtn:disabled {
+  opacity: 0.45;
+  cursor: not-allowed;
+}
+/* Compact carries text (the token count), so it's a rounded pill, not a
+   circle. */
+.chat-cbtn-compact {
+  width: auto;
+  border-radius: 999px;
+  gap: 5px;
+  padding: 0 11px;
+  font-size: 11px;
+  font-weight: 500;
+  white-space: nowrap;
+}


### PR DESCRIPTION
Two follow-ups on the studio debug/events rail (after #118).

## 1. Toggle affordance: << / >> on the rail, no bell
- Removed the header bell toggle added in #118 (disliked). The rail is now toggled from its own handle.
- The handle is a double chevron: **<<** at the top of the collapsed rail to expand it, **>>** in the open panel header to collapse it (new `chevrons-left`/`chevrons-right` icons). Also dropped the decorative bell from the panel header.
- The collapse state stays store-owned (from #118), so the width is state-driven and persisted; only the affordance changed.

## 2. Workspace Activity fills to the bottom
The event list was capped at `maxHeight: 520`, so on a tall sidebar it stopped halfway and left dead space below (which read as "reserved for User Interaction"). Added a `fillHeight` prop to `WorkspaceTap`: the Studio Workspace Activity panel passes it to drop the cap and let the list grow (`flex:1`) all the way down. Standalone/page usages (e.g. the /workspaces events panel) keep the original 520px cap.

## Tests
`tests/ui/` full suite: 1037 passed, 1 skipped. Updated the rail-toggle/header tests to the new model and added coverage for the double-chevron handle and the fillHeight fill.