### PR TITLE
fix(release): read RELEASE_APP_ID from secrets (namespace fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -116,7 +116,11 @@ jobs:
         id: app-token
         uses: actions/create-github-app-token@v1
         with:
-          app-id: ${{ vars.RELEASE_APP_ID }}
+          # RELEASE_APP_ID is stored as a (org) SECRET alongside the private
+          # key, so read it from secrets.* — reading vars.RELEASE_APP_ID (a
+          # different namespace) resolved to empty and failed the token step
+          # with "Input required and not supplied: app-id".
+          app-id: ${{ secrets.RELEASE_APP_ID }}
           private-key: ${{ secrets.RELEASE_APP_PRIVATE_KEY }}
       - uses: actions/checkout@v7
         with:


### PR DESCRIPTION
The release job failed at the GitHub App token step with `Input required and not supplied: app-id`.

Root cause: `RELEASE_APP_ID` is configured as an **org secret** (alongside `RELEASE_APP_PRIVATE_KEY`), but the workflow read it as a **variable** (`vars.RELEASE_APP_ID`). `vars.*` and `secrets.*` are separate namespaces, so it resolved to empty.

Fix: read `app-id` from `secrets.RELEASE_APP_ID` — consistent with the private key (also `secrets.*`) and matching where the value actually lives. No app/secret changes needed. After merge, re-dispatch `release.yml` to cut 0.2.0.