### PR TITLE
fix(ui): T0711 banner renders for any 5xx + CI hang backstop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,12 @@ permissions:
 jobs:
   test:
     runs-on: ubuntu-latest
+    # Backstop against a wedged test: the sweep normally finishes in ~12 min,
+    # but a test blocked in a native/uninterruptible call (a socket, a
+    # subprocess, or a Docker-backend op) is NOT killed by the pytest
+    # --timeout-method=thread, so without this the job runs to GitHub's 6-hour
+    # default. 25 min fails a hang fast (with the hung test's traceback) instead.
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v7
       - uses: astral-sh/setup-uv@v7

--- a/tests/ui/test_t0711_banner_status.py
+++ b/tests/ui/test_t0711_banner_status.py
@@ -1,0 +1,51 @@
+"""T0711 anomaly-banner status guard.
+
+An unreachable / erroring MCP-HTTP toolset's ``GET /toolsets/{id}/tools`` now
+returns a proper 5xx (an unreachable upstream is a ``NetworkError`` -> 504,
+a bad upstream response a ``ProviderError`` -> 502, ...) rather than the old
+leaked 500. The "Tools list unavailable" (T0711) banner must therefore trigger
+on the whole server-error class, not a strict ``=== 500`` -- otherwise the
+banner silently stops rendering and only the slow, expensive ui-e2e journeys
+(U0008 / U0009) catch it. This locks the condition cheaply.
+"""
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+COMPONENTS = ROOT / "ui" / "components"
+
+
+def _src(name: str) -> str:
+    return (COMPONENTS / name).read_text(encoding="utf-8")
+
+
+def test_toolset_tools_banner_triggers_on_5xx_not_only_500():
+    src = _src("toolsets.jsx")
+    assert "tools.error.status >= 500" in src, (
+        "toolset Tools-tab T0711 banner must match the 5xx server-error class"
+    )
+    # Must not regress to a strict 500 check (unreachable MCP-HTTP is 504).
+    assert "tools.error.status === 500" not in src
+
+
+def test_agent_tools_banner_triggers_on_5xx_not_only_500():
+    src = _src("agents.jsx")
+    assert src.count("tools.error?.status >= 500") >= 2, (
+        "both agent T0711 surfaces (ref-row pill + per-toolset panel) must "
+        "match the 5xx server-error class"
+    )
+    assert "tools.error?.status === 500" not in src
+
+
+def test_t0711_marker_still_present_in_both_surfaces():
+    # The tests U0008/U0009 assert a stable "T0711" tag in the rendered banner;
+    # keep it in both source files so a copy-edit that drops it fails here too.
+    assert "T0711" in _src("toolsets.jsx")
+    assert "T0711" in _src("agents.jsx")
+
+
+def test_bundle_transpiles():
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(ROOT / "ui")
+    assert etag and body

--- a/tests/ui_e2e/test_anomaly_surfaces.py
+++ b/tests/ui_e2e/test_anomaly_surfaces.py
@@ -6,7 +6,8 @@ its own test here. Setup creates the backend precondition via API
 
 Covers:
 * U0008 - T0711 anomaly banner on toolset detail Tools tab when an
-  MCP-HTTP toolset points at an unreachable URL (server returns 500).
+  MCP-HTTP toolset points at an unreachable URL (server returns a 5xx --
+  an unreachable upstream is a NetworkError -> 504).
 
 UI spec §5 documents this surface as required.
 """
@@ -36,9 +37,9 @@ def test_u0008_toolset_tools_tab_renders_t0711_anomaly_banner(
     blank-page crash).
 
     Priority 3 - anomaly surface. The Tools tab calls
-    GET /v1/toolsets/{id}/tools which leaks 500 /errors/internal
-    when the MCP-HTTP transport's upstream is unreachable. The UI
-    detects (tools.error.status === 500 && config.transport === "http")
+    GET /v1/toolsets/{id}/tools which returns a 5xx (an unreachable
+    MCP-HTTP upstream classifies as NetworkError -> 504). The UI
+    detects (tools.error.status >= 500 && config.transport === "http")
     and renders a dedicated Banner with retry + invalidate actions.
     """
     toolset_id = f"ts-u0008-{unique_suffix}"

--- a/ui/components/agents.jsx
+++ b/ui/components/agents.jsx
@@ -1335,7 +1335,9 @@ function AG_ToolsetRefRow({ tsId, registeredCount, navigate }) {
     { pollMs: null, deps: [tsId] }
   );
   const exposedCount = tools.data?.tools?.length;
-  const t711 = tools.error?.status === 500;
+  // Any 5xx on an MCP-HTTP toolset's /tools (unreachable -> 504, etc.) is the
+  // T0711 "tools unavailable" surface, not just the old leaked 500.
+  const t711 = tools.error?.status >= 500;
   return (
     <div className="ref-row">
       <Icon name="tools" size={13} className="ico" />
@@ -1355,7 +1357,7 @@ function AG_ToolsetRefRow({ tsId, registeredCount, navigate }) {
       {tools.loading ? (
         <span className="muted text-sm">…</span>
       ) : t711 ? (
-        <span className="pill pill-failed" title="T0711 — MCP-HTTP 500 leak"><span className="dot"></span>T0711</span>
+        <span className="pill pill-failed" title="T0711 — MCP-HTTP server unreachable"><span className="dot"></span>T0711</span>
       ) : tools.error ? (
         <span className="pill pill-failed"><span className="dot"></span>err</span>
       ) : (
@@ -1428,9 +1430,10 @@ function AG_ToolsetSection({ tsId, registeredBareIds }) {
     [registeredBareIds],
   );
 
-  // T0711 MCP-HTTP leak — for any toolset returning 500, surface the
-  // anomaly block instead of crashing the rest of the page (U0009).
-  if (tools.error?.status === 500) {
+  // T0711 — for any toolset whose /tools returns a 5xx (unreachable MCP-HTTP
+  // upstream -> 504, etc.), surface the anomaly block instead of crashing the
+  // rest of the page (U0009).
+  if (tools.error?.status >= 500) {
     return (
       <div className="panel" style={{ marginBottom: 14 }}>
         <div className="panel-h">
@@ -1442,7 +1445,7 @@ function AG_ToolsetSection({ tsId, registeredBareIds }) {
           <Banner
             kind="error"
             title="Tools list unavailable"
-            detail="The documented bug pinned by T0711 — MCP-HTTP transport leaks 500/errors/internal when the remote server is unreachable. Visit the toolset detail to Invalidate the cached provider and retry."
+            detail="The MCP-HTTP server for this toolset is unreachable (T0711), so its tools can't be listed. Visit the toolset detail to Invalidate the cached provider and retry."
             actions={<Btn size="sm" icon="refresh" onClick={tools.refetch}>Retry</Btn>}
           />
         </div>

--- a/ui/components/toolsets.jsx
+++ b/ui/components/toolsets.jsx
@@ -845,10 +845,12 @@ function TS_ToolsTab({ id, ts, onInvalidate }) {
     return <div className="muted text-sm" style={{ padding: 24, textAlign: "center" }}>Loading tools…</div>;
   }
   if (tools.error) {
-    // T0711 — GET /v1/toolsets/{id}/tools leaks 500/errors/internal for
-    // the MCP-HTTP transport when the remote server is unreachable.
+    // T0711 — an unreachable / erroring MCP-HTTP upstream. It now surfaces as
+    // a proper 5xx (NetworkError -> 504, ProviderError -> 502, ...) rather than
+    // the old leaked 500, so treat any server-side failure on an HTTP toolset
+    // as the "tools unavailable" anomaly surface.
     const transport = _tsTransport(ts);
-    const t711 = tools.error.status === 500 && transport === "http";
+    const t711 = transport === "http" && tools.error.status >= 500;
     if (t711) {
       return (
         <div style={{ padding: 14 }}>
@@ -856,10 +858,9 @@ function TS_ToolsTab({ id, ts, onInvalidate }) {
             kind="error"
             title="Tools list unavailable"
             detail={
-              "This is the documented bug pinned by T0711 — the MCP-HTTP " +
-              "transport leaks 500 /errors/internal when the remote server " +
-              "is unreachable. Confirm the URL is reachable, then Invalidate " +
-              "to drop the cached provider and retry."
+              "The MCP-HTTP server for this toolset is unreachable (T0711), " +
+              "so its tools can't be listed. Confirm the URL is reachable, " +
+              "then Invalidate to drop the cached provider and retry."
             }
             actions={
               <>


### PR DESCRIPTION
## Fix the T0711 tools-unavailable banner (renders for any 5xx) + CI hang backstop

Two small, unrelated `main`-fixes, extracted so they can land independently of the larger feature PRs (#126, #127) that also contain them.

### 1. T0711 banner: render for any 5xx, not just a leaked 500
Since the MCP graceful-degradation fix, an unreachable MCP-HTTP toolset's `GET /toolsets/{id}/tools` returns a proper **504** (`NetworkError`), not the old leaked **500**. But the "Tools list unavailable" (T0711) banner was gated on `tools.error.status === 500`, so it stopped rendering for the 504 — the `ui-e2e` journeys `U0008`/`U0009` time out waiting for it (**`main`'s `ui-e2e` is currently red for this reason**, and every branch off `main` inherits it).

Broaden the detection to `status >= 500` in `toolsets.jsx` (Tools tab) and `agents.jsx` (ref-row pill + per-toolset panel); refresh the now-inaccurate "leaks 500" copy while keeping the stable `T0711` tag the journeys assert; add a source-guard unit test so it can't silently regress to `=== 500`.

### 2. CI backstop: 25-min `timeout-minutes` on the `test` job
The unit sweep runs ~12 min, but a test blocked in a native/uninterruptible call (a socket, subprocess, or Docker-backend op) isn't killed by pytest's `--timeout-method=thread`, and the job had **no `timeout-minutes`** — so a wedged test ran to GitHub's 6-hour default (observed: a 2-hour hang). Cap it so a hang fails fast *with the hung test's traceback*.

Both changes are already CI-verified on #126 (its `ui-e2e` is green). Merging this un-breaks `main`'s `ui-e2e` for all branches.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
