### PR TITLE
fix(api): report the real released version in /v1/health (was frozen at 0.1.0)

### DIFF
--- a/primer/api/version.py
+++ b/primer/api/version.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from importlib.metadata import PackageNotFoundError, version
+
 API_VERSION = "v1"
 """URL-prefix segment for every router in this API.
 
@@ -11,9 +13,15 @@ introduced as additional routers (``/v2/...``) sharing the same
 process.
 """
 
-APP_VERSION = "0.1.0"
-"""Semver of the API surface itself, surfaced in OpenAPI ``info.version``
-and the ``GET /v1/health`` payload. Bump on backwards-compatible
-additions; reset minor on breaking changes."""
+try:
+    APP_VERSION = version("primer-ai")
+except PackageNotFoundError:  # source tree with no installed distribution
+    APP_VERSION = "0.0.0+dev"
+"""Semver of the running build, surfaced in OpenAPI ``info.version`` and the
+``GET /v1/health`` payload. Read from the installed ``primer-ai`` distribution
+metadata (which python-semantic-release bumps at release time) so it can never
+drift from the published version — a hand-maintained constant here silently
+froze at 0.1.0 through the 0.2.0 release. Falls back to ``0.0.0+dev`` when
+imported from a source checkout with no installed distribution."""
 
 __all__ = ["API_VERSION", "APP_VERSION"]


### PR DESCRIPTION
Found while dogfooding the 0.2.0 install: `GET /v1/health` and the startup log report `"version":"0.1.0"` even on 0.2.0.

**Root cause:** `primer/api/version.py` hard-coded `APP_VERSION = "0.1.0"`. python-semantic-release bumps the three `pyproject.toml`s but never touched this constant, so the runtime version froze at 0.1.0 through the 0.2.0 release while the package metadata correctly read 0.2.0.

**Fix:** derive `APP_VERSION` from the installed `primer-ai` distribution metadata (`importlib.metadata.version`), which PSR bumps at release time — single source of truth, can't drift again. Falls back to `0.0.0+dev` in a source checkout with no installed distribution.

Verified: `APP_VERSION` now resolves to `0.2.0` in an editable install; `tests/api/test_health.py` (6) passes (it compares health↔APP_VERSION, so it stays self-consistent); ruff + docs hygiene gates pass. No OpenAPI test asserts `info.version`, so nothing else changes.

`fix:` commit so the next release cuts **0.2.1** and the reported version finally catches up.