### PR TITLE
fix(ui): open the workspace-events panel from a prominent header toggle (holistic sidebar fix)

### DIFF
--- a/tests/ui/test_studio_debug_sidebar.py
+++ b/tests/ui/test_studio_debug_sidebar.py
@@ -409,14 +409,16 @@ def test_collapsed_rail_shows_a_vertical_debug_label_as_the_expand_handle() -> N
     assert 'writingMode: "vertical-rl"' in fn
 
 
-def test_st_body_grid_shrinks_the_right_track_when_the_rail_is_collapsed() -> None:
+def test_closed_rail_collapses_to_zero_width() -> None:
+    # The closed rail is 0-width — width is driven by --st-right-w on .st-root
+    # (studio.jsx sets it to 0 when s.debugOpen is false), NOT a 40px edge rail.
+    # The :has(.is-collapsed) block also hides the resize handle + column border
+    # and zeroes the rail so nothing lingers at the screen edge (the panel is
+    # opened from the header events toggle).
     css = _styles_src()
     assert ".st-body:has(.studio-activity-root.is-collapsed)" in css
-    assert (
-        "grid-template-columns: var(--st-left-w, 248px) 5px minmax(0, 1fr) 5px 40px;"
-        in css
-    )
-    assert '.studio-activity-root.is-collapsed { width: 40px; min-width: 40px; }' in css
+    assert '.studio-activity-root.is-collapsed { width: 0; min-width: 0; overflow: hidden; }' in css
+    assert ".st-body:has(.studio-activity-root.is-collapsed) .st-col-right" in css
 
 
 def test_activity_root_actually_carries_the_class_the_collapse_css_targets() -> None:

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -49,27 +49,33 @@ def test_studio_file_exists_and_exports() -> None:
 
 
 def test_debug_rail_open_state_lives_in_the_studio_store() -> None:
-    # The right debug/activity rail's open state is store-owned (persisted) so
-    # the rail's own << handle and the state-driven column width share ONE
-    # source of truth (StudioActivity's old internal useState left the width and
-    # the toggle out of sync, and nothing outside the rail could reach it).
+    # The right events/debug rail's open state is store-owned (persisted) so the
+    # header toggle and the state-driven column width share ONE source of truth.
     src = _studio_src()
     assert '"debugOpen",' in src                     # persisted across reloads
-    assert "debugOpen: false," in src                # default collapsed
+    assert "debugOpen: false," in src                # default closed
     assert "debugOpen: !s.debugOpen" in src          # toggleDebug callback
     assert "toggleDebug: toggleDebug," in src        # exposed on the store
-    # Column width is driven directly from state (bulletproof — not solely via
-    # the :has(.is-collapsed) CSS): 40px rail when closed, rightWidth when open.
-    assert '"--st-right-w": (s.debugOpen ? s.rightWidth : 40) + "px"' in src
+    # Column width is a clean binary driven from state: 0 (fully hidden) when
+    # closed, rightWidth when open — opened from the header events toggle.
+    assert '"--st-right-w": (s.debugOpen ? s.rightWidth : 0) + "px"' in src
 
 
-def test_no_header_debug_toggle_the_rail_owns_it() -> None:
-    # Per user preference the events panel is opened from the rail's own << handle
-    # (studio-activity.jsx), NOT a header button — the earlier header bell was
-    # removed. Guard against re-introducing header debug wiring.
+def test_events_panel_opened_from_a_prominent_header_toggle() -> None:
+    # The rail-edge affordance failed operators repeatedly (a thin strip at the
+    # extreme screen edge — three iterations, none openable). The events panel is
+    # now opened/closed from a prominent, always-visible HEADER control — the same
+    # proven pattern as the terminal toggle beside it — using a panel icon (not a
+    # bell, per earlier feedback). This is the primary control.
     src = _studio_src()
-    assert 'data-testid="studio-debug-toggle"' not in src
-    assert "onToggleDebug" not in src
+    assert 'data-testid="studio-debug-toggle"' in src
+    assert "onClick={onToggleDebug}" in src
+    assert 'debugOpen ? " is-active"' in src
+    assert "desktop-only" in src
+    assert 'name="panel-right"' in src
+    # Wired from the store through the header props.
+    assert "onToggleDebug={studio.toggleDebug}" in src
+    assert "debugOpen={s.debugOpen}" in src
 
 
 def test_studio_shell_root_and_header_testids() -> None:

--- a/tests/ui_e2e/_studio_helpers.py
+++ b/tests/ui_e2e/_studio_helpers.py
@@ -174,22 +174,23 @@ def open_workspace_settings(
 
 
 def expand_debug_sidebar(page: Page, *, timeout: int = 10_000) -> None:
-    """Expand the Studio's right-sidebar debug panel.
+    """Expand the Studio's right-sidebar workspace-events panel.
 
-    ``StudioActivity`` (studio-activity.jsx) starts COLLAPSED by default
-    (``collapsed = React.useState(true)``) so an operator who isn't
-    actively debugging doesn't lose screen real estate — the
-    ``ActionRequired`` list (``action-item`` / ``action-required-count`` /
-    approval + ask_user controls) and ``WorkspaceActivity`` feed only
-    become VISIBLE once ``debug-sidebar-toggle`` is clicked (it flips the
-    ``debug-sidebar-body`` wrapper's ``display``; both stay mounted so
-    their poll timers never reset). Any test that asserts on content
-    inside that body must call this first — right after ``open_studio`` /
+    The panel (``ActionRequired`` list — ``action-item`` /
+    ``action-required-count`` / approval + ask_user controls — and the
+    ``WorkspaceActivity`` feed) starts CLOSED by default (``debugOpen: false``);
+    the right column is 0-width until opened. It is opened from the prominent
+    ``studio-debug-toggle`` button in the studio HEADER (the same show/hide
+    pattern as the terminal toggle — the earlier edge-rail affordance proved
+    unclickable). Opening flips ``debugOpen`` so the column expands and the
+    ``debug-sidebar-body`` becomes visible (both children stay mounted so their
+    poll timers never reset). Any test that asserts on content inside that body
+    must call this first — right after ``open_studio`` /
     ``open_session_in_studio`` / ``open_session_via_sidebar``.
     """
-    toggle = page.locator("[data-testid='debug-sidebar-toggle']")
+    toggle = page.locator("[data-testid='studio-debug-toggle']")
     expect(toggle).to_be_visible(timeout=timeout)
-    if toggle.get_attribute("aria-expanded") != "true":
+    if toggle.get_attribute("aria-pressed") != "true":
         toggle.click()
     expect(page.locator("[data-testid='debug-sidebar-body']")).to_be_visible(timeout=timeout)
 

--- a/ui/components/shared.jsx
+++ b/ui/components/shared.jsx
@@ -41,6 +41,7 @@ const Icon = ({ name, size = 14, ...rest }) => {
     case "warn-circle": return <svg {...props}><circle cx="12" cy="12" r="9" /><path d="M12 7v6M12 16v.5" /></svg>;
     case "command": return <svg {...props}><path d="M9 6V3a3 3 0 110 6H3v0a3 3 0 116 0v12a3 3 0 11-6 0v0h6m6-12v-3a3 3 0 116 0 3 3 0 01-3 3h-3m0 0v12a3 3 0 113 3 3 3 0 01-3-3v-3" /></svg>;
     case "panel-left": return <svg {...props}><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M9 4v16" /></svg>;
+    case "panel-right": return <svg {...props}><rect x="3" y="4" width="18" height="16" rx="2" /><path d="M15 4v16" /></svg>;
     case "settings": return <svg {...props}><circle cx="12" cy="12" r="3" /><path d="M19.4 15a1.7 1.7 0 00.3 1.8l.1.1a2 2 0 01-2.8 2.8l-.1-.1a1.7 1.7 0 00-1.8-.3 1.7 1.7 0 00-1 1.5V21a2 2 0 11-4 0v-.1a1.7 1.7 0 00-1.1-1.5 1.7 1.7 0 00-1.8.3l-.1.1a2 2 0 11-2.8-2.8l.1-.1a1.7 1.7 0 00.3-1.8 1.7 1.7 0 00-1.5-1H3a2 2 0 110-4h.1a1.7 1.7 0 001.5-1.1 1.7 1.7 0 00-.3-1.8l-.1-.1a2 2 0 112.8-2.8l.1.1a1.7 1.7 0 001.8.3H9a1.7 1.7 0 001-1.5V3a2 2 0 114 0v.1a1.7 1.7 0 001 1.5 1.7 1.7 0 001.8-.3l.1-.1a2 2 0 112.8 2.8l-.1.1a1.7 1.7 0 00-.3 1.8V9a1.7 1.7 0 001.5 1H21a2 2 0 110 4h-.1a1.7 1.7 0 00-1.5 1z" /></svg>;
     case "trash": return <svg {...props}><path d="M3 6h18M8 6V4a1 1 0 011-1h6a1 1 0 011 1v2M6 6l1 14a2 2 0 002 2h6a2 2 0 002-2l1-14" /></svg>;
     case "edit": return <svg {...props}><path d="M11 4H4a2 2 0 00-2 2v14a2 2 0 002 2h14a2 2 0 002-2v-7" /><path d="M18.5 2.5a2.12 2.12 0 013 3L12 15l-4 1 1-4 9.5-9.5z" /></svg>;

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -484,7 +484,7 @@ function useStudioState(wid, initialOpen) {
 // collapse to a single document there.
 // ---------------------------------------------------------------------------
 
-function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, onToggleLeftPanel, onToggleRightPanel }) {
+function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, debugOpen, onToggleDebug, onToggleLeftPanel, onToggleRightPanel }) {
   var { useResource, apiFetch } = window.primerApi;
   var [menuOpen, setMenuOpen] = React.useState(false);
   // Workspace Settings overlay — restores the orphaned WorkspaceDetail tabs
@@ -612,6 +612,24 @@ function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, term
         onClick={onToggleTerminal}
       >
         <Icon name="code" size={15} />
+      </button>
+
+      {/* Desktop Workspace-events toggle. The right rail (Action Required +
+          Workspace Activity) is opened/closed from HERE — a prominent, always-
+          visible header control, the same proven pattern as the terminal toggle
+          beside it. Earlier attempts put the only affordance on the collapsed
+          rail itself (a thin strip at the screen edge); operators repeatedly
+          could not open it, so the primary control lives in the header. Uses a
+          panel icon (not a bell — per earlier feedback). */}
+      <button
+        className={"st-hbtn touch-target desktop-only" + (debugOpen ? " is-active" : "")}
+        data-testid="studio-debug-toggle"
+        title="Workspace events (Action Required + Activity)"
+        aria-label="Toggle workspace events panel"
+        aria-pressed={debugOpen ? "true" : "false"}
+        onClick={onToggleDebug}
+      >
+        <Icon name="panel-right" size={15} />
       </button>
 
       {/* Mobile-only panel-drawer toggle (right: Action Required + Activity). */}
@@ -778,7 +796,9 @@ function Studio({ wid, pushToast, initialOpen }) {
       // --st-right-w collapses to the 40px rail directly from state (not only
       // via the :has(.is-collapsed) CSS) so the debug rail width is bulletproof
       // regardless of :has() support, and the header Debug toggle controls it.
-      style={{ "--st-left-w": s.leftWidth + "px", "--st-right-w": (s.debugOpen ? s.rightWidth : 40) + "px", "--st-term-h": s.terminalHeight + "px" }}
+      // Right rail is a clean binary: full width when open, 0 (fully hidden)
+      // when closed — opened from the header toggle, not a thin edge rail.
+      style={{ "--st-left-w": s.leftWidth + "px", "--st-right-w": (s.debugOpen ? s.rightWidth : 0) + "px", "--st-term-h": s.terminalHeight + "px" }}
     >
       <StudioHeader
         wid={wid}
@@ -787,6 +807,8 @@ function Studio({ wid, pushToast, initialOpen }) {
         onSelectWorkspace={selectWorkspace}
         terminalOpen={s.terminalOpen}
         onToggleTerminal={studio.toggleTerminal}
+        debugOpen={s.debugOpen}
+        onToggleDebug={studio.toggleDebug}
         onToggleLeftPanel={function () { setRightPanelOpen(false); setLeftPanelOpen(function (o) { return !o; }); }}
         onToggleRightPanel={function () { setLeftPanelOpen(false); setRightPanelOpen(function (o) { return !o; }); }}
       />

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -283,13 +283,17 @@
    body's grid-template-columns even though the drawer itself is
    invisible there. */
 @media (min-width: 640px) {
-  .st-body:has(.studio-activity-root.is-collapsed) {
-    grid-template-columns: var(--st-left-w, 248px) 5px minmax(0, 1fr) 5px 40px;
-  }
+  /* Closed rail is 0-width (driven by --st-right-w on .st-root — set to 0 when
+     s.debugOpen is false). Also hide the resize handle and the column's left
+     border so nothing lingers at the screen edge; the panel is opened from the
+     header "Workspace events" toggle, not a thin edge rail. */
   .st-body:has(.studio-activity-root.is-collapsed) [data-testid="studio-resize-right"] {
     display: none;
   }
-  .studio-activity-root.is-collapsed { width: 40px; min-width: 40px; }
+  .st-body:has(.studio-activity-root.is-collapsed) .st-col-right {
+    border-left: none;
+  }
+  .studio-activity-root.is-collapsed { width: 0; min-width: 0; overflow: hidden; }
 }
 
 /* Column resize handles (left/right). 5px hit area straddling the border. */


### PR DESCRIPTION
Holistic fix for the recurring "I can't open the workspace-events sidebar" problem.

## Zoomed-out analysis
Across four iterations the events panel could not be opened by the user:
- collapse worked (#116), but the **only** open affordance kept living on the rail itself: a header **bell** (#118), then a thin `<<` edge rail (#119), then a full-height clickable edge rail (#120).
- The one version that demonstrably worked was #118's **header button** — the user opened the panel and saw Workspace Activity. Every rail-at-the-screen-edge variant failed.

The evidence points at the affordance's **location**, not its styling: a 40px control pinned to the far screen edge is unreliable to find/hit, while a control in the header (outside the grid, like the terminal toggle) works. So the fix is structural, not another restyle.

## Fix
- **Primary control is a header toggle** — a prominent, always-visible "Workspace events" button in the studio header, right next to the terminal toggle (the same proven show/hide pattern). Uses a `panel-right` icon, not a bell (per earlier feedback), and lights up when open.
- **Closed = 0-width (fully hidden)**, not a phantom edge rail: `--st-right-w` is `rightWidth` when open, `0` when closed; the `:has(.is-collapsed)` block hides the resize handle + column border so nothing lingers at the edge.
- Open state is unchanged (panel with Action Required + Workspace Activity, its own `>>` close, resizable), and it stays mounted while closed so subscriptions/badge stay warm. Mobile drawer path untouched.

## Tests
`tests/ui/` full suite: 1065 passed, 1 skipped. Retargeted the shell/debug-sidebar tests to the header-toggle + 0-width model (replacing the `no header toggle` / `40px rail` assertions).

Note: the now-hidden collapsed-rail markup in studio-activity.jsx is left in place (it doubles as the open-panel header/close); a follow-up can delete the dead collapsed branch.