### PR TITLE
test(e2e): opt intentionally-unreachable toolset seeds out of the create probe (fix main)

### DIFF
--- a/tests/e2e/test_builtin_toolsets.py
+++ b/tests/e2e/test_builtin_toolsets.py
@@ -547,7 +547,9 @@ async def test_t0711_mcp_http_transport_tools_unreachable_url_clean(
             },
         },
     }
-    create = await client.post(base, json=body)
+    # allow_unreachable: T0711 intentionally seeds an unreachable HTTP MCP
+    # toolset to exercise the /tools anomaly path; opt out of the create probe.
+    create = await client.post(base + "?allow_unreachable=true", json=body)
     assert create.status_code == 201, create.text
 
     try:

--- a/tests/e2e/test_toolset_crud.py
+++ b/tests/e2e/test_toolset_crud.py
@@ -156,7 +156,9 @@ async def test_t0451_toolset_mcp_http_url_variations_round_trip(
                     "config": {"url": url},
                 },
             }
-            resp = await client.post("/v1/toolsets", json=body)
+            # allow_unreachable: this round-trip test seeds unreachable HTTP MCP
+            # toolsets on purpose (it checks URL storage, not connectivity).
+            resp = await client.post("/v1/toolsets?allow_unreachable=true", json=body)
             envelope = resp.json() if resp.content else {}
             assert envelope.get("type") != "/errors/internal", (
                 f"url={url!r} leaked /errors/internal: {resp.text}"


### PR DESCRIPTION
## Fix `main`: opt the last 2 intentional-unreachable toolset seeds out of the create probe

`main` went red on `e2e (live server)` after #127 (the toolset connectivity block) merged: `POST /toolsets` now rejects an unreachable MCP-HTTP toolset (`400 /errors/toolset-unreachable`), but two e2e tests **deliberately** seed such a toolset and asserted `201`:
- `tests/e2e/test_builtin_toolsets.py::test_t0711_...` (seeds `http://127.0.0.1:1/nonexistent` to exercise the `/tools` anomaly envelope)
- `tests/e2e/test_toolset_crud.py::test_t0451_...` (seeds unreachable URLs to check URL round-trip storage)

Add `?allow_unreachable=true` (the API "Create anyway") so each seed succeeds and the test exercises its real subject. The 3 `ui_e2e` equivalents were already opted out in #127; these two `e2e` seeds were the same fix but landed on the #127 branch after it merged, so they never reached `main`.

`main`'s only failures this run were exactly these two (`test_t0812_park_resume` passed — it's an unrelated pre-existing timing flake). Test-only change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
