### PR TITLE
feat(toolsets): block creating an unreachable MCP toolset (with Create-anyway)

### DIFF
--- a/primer/api/errors.py
+++ b/primer/api/errors.py
@@ -28,6 +28,7 @@ from primer.model.except_ import (
     ProviderError,
     RateLimitError,
     ServerError,
+    ToolsetUnreachableError,
     UnsupportedContentError,
     ValidationError,
 )
@@ -45,6 +46,13 @@ PROBLEM_JSON_MEDIA_TYPE = "application/problem+json"
 # falls through to the most specific match.
 _PRIMER_ERROR_MAP: list[tuple[type[PrimerError], int, str, str]] = [
     (BadRequestError, 400, "/errors/bad-request", "Bad Request"),
+    # ToolsetUnreachableError subclasses BadRequestError but carries its own
+    # type URI so the Console can detect it precisely and offer "Create
+    # anyway". Dispatch is by exception class + MRO (not list order), so it
+    # still gets its own handler; it is placed AFTER BadRequestError so the
+    # shared 400 response description in _RESPONSES_BY_CODE stays the generic
+    # "Bad Request" that every other 400 route documents.
+    (ToolsetUnreachableError, 400, "/errors/toolset-unreachable", "Toolset Unreachable"),
     (AuthenticationError, 401, "/errors/authentication-failed", "Authentication Failed"),
     (AuthRequiredError, 401, "/errors/auth-required", "Authentication Required"),
     (ModelNotFoundError, 404, "/errors/model-not-found", "Model Not Found"),

--- a/primer/api/routers/providers.py
+++ b/primer/api/routers/providers.py
@@ -47,7 +47,13 @@ from primer.api.deps import (
     get_toolset_storage,
 )
 from primer.api.errors import common_responses
-from primer.model.except_ import BadRequestError
+from primer.model.except_ import (
+    AuthRequiredError,
+    BadRequestError,
+    ConfigError,
+    PrimerError,
+    ToolsetUnreachableError,
+)
 from primer.api.registries import ProviderRegistry
 from primer.api.registries.provider_registry import (
     RESERVED_CROSS_ENCODER_IDS,
@@ -64,6 +70,8 @@ from primer.model.provider import (
     LLMProvider,
     OpenRouterConfig,
     Toolset,
+    ToolsetProviderType,
+    TransportType,
 )
 from primer.api.routers._references import ReferenceCheck
 from primer.model.storage import OffsetPage
@@ -535,6 +543,118 @@ def _get_tool_approval_policy_storage(request: Request):
     return request.app.state.storage_provider.get_storage(ToolApprovalPolicy)
 
 
+# ---- Toolset create connectivity probe -------------------------------------
+#
+# Before persisting an MCP toolset that talks to a remote endpoint over the
+# network (transport=http), we drain a live tools/list to confirm the endpoint
+# is reachable. An unreachable endpoint is rejected BEFORE storage.create so
+# the operator gets an immediate, actionable error instead of a blind save that
+# only surfaces when an agent later fails to open a session.
+#
+# Error contract (shared verbatim with ui/components/toolsets.jsx): the reject
+# is a ToolsetUnreachableError -> HTTP 400 + problem type
+# "/errors/toolset-unreachable". The Console matches on that `type` to render
+# the inline error plus a "Create anyway" button that re-POSTs with
+# ?allow_unreachable=true (which skips this probe).
+
+
+def _toolset_probe_bypassed(request: Request) -> bool:
+    """Whether the caller opted out of the probe via ``?allow_unreachable``.
+
+    This is the "Create anyway" escape hatch: create the row regardless of
+    reachability. Accepts ``1`` / ``true`` / ``yes`` (case-insensitive).
+    """
+    raw = request.query_params.get("allow_unreachable")
+    return str(raw).strip().lower() in ("1", "true", "yes")
+
+
+def _toolset_unreachable(
+    entity: Toolset, cause: BaseException, *, timed_out: bool = False
+) -> ToolsetUnreachableError:
+    """Build the single reject error for a failed connectivity probe."""
+    if timed_out:
+        why = "connection timed out after 8s"
+    elif isinstance(cause, PrimerError):
+        why = cause.message
+    else:
+        why = f"{type(cause).__name__}: {cause}"
+    return ToolsetUnreachableError(
+        f"Could not connect to the MCP endpoint for toolset {entity.id!r}: "
+        f"{why}. Fix the URL/headers, or create it anyway to save it despite "
+        "being unreachable.",
+        cause=cause if isinstance(cause, Exception) else None,
+    )
+
+
+async def _probe_mcp_reachable(entity: Toolset, request: Request) -> None:
+    """Fully drain ``list_tools`` to confirm the http MCP endpoint is reachable.
+
+    Builds a transient :class:`McpToolsetProvider` (no persistence, no
+    registry) and consumes the whole ``tools/list`` under an 8s cap. Reachable-
+    but-needs-OAuth (:class:`AuthRequiredError`) and invalid-config
+    (:class:`ConfigError`) bubble as their own envelopes; every other failure
+    becomes the single :class:`ToolsetUnreachableError` reject.
+
+    The ``BaseExceptionGroup`` / ``PrimerError`` unwrapping mirrors
+    :func:`list_toolset_tools` above: HTTP MCP runs inside anyio task groups
+    that wrap any sub-exception in a ``BaseExceptionGroup``.
+    """
+    import asyncio
+
+    from primer.toolset.mcp import McpToolsetProvider
+
+    principal = getattr(request.state, "principal", None)
+    # Transient provider: this path is only reached for http transport, so the
+    # stdio allowlist is irrelevant (None). McpToolsetProvider.list_tools opens
+    # and closes its own short-lived session per call, so nothing leaks.
+    provider = McpToolsetProvider(
+        toolset_id=entity.id,
+        config=entity.config,  # type: ignore[arg-type]  # http => McpConfig set
+        allowed_stdio_commands=None,
+    )
+    try:
+        async with asyncio.timeout(8):
+            async for _tool in provider.list_tools(principal=principal):
+                pass  # drain fully: connect + handshake + tools/list happen here
+    except (ConfigError, AuthRequiredError):
+        # Reachable-but-needs-OAuth / caller-input config error: bubble as-is.
+        raise
+    except BaseExceptionGroup as group:
+        # Surface a documented PrimerError sub-exception if present; a
+        # Config/Auth leaf still bubbles as-is, everything else is a reject.
+        for sub in group.exceptions:
+            if isinstance(sub, (ConfigError, AuthRequiredError)):
+                raise sub from group
+        for sub in group.exceptions:
+            if isinstance(sub, PrimerError):
+                raise _toolset_unreachable(entity, sub) from group
+        first = group.exceptions[0] if group.exceptions else group
+        raise _toolset_unreachable(entity, first) from group
+    except TimeoutError as exc:
+        raise _toolset_unreachable(entity, exc, timed_out=True) from exc
+    except Exception as exc:
+        # NetworkError / ProviderError / third-party leaks -> single reject.
+        raise _toolset_unreachable(entity, exc) from exc
+
+
+async def _toolset_on_pre_create(entity: Toolset, request: Request) -> None:
+    """Reject creating an MCP-http toolset whose endpoint is unreachable.
+
+    Runs before ``storage.create`` (raising aborts the create, persisting
+    nothing). Only network MCP transports are probed; the ``allow_unreachable``
+    bypass, non-MCP toolsets, and stdio MCP (no remote endpoint -- probing it
+    would launch a subprocess) all skip the probe.
+    """
+    if _toolset_probe_bypassed(request):
+        return
+    if entity.provider != ToolsetProviderType.MCP:
+        return
+    config = entity.config
+    if config is None or config.transport != TransportType.HTTP:
+        return
+    await _probe_mcp_reachable(entity, request)
+
+
 # ---- Toolset router --------------------------------------------------------
 
 toolset_router = make_crud_router(
@@ -544,6 +664,7 @@ toolset_router = make_crud_router(
     tag="toolsets",
     on_update=_invalidate_toolset,
     on_delete=_invalidate_toolset,
+    on_pre_create=_toolset_on_pre_create,
     managed_by_field="harness_id",
     references=[
         ReferenceCheck(

--- a/primer/api/routers/providers.py
+++ b/primer/api/routers/providers.py
@@ -26,6 +26,7 @@ Models" button. They build a transient adapter, call its
 
 from __future__ import annotations
 
+import logging
 from typing import Any
 from uuid import uuid4
 
@@ -48,9 +49,8 @@ from primer.api.deps import (
 )
 from primer.api.errors import common_responses
 from primer.model.except_ import (
-    AuthRequiredError,
     BadRequestError,
-    ConfigError,
+    NetworkError,
     PrimerError,
     ToolsetUnreachableError,
 )
@@ -76,6 +76,9 @@ from primer.model.provider import (
 from primer.api.routers._references import ReferenceCheck
 from primer.model.storage import OffsetPage
 from primer.model.tool_approval import ToolApprovalPolicy
+
+
+logger = logging.getLogger(__name__)
 
 
 # ---- Reserved-id protection helpers ---------------------------------------
@@ -547,9 +550,18 @@ def _get_tool_approval_policy_storage(request: Request):
 #
 # Before persisting an MCP toolset that talks to a remote endpoint over the
 # network (transport=http), we drain a live tools/list to confirm the endpoint
-# is reachable. An unreachable endpoint is rejected BEFORE storage.create so
-# the operator gets an immediate, actionable error instead of a blind save that
-# only surfaces when an agent later fails to open a session.
+# can be REACHED. The reject means strictly "the backend could not connect" --
+# a connection refusal / DNS failure / network error, or the probe timing out.
+# It is rejected BEFORE storage.create so the operator gets an immediate,
+# actionable error instead of a blind save.
+#
+# A server that RESPONDS at all is reachable and is allowed through, even if it
+# responds with an error: OAuth-protected servers (401 -> AuthenticationError),
+# needs-consent (AuthRequiredError), 5xx (ProviderError/ServerError), or a
+# ConfigError are all "reachable" -- an OAuth toolset in particular MUST be
+# creatable so the user can then consent. The post-create TS_ConnectResult
+# probe + the T0711 banner surface those reachable-but-erroring toolsets after
+# creation, so nothing is lost by allowing them.
 #
 # Error contract (shared verbatim with ui/components/toolsets.jsx): the reject
 # is a ToolsetUnreachableError -> HTTP 400 + problem type
@@ -586,18 +598,58 @@ def _toolset_unreachable(
     )
 
 
+def _informative_leaf(exc: BaseException) -> BaseException:
+    """Unwrap anyio ``BaseExceptionGroup`` wrappers to the informative leaf.
+
+    HTTP MCP runs inside anyio task groups, which wrap any sub-exception in a
+    ``BaseExceptionGroup``. Prefer an already-classified :class:`PrimerError`
+    leaf (what :class:`McpToolsetProvider` raises for connection failures via
+    ``classify_mcp_exception``), exactly like :func:`list_toolset_tools` above;
+    otherwise fall back to the first leaf.
+    """
+    if not isinstance(exc, BaseExceptionGroup):
+        return exc
+    leaves: list[BaseException] = []
+    pending: list[BaseException] = [exc]
+    while pending:
+        cur = pending.pop()
+        if isinstance(cur, BaseExceptionGroup):
+            pending.extend(cur.exceptions)
+        else:
+            leaves.append(cur)
+    for leaf in leaves:
+        if isinstance(leaf, PrimerError):
+            return leaf
+    return leaves[0] if leaves else exc
+
+
+def _is_connection_failure(leaf: BaseException) -> bool:
+    """Pure decision: does this probe outcome mean "could not connect"?
+
+    Only a genuine transport-level failure counts as unreachable -> reject:
+
+    * :class:`NetworkError` -- connection refused / DNS failure / network error
+      (no response received), and
+    * :class:`TimeoutError` -- the 8s probe cap fired before the handshake
+      completed.
+
+    Every "the server responded" outcome is REACHABLE -> allow the create:
+    :class:`AuthenticationError` (401/403), :class:`AuthRequiredError`
+    (needs OAuth consent), :class:`ProviderError` / :class:`ServerError`
+    (5xx from a responding server), :class:`ConfigError`, or anything else.
+    """
+    return isinstance(leaf, (NetworkError, TimeoutError))
+
+
 async def _probe_mcp_reachable(entity: Toolset, request: Request) -> None:
     """Fully drain ``list_tools`` to confirm the http MCP endpoint is reachable.
 
     Builds a transient :class:`McpToolsetProvider` (no persistence, no
-    registry) and consumes the whole ``tools/list`` under an 8s cap. Reachable-
-    but-needs-OAuth (:class:`AuthRequiredError`) and invalid-config
-    (:class:`ConfigError`) bubble as their own envelopes; every other failure
-    becomes the single :class:`ToolsetUnreachableError` reject.
-
-    The ``BaseExceptionGroup`` / ``PrimerError`` unwrapping mirrors
-    :func:`list_toolset_tools` above: HTTP MCP runs inside anyio task groups
-    that wrap any sub-exception in a ``BaseExceptionGroup``.
+    registry) and consumes the whole ``tools/list`` under an 8s cap. Rejects
+    the create with :class:`ToolsetUnreachableError` ONLY when the endpoint
+    could not be connected to (:func:`_is_connection_failure`); any outcome
+    where the server responded (auth / provider / config / other) is allowed
+    through -- the post-create probe surfaces those errors.
     """
     import asyncio
 
@@ -616,25 +668,23 @@ async def _probe_mcp_reachable(entity: Toolset, request: Request) -> None:
         async with asyncio.timeout(8):
             async for _tool in provider.list_tools(principal=principal):
                 pass  # drain fully: connect + handshake + tools/list happen here
-    except (ConfigError, AuthRequiredError):
-        # Reachable-but-needs-OAuth / caller-input config error: bubble as-is.
-        raise
-    except BaseExceptionGroup as group:
-        # Surface a documented PrimerError sub-exception if present; a
-        # Config/Auth leaf still bubbles as-is, everything else is a reject.
-        for sub in group.exceptions:
-            if isinstance(sub, (ConfigError, AuthRequiredError)):
-                raise sub from group
-        for sub in group.exceptions:
-            if isinstance(sub, PrimerError):
-                raise _toolset_unreachable(entity, sub) from group
-        first = group.exceptions[0] if group.exceptions else group
-        raise _toolset_unreachable(entity, first) from group
-    except TimeoutError as exc:
-        raise _toolset_unreachable(entity, exc, timed_out=True) from exc
     except Exception as exc:
-        # NetworkError / ProviderError / third-party leaks -> single reject.
-        raise _toolset_unreachable(entity, exc) from exc
+        # asyncio.timeout raises TimeoutError; the mcp transport raises a
+        # classified PrimerError (often wrapped in a BaseExceptionGroup).
+        leaf = _informative_leaf(exc)
+        if _is_connection_failure(leaf):
+            raise _toolset_unreachable(
+                entity, leaf, timed_out=isinstance(leaf, TimeoutError)
+            ) from exc
+        # Reachable but errored (auth / provider / config / other): allow the
+        # create. The post-create TS_ConnectResult probe surfaces the error.
+        logger.debug(
+            "toolset %r create probe: endpoint reachable but errored (%s); "
+            "allowing create",
+            entity.id,
+            type(leaf).__name__,
+        )
+        return
 
 
 async def _toolset_on_pre_create(entity: Toolset, request: Request) -> None:

--- a/primer/model/except_.py
+++ b/primer/model/except_.py
@@ -134,6 +134,19 @@ class BadRequestError(ProviderError):
     """Provider rejected the request as malformed or invalid (400-style)."""
 
 
+class ToolsetUnreachableError(BadRequestError):
+    """Create of an MCP toolset was blocked because its endpoint is unreachable.
+
+    Raised by the ``POST /v1/toolsets`` pre-create connectivity probe when a
+    network (http) MCP endpoint cannot be reached. Serialised as HTTP 400 with
+    problem ``type == "/errors/toolset-unreachable"`` so the Console can offer
+    a "Create anyway" action (re-POST with ``?allow_unreachable=true``, which
+    skips the probe). Distinct from :class:`AuthRequiredError` (endpoint is
+    reachable but needs OAuth) and :class:`ConfigError` (caller supplied an
+    invalid config) -- both of those bubble as their own envelopes.
+    """
+
+
 class ServerError(ProviderError):
     """Provider encountered an internal error (5xx)."""
 

--- a/tests/api/test_toolset_create_probe.py
+++ b/tests/api/test_toolset_create_probe.py
@@ -49,6 +49,18 @@ async def test_unreachable_http_mcp_is_rejected_and_not_persisted(client):
 
 
 @pytest.mark.asyncio
+async def test_allow_unreachable_false_does_not_bypass(client):
+    # Only a truthy flag bypasses; allow_unreachable=false still probes and
+    # rejects the dead-port create.
+    r = await client.post(
+        "/v1/toolsets?allow_unreachable=false",
+        json=_http_mcp_body("ts-dead-false"),
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["type"] == "/errors/toolset-unreachable"
+
+
+@pytest.mark.asyncio
 async def test_allow_unreachable_bypasses_the_probe_and_creates(client):
     r = await client.post(
         "/v1/toolsets?allow_unreachable=true",
@@ -92,3 +104,66 @@ async def test_non_mcp_toolset_is_created_without_probing(client):
     assert r.status_code == 201, r.text
     g = await client.get("/v1/toolsets/ts-internal")
     assert g.status_code == 200, g.text
+
+
+# ----------------------------------------------------------------------------
+# Pure classification helper: "unreachable" == genuine connection failure only.
+# Non-flaky unit test of the decision that gates the reject (no real server).
+# ----------------------------------------------------------------------------
+
+
+def test_is_connection_failure_only_for_network_and_timeout():
+    from primer.api.routers.providers import _is_connection_failure
+    from primer.model.except_ import (
+        AuthenticationError,
+        AuthRequiredError,
+        ConfigError,
+        NetworkError,
+        ProviderError,
+        ServerError,
+    )
+
+    # Genuine connection failures -> reject the create.
+    assert _is_connection_failure(NetworkError("connection refused")) is True
+    assert _is_connection_failure(TimeoutError()) is True
+
+    # The server responded (or config is the caller's) -> reachable -> allow.
+    assert _is_connection_failure(AuthenticationError("401")) is False
+    assert _is_connection_failure(
+        AuthRequiredError("consent", auth_url="https://a/authorize", state="s")
+    ) is False
+    assert _is_connection_failure(ProviderError("weird 4xx")) is False
+    assert _is_connection_failure(ServerError("500")) is False
+    assert _is_connection_failure(ConfigError("bad config")) is False
+    assert _is_connection_failure(ValueError("other")) is False
+
+
+def test_informative_leaf_unwraps_group_to_network_error():
+    from primer.api.routers.providers import (
+        _informative_leaf,
+        _is_connection_failure,
+    )
+    from primer.model.except_ import NetworkError
+
+    # anyio wraps transport failures in a BaseExceptionGroup; the classified
+    # NetworkError leaf must be found and judged a connection failure.
+    net = NetworkError("could not connect to the MCP server")
+    group = BaseExceptionGroup("unhandled", [net])
+    leaf = _informative_leaf(group)
+    assert leaf is net
+    assert _is_connection_failure(leaf) is True
+
+
+def test_informative_leaf_prefers_responded_primer_error_over_reject():
+    from primer.api.routers.providers import (
+        _informative_leaf,
+        _is_connection_failure,
+    )
+    from primer.model.except_ import AuthenticationError
+
+    # A responded-with-401 leaf inside a group is reachable -> allow.
+    auth = AuthenticationError("MCP server rejected credentials (401)")
+    group = BaseExceptionGroup("unhandled", [auth])
+    leaf = _informative_leaf(group)
+    assert leaf is auth
+    assert _is_connection_failure(leaf) is False

--- a/tests/api/test_toolset_create_probe.py
+++ b/tests/api/test_toolset_create_probe.py
@@ -1,0 +1,94 @@
+"""POST /v1/toolsets connectivity probe: block creating an MCP toolset
+whose http endpoint is unreachable, with a ``?allow_unreachable=true``
+escape hatch ("Create anyway").
+
+Contract under test (single source of truth shared with the Console):
+an unreachable http MCP toolset is rejected BEFORE persistence with
+HTTP 400 + problem ``type == "/errors/toolset-unreachable"``. The probe
+is skipped for the bypass flag, for non-MCP toolsets, and for stdio MCP
+(which has no remote endpoint).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+
+# A closed loopback port: connecting refuses immediately (ECONNREFUSED),
+# so the probe fails fast without leaning on the 8s timeout.
+_DEAD_URL = "http://127.0.0.1:1/mcp"
+
+
+def _http_mcp_body(tid: str, url: str = _DEAD_URL) -> dict:
+    return {
+        "id": tid,
+        "provider": "mcp",
+        "config": {
+            "transport": "http",
+            "config": {"url": url, "headers": {}},
+        },
+    }
+
+
+@pytest.mark.asyncio
+async def test_unreachable_http_mcp_is_rejected_and_not_persisted(client):
+    r = await client.post("/v1/toolsets", json=_http_mcp_body("ts-dead"))
+    assert r.status_code == 400, r.text
+
+    body = r.json()
+    # Frontend-detectable contract: the dedicated problem type URI.
+    assert body["type"] == "/errors/toolset-unreachable"
+    assert body["status"] == 400
+    assert "content-type" in {k.lower() for k in r.headers}
+    assert r.headers["content-type"].startswith("application/problem+json")
+    assert "connect" in body["detail"].lower()
+
+    # Nothing was persisted — the create was aborted before storage.create.
+    g = await client.get("/v1/toolsets/ts-dead")
+    assert g.status_code == 404, g.text
+
+
+@pytest.mark.asyncio
+async def test_allow_unreachable_bypasses_the_probe_and_creates(client):
+    r = await client.post(
+        "/v1/toolsets?allow_unreachable=true",
+        json=_http_mcp_body("ts-anyway"),
+    )
+    assert r.status_code == 201, r.text
+    assert r.json()["id"] == "ts-anyway"
+
+    # Persisted despite being unreachable.
+    g = await client.get("/v1/toolsets/ts-anyway")
+    assert g.status_code == 200, g.text
+
+
+@pytest.mark.asyncio
+async def test_stdio_mcp_is_created_without_probing(client):
+    # stdio has no remote endpoint to reach; the probe is skipped, so the
+    # row is created even though the command would never launch.
+    r = await client.post(
+        "/v1/toolsets",
+        json={
+            "id": "ts-stdio",
+            "provider": "mcp",
+            "config": {
+                "transport": "stdio",
+                "config": {"command": ["definitely-not-a-real-binary"], "env": {}},
+            },
+        },
+    )
+    assert r.status_code == 201, r.text
+    g = await client.get("/v1/toolsets/ts-stdio")
+    assert g.status_code == 200, g.text
+
+
+@pytest.mark.asyncio
+async def test_non_mcp_toolset_is_created_without_probing(client):
+    # An internal (non-MCP) toolset has no endpoint; never probed.
+    r = await client.post(
+        "/v1/toolsets",
+        json={"id": "ts-internal", "provider": "internal"},
+    )
+    assert r.status_code == 201, r.text
+    g = await client.get("/v1/toolsets/ts-internal")
+    assert g.status_code == 200, g.text

--- a/tests/ui/test_toolset_create_anyway.py
+++ b/tests/ui/test_toolset_create_anyway.py
@@ -1,0 +1,70 @@
+"""toolsets.jsx: TS_NewToolsetModal "Create anyway" escape hatch.
+
+When POST /toolsets is rejected because the MCP endpoint is unreachable
+(400 + problem type "/errors/toolset-unreachable"), the modal must surface
+the message inline with a "Create anyway" button that re-submits the same
+body with ?allow_unreachable=true (skipping the backend probe).
+
+Static-source checks + a transpile gate (the tests/ui convention — no
+DOM/browser harness).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+TOOLSETS = UI / "components" / "toolsets.jsx"
+
+
+def _src() -> str:
+    return TOOLSETS.read_text(encoding="utf-8")
+
+
+def _modal_src() -> str:
+    src = _src()
+    start = src.index("function TS_NewToolsetModal(")
+    end = src.index("function TS_KvEditor(", start)
+    return src[start:end]
+
+
+def test_onerror_detects_the_unreachable_contract_type_uri() -> None:
+    # Single shared contract with the backend reject: the dedicated type URI.
+    modal = _modal_src()
+    assert 'err.type === "/errors/toolset-unreachable"' in modal
+
+
+def test_create_anyway_button_present() -> None:
+    modal = _modal_src()
+    assert 'data-testid="toolset-create-anyway"' in modal
+    assert "Create anyway" in modal
+
+
+def test_inline_unreachable_block_rendered() -> None:
+    modal = _modal_src()
+    assert 'data-testid="toolset-unreachable"' in modal
+
+
+def test_bypass_flag_appends_allow_unreachable_query() -> None:
+    modal = _modal_src()
+    assert 'allowUnreachable ? "?allow_unreachable=true" : ""' in modal
+
+
+def test_create_anyway_resubmits_same_body_with_bypass() -> None:
+    modal = _modal_src()
+    # The click handler re-submits the remembered body with the bypass flag.
+    assert "create.mutate({ body: lastBody, allowUnreachable: true })" in modal
+    # The normal submit path stores the body and sends without the bypass.
+    assert "setLastBody(body)" in modal
+    assert "create.mutate({ body, allowUnreachable: false })" in modal
+
+
+def test_bundle_transpiles_with_create_anyway_flow() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    build_jsx_bundle.cache_clear()
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    text = body.decode("utf-8")
+    assert "/* === components/toolsets.jsx === */" in text

--- a/tests/ui_e2e/test_anomaly_surfaces.py
+++ b/tests/ui_e2e/test_anomaly_surfaces.py
@@ -47,7 +47,9 @@ def test_u0008_toolset_tools_tab_renders_t0711_anomaly_banner(
         # Create MCP-HTTP toolset pointing at a deliberately
         # unreachable URL - port 9999 on localhost is unlikely to
         # have anything listening.
-        r = c.post("/v1/toolsets", json={
+        # allow_unreachable: this suite deliberately seeds an unreachable
+        # MCP-HTTP toolset; opt out of the create-time connectivity probe.
+        r = c.post("/v1/toolsets?allow_unreachable=true", json={
             "id": toolset_id,
             "provider": "mcp",
             "config": {
@@ -352,7 +354,9 @@ def test_u0009_agent_tools_tab_isolates_one_failing_toolset(
         assert r.status_code == 201, f"seed LLM failed: {r.text}"
 
         # Seed the broken MCP-HTTP toolset (T0711 trigger).
-        r = c.post("/v1/toolsets", json={
+        # allow_unreachable: this suite deliberately seeds an unreachable
+        # MCP-HTTP toolset; opt out of the create-time connectivity probe.
+        r = c.post("/v1/toolsets?allow_unreachable=true", json={
             "id": bad_toolset_id,
             "provider": "mcp",
             "config": {

--- a/tests/ui_e2e/test_empty_states_and_lifecycle.py
+++ b/tests/ui_e2e/test_empty_states_and_lifecycle.py
@@ -48,7 +48,9 @@ def test_u0045_toolset_tools_tab_deep_link_survives_reload(
     """
     toolset_id = f"ts-u0045-{unique_suffix}"
     with httpx.Client(base_url=base_url, timeout=30.0) as c:
-        r = c.post("/v1/toolsets", json={
+        # allow_unreachable: this lifecycle test seeds an unreachable MCP-HTTP
+        # toolset on purpose; opt out of the create-time connectivity probe.
+        r = c.post("/v1/toolsets?allow_unreachable=true", json={
             "id": toolset_id,
             "provider": "mcp",
             "config": {

--- a/ui/components/toolsets.jsx
+++ b/ui/components/toolsets.jsx
@@ -322,6 +322,12 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
     () => _dictToPairs(existing?.config?.config?.headers)
   );
   const [fieldErrors, setFieldErrors] = React.useState({});
+  // "Create anyway" escape hatch. When the backend rejects the create because
+  // the MCP endpoint is unreachable (400 + type "/errors/toolset-unreachable"),
+  // we hold the connection message + the exact body so the operator can
+  // re-submit with ?allow_unreachable=true to save it despite being down.
+  const [unreachable, setUnreachable] = React.useState(null); // {message} | null
+  const [lastBody, setLastBody] = React.useState(null);
 
   // After the row is saved we probe it (reusing the now-graceful
   // GET /toolsets/{id}/tools) so the operator sees whether it actually
@@ -352,9 +358,12 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
   }, [createdRow, apiFetch]);
 
   const create = useMutation(
-    (body) => isEdit
+    // mutate({ body, allowUnreachable }): allowUnreachable appends
+    // ?allow_unreachable=true so the create skips the backend connectivity
+    // probe ("Create anyway"). Edit (PUT) never probes.
+    ({ body, allowUnreachable }) => isEdit
       ? apiFetch("PUT", "/toolsets/" + encodeURIComponent(existing.id), body)
-      : apiFetch("POST", "/toolsets", body),
+      : apiFetch("POST", "/toolsets" + (allowUnreachable ? "?allow_unreachable=true" : ""), body),
     {
       invalidates: isEdit
         ? ["toolsets:list", "toolset-detail:" + (existing?.id || "")]
@@ -369,6 +378,11 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
             next[(fe.loc || []).join(".")] = fe.msg;
           }
           setFieldErrors(next);
+        } else if (err && err.type === "/errors/toolset-unreachable") {
+          // Endpoint unreachable — surface inline with a "Create anyway"
+          // button instead of a toast. Contract mirrors the backend reject in
+          // primer/api/routers/providers.py (_toolset_on_pre_create).
+          setUnreachable({ message: err.detail || err.message || "Could not connect to the MCP endpoint." });
         } else if (typeof pushToast === "function") {
           pushToast({
             kind: "error",
@@ -387,6 +401,7 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
 
   const submit = async () => {
     setFieldErrors({});
+    setUnreachable(null);
     let config = null;
     if (provider === "mcp") {
       config = transport === "stdio"
@@ -410,7 +425,9 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
       provider,
       ...(config ? { config } : {}),
     };
-    try { await create.mutate(body); } catch (_e) { /* surfaced via onError */ }
+    // Remember the exact body so "Create anyway" can re-submit it unchanged.
+    setLastBody(body);
+    try { await create.mutate({ body, allowUnreachable: false }); } catch (_e) { /* surfaced via onError */ }
   };
 
   const canSubmit = provider === "mcp"
@@ -440,6 +457,40 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
         <TS_ConnectResult row={createdRow} isEdit={isEdit} probing={probing} probe={probe} />
       ) : (
       <>
+      {unreachable && (
+        <div
+          data-testid="toolset-unreachable"
+          style={{ padding: "12px", marginBottom: 12, background: "var(--red-dim)", borderRadius: 8 }}
+        >
+          <div style={{ display: "flex", alignItems: "center", gap: 10, color: "var(--red)" }}>
+            <Icon name="alert" size={16} />
+            <strong>Endpoint unreachable.</strong>
+          </div>
+          <div className="text-sm" style={{ marginTop: 6, color: "var(--text-2)", wordBreak: "break-word" }}>
+            {unreachable.message}
+          </div>
+          <div className="field-help" style={{ marginTop: 8 }}>
+            The create was blocked because the MCP endpoint could not be reached. Fix the URL/headers and try again — or create it anyway and its tools will stay unavailable until it connects.
+          </div>
+          <div style={{ marginTop: 10 }}>
+            <Btn
+              size="sm"
+              kind="secondary"
+              icon="plus"
+              data-testid="toolset-create-anyway"
+              disabled={create.loading || !lastBody}
+              onClick={async () => {
+                setUnreachable(null);
+                // Re-submit the SAME body with ?allow_unreachable=true.
+                try { await create.mutate({ body: lastBody, allowUnreachable: true }); }
+                catch (_e) { /* surfaced via onError */ }
+              }}
+            >
+              {create.loading ? "Creating…" : "Create anyway"}
+            </Btn>
+          </div>
+        </div>
+      )}
       <div className="field">
         <label className="field-label">ID {isEdit
           ? <span className="hint">locked — id cannot change after create</span>


### PR DESCRIPTION
## Block creating an unreachable MCP toolset (with "Create anyway")

Creating an MCP toolset whose remote endpoint the backend **can't connect to** used to succeed silently. Now the create is **probed before it's persisted**: if the endpoint is unreachable, the create is rejected (nothing saved) and the Console offers a **"Create anyway"** escape hatch.

> Unrelated to the collection-mount PR (#126) — this is a focused toolset-UX fix on its own branch off `main`.

### Behavior
- `POST /v1/toolsets` for an **MCP / http** toolset: a bounded (`asyncio.timeout(8)`) transient probe attempts the connection **before** persisting.
  - **Genuine connection failure** (`NetworkError` — refused / DNS / network — or a probe timeout) → **reject, persist nothing**, `HTTP 400` + problem `type: /errors/toolset-unreachable`.
  - **Reachable but erroring** (an OAuth server returning 401, a 5xx from a responding server, a config error, …) → **allowed**. "Unreachable" means *couldn't connect*, not *connected-but-unhappy* — so an up OAuth server that needs consent is never blocked; the existing post-create probe + T0711 banner still surface its status.
- `POST /v1/toolsets?allow_unreachable=true` → **skips the probe** ("Create anyway").
- **Non-MCP** and **stdio** MCP toolsets are never probed (no remote endpoint).

### How
- Backend: a `_toolset_on_pre_create` hook on the toolset CRUD router builds a **transient `McpToolsetProvider`** from the config (no persistence, no registry) and drains `list_tools` once. A pure `_is_connection_failure` helper (`NetworkError`/`TimeoutError` only) decides reject-vs-allow after `_informative_leaf` unwraps the anyio `BaseExceptionGroup` — reusing the exact pattern from `list_toolset_tools`. New `ToolsetUnreachableError` (→ 400 + `/errors/toolset-unreachable`).
- Console: `TS_NewToolsetModal` detects the reject via `err.type === "/errors/toolset-unreachable"`, shows the connection message inline, and a **"Create anyway"** button re-submits the same body with `allow_unreachable=true`.

### Tests
- Backend: dead-port create → **rejected + `GET`→404** (not persisted); `?allow_unreachable=true` → 201; `?allow_unreachable=false` → still rejected; stdio + non-MCP → created without a probe; plus non-flaky **pure unit tests** of `_is_connection_failure` / `_informative_leaf`.
- Frontend: source-string asserts for the create-anyway flow + a Babel transpile gate.
- Full touched suite green (probe + UI + providers + error-handler), `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
