### PR TITLE
feat(harness): make git_url optional for outbound harnesses

### DIFF
--- a/primer/api/routers/harness.py
+++ b/primer/api/routers/harness.py
@@ -61,7 +61,7 @@ harness_router = APIRouter(prefix="/v1/harnesses", tags=["harnesses"])
 class HarnessCreateBody(BaseModel):
     name: str = Field(..., min_length=1, max_length=200)
     slug: str = Field(..., min_length=2, max_length=64)
-    git_url: str = Field(..., min_length=1)
+    git_url: str | None = Field(default=None, min_length=1)
     ref: str | None = Field(default=None, min_length=1)
     subpath: str | None = None
     git_token: str | None = None
@@ -75,6 +75,7 @@ class HarnessUpdateBody(BaseModel):
     description: str | None = Field(default=None, max_length=2000)
     ref: str | None = Field(default=None, min_length=1)
     subpath: str | None = None
+    git_url: str | None = Field(default=None, min_length=1)
     git_token: str | None = None
 
 
@@ -139,6 +140,22 @@ async def create_harness(
                     },
                 )
             seen.add(te.template_name)
+
+    # Inbound harnesses install FROM a git repo, so a remote is mandatory.
+    # Outbound harnesses render from the live DB and can be consumed via the
+    # bundle tarball, so git is optional — a push target only if the user wants
+    # one.
+    if body.direction == HarnessDirection.INBOUND and not body.git_url:
+        return JSONResponse(
+            status_code=422,
+            content={
+                "code": "git_url_required_inbound",
+                "detail": (
+                    "inbound harnesses install from a git repo, so git_url "
+                    "is required"
+                ),
+            },
+        )
 
     # Enforce slug uniqueness
     slug_pred = Q(Harness).where("slug", body.slug).build()
@@ -270,6 +287,25 @@ async def update_harness(
         overrides_dirty = True
     if body.git_token is not None:
         harness.git_token = SecretStr(body.git_token)
+    if "git_url" in body.model_fields_set:
+        # Explicitly provided (possibly null). Outbound harnesses may clear
+        # their remote (git is optional); inbound must always keep one to
+        # install from.
+        if (
+            body.git_url is None
+            and harness.direction == HarnessDirection.INBOUND
+        ):
+            return JSONResponse(
+                status_code=422,
+                content={
+                    "code": "git_url_required_inbound",
+                    "detail": (
+                        "inbound harnesses require a git_url; it cannot be "
+                        "cleared"
+                    ),
+                },
+            )
+        harness.git_url = body.git_url
 
     harness.overrides_dirty = overrides_dirty
     return await storage.update(harness)
@@ -825,6 +861,18 @@ async def push_harness(
             content={
                 "code": "outbound_no_entities",
                 "detail": "No tracked entities; nothing to push",
+            },
+        )
+
+    if not harness.git_url:
+        return JSONResponse(
+            status_code=422,
+            content={
+                "code": "git_remote_not_configured",
+                "detail": (
+                    "This harness has no git_url configured; set one before "
+                    "pushing, or download the bundle via /bundle.tar.gz"
+                ),
             },
         )
 

--- a/primer/harness/dispatch.py
+++ b/primer/harness/dispatch.py
@@ -1243,6 +1243,14 @@ async def _do_push(
             "message": "no tracked entities; cannot push",
         })
 
+    if not harness.git_url:
+        # Defence in depth — the push route already rejects this (422). A
+        # git-less outbound harness is consumed via build/download, not push.
+        return HarnessStatus.ERROR, json.dumps({
+            "code": "git_remote_not_configured",
+            "message": "no git_url configured; cannot push (build/download instead)",
+        })
+
     try:
         result = await build_outbound(
             harness, storage_provider=deps.storage_provider,

--- a/primer/model/harness.py
+++ b/primer/model/harness.py
@@ -112,7 +112,7 @@ class Harness(Identifiable):
     slug: str = Field(..., min_length=2, max_length=64)
     name: str = Field(..., min_length=1, max_length=200)
     description: str | None = Field(default=None, max_length=2000)
-    git_url: str = Field(..., min_length=1)
+    git_url: str | None = Field(default=None, min_length=1)
     git_token: SecretStr | None = None
     subpath: str | None = None
     ref: str = Field(default="main", min_length=1)

--- a/tests/api/test_harness_outbound_router.py
+++ b/tests/api/test_harness_outbound_router.py
@@ -544,3 +544,101 @@ async def test_download_bundle_inbound_rejected(client, app, fake_storage_provid
 async def test_download_bundle_not_found(client):
     r = await client.get("/v1/harnesses/hns_nope/bundle.tar.gz")
     assert r.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# git is optional for outbound harnesses
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_create_outbound_without_git_url_ok(client):
+    """An outbound harness renders from the DB, so git_url is optional."""
+    r = await client.post(
+        "/v1/harnesses",
+        json={
+            "name": "No Git Outbound",
+            "slug": "no-git-outbound",
+            "direction": "outbound",
+            "tracked_entities": [
+                {"kind": "agent", "source_id": "ag-1", "template_name": "assistant"},
+            ],
+        },
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["direction"] == "outbound"
+    assert body["git_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_create_inbound_without_git_url_rejected(client):
+    """Inbound harnesses install FROM a repo, so git_url stays required."""
+    r = await client.post(
+        "/v1/harnesses",
+        json={
+            "name": "No Git Inbound",
+            "slug": "no-git-inbound",
+            "direction": "inbound",
+        },
+    )
+    assert r.status_code == 422, r.text
+    assert r.json()["code"] == "git_url_required_inbound"
+
+
+@pytest.mark.asyncio
+async def test_push_without_git_url_rejected(client, app, fake_storage_provider):
+    """Pushing a git-less harness is rejected up front (never enters ERROR)."""
+    harness = _make_outbound_harness(
+        id="hns_push_nogit", slug="push-nogit", git_url=None,
+    )
+    await fake_storage_provider.get_storage(Harness).create(harness)
+
+    r = await client.post("/v1/harnesses/hns_push_nogit/push")
+    assert r.status_code == 422, r.text
+    assert r.json()["code"] == "git_remote_not_configured"
+
+
+@pytest.mark.asyncio
+async def test_bundle_download_without_git_url(client, app, fake_storage_provider):
+    """A git-less outbound harness is still consumable via the tarball."""
+    await fake_storage_provider.get_storage(Agent).create(_make_agent(id="ag-bot"))
+    harness = _make_outbound_harness(
+        id="hns_bundle_nogit", slug="bundle-nogit", git_url=None,
+    )
+    await fake_storage_provider.get_storage(Harness).create(harness)
+
+    r = await client.get("/v1/harnesses/hns_bundle_nogit/bundle.tar.gz")
+    assert r.status_code == 200, r.text
+    assert r.headers["content-type"] == "application/gzip"
+    tf = tarfile.open(fileobj=io.BytesIO(r.content), mode="r:gz")
+    names = tf.getnames()
+    assert "harness.yaml" in names
+    assert "templates/assistant.yaml" in names
+
+
+@pytest.mark.asyncio
+async def test_update_clear_git_url_outbound(client, app, fake_storage_provider):
+    """An outbound harness can drop its remote via PUT git_url=null."""
+    harness = _make_outbound_harness(
+        id="hns_clr_git", slug="clr-git",
+        git_url="https://github.com/example/x",
+    )
+    await fake_storage_provider.get_storage(Harness).create(harness)
+
+    r = await client.put("/v1/harnesses/hns_clr_git", json={"git_url": None})
+    assert r.status_code == 200, r.text
+    assert r.json()["git_url"] is None
+
+
+@pytest.mark.asyncio
+async def test_update_clear_git_url_inbound_rejected(
+    client, app, fake_storage_provider,
+):
+    """Inbound harnesses cannot clear their git_url."""
+    harness = _make_inbound_harness(id="hns_clr_in", slug="clr-in")
+    await fake_storage_provider.get_storage(Harness).create(harness)
+
+    r = await client.put("/v1/harnesses/hns_clr_in", json={"git_url": None})
+    assert r.status_code == 422, r.text
+    assert r.json()["code"] == "git_url_required_inbound"

--- a/tests/harness/test_dispatch_outbound.py
+++ b/tests/harness/test_dispatch_outbound.py
@@ -455,3 +455,63 @@ async def test_outbound_uninstall_deletes_harness(fake_storage_provider, tmp_pat
 
     # Deleted — not released as a direction_mismatch ERROR.
     assert await harness_storage.get("h-out-del") is None
+
+
+# ---------------------------------------------------------------------------
+# git is optional for outbound: BUILD without a remote is healthy, PUSH is not
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_build_git_less_outbound_not_error(fake_storage_provider, tmp_path):
+    """A git-less outbound harness builds fine and rests at DRAFT, not ERROR."""
+    deps = _make_deps(fake_storage_provider)
+    harness_storage = fake_storage_provider.get_storage(Harness)
+    agent_storage = fake_storage_provider.get_storage(Agent)
+
+    await agent_storage.create(_make_agent())
+    harness = _make_outbound_harness(
+        "h-build-nogit",
+        git_url=None,
+        pending=HarnessOperation.BUILD,
+    )
+    await harness_storage.create(harness)
+
+    await run_one_harness_operation(
+        deps, harness_id="h-build-nogit", worker_id="w1",
+    )
+
+    updated = await harness_storage.get("h-build-nogit")
+    assert updated is not None
+    assert updated.status == HarnessStatus.DRAFT
+    assert updated.pending_operation is None
+    assert updated.bundle_hash is not None
+
+
+@pytest.mark.asyncio
+async def test_push_git_less_outbound_errors(fake_storage_provider, tmp_path):
+    """Defence in depth: a PUSH with no remote fails cleanly, not with a stack."""
+    deps = _make_deps(fake_storage_provider)
+    harness_storage = fake_storage_provider.get_storage(Harness)
+    agent_storage = fake_storage_provider.get_storage(Agent)
+
+    await agent_storage.create(_make_agent())
+    harness = _make_outbound_harness(
+        "h-push-nogit",
+        git_url=None,
+        pending=HarnessOperation.PUSH,
+    )
+    await harness_storage.create(harness)
+
+    await run_one_harness_operation(
+        deps, harness_id="h-push-nogit", worker_id="w1",
+    )
+
+    updated = await harness_storage.get("h-push-nogit")
+    assert updated is not None
+    assert updated.status == HarnessStatus.ERROR
+    assert updated.last_operation_error is not None
+    assert (
+        json.loads(updated.last_operation_error)["code"]
+        == "git_remote_not_configured"
+    )


### PR DESCRIPTION
## What

Outbound harnesses render entirely from the live DB and are already consumable without git via `GET /v1/harnesses/{id}/bundle.tar.gz`. Git-push is just one of two distribution channels, so a git remote should be **optional** for outbound harnesses — it's only genuinely required for **inbound** harnesses, which install *from* a repo.

Previously `git_url` was mandatory on every harness. That forced outbound harnesses to point at some remote and left them stuck in `ERROR` when a push failed against a stale/dead URL.

## Changes

- **model** — `Harness.git_url` is now `Optional[str]` (nullable).
- **create** — `git_url` optional; an inbound harness without one → `422 git_url_required_inbound`.
- **update** — `git_url` can be set or cleared (detected via `model_fields_set`, so an explicit `null` clears it); inbound harnesses cannot clear it → `422`.
- **push** — `POST /{id}/push` returns `422 git_remote_not_configured` when no remote is set, so a git-less harness never enters `ERROR` through push. `_do_push` guards the same case defensively (belt-and-braces).

A git-less outbound harness builds and serves its bundle normally and rests at `DRAFT`/`OUTDATED` — never `ERROR`.

## Tests

8 new (6 router + 2 dispatch): create outbound no-git → 201; create inbound no-git → 422; push git-less → 422; bundle download git-less → 200; update clear-git outbound → 200 / inbound → 422; dispatch build git-less → DRAFT (not ERROR); dispatch push git-less → clean coded error.

`ruff` clean; targeted + broad harness suites green (197 passed).

## Follow-up (not in this PR)

The UI create form still marks `git_url` required — a small frontend change would let users create git-less outbound harnesses directly from the UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
