### PR TITLE
fix(ui): studio theme unify + profile dropdown + events-rail discoverability + undefined CSS vars

### DIFF
--- a/tests/ui/test_css_var_integrity.py
+++ b/tests/ui/test_css_var_integrity.py
@@ -1,0 +1,81 @@
+"""CSS custom-property integrity.
+
+A recurring class of UI bugs: a component (or a CSS rule) uses `var(--foo)`
+where `--foo` is never defined, so it resolves to nothing — a transparent
+background, an unstyled surface, or a missing font. Real cases fixed:
+  - `--surface`   (profile menu dropdown → see-through, illegible)
+  - `--bg-0`      (agent tool-picker sticky header → rows bled through; also
+                   several code/panel backgrounds)
+  - `--surface-1` (triggers / api-tokens surfaces)
+  - `--mono`      (providers row → font var that never existed)
+
+These read as "muddled/illegible" or "can't scroll" to operators. This test
+fails if any `var(--NAME)` used across the UI has no definition, so the class
+can't come back.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+STYLES = UI / "styles.css"
+
+# Vars supplied at runtime rather than declared in styles.css: React inline
+# `style={{ "--x": ... }}` and JS `setProperty("--x", ...)`. Collected below so
+# the check stays zero-maintenance, but a couple are only ever written from
+# code the regexes below might miss — list those here.
+_RUNTIME_ALLOW: set[str] = set()
+
+
+def _jsx_files() -> list[Path]:
+    return sorted(UI.rglob("*.jsx"))
+
+
+def _defined_vars() -> set[str]:
+    defined: set[str] = set()
+    css = STYLES.read_text(encoding="utf-8")
+    # `--name:` declarations in styles.css
+    defined.update(re.findall(r"(--[a-z0-9-]+)\s*:", css))
+    # Runtime-provided vars: setProperty("--x", …) and inline style {"--x": …}
+    for f in _jsx_files() + [UI / "app.jsx"]:
+        src = f.read_text(encoding="utf-8")
+        defined.update(re.findall(r"""setProperty\(\s*['"](--[a-z0-9-]+)""", src))
+        defined.update(re.findall(r'"(--[a-z0-9-]+)"\s*:', src))
+    return defined | _RUNTIME_ALLOW
+
+
+def _used_vars() -> dict[str, list[str]]:
+    """name -> list of 'file:line' where var(--name) is used WITHOUT a fallback.
+
+    `var(--x, default)` is safe even when --x is undefined (it resolves to the
+    default), so only bare `var(--x)` usages can produce the transparent/unstyled
+    bug this test guards against.
+    """
+    used: dict[str, list[str]] = {}
+    files = _jsx_files() + [STYLES]
+    for f in files:
+        for i, line in enumerate(f.read_text(encoding="utf-8").splitlines(), 1):
+            for name in re.findall(r"var\(\s*(--[a-z0-9-]+)\s*\)", line):
+                used.setdefault(name, []).append(f"{f.relative_to(ROOT)}:{i}")
+    return used
+
+
+def test_no_undefined_css_vars_used() -> None:
+    defined = _defined_vars()
+    used = _used_vars()
+    undefined = {name: locs for name, name_locs in used.items()
+                 for locs in [name_locs] if name not in defined}
+    assert not undefined, (
+        "var(--NAME) used with no definition (transparent/unstyled bug):\n"
+        + "\n".join(f"  {n} @ {', '.join(locs[:5])}" for n, locs in sorted(undefined.items()))
+    )
+
+
+def test_specific_regressions_stay_fixed() -> None:
+    # The exact vars behind reported bugs must never reappear as `var(...)`.
+    blob = "\n".join(f.read_text(encoding="utf-8") for f in _jsx_files() + [STYLES])
+    for bad in ("var(--surface)", "var(--surface-1)", "var(--bg-0)", "var(--mono)"):
+        assert bad not in blob, f"{bad} is undefined and must not be used"

--- a/tests/ui/test_studio_debug_sidebar.py
+++ b/tests/ui/test_studio_debug_sidebar.py
@@ -393,7 +393,9 @@ def test_collapsed_rail_hides_bell_and_label_but_keeps_chevron_and_badge() -> No
 def test_collapsed_toggle_button_restyles_into_a_narrow_column() -> None:
     fn = _studio_activity_fn_src()
     assert 'flexDirection: collapsed ? "column" : "row"' in fn
-    assert 'height: collapsed ? "auto" : 34' in fn
+    # Collapsed the button fills the FULL 40px rail height so the entire strip is
+    # the click target (discoverability fix), not just a 64px cap at the top.
+    assert 'height: collapsed ? "100%" : 34' in fn
     assert 'padding: collapsed ? "10px 4px" : "0 12px"' in fn
 
 

--- a/tests/ui/test_studio_theme_dropdown_rail.py
+++ b/tests/ui/test_studio_theme_dropdown_rail.py
@@ -1,0 +1,185 @@
+"""Structural guards for three console UX fixes (branch
+fix/studio-theme-dropdown-rail):
+
+  1. The topbar user-menu dropdown paints on a REAL surface token
+     (var(--bg-1)) instead of the undefined var(--surface) — which resolved to
+     nothing, so the menu painted transparent and text overlapped the page.
+  2. Theme + density have a SINGLE owner: the global `tweaks` store
+     (foundation/tweaks.js), applied to <html> by app.jsx. The Studio no longer
+     keeps its own theme/density or stamps <html data-theme>/data-density — that
+     second owner reverted the theme on navigate and desynced the graph canvas'
+     <html data-theme> observer. The Studio toggles (⌘K palette) route through
+     setTweak instead.
+  3. The collapsed debug rail is an obviously-clickable button: the WHOLE 40px
+     strip is the click target with a theme-legible hover highlight and a
+     prominent << (chevrons-left) + vertical Debug label.
+
+Static-source checks only (no React rendering), matching the tests/ui suite
+convention (see test_studio_shell.py / test_studio_debug_sidebar.py).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+CHROME = UI / "components" / "chrome.jsx"
+STUDIO = UI / "components" / "studio.jsx"
+ACTIVITY = UI / "components" / "studio-activity.jsx"
+PALETTE = UI / "components" / "studio-palette.jsx"
+TERMINAL = UI / "components" / "studio-terminal.jsx"
+STYLES = UI / "styles.css"
+
+
+def _read(p: Path) -> str:
+    return p.read_text(encoding="utf-8")
+
+
+def _slice(src: str, start_marker: str, end_marker: str) -> str:
+    start = src.index(start_marker)
+    end = src.index(end_marker, start)
+    return src[start:end]
+
+
+# ---------------------------------------------------------------------------
+# Bug 1 — user-menu dropdown surface token
+# ---------------------------------------------------------------------------
+
+
+def test_user_menu_dropdown_uses_bg1_not_undefined_surface_var() -> None:
+    src = _read(CHROME)
+    # --surface is defined NOWHERE in styles.css, so the old value resolved to
+    # transparent. The dropdown must paint on a real token — the same var the
+    # Studio's own popovers (.st-ws-menu) use.
+    assert "var(--surface)" not in src, "dropdown must not reference the undefined --surface"
+    # The bg-1 background sits on the absolutely-positioned menu, just above the
+    # "Signed in as" label.
+    idx = src.index("Signed in as")
+    window = src[idx - 400:idx]
+    assert 'background: "var(--bg-1)"' in window
+
+
+def test_surface_token_is_not_defined_in_styles() -> None:
+    # The root cause: there is no --surface custom property to resolve against.
+    assert "--surface" not in _read(STYLES)
+
+
+# ---------------------------------------------------------------------------
+# Bug 2 — theme/density owned solely by the global tweaks store
+# ---------------------------------------------------------------------------
+
+
+def test_studio_does_not_stamp_html_theme_or_density_itself() -> None:
+    src = _read(STUDIO)
+    # app.jsx is the ONLY writer of <html data-theme>/data-density; the Studio
+    # no longer sets (or restores) them.
+    assert 'setAttribute("data-theme"' not in src
+    assert 'setAttribute("data-density"' not in src
+
+
+def test_studio_subscribes_to_global_tweaks() -> None:
+    src = _read(STUDIO)
+    assert "var [tweaks, setTweak] = window.useTweaks();" in src
+
+
+def test_studio_toggles_route_through_set_tweak() -> None:
+    src = _read(STUDIO)
+    assert 'setTweak("theme", tweaks.theme === "dark" ? "light" : "dark")' in src
+    assert 'setTweak("density", tweaks.density === "comfortable" ? "compact" : "comfortable")' in src
+    # The toggles keep their names + exports so studio-palette.jsx keeps working.
+    assert "toggleTheme: toggleTheme," in src
+    assert "toggleDensity: toggleDensity," in src
+
+
+def test_studio_root_does_not_hardcode_theme_or_density_attrs() -> None:
+    src = _read(STUDIO)
+    # Tokens resolve from <html data-theme>/data-density (app.jsx); there are 0
+    # scoped .st-*[data-theme] selectors, so the st-root needs no attrs.
+    assert "data-theme={s.theme}" not in src
+    assert "data-density={s.density}" not in src
+
+
+def test_studio_default_state_drops_theme_and_density() -> None:
+    default_state = _slice(_read(STUDIO), "function ST_defaultState(", "function useStudioState(")
+    assert 'theme: "dark"' not in default_state
+    assert 'density: "comfortable"' not in default_state
+
+
+def test_studio_persist_keys_drop_theme_and_density() -> None:
+    persist = _slice(_read(STUDIO), "var ST_PERSIST_KEYS = [", "];")
+    assert '"theme"' not in persist
+    assert '"density"' not in persist
+
+
+def test_palette_theme_and_density_commands_still_call_studio_toggles() -> None:
+    src = _read(PALETTE)
+    assert "studio.toggleTheme();" in src
+    assert "studio.toggleDensity();" in src
+
+
+def test_terminal_live_theme_trigger_reads_global_tweak_not_studio_state() -> None:
+    src = _read(TERMINAL)
+    # The per-terminal repaint effect keys off a `theme` change signal; that
+    # signal is now the global tweak, not the removed studio state.theme.
+    assert "theme={s.theme}" not in src
+    assert "var theme = window.useTweaks()[0].theme;" in src
+    assert "theme={theme}" in src
+
+
+# ---------------------------------------------------------------------------
+# Bug 3 — collapsed debug rail reads as an obvious button
+# ---------------------------------------------------------------------------
+
+
+def _activity_fn() -> str:
+    return _slice(_read(ACTIVITY), "function StudioActivity(", "window.StudioActivity = StudioActivity;")
+
+
+def test_collapsed_rail_whole_strip_is_the_click_target() -> None:
+    fn = _activity_fn()
+    # Full-height button + pointer cursor => the entire 40px strip is clickable,
+    # not just a small cap at the top.
+    assert 'height: collapsed ? "100%" : 34' in fn
+    assert 'cursor: "pointer"' in fn
+    # Prominent << (chevrons-left) as the collapsed expand indicator.
+    assert 'Icon name={collapsed ? "chevrons-left" : "chevrons-right"}' in fn
+
+
+def test_collapsed_rail_has_a_hover_highlight_via_css_class() -> None:
+    fn = _activity_fn()
+    # The button carries the st-debug-toggle class (+ is-rail when collapsed) so
+    # the hover fill lives in CSS and can win over the base background.
+    assert 'className={"st-debug-toggle" + (collapsed ? " is-rail" : "")}' in fn
+    css = _read(STYLES)
+    assert ".st-debug-toggle:hover" in css
+    assert ".st-debug-toggle.is-rail:hover" in css
+    # No inline background on the button — an inline background would out-specify
+    # the :hover rule and kill the affordance.
+    assert 'background: "transparent"' not in fn
+
+
+def test_collapsed_rail_label_uses_a_legible_token() -> None:
+    fn = _activity_fn()
+    # The vertical Debug label must use a mid/high-contrast token legible in both
+    # themes (--text-2), not a near-background token.
+    label = _slice(fn, 'data-testid="debug-sidebar-rail-label"', "Debug")
+    assert 'color: "var(--text-2)"' in label
+    assert 'color: "var(--text-3)"' not in label
+
+
+# ---------------------------------------------------------------------------
+# The whole bundle still transpiles with all three edits.
+# ---------------------------------------------------------------------------
+
+
+def test_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    build_jsx_bundle.cache_clear()
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/studio.jsx === */" in text
+    assert "/* === components/studio-activity.jsx === */" in text
+    assert "/* === components/chrome.jsx === */" in text

--- a/ui/components/agents.jsx
+++ b/ui/components/agents.jsx
@@ -735,7 +735,7 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
                         key={`h-${entry.id}-p${toolPage}`}
                         style={{
                           display: "flex", alignItems: "center", gap: 8,
-                          padding: "8px 10px", background: "var(--bg-0)",
+                          padding: "8px 10px", background: "var(--bg-2)",
                           borderTop: lastToolsetId === null ? "none" : "1px solid var(--border)",
                           borderBottom: "1px solid var(--border)",
                           position: "sticky", top: 0, zIndex: 1,
@@ -769,7 +769,7 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
                         display: "flex", alignItems: "flex-start", gap: 8,
                         padding: "6px 10px 6px 28px", cursor: "pointer",
                         borderTop: "1px solid var(--bg-1)",
-                        background: checked ? "var(--bg-0)" : "transparent",
+                        background: checked ? "var(--bg-2)" : "transparent",
                       }}
                       data-testid={`agent-tool-${t.scoped_id}`}
                     >

--- a/ui/components/api_tokens.jsx
+++ b/ui/components/api_tokens.jsx
@@ -508,7 +508,7 @@ function AT_PlaintextOneTimeDialog({ token, onClose }) {
               padding: "10px 12px",
               border: "1px solid var(--border)",
               borderRadius: 4,
-              background: "var(--surface-1)",
+              background: "var(--bg-1)",
               fontSize: 12,
               userSelect: "text",
               whiteSpace: "pre-wrap",

--- a/ui/components/chat/transcript.jsx
+++ b/ui/components/chat/transcript.jsx
@@ -275,7 +275,7 @@ function CT_ExpandableToolRow({
         <pre style={{
           marginTop: 6,
           padding: "10px 12px",
-          background: "var(--bg-0)",
+          background: "var(--bg)",
           border: "1px solid var(--border)",
           borderRadius: 6,
           fontSize: 11.5,
@@ -776,7 +776,7 @@ function CT_FileChip({ part, mime, src }) {
     <div style={{
       display: "inline-flex", alignItems: "center", gap: 6,
       padding: "4px 8px", border: "1px solid var(--border)",
-      borderRadius: 4, background: "var(--bg-0)",
+      borderRadius: 4, background: "var(--bg)",
     }}>
       <Icon name="file" size={12} className="muted" />
       <span className="mono text-sm">{filename}</span>

--- a/ui/components/chats.jsx
+++ b/ui/components/chats.jsx
@@ -832,7 +832,7 @@ function CT_AttachmentChip({ attachment, onRemove }) {
         padding: "4px 6px 4px 4px",
         border: "1px solid var(--border)",
         borderRadius: 6,
-        background: "var(--bg-0)",
+        background: "var(--bg)",
       }}
     >
       {attachment.kind === "image" && attachment.preview ? (

--- a/ui/components/chrome.jsx
+++ b/ui/components/chrome.jsx
@@ -379,7 +379,7 @@ function UserMenu() {
         <div
           style={{
             position: "absolute", right: 0, top: "calc(100% + 6px)",
-            background: "var(--surface)", border: "1px solid var(--border)",
+            background: "var(--bg-1)", border: "1px solid var(--border)",
             borderRadius: 6, padding: 8, minWidth: 160, zIndex: 100,
             boxShadow: "0 4px 12px rgba(0,0,0,0.15)",
           }}

--- a/ui/components/harness_outbound_builder.jsx
+++ b/ui/components/harness_outbound_builder.jsx
@@ -845,7 +845,7 @@ function HOB_TemplatizeModal({ target, onClose, onAdd }) {
       </div>
       <div className="field">
         <label className="field-label">Default value</label>
-        <div className="mono text-sm" style={{ background: "var(--bg-0)", padding: "6px 8px", border: "1px solid var(--border)", borderRadius: 4, fontSize: 11 }}>
+        <div className="mono text-sm" style={{ background: "var(--bg)", padding: "6px 8px", border: "1px solid var(--border)", borderRadius: 4, fontSize: 11 }}>
           {JSON.stringify(target.default)}
         </div>
       </div>

--- a/ui/components/harnesses.jsx
+++ b/ui/components/harnesses.jsx
@@ -911,7 +911,7 @@ function HR_ManagedObjects({ harnessId, slug }) {
             {filtered.length > 0 && (
               <div style={{ display: "flex", flexWrap: "wrap", gap: 4 }}>
                 {filtered.map((row) => (
-                  <span key={row.id} className="mono" style={{ fontSize: 11, color: "var(--text-2)", background: "var(--bg-0)", border: "1px solid var(--border)", borderRadius: 4, padding: "2px 6px" }}>
+                  <span key={row.id} className="mono" style={{ fontSize: 11, color: "var(--text-2)", background: "var(--bg)", border: "1px solid var(--border)", borderRadius: 4, padding: "2px 6px" }}>
                     {row.id}
                   </span>
                 ))}

--- a/ui/components/providers.jsx
+++ b/ui/components/providers.jsx
@@ -515,7 +515,7 @@ function OpenRouterModelPicker({ discovered, selected, onSelect, onDeselect }) {
             >
               <input type="checkbox" checked={isSel} readOnly />
               <div>
-                <div style={{ fontFamily: "var(--mono)" }}>{row.id}</div>
+                <div className="mono">{row.id}</div>
                 <div className="muted text-sm">{row.name}</div>
               </div>
               <div className="muted text-sm">{row.context_length ?? "?"} ctx</div>

--- a/ui/components/session-frame.jsx
+++ b/ui/components/session-frame.jsx
@@ -300,7 +300,7 @@ function _SLS_ExpandableRow({ icon, iconColor, borderColor, name, separator, pre
       {open && (
         <pre style={{
           marginTop: 6, padding: "10px 12px",
-          background: "var(--bg-0)", border: "1px solid var(--border)",
+          background: "var(--bg)", border: "1px solid var(--border)",
           borderRadius: 6, fontSize: 11.5, lineHeight: 1.5,
           fontFamily: "IBM Plex Mono, monospace", color: "var(--text-2)",
           whiteSpace: "pre-wrap", wordBreak: "break-all",

--- a/ui/components/studio-activity.jsx
+++ b/ui/components/studio-activity.jsx
@@ -750,24 +750,31 @@ function StudioActivity({ wid, studio }) {
       <button
         type="button"
         data-testid="debug-sidebar-toggle"
+        // st-debug-toggle carries the base (transparent) background + the hover
+        // highlight in CSS (styles.css) so the WHOLE collapsed strip reads as an
+        // obviously-clickable button — an inline background would out-specify the
+        // :hover rule. `is-rail` scopes the stronger collapsed-rail hover fill.
+        className={"st-debug-toggle" + (collapsed ? " is-rail" : "")}
         aria-expanded={collapsed ? "false" : "true"}
         aria-controls="debug-sidebar-body"
         aria-label={collapsed ? "Expand debug panel" : "Collapse debug panel"}
         title={collapsed ? "Expand debug panel (Action Required + Activity)" : "Collapse debug panel"}
         onClick={toggle}
         style={{
-          flexShrink: 0,
+          // Collapsed: fill the full 40px rail height so the ENTIRE strip is the
+          // click target (not just a 64px cap at the top), with the chevron +
+          // vertical label pinned to the top.
+          flex: collapsed ? "1 1 auto" : "0 0 auto",
           display: "flex",
           flexDirection: collapsed ? "column" : "row",
           alignItems: "center",
-          justifyContent: "center",
+          justifyContent: collapsed ? "flex-start" : "center",
           gap: collapsed ? 6 : 8,
-          height: collapsed ? "auto" : 34,
+          height: collapsed ? "100%" : 34,
           minHeight: collapsed ? 64 : "auto",
           padding: collapsed ? "10px 4px" : "0 12px",
           border: "none",
           borderBottom: collapsed ? "none" : "1px solid var(--border)",
-          background: "transparent",
           color: "var(--text-2)",
           cursor: "pointer",
           fontSize: 10.5,
@@ -781,11 +788,12 @@ function StudioActivity({ wid, studio }) {
         {expanded && <span style={{ flex: 1, textAlign: "left" }}>Debug</span>}
         {/* Collapsed: a vertical "Debug" label so the thin rail is legibly the
             expand handle. The chevron alone was too subtle — operators couldn't
-            tell the strip was clickable (or that it was the debug panel). */}
+            tell the strip was clickable (or that it was the debug panel). Uses
+            --text-2 (not a near-background token) so it's legible in both themes. */}
         {collapsed && (
           <span
             data-testid="debug-sidebar-rail-label"
-            style={{ writingMode: "vertical-rl", letterSpacing: "0.12em", color: "var(--text-3)" }}
+            style={{ writingMode: "vertical-rl", letterSpacing: "0.12em", color: "var(--text-2)" }}
           >
             Debug
           </span>

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -1090,7 +1090,7 @@ function ST_InlineYields({ wid, sid, pending, messages, pushToast }) {
                     setDraft(item.tool_call_id || String(idx), "");
                   }}
                   style={{
-                    flex: 1, background: "var(--bg-0)", border: "1px solid var(--border)",
+                    flex: 1, background: "var(--bg)", border: "1px solid var(--border)",
                     borderRadius: 6, padding: "5px 10px", fontSize: 12.5, color: "var(--text)",
                     fontFamily: "inherit", outline: "none",
                   }}

--- a/ui/components/studio-terminal.jsx
+++ b/ui/components/studio-terminal.jsx
@@ -272,6 +272,11 @@ function ST_TerminalInstance({ wid, tab, active, theme, onState }) {
 
 function TerminalPanel({ wid, studio }) {
   var s = studio.state;
+  // Theme is a GLOBAL tweak (foundation/tweaks.js), not studio state — read it
+  // reactively so a dark/light toggle re-triggers each open terminal's repaint
+  // effect (ST_xtermTheme reads the live <html> tokens; this prop is just the
+  // change signal).
+  var theme = window.useTweaks()[0].theme;
   var termTabs = s.termTabs && s.termTabs.length ? s.termTabs : [];
   var activeTermId = s.activeTermId;
   var [connStates, setConnStates] = React.useState({});
@@ -391,7 +396,7 @@ function TerminalPanel({ wid, studio }) {
               wid={wid}
               tab={tab}
               active={tab.id === activeTermId}
-              theme={s.theme}
+              theme={theme}
               onState={handleState}
             />
           );

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -32,8 +32,6 @@ var ST_PERSIST_KEYS = [
   "debugOpen",
   "activeTermId",
   "termTabs",
-  "density",
-  "theme",
   "activeChips",
   "leftWidth",
   "rightWidth",
@@ -160,9 +158,11 @@ function ST_syncUrl(activeTabId) {
 
 function ST_defaultState() {
   return {
-    // Layout / appearance
-    theme: "dark",
-    density: "comfortable",
+    // Layout / appearance. NOTE: theme + density are NOT owned here — they are
+    // GLOBAL tweaks (foundation/tweaks.js) applied to <html> by app.jsx. The
+    // Studio used to keep its own theme/density (and stamp <html data-theme>),
+    // which desynced the graph canvas' <html data-theme> observer and reverted
+    // the app theme on navigate; the toggles now route through setTweak instead.
     leftWidth: 248,
     rightWidth: 332,
     // Left sidebar
@@ -211,6 +211,12 @@ function useStudioState(wid, initialOpen) {
   var [state, setState] = React.useState(function () {
     return ST_applyUrlTab(Object.assign(ST_defaultState(), ST_loadPersisted(wid)), initialOpen);
   });
+
+  // Theme + density are owned GLOBALLY by tweaks (foundation/tweaks.js) and
+  // applied to <html data-theme>/<html data-density> by app.jsx. A custom hook
+  // may call hooks, so we subscribe here to drive the appearance toggles below
+  // (⌘K palette + the app topbar ThemeToggle share this one setTweak path).
+  var [tweaks, setTweak] = window.useTweaks();
 
   // New-session form visibility, lifted out of the sidebar so BOTH the sidebar
   // "+" button and the ⌘K palette's "New session" action can open it. Kept as
@@ -270,22 +276,6 @@ function useStudioState(wid, initialOpen) {
       window.removeEventListener("popstate", onUrlChange);
     };
   }, []);
-
-  // Apply theme/density attrs to <html> so the design tokens resolve. The
-  // Studio root <div> also carries them (see render) for scoped reads.
-  React.useEffect(function () {
-    var html = document.documentElement;
-    var prevTheme = html.getAttribute("data-theme");
-    var prevDensity = html.getAttribute("data-density");
-    html.setAttribute("data-theme", state.theme);
-    html.setAttribute("data-density", state.density);
-    return function () {
-      // Restore prior attrs on unmount so leaving the Studio doesn't strand
-      // the rest of the console in Studio's density.
-      if (prevTheme) html.setAttribute("data-theme", prevTheme);
-      if (prevDensity) html.setAttribute("data-density", prevDensity);
-    };
-  }, [state.theme, state.density]);
 
   // ---- tab management (consumed by B2/B3) ----
   var openTab = React.useCallback(function (tab) {
@@ -385,15 +375,17 @@ function useStudioState(wid, initialOpen) {
     });
   }, []);
 
-  // ---- appearance ----
+  // ---- appearance (global tweaks — see the useTweaks subscription above) ----
+  // These flip the GLOBAL tweak; app.jsx then stamps <html data-theme>/
+  // data-density once, and the graph canvas' <html data-theme> MutationObserver
+  // (graph-canvas.jsx) restyles for free. The Studio no longer stamps <html>
+  // itself, so there is no second owner to desync or revert on navigate.
   var toggleTheme = React.useCallback(function () {
-    setState(function (s) { return Object.assign({}, s, { theme: s.theme === "dark" ? "light" : "dark" }); });
-  }, []);
+    setTweak("theme", tweaks.theme === "dark" ? "light" : "dark");
+  }, [tweaks.theme, setTweak]);
   var toggleDensity = React.useCallback(function () {
-    setState(function (s) {
-      return Object.assign({}, s, { density: s.density === "comfortable" ? "compact" : "comfortable" });
-    });
-  }, []);
+    setTweak("density", tweaks.density === "comfortable" ? "compact" : "comfortable");
+  }, [tweaks.density, setTweak]);
 
   // ---- terminal (TerminalPanel mounts in the center column when open) ----
   var toggleTerminal = React.useCallback(function () {
@@ -782,8 +774,6 @@ function Studio({ wid, pushToast, initialOpen }) {
   return (
     <div
       className="st-root"
-      data-theme={s.theme}
-      data-density={s.density}
       data-testid="studio-root"
       // --st-right-w collapses to the 40px rail directly from state (not only
       // via the :has(.is-collapsed) CSS) so the debug rail width is bulletproof

--- a/ui/components/triggers.jsx
+++ b/ui/components/triggers.jsx
@@ -711,7 +711,7 @@ function TR_CreateTriggerDialog({ onClose, onCreated }) {
           <div className="field">
             <div
               className="panel"
-              style={{ background: "var(--surface-1)", padding: "10px 14px", borderRadius: 4 }}
+              style={{ background: "var(--bg-1)", padding: "10px 14px", borderRadius: 4 }}
             >
               <div style={{ display: "flex", alignItems: "center", gap: 8 }}>
                 <Icon name="info" size={13} />
@@ -1851,7 +1851,7 @@ function TR_SubscriptionDialog({ triggerId, mode, initial, onClose, onSaved }) {
             {isEdit && <span className="hint"> locked — config is immutable</span>}
           </label>
           {isEdit ? (
-            <div className="mono" style={{ padding: "6px 8px", border: "1px solid var(--border)", borderRadius: 4, background: "var(--surface-1)" }}>
+            <div className="mono" style={{ padding: "6px 8px", border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-1)" }}>
               {kind}
             </div>
           ) : (
@@ -1992,7 +1992,7 @@ function TR_SubscriptionDialog({ triggerId, mode, initial, onClose, onSaved }) {
         {isEdit && (
           <div className="field">
             <label className="field-label">Target <span className="hint">locked</span></label>
-            <div className="mono" style={{ padding: "6px 8px", border: "1px solid var(--border)", borderRadius: 4, background: "var(--surface-1)" }}>
+            <div className="mono" style={{ padding: "6px 8px", border: "1px solid var(--border)", borderRadius: 4, background: "var(--bg-1)" }}>
               <TR_SubTargetLabel sub={initial} />
             </div>
           </div>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -5,6 +5,11 @@
   --accent-c: 0.18;
   --accent-l: 0.85;
 
+  /* Monospace stack — theme-independent. Consumers use var(--font-mono,
+     monospace); defining it here upgrades them from the generic fallback to
+     IBM Plex Mono (matching the .mono class). */
+  --font-mono: "IBM Plex Mono", ui-monospace, monospace;
+
   /* Studio type / spacing / radius scale (FC2). Theme-independent, so declared
      once on the base :root. Names the recurring magic numbers the FE port-map
      flagged (≈10.5/11.5/12.5px type; 4/8/12/14px spacing; 6/9/12px radii) as
@@ -1582,7 +1587,7 @@ input, textarea, select { font: inherit; color: inherit; }
   padding: 4px 10px;
   border-left: 3px solid var(--border-strong);
   color: var(--text-2);
-  background: var(--bg-0);
+  background: var(--bg);
   border-radius: 0 4px 4px 0;
 }
 .md-body .md-hr {
@@ -1593,7 +1598,7 @@ input, textarea, select { font: inherit; color: inherit; }
 .md-body .md-code {
   font-family: "IBM Plex Mono", ui-monospace, monospace;
   font-size: 12px;
-  background: var(--bg-0);
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 3px;
   padding: 1px 5px;
@@ -1606,7 +1611,7 @@ input, textarea, select { font: inherit; color: inherit; }
 .md-body .md-pre {
   margin: 0 0 8px;
   padding: 10px 12px;
-  background: var(--bg-0);
+  background: var(--bg);
   border: 1px solid var(--border);
   border-radius: 6px;
   overflow-x: auto;

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -2614,3 +2614,16 @@ input, textarea, select { font: inherit; color: inherit; }
   font-weight: 500;
   white-space: nowrap;
 }
+
+/* Studio debug-rail expand handle (studio-activity.jsx). The base background
+   lives here (not inline) so the :hover highlight can win — an inline
+   `background` would out-specify a stylesheet :hover. Collapsed (`is-rail`) the
+   whole 40px strip is the button, so it needs an unmistakable hover fill; the
+   pointer cursor is set inline. Tokens (--bg-hover / --bg-2) are theme-aware,
+   so the affordance is legible in both light and dark. */
+.st-debug-toggle {
+  background: transparent;
+  transition: background 0.12s ease;
+}
+.st-debug-toggle:hover { background: var(--bg-hover); }
+.st-debug-toggle.is-rail:hover { background: var(--bg-2); }


### PR DESCRIPTION
Four console bug fixes from real-usage feedback.

## 1. Profile menu dropdown was transparent/illegible
The user menu used `background: var(--surface)`, but `--surface` is defined nowhere → the dropdown painted see-through and text overlapped the page. Now uses `var(--bg-1)` (the token other popovers use).

## 2. Dark-mode toggle broken in Studio (graph didn't restyle; theme reverted on navigate)
Studio kept its own `s.theme`/`s.density` and stamped `<html data-theme>`, then **restored the previous value on unmount** — fighting the global `tweaks` theme (`app.jsx` owns `<html data-theme>`). That desynced the graph canvas' `data-theme` observer (graph looked stuck until refresh) and reverted the theme when leaving Studio. Now the global `tweaks` store is the single owner: studio's toggles route through `setTweak`, studio no longer writes `<html data-theme>`, and st-root drops its `data-theme={s.theme}` (0 scoped selectors depend on it). The graph's existing `<html data-theme>` MutationObserver restyles the canvas on toggle with no refresh.

## 3. "Still can't open the workspace events view"
The collapse toggle was wired correctly but the only affordance was a thin 40px `<<` at the screen edge. The whole collapsed rail is now an obvious click target (full-height button, pointer cursor, hover highlight, prominent `<<` + legible label).

## 4. Tool search couldn't be scrolled / overlapped when creating agents
The tool-picker sticky headers used `background: var(--bg-0)` — **also undefined** → transparent headers that scrolling rows bled through (read as "can't scroll"). This was a whole class: swept every undefined CSS var (`--bg-0`, `--surface-1`, `--mono`) across the console, mapped them to real tokens (or defined `--font-mono`), and added `tests/ui/test_css_var_integrity.py` — a fallback-aware guard that fails if any bare `var(--x)` has no definition, so this class can't recur.

## Tests
`tests/ui/` full suite: 1065 passed, 1 skipped.