### PR TITLE
feat(harness): finish outbound git-optional (UI + clear resets push history)

### DIFF
--- a/primer/api/routers/harness.py
+++ b/primer/api/routers/harness.py
@@ -306,6 +306,14 @@ async def update_harness(
                 },
             )
         harness.git_url = body.git_url
+        if body.git_url is None:
+            # Clearing the remote forgets the push history: those stamps point
+            # at a repo we're no longer publishing to, so a later build reads
+            # DRAFT (never-pushed) rather than OUTDATED (drifted-from-remote).
+            # (Inbound already returned 422 above, so this is outbound-only.)
+            harness.last_pushed_commit = None
+            harness.last_pushed_bundle_hash = None
+            harness.last_pushed_at = None
 
     harness.overrides_dirty = overrides_dirty
     return await storage.update(harness)

--- a/tests/api/test_harness_outbound_router.py
+++ b/tests/api/test_harness_outbound_router.py
@@ -642,3 +642,23 @@ async def test_update_clear_git_url_inbound_rejected(
     r = await client.put("/v1/harnesses/hns_clr_in", json={"git_url": None})
     assert r.status_code == 422, r.text
     assert r.json()["code"] == "git_url_required_inbound"
+
+
+@pytest.mark.asyncio
+async def test_clear_git_url_resets_push_history(client, app, fake_storage_provider):
+    """Clearing an outbound remote forgets the now-irrelevant push history,
+    so a later build reads DRAFT rather than OUTDATED."""
+    harness = _make_outbound_harness(
+        id="hns_clr_hist", slug="clr-hist",
+        git_url="https://github.com/example/x",
+        last_pushed_commit="deadbeefcafe",
+        last_pushed_bundle_hash="84add0f16ad5",
+    )
+    await fake_storage_provider.get_storage(Harness).create(harness)
+
+    r = await client.put("/v1/harnesses/hns_clr_hist", json={"git_url": None})
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["git_url"] is None
+    assert body["last_pushed_commit"] is None
+    assert body["last_pushed_bundle_hash"] is None

--- a/ui/components/harness_outbound_builder.jsx
+++ b/ui/components/harness_outbound_builder.jsx
@@ -139,7 +139,9 @@ function HarnessOutboundBuilder({ onClose, onCreated, initialStep, initialHarnes
     return () => { if (debouncedSlugRef.current) clearTimeout(debouncedSlugRef.current); };
   }, [slug]);
 
-  const step1Valid = name && slug && gitUrl && !slugError;
+  // git_url is optional for outbound harnesses — the bundle is downloadable
+  // and the DB is the source of truth; a remote is only needed to push.
+  const step1Valid = name && slug && !slugError;
 
   // Step 2 — unique template_names
   const templateNameSet = new Set();
@@ -174,7 +176,7 @@ function HarnessOutboundBuilder({ onClose, onCreated, initialStep, initialHarnes
           name: name || slug,
           slug,
           direction: "outbound",
-          git_url: gitUrl,
+          git_url: gitUrl || null,
           ref: ref || "main",
           tracked_entities: tracked,
         };
@@ -202,7 +204,7 @@ function HarnessOutboundBuilder({ onClose, onCreated, initialStep, initialHarnes
         return;
       }
 
-      if (pushNow) {
+      if (pushNow && gitUrl) {
         await apiFetch("POST", "/harnesses/" + encodeURIComponent(created.id) + "/push", {});
         if (!mountedRef.current) return;
         polled = await HOB_pollUntilDone(apiFetch, created.id, (row) => row.pending_operation == null);
@@ -371,7 +373,7 @@ function HOB_Step1Metadata({
         />
       </div>
       <div className="field">
-        <label className="field-label" htmlFor="hob-git-url">Git URL <span className="hint">HTTPS</span></label>
+        <label className="field-label" htmlFor="hob-git-url">Git URL <span className="hint">optional · HTTPS · leave blank to keep it local</span></label>
         <input
           id="hob-git-url"
           className="input mono"
@@ -894,10 +896,12 @@ function HOB_Step4Link({ name, slug, description, ref_, subpath, gitUrl, tracked
       <label style={{ display: "flex", alignItems: "center", gap: 6, fontSize: 12.5 }}>
         <input
           type="checkbox"
-          checked={pushNow}
+          checked={pushNow && !!gitUrl}
+          disabled={!gitUrl}
           onChange={(e) => onPushNowChange(e.target.checked)}
         />
         Push now after build
+        {!gitUrl && <span className="hint" style={{ marginLeft: 4 }}>needs a Git URL</span>}
       </label>
 
       {createError && <Banner kind="error" title="Operation failed" detail={createError} />}


### PR DESCRIPTION
Follow-ups to #129 (git optional for outbound harnesses).

## Backend — clearing a remote forgets its push history

When an outbound harness clears its `git_url`, `update_harness` now also resets `last_pushed_commit` / `last_pushed_bundle_hash` / `last_pushed_at`. Those stamps referenced a repo we're no longer publishing to, so a subsequent build reads `DRAFT` (never-pushed) instead of `OUTDATED` (drifted-from-a-remote-that's-gone). Inbound is unaffected — it already 422s on a clear.

## UI — the outbound builder no longer forces a Git URL

`ui/components/harness_outbound_builder.jsx`:
- Step 1 advances without a Git URL (`step1Valid` no longer requires it).
- The create body sends `git_url: null` when the field is blank.
- The field is relabelled **optional · leave blank to keep it local**.
- **Push now after build** is disabled (and never fires in `doCreate`) when there's no Git URL, with a "needs a Git URL" hint — so a git-less build can't trip the push guard.

## Tests

Adds `test_clear_git_url_resets_push_history`. `ruff` clean; harness router + dispatch suites green (58 passed).

## Note

Once this deploys, primer-basic (already git-less and healthy at `outdated`) can be settled to `draft` with a single `PUT {git_url: null}` (now resets the stamps) + build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
