### PR TITLE
fix(mcp): HTTP toolset failures degrade gracefully (no more 500 on the tools page) + registration connection feedback

### DIFF
--- a/primer/common/mcp_errors.py
+++ b/primer/common/mcp_errors.py
@@ -38,7 +38,40 @@ def classify_mcp_exception(exc: Exception) -> PrimerError:
     | ``httpx.TimeoutException``, ``httpx.NetworkError`` | :class:`NetworkError` |
     | ``mcp.shared.exceptions.McpError`` | :class:`ProviderError` (carries the JSON-RPC error code) |
     | anything else | :class:`ProviderError` |
+
+    Already-classified :class:`PrimerError` inputs pass through unchanged, and
+    anyio ``(Base)ExceptionGroup`` wrappers (streamable-http / stdio transports
+    run inside anyio task groups) are unwrapped to their most informative leaf
+    so callers see e.g. "connection refused" instead of the opaque "unhandled
+    errors in a TaskGroup".
     """
+    # Idempotent: re-classifying at an outer layer is a no-op.
+    if isinstance(exc, PrimerError):
+        return exc
+    # Unwrap anyio task-group wrappers to the real failure. Prefer an
+    # already-classified PrimerError leaf, else classify the first Exception
+    # leaf (typically the httpx.ConnectError behind a failed MCP connection).
+    if isinstance(exc, BaseExceptionGroup):
+        leaves: list[BaseException] = []
+        pending: list[BaseException] = [exc]
+        while pending:
+            cur = pending.pop()
+            if isinstance(cur, BaseExceptionGroup):
+                pending.extend(cur.exceptions)
+            else:
+                leaves.append(cur)
+        for leaf in leaves:
+            if isinstance(leaf, PrimerError):
+                return leaf
+        for leaf in leaves:
+            if isinstance(leaf, Exception):
+                return classify_mcp_exception(leaf)
+        return ProviderError(str(exc), cause=exc)
+    if isinstance(exc, httpx.ConnectError):
+        return NetworkError(
+            f"could not connect to the MCP server: {exc}",
+            cause=exc,
+        )
     if isinstance(exc, httpx.HTTPStatusError):
         status = exc.response.status_code
         if status in (401, 403):

--- a/primer/toolset/mcp.py
+++ b/primer/toolset/mcp.py
@@ -118,6 +118,26 @@ class McpToolsetProvider(ToolsetProvider):
         *,
         principal: str | None = None,
     ) -> AsyncIterator[Tool]:
+        # Materialise the MCP round-trip in a PLAIN coroutine, then yield from
+        # the finished list. list_tools must not hold the MCP session open
+        # across `yield`s: the session runs an anyio task group, and driving it
+        # from inside an async generator lets the generator's finalisation tear
+        # the task group down in a different task on error (see _open_session's
+        # note) -- which surfaced as a hung request / generic 500.
+        for mcp_tool in await self._fetch_mcp_tools(principal=principal):
+            yield self._mcp_tool_to_primer(mcp_tool)
+
+    async def _fetch_mcp_tools(
+        self,
+        *,
+        principal: str | None = None,
+    ) -> list[mcp_types.Tool]:
+        """One MCP ``tools/list`` round-trip, fully contained in this coroutine.
+
+        Connection / handshake / listing failures are mapped onto the primer
+        error hierarchy so a broken toolset degrades (502 / ``available:false``)
+        instead of escaping as an unhandled 500.
+        """
         async with self._open_session(principal=principal) as session:
             try:
                 result = await session.list_tools()
@@ -131,8 +151,7 @@ class McpToolsetProvider(ToolsetProvider):
         self._task_tools = {
             t.name for t in result.tools if is_mcp_task_tool(t)
         }
-        for mcp_tool in result.tools:
-            yield self._mcp_tool_to_primer(mcp_tool)
+        return result.tools
 
     async def call(
         self,
@@ -355,36 +374,38 @@ class McpToolsetProvider(ToolsetProvider):
                 auth_headers = await self._oauth.authorize(principal=principal)
                 base_headers.update(auth_headers)
 
-            stack = AsyncExitStack()
+            # Structured, lexically-nested `async with` -- NOT AsyncExitStack.
+            # streamablehttp_client runs an anyio task group whose cancel scope
+            # must be entered AND exited in the same task. AsyncExitStack defers
+            # its __aexit__ callbacks, so on any failure (a refused connection is
+            # the common case -- e.g. a containerised Primer reaching a host
+            # `localhost:PORT` MCP URL) the task group got torn down in a
+            # different task -> "Attempted to exit cancel scope in a different
+            # task than it was entered in". That RuntimeError escaped the
+            # caller's error handling as a generic 500 and took the whole
+            # /v1/tools catalogue down with it. Lexical nesting keeps enter+exit
+            # in one task; the try/except maps connection/handshake failures
+            # onto the documented ProviderError/NetworkError envelope.
             try:
-                streams = await stack.enter_async_context(
-                    streamablehttp_client(
-                        url=http_cfg.url,
-                        headers=base_headers if base_headers else None,
-                    )
-                )
-                # mcp >= 1.16 yields (read, write, get_session_id);
-                # older releases yield (read, write).
-                if len(streams) >= 2:
+                async with streamablehttp_client(
+                    url=http_cfg.url,
+                    headers=base_headers if base_headers else None,
+                ) as streams:
+                    # mcp >= 1.16 yields (read, write, get_session_id);
+                    # older releases yield (read, write).
+                    if len(streams) < 2:  # pragma: no cover - older mcp
+                        raise ConfigError(
+                            "streamablehttp_client returned an unexpected "
+                            "stream tuple"
+                        )
                     read, write = streams[0], streams[1]
-                else:  # pragma: no cover - defensive for older mcp
-                    raise ConfigError(
-                        "streamablehttp_client returned an unexpected stream tuple"
-                    )
-
-                session = await stack.enter_async_context(ClientSession(read, write))
-                await session.initialize()
-            except (ConfigError, AuthRequiredError):
-                await stack.aclose()
+                    async with ClientSession(read, write) as session:
+                        await session.initialize()
+                        yield session
+            except (ConfigError, AuthRequiredError, GeneratorExit):
                 raise
             except Exception as exc:
-                await stack.aclose()
                 raise classify_mcp_exception(exc) from exc
-
-            try:
-                yield session
-            finally:
-                await stack.aclose()
             return
 
         raise ConfigError(f"unknown transport {self._config.transport!r}")

--- a/tests/toolset/test_mcp.py
+++ b/tests/toolset/test_mcp.py
@@ -16,7 +16,11 @@ from mcp.server.lowlevel import Server
 from mcp.shared.memory import create_connected_server_and_client_session
 
 from primer.model.chat import Tool, ToolCallResult
-from primer.model.except_ import ConfigError, UnsupportedContentError
+from primer.model.except_ import (
+    ConfigError,
+    PrimerError,
+    UnsupportedContentError,
+)
 from primer.model.provider import HttpConfig, McpConfig, StdioConfig, TransportType
 from primer.toolset.mcp import McpToolsetProvider
 
@@ -241,12 +245,16 @@ class TestHttpTransportRouting:
     surfaces as the right primer exception.
     """
 
-    @pytest.mark.skip(
-        reason="MCP SDK swallows transport exceptions in task groups; needs follow-up"
-    )
     async def test_unreachable_endpoint_raises_primer_error(self) -> None:
-        from primer.model.except_ import PrimerError
-
+        # Regression (was @skip: "MCP SDK swallows transport exceptions in task
+        # groups; needs follow-up"). A refused/unreachable HTTP MCP connection
+        # must surface as a clean PrimerError -- NOT the raw RuntimeError the
+        # SDK's anyio task group leaked when torn down via AsyncExitStack in a
+        # different task ("Attempted to exit cancel scope in a different task
+        # than it was entered in"). That RuntimeError escaped as a generic 500
+        # and took the whole /v1/tools catalogue down. Fixed by structured
+        # nested `async with` in _open_session + materialising list_tools in a
+        # plain coroutine (no task group held across generator yields).
         provider = McpToolsetProvider(
             toolset_id="ts1",
             config=McpConfig(

--- a/ui/components/toolsets.jsx
+++ b/ui/components/toolsets.jsx
@@ -238,6 +238,57 @@ function _tsTarget(t) {
   return null;
 }
 
+// Post-registration connection result shown inside the New/Edit modal: a
+// loading state while we probe, then "connected · N tools" or the classified
+// connection error (so a bad URL / unreachable server is obvious immediately
+// instead of a silent save).
+function TS_ConnectResult({ row, isEdit, probing, probe }) {
+  const spinner = (
+    <span
+      aria-hidden="true"
+      style={{
+        width: 16, height: 16, flexShrink: 0, borderRadius: "50%",
+        border: "2px solid var(--border)", borderTopColor: "var(--accent)",
+        animation: "spin 0.8s linear infinite",
+      }}
+    />
+  );
+  return (
+    <div style={{ padding: "4px 2px" }} data-testid="toolset-connect-result">
+      <div className="field-help" style={{ marginBottom: 12 }}>
+        {isEdit ? "Saved" : "Registered"} <span className="mono">{row.id}</span> — checking the connection.
+      </div>
+      {probing && (
+        <div style={{ display: "flex", alignItems: "center", gap: 10, padding: "14px 12px", background: "var(--bg-2)", borderRadius: 8 }}>
+          {spinner}
+          <span className="muted text-sm">Connecting to the MCP server and importing tools…</span>
+        </div>
+      )}
+      {!probing && probe && probe.ok && (
+        <div
+          data-testid="toolset-connect-ok"
+          style={{ display: "flex", alignItems: "center", gap: 10, padding: "14px 12px", background: "var(--green-dim)", borderRadius: 8, color: "var(--green)" }}
+        >
+          <Icon name="check" size={16} />
+          <span><strong>Connected.</strong> {probe.count} tool{probe.count === 1 ? "" : "s"} imported.</span>
+        </div>
+      )}
+      {!probing && probe && !probe.ok && (
+        <div data-testid="toolset-connect-error" style={{ padding: "14px 12px", background: "var(--red-dim)", borderRadius: 8 }}>
+          <div style={{ display: "flex", alignItems: "center", gap: 10, color: "var(--red)" }}>
+            <Icon name="alert" size={16} />
+            <strong>Could not connect.</strong>
+          </div>
+          <div className="text-sm" style={{ marginTop: 6, color: "var(--text-2)", wordBreak: "break-word" }}>{probe.message}</div>
+          <div className="field-help" style={{ marginTop: 8 }}>
+            The toolset is saved, but its tools stay unavailable until it connects. Double-check the URL/command — if Primer runs in a container, <span className="mono">localhost</span> is the container, not your host (try the host IP or <span className="mono">host.docker.internal</span>).
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
 // ============================================================================
 // New toolset modal — MCP-stdio + MCP-http variants
 // ============================================================================
@@ -272,6 +323,34 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
   );
   const [fieldErrors, setFieldErrors] = React.useState({});
 
+  // After the row is saved we probe it (reusing the now-graceful
+  // GET /toolsets/{id}/tools) so the operator sees whether it actually
+  // connected and how many tools were imported -- instead of a blind save
+  // with no signal. `createdRow` flips the modal from the form to the result.
+  const [createdRow, setCreatedRow] = React.useState(null);
+  const [probing, setProbing] = React.useState(false);
+  const [probe, setProbe] = React.useState(null); // {ok:true,count} | {ok:false,message}
+
+  React.useEffect(() => {
+    if (!createdRow) return undefined;
+    let alive = true;
+    setProbing(true);
+    setProbe(null);
+    apiFetch("GET", "/toolsets/" + encodeURIComponent(createdRow.id) + "/tools")
+      .then((res) => {
+        if (alive) {
+          setProbe({ ok: true, count: Array.isArray(res && res.tools) ? res.tools.length : 0 });
+        }
+      })
+      .catch((err) => {
+        if (alive) {
+          setProbe({ ok: false, message: (err && (err.detail || err.message || err.title)) || "Could not connect" });
+        }
+      })
+      .finally(() => { if (alive) setProbing(false); });
+    return () => { alive = false; };
+  }, [createdRow, apiFetch]);
+
   const create = useMutation(
     (body) => isEdit
       ? apiFetch("PUT", "/toolsets/" + encodeURIComponent(existing.id), body)
@@ -280,7 +359,9 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
       invalidates: isEdit
         ? ["toolsets:list", "toolset-detail:" + (existing?.id || "")]
         : ["toolsets:list"],
-      onSuccess: (row) => onCreate(row),
+      // Don't close yet -- show the connection result first (see the effect
+      // above). `onCreate` fires from the "Done" button.
+      onSuccess: (row) => setCreatedRow(row),
       onError: (err) => {
         if (err && err.status === 422 && Array.isArray(err.fieldErrors)) {
           const next = {};
@@ -341,14 +422,24 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
       title={isEdit ? `Edit toolset · ${existing.id}` : "New toolset"}
       onClose={onClose}
       footer={
-        <>
-          <Btn kind="ghost" onClick={onClose}>Cancel</Btn>
-          <Btn kind="primary" icon={isEdit ? "check" : "plus"} onClick={submit} disabled={!canSubmit || create.loading}>
-            {create.loading ? (isEdit ? "Saving…" : "Creating…") : (isEdit ? "Save changes" : "Create")}
+        createdRow ? (
+          <Btn kind="primary" icon="check" onClick={() => onCreate(createdRow)} disabled={probing} data-testid="toolset-connect-done">
+            {probing ? "Connecting…" : "Done"}
           </Btn>
-        </>
+        ) : (
+          <>
+            <Btn kind="ghost" onClick={onClose}>Cancel</Btn>
+            <Btn kind="primary" icon={isEdit ? "check" : "plus"} onClick={submit} disabled={!canSubmit || create.loading}>
+              {create.loading ? (isEdit ? "Saving…" : "Creating…") : (isEdit ? "Save changes" : "Create")}
+            </Btn>
+          </>
+        )
       }
     >
+      {createdRow ? (
+        <TS_ConnectResult row={createdRow} isEdit={isEdit} probing={probing} probe={probe} />
+      ) : (
+      <>
       <div className="field">
         <label className="field-label">ID {isEdit
           ? <span className="hint">locked — id cannot change after create</span>
@@ -456,6 +547,8 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
             </>
           )}
         </>
+      )}
+      </>
       )}
     </Modal>
   );


### PR DESCRIPTION
Found while dogfooding on a live instance: registering an HTTP-transport MCP server made the whole **Toolsets page** return "Internal Error".

## The bug
`GET /v1/tools` (and `/v1/toolsets/{id}/tools`) 500'd whenever one MCP toolset failed to list its tools. Root cause: `McpToolsetProvider._open_session` opened the MCP `streamablehttp_client` (an anyio task group) via `AsyncExitStack` **inside an async generator** (`list_tools`). On any failure (a refused connection is the common case — e.g. a containerised Primer reaching a host `localhost:PORT` URL), the task group tore down in a **different task** → `RuntimeError: Attempted to exit cancel scope in a different task than it was entered in`. That escaped the endpoint's error handling as a generic 500, and because `/v1/tools` aggregates across toolsets, **one bad MCP server took down the entire catalogue + page**.

## The fix
- `_open_session` (HTTP): structured, lexically-nested `async with` instead of `AsyncExitStack` — enter/exit stay in one task.
- `list_tools`: materialise the round-trip in a plain coroutine (`_fetch_mcp_tools`), then yield — never hold the task group across `yield`s.
- `classify_mcp_exception`: idempotent + unwraps anyio `ExceptionGroup`s + a clear `NetworkError: could not connect to the MCP server: …`.
- **Un-skipped** the pre-existing regression test that was parked on this exact bug (`"MCP SDK swallows transport exceptions in task groups; needs follow-up"`).

Now a failing toolset degrades to `available:false` with a reason (the page loads), and `/v1/toolsets/{id}/tools` returns a clean 502 instead of a 500.

## Registration UX
The New-toolset modal previously saved blindly. It now probes the connection and shows **connecting → connected · N tools imported / could not connect: reason** (with a `host.docker.internal` hint for the containerised-`localhost` case).

## Tests
`tests/toolset/` 440 passed (incl. the un-skipped regression); `tests/ui/` 1065 passed; JSX transpiles; CSS vars all defined.