### PR TITLE
fix(harness): make cascade-delete of tracked entities optional on delete

### DIFF
--- a/primer/api/routers/harness.py
+++ b/primer/api/routers/harness.py
@@ -287,6 +287,17 @@ async def update_harness(
 )
 async def delete_harness(
     harness_id: str = Path(...),
+    cascade: bool | None = Query(
+        None,
+        description=(
+            "Also delete the harness's tracked/managed entities (agents, "
+            "graphs, collections, documents, toolsets). Omitted: defaults by "
+            "direction — inbound (installed) harnesses cascade so uninstall "
+            "removes the installed objects; outbound harnesses do NOT, so "
+            "deleting one keeps the objects it merely tracks. Pass true/false "
+            "to override."
+        ),
+    ),
     sp=Depends(get_storage_provider),
     event_bus=Depends(get_event_bus),
     engine=Depends(get_claim_engine),
@@ -303,6 +314,13 @@ async def delete_harness(
         )
 
     harness.pending_operation = HarnessOperation.UNINSTALL
+    # Explicit toggle wins; when omitted, default by direction — inbound
+    # (installed) harnesses cascade, outbound harnesses keep their tracked
+    # objects.
+    harness.uninstall_cascade = (
+        cascade if cascade is not None
+        else harness.direction == HarnessDirection.INBOUND
+    )
     updated = await storage.update(harness)
     await event_bus.publish("harness-claimable", {"harness_id": harness_id})
     # Also notify the ClaimEngine (forward-compat; no-op when not wired).

--- a/primer/harness/dispatch.py
+++ b/primer/harness/dispatch.py
@@ -175,16 +175,17 @@ async def run_one_harness_operation(
         )
         return
 
-    # Direction guard: outbound rows can only run BUILD/PUSH; inbound
-    # rows can only run FETCH/INSTALL/SYNC/UNINSTALL. Mismatches release
-    # with a clear error so the user sees what went wrong rather than a
-    # cryptic stack from a downstream helper.
+    # Direction guard: outbound rows run BUILD/PUSH; inbound rows run
+    # FETCH/INSTALL/SYNC. UNINSTALL (delete the harness) is allowed on BOTH
+    # directions — a harness can always be deleted, and for an outbound
+    # harness a non-cascade uninstall simply removes the harness itself.
+    # Mismatches release with a clear error so the user sees what went wrong
+    # rather than a cryptic stack from a downstream helper.
     _outbound_ops = {HarnessOperation.BUILD, HarnessOperation.PUSH}
     _inbound_ops = {
         HarnessOperation.FETCH,
         HarnessOperation.INSTALL,
         HarnessOperation.SYNC,
-        HarnessOperation.UNINSTALL,
     }
     if (
         harness.direction == HarnessDirection.INBOUND
@@ -1113,6 +1114,7 @@ async def _do_uninstall(
         await apply_uninstall(
             storage_provider=deps.storage_provider,
             harness=harness,
+            cascade=harness.uninstall_cascade,
         )
     except Exception:
         logger.exception("_do_uninstall error for harness %s", harness.id)

--- a/primer/harness/service.py
+++ b/primer/harness/service.py
@@ -863,40 +863,50 @@ async def apply_uninstall(
     *,
     storage_provider: Any,
     harness: Harness,
+    cascade: bool = True,
 ) -> None:
-    """Delete every managed entity, then the rendering, then the harness row.
+    """Remove the harness. When ``cascade`` is True (default), also delete
+    every managed entity in reverse-DAG order (graph → agent → document →
+    collection → toolset); when False, delete ONLY the harness row and its
+    rendering, leaving the tracked entities intact.
 
-    Order: graph → agent → document → collection → toolset.
+    ``cascade`` rides in on the harness row (``harness.uninstall_cascade``,
+    chosen at delete time). It defaults to True here so a direct call keeps
+    the classic "uninstall removes the installed objects" behaviour; the API
+    delete path defaults it to False so deleting a harness never unexpectedly
+    wipes the user's own tracked objects.
+
     Tolerates "not found" for already-removed entities.
     """
     rendering_storage = storage_provider.get_storage(HarnessRendering)
     rendering = await rendering_storage.get(harness.id)
 
     if rendering is not None:
-        # Sort entries in reverse-DAG order for deletion
-        entries_by_kind: dict[str, list[RenderedEntry]] = {}
-        for entry in rendering.entries:
-            entries_by_kind.setdefault(entry.kind, []).append(entry)
+        if cascade:
+            # Sort entries in reverse-DAG order for deletion
+            entries_by_kind: dict[str, list[RenderedEntry]] = {}
+            for entry in rendering.entries:
+                entries_by_kind.setdefault(entry.kind, []).append(entry)
 
-        for kind in _UNINSTALL_ORDER:
-            for entry in entries_by_kind.get(kind, []):
-                storage = _storage_for_kind(storage_provider, kind)
-                try:
-                    await storage.delete(entry.resolved_id)
-                except Exception:
-                    pass  # tolerate "not found"
-                # Documents also own a content-store row keyed by the same
-                # stable id; delete it so no orphan body leaks (which would
-                # trip the content store's UNIQUE(collection_id, path) on a
-                # later reinstall at the same path). No-op if absent.
-                if kind == "document":
+            for kind in _UNINSTALL_ORDER:
+                for entry in entries_by_kind.get(kind, []):
+                    storage = _storage_for_kind(storage_provider, kind)
                     try:
-                        await _delete_document_content(
-                            storage_provider=storage_provider,
-                            document_id=entry.resolved_id,
-                        )
+                        await storage.delete(entry.resolved_id)
                     except Exception:
-                        pass
+                        pass  # tolerate "not found"
+                    # Documents also own a content-store row keyed by the same
+                    # stable id; delete it so no orphan body leaks (which would
+                    # trip the content store's UNIQUE(collection_id, path) on a
+                    # later reinstall at the same path). No-op if absent.
+                    if kind == "document":
+                        try:
+                            await _delete_document_content(
+                                storage_provider=storage_provider,
+                                document_id=entry.resolved_id,
+                            )
+                        except Exception:
+                            pass
 
         # Delete the rendering row
         try:

--- a/primer/model/harness.py
+++ b/primer/model/harness.py
@@ -129,6 +129,19 @@ class Harness(Identifiable):
     overrides_dirty: bool = False
     schema_missing_input: bool = False
     pending_operation: HarnessOperation | None = None
+    uninstall_cascade: bool = Field(
+        default=False,
+        description=(
+            "For an enqueued UNINSTALL (harness delete): also delete the "
+            "harness's tracked/managed entities (agents, graphs, collections, "
+            "documents, toolsets). When False, removes ONLY the harness row "
+            "and its rendering, leaving every tracked entity intact. The "
+            "delete endpoint resolves this per request: an explicit "
+            "``?cascade=`` wins, otherwise it defaults by direction (inbound "
+            "cascades so uninstall removes the installed objects; outbound "
+            "does not, keeping the user's own tracked objects)."
+        ),
+    )
     last_operation_at: datetime | None = None
     last_operation_error: str | None = None
     dependencies_resolved: list[ResolvedDependency] = Field(default_factory=list)

--- a/tests/api/test_harness_router.py
+++ b/tests/api/test_harness_router.py
@@ -18,7 +18,12 @@ import pytest
 from httpx import ASGITransport, AsyncClient
 
 from primer.harness.hashes import hash_overrides
-from primer.model.harness import Harness, HarnessOperation, HarnessStatus
+from primer.model.harness import (
+    Harness,
+    HarnessDirection,
+    HarnessOperation,
+    HarnessStatus,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -217,10 +222,13 @@ async def test_install_rejects_pending_op(client, app, fake_storage_provider):
 
 @pytest.mark.asyncio
 async def test_delete_enqueues_uninstall(client, app, fake_storage_provider):
+    """DELETE enqueues UNINSTALL (202). An inbound harness with no ?cascade
+    defaults to cascade — uninstall removes the installed objects."""
     harness = _make_harness(
         id="hns_todelete",
         slug="to-delete",
         status=HarnessStatus.INSTALLED,
+        direction=HarnessDirection.INBOUND,
     )
     storage = fake_storage_provider.get_storage(Harness)
     await storage.create(harness)
@@ -229,6 +237,49 @@ async def test_delete_enqueues_uninstall(client, app, fake_storage_provider):
     assert r.status_code == 202
     body = r.json()
     assert body["pending_operation"] == "uninstall"
+    assert body["uninstall_cascade"] is True  # inbound default: cascade
+    assert (await storage.get("hns_todelete")).uninstall_cascade is True
+
+
+@pytest.mark.asyncio
+async def test_delete_outbound_default_keeps_entities(client, app, fake_storage_provider):
+    """An OUTBOUND harness deleted with no ?cascade defaults to non-cascade —
+    only the harness is removed; the objects it tracks are kept."""
+    harness = _make_harness(
+        id="hns_outdel",
+        slug="out-del",
+        status=HarnessStatus.INSTALLED,
+        direction=HarnessDirection.OUTBOUND,
+    )
+    storage = fake_storage_provider.get_storage(Harness)
+    await storage.create(harness)
+
+    r = await client.delete("/v1/harnesses/hns_outdel")
+    assert r.status_code == 202
+    assert r.json()["uninstall_cascade"] is False
+    assert (await storage.get("hns_outdel")).uninstall_cascade is False
+
+
+@pytest.mark.asyncio
+async def test_delete_explicit_cascade_overrides_direction(client, app, fake_storage_provider):
+    """An explicit ?cascade= overrides the direction default either way."""
+    storage = fake_storage_provider.get_storage(Harness)
+    # Outbound + ?cascade=true -> cascade despite the safe default.
+    await storage.create(_make_harness(
+        id="hns_ovr1", slug="ovr1", status=HarnessStatus.INSTALLED,
+        direction=HarnessDirection.OUTBOUND,
+    ))
+    r = await client.delete("/v1/harnesses/hns_ovr1?cascade=true")
+    assert r.status_code == 202
+    assert (await storage.get("hns_ovr1")).uninstall_cascade is True
+    # Inbound + ?cascade=false -> keep the installed objects.
+    await storage.create(_make_harness(
+        id="hns_ovr2", slug="ovr2", status=HarnessStatus.INSTALLED,
+        direction=HarnessDirection.INBOUND,
+    ))
+    r = await client.delete("/v1/harnesses/hns_ovr2?cascade=false")
+    assert r.status_code == 202
+    assert (await storage.get("hns_ovr2")).uninstall_cascade is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/harness/test_dispatch.py
+++ b/tests/harness/test_dispatch.py
@@ -360,6 +360,7 @@ async def test_uninstall_cleans_up(fake_storage_provider, bare_repo):
     installed = await harness_storage.get("h6")
     installed = installed.model_copy(update={
         "pending_operation": HarnessOperation.UNINSTALL,
+        "uninstall_cascade": True,  # inbound uninstall removes installed objects
     })
     await harness_storage.update(installed)
 
@@ -376,6 +377,39 @@ async def test_uninstall_cleans_up(fake_storage_provider, bare_repo):
     # Harness row must be gone
     harness_after = await harness_storage.get("h6")
     assert harness_after is None
+
+
+@pytest.mark.asyncio
+async def test_uninstall_no_cascade_keeps_entities(fake_storage_provider, bare_repo):
+    """Default (non-cascade) uninstall removes ONLY the harness + rendering
+    rows; the installed entities survive. This is the data-loss fix — deleting
+    a harness must not wipe the objects it tracks unless cascade is set."""
+    deps = _make_deps(fake_storage_provider)
+    harness_storage = fake_storage_provider.get_storage(Harness)
+
+    harness = _make_harness(
+        "h7", git_url=bare_repo, slug="acme7", status=HarnessStatus.DRAFT,
+        overrides={"model_name": "gpt-4"},
+    )
+    await harness_storage.create(harness)
+    await run_one_harness_operation(deps, harness_id="h7", worker_id="w1")
+    fetched = await harness_storage.get("h7")
+    fetched = fetched.model_copy(update={"pending_operation": HarnessOperation.INSTALL})
+    await harness_storage.update(fetched)
+    await run_one_harness_operation(deps, harness_id="h7", worker_id="w1")
+
+    assert await fake_storage_provider.get_storage(Agent).get("acme7__assistant") is not None
+
+    # Uninstall with NO cascade flag (uninstall_cascade defaults False).
+    installed = await harness_storage.get("h7")
+    installed = installed.model_copy(update={"pending_operation": HarnessOperation.UNINSTALL})
+    await harness_storage.update(installed)
+    await run_one_harness_operation(deps, harness_id="h7", worker_id="w1")
+
+    # The installed entity SURVIVES; only the harness + rendering rows are gone.
+    assert await fake_storage_provider.get_storage(Agent).get("acme7__assistant") is not None
+    assert await fake_storage_provider.get_storage(HarnessRendering).get("h7") is None
+    assert await harness_storage.get("h7") is None
 
 
 # ---------------------------------------------------------------------------

--- a/tests/harness/test_dispatch_install_deps.py
+++ b/tests/harness/test_dispatch_install_deps.py
@@ -283,6 +283,7 @@ async def test_install_uninstall_removes_all_including_sub_entities(
     ) is not None
 
     installed = await harness_storage.get("h-uninstall")
+    installed = installed.model_copy(update={"uninstall_cascade": True})
     await _do_uninstall(deps, installed)
 
     # Both entity rows AND the rendering AND the harness row are gone.

--- a/tests/harness/test_dispatch_outbound.py
+++ b/tests/harness/test_dispatch_outbound.py
@@ -428,3 +428,30 @@ async def test_direction_mismatch_blocks_outbound_op_on_inbound(
     err = json.loads(updated.last_operation_error)
     assert err["code"] == "direction_mismatch"
     assert err["operation"] == "build"
+
+
+# ---------------------------------------------------------------------------
+# 7. UNINSTALL is allowed on an OUTBOUND harness (a harness is always deletable)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_outbound_uninstall_deletes_harness(fake_storage_provider, tmp_path):
+    """UNINSTALL runs on an OUTBOUND harness rather than being blocked as a
+    direction_mismatch. With the default non-cascade, only the harness row is
+    removed (the objects it tracks are left intact)."""
+    bare = _init_bare(tmp_path)
+    deps = _make_deps(fake_storage_provider)
+    harness_storage = fake_storage_provider.get_storage(Harness)
+
+    harness = _make_outbound_harness(
+        "h-out-del",
+        git_url=f"file://{bare}",
+        pending=HarnessOperation.UNINSTALL,
+    )
+    await harness_storage.create(harness)
+
+    await run_one_harness_operation(deps, harness_id="h-out-del", worker_id="w1")
+
+    # Deleted — not released as a direction_mismatch ERROR.
+    assert await harness_storage.get("h-out-del") is None

--- a/tests/harness/test_service.py
+++ b/tests/harness/test_service.py
@@ -1078,6 +1078,57 @@ async def test_apply_uninstall_deletes_in_reverse_order(fake_storage_provider):
     assert h is None
 
 
+@pytest.mark.asyncio
+async def test_apply_uninstall_no_cascade_keeps_entities(fake_storage_provider):
+    """cascade=False removes ONLY the harness + its rendering rows; every
+    tracked/managed entity survives. This is the safe default for the
+    harness-delete toggle — deleting an outbound harness must not wipe the
+    user's own agents/graphs it merely tracks."""
+    from primer.model.agent import Agent, AgentModel
+    from primer.model.graph import Graph
+
+    harness = _make_harness("keep")
+    await fake_storage_provider.get_storage(Agent).create(
+        Agent(
+            id="keep__asst", description="asst",
+            model=AgentModel(provider_id="p", model_name="m"),
+            harness_id=harness.id,
+        )
+    )
+    await fake_storage_provider.get_storage(Graph).create(
+        Graph(
+            id="keep__wf", description="wf",
+            nodes=[{"kind": "begin", "id": "begin"}, {"kind": "end", "id": "t"}],
+            edges=[{"kind": "static", "from_node": "begin", "to_node": "t"}],
+            harness_id=harness.id,
+        )
+    )
+    rendering = HarnessRendering(
+        id=harness.id, harness_id=harness.id,
+        bundle_hash="bh", overrides_hash="oh", schema_hash=None,
+        entries=[
+            RenderedEntry(kind="agent", template_name="asst", resolved_id="keep__asst",
+                          template_source_hash="h", rendered_hash="h1", rendered_payload={}),
+            RenderedEntry(kind="graph", template_name="wf", resolved_id="keep__wf",
+                          template_source_hash="h", rendered_hash="h2", rendered_payload={}),
+        ],
+        rendered_at=datetime.now(timezone.utc),
+    )
+    await fake_storage_provider.get_storage(HarnessRendering).create(rendering)
+    await fake_storage_provider.get_storage(Harness).create(harness)
+
+    await apply_uninstall(
+        storage_provider=fake_storage_provider, harness=harness, cascade=False,
+    )
+
+    # Tracked entities SURVIVE.
+    assert await fake_storage_provider.get_storage(Agent).get("keep__asst") is not None
+    assert await fake_storage_provider.get_storage(Graph).get("keep__wf") is not None
+    # The harness + its rendering rows are gone.
+    assert await fake_storage_provider.get_storage(HarnessRendering).get(harness.id) is None
+    assert await fake_storage_provider.get_storage(Harness).get(harness.id) is None
+
+
 # ---------------------------------------------------------------------------
 # 9. apply_sync — fast path when hashes match
 # ---------------------------------------------------------------------------

--- a/ui/components/harnesses.jsx
+++ b/ui/components/harnesses.jsx
@@ -359,6 +359,7 @@ function HarnessDetail({ id }) {
   const { navigate } = useRouter();
 
   const [confirmUninstall, setConfirmUninstall] = React.useState(false);
+  const [cascadeDelete, setCascadeDelete] = React.useState(false);
   const [editTrackedOpen, setEditTrackedOpen] = React.useState(false);
 
   const detail = useResource(
@@ -396,7 +397,10 @@ function HarnessDetail({ id }) {
     }
   );
   const uninstallMut = useMutation(
-    () => apiFetch("DELETE", "/harnesses/" + encodeURIComponent(id)),
+    () => apiFetch(
+      "DELETE",
+      "/harnesses/" + encodeURIComponent(id) + (cascadeDelete ? "?cascade=true" : "")
+    ),
     {
       onSuccess: () => navigate("/harnesses"),
       onError: () => detail.refetch(),
@@ -626,12 +630,12 @@ function HarnessDetail({ id }) {
       {/* Confirm uninstall */}
       {confirmUninstall && (
         <Modal
-          title={`Uninstall ${h.name || h.slug}?`}
+          title={`${isOutbound ? "Delete" : "Uninstall"} ${h.name || h.slug}?`}
           danger
-          onClose={() => setConfirmUninstall(false)}
+          onClose={() => { setConfirmUninstall(false); setCascadeDelete(false); }}
           footer={
             <>
-              <Btn kind="ghost" onClick={() => setConfirmUninstall(false)}>Cancel</Btn>
+              <Btn kind="ghost" onClick={() => { setConfirmUninstall(false); setCascadeDelete(false); }}>Cancel</Btn>
               <Btn
                 kind="danger"
                 icon="trash"
@@ -639,18 +643,36 @@ function HarnessDetail({ id }) {
                 onClick={async () => {
                   setConfirmUninstall(false);
                   try { await uninstallMut.mutate(); } catch (_e) {}
+                  setCascadeDelete(false);
                 }}
               >
-                {uninstallMut.loading ? "Uninstalling…" : "Uninstall"}
+                {uninstallMut.loading
+                  ? "Deleting…"
+                  : (cascadeDelete ? "Delete harness + entities" : "Delete harness only")}
               </Btn>
             </>
           }
         >
           <ul>
-            <li>Enqueues UNINSTALL — the worker cascades-deletes all managed entities.</li>
             <li>The harness row is removed once the worker finishes.</li>
+            <li>
+              {cascadeDelete
+                ? "It will ALSO permanently delete every agent, graph, collection, and document this harness tracks."
+                : "The agents, graphs, collections, and documents this harness tracks are kept — only the harness itself is removed."}
+            </li>
             <li>This action cannot be undone.</li>
           </ul>
+          <label
+            style={{ display: "flex", alignItems: "flex-start", gap: 8, marginTop: 12, cursor: "pointer" }}
+          >
+            <input
+              type="checkbox"
+              checked={cascadeDelete}
+              onChange={(e) => setCascadeDelete(e.target.checked)}
+              style={{ marginTop: 3 }}
+            />
+            <span>Also delete the entities this harness tracks (cascade). Leave off to remove only the harness.</span>
+          </label>
         </Modal>
       )}
     </div>


### PR DESCRIPTION
## Problem

Deleting a harness ran `apply_uninstall`, which **unconditionally** deleted every rendered entity by `resolved_id`. For an **outbound** harness (which merely *tracks* the user's own agents/graphs/collections/documents), deleting the harness cascade-deleted all of them — a data-loss trap. Separately, the dispatch direction guard classed `UNINSTALL` as inbound-only, so an outbound harness **could not be deleted at all** (released as a `direction_mismatch` ERROR).

## Fix — cascade is now an explicit, direction-aware toggle

- **`DELETE /v1/harnesses/{id}?cascade=<bool>`** — explicit toggle. When omitted, it defaults **by direction**: inbound (installed) harnesses cascade so uninstall removes the installed objects; outbound harnesses do **not**, so deleting one keeps the objects it tracks. An explicit `?cascade=` overrides either way.
- **`Harness.uninstall_cascade`** carries the resolved choice to the async worker.
- **`apply_uninstall(cascade)`** — when `False`, deletes only the harness + its rendering rows, leaving every tracked entity intact.
- **Allow `UNINSTALL` on outbound harnesses** — a harness is always deletable.
- **UI** — a cascade checkbox in the delete confirm dialog (default off), with the explanation + button label reflecting the choice.

## Tests (184 passing, ruff clean)

- **service**: `no_cascade_keeps_entities` (entities survive; harness+rendering gone) + existing cascade path.
- **router**: inbound default → cascade; outbound default → keep; explicit `?cascade=` overrides both directions.
- **dispatch**: inbound cascade + non-cascade end-to-end; outbound `UNINSTALL` now deletes (not ERROR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)