### PR TITLE
fix(mounts): make collection→workspace mount work on real backends

### DIFF
--- a/primer/api/routers/workspace_mounts.py
+++ b/primer/api/routers/workspace_mounts.py
@@ -54,7 +54,10 @@ async def create_mount(
     manifest = await mm.load_manifest(ws)
     if mm.find_by_collection(manifest, body.collection_id) is not None:
         raise ConflictError(f"Collection {body.collection_id!r} is already mounted")
-    dest = sanitize_dest(body.dest or coll.description or coll.id)
+    # A Collection has no human name field -- only ``id`` (short, e.g.
+    # "agent-engineering") and a long ``description``. Use the id, never the
+    # description, for the dir name and the manifest's collection_name.
+    dest = sanitize_dest(body.dest or coll.id)
     if mm.find_by_dest(manifest, dest) is not None:
         raise ConflictError(f"A mount already uses dest {dest!r}")
     # dest must not already exist as real files. A missing dest surfaces as
@@ -79,23 +82,36 @@ async def create_mount(
     # actually show up as a "dir" kind entry even when it's populated with
     # files in the same call.
     await ws.make_dir(dest)
-    if not entries:
-        await ws.write_file(f"{dest}/.gitkeep", b"")
-    else:
-        for e in entries:
-            res = await service.read(collection_id=body.collection_id, path=e.path)
-            await ws.write_file(join_dest(dest, e.path), res.content.encode("utf-8"))
+    # From here on the dest dir exists on disk. If anything below fails
+    # (a document read, a file write, or the manifest save), roll the dir
+    # back so a retry doesn't trip the "dest already exists" guard above and
+    # so we never leave an orphan directory with no manifest entry behind.
+    try:
+        if not entries:
+            await ws.write_file(f"{dest}/.gitkeep", b"")
+        else:
+            for e in entries:
+                res = await service.read(collection_id=body.collection_id, path=e.path)
+                await ws.write_file(join_dest(dest, e.path), res.content.encode("utf-8"))
 
-    base = await build_base_snapshot(service, body.collection_id)
-    entry = mm.MountEntry(
-        mount_id=f"wsmnt-{uuid.uuid4().hex[:12]}",
-        collection_id=body.collection_id,
-        collection_name=coll.description or coll.id,
-        dest=dest,
-        mounted_at=datetime.now(timezone.utc),
-        base=base,
-    )
-    await mm.save_manifest(ws, mm.add_mount(manifest, entry))
+        base = await build_base_snapshot(service, body.collection_id)
+        entry = mm.MountEntry(
+            mount_id=f"wsmnt-{uuid.uuid4().hex[:12]}",
+            collection_id=body.collection_id,
+            collection_name=coll.id,
+            dest=dest,
+            mounted_at=datetime.now(timezone.utc),
+            base=base,
+        )
+        await mm.save_manifest(ws, mm.add_mount(manifest, entry))
+    except Exception:
+        # Best-effort rollback: never let a cleanup failure mask the real
+        # mount error (that original exception must be what the client sees).
+        try:
+            await ws.delete_file(dest, recursive=True)
+        except Exception:
+            pass
+        raise
     return entry
 
 

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -105,7 +105,7 @@ class MountRequest(BaseModel):
     collection_id: str = Field(..., min_length=1)
     dest: str | None = Field(
         default=None,
-        description="Dir name under the workspace root; defaults to a sanitized collection name.",
+        description="Dir name under the workspace root; defaults to a sanitized collection id.",
     )
 
 
@@ -535,7 +535,10 @@ async def create_workspace(
                 raise NotFoundError(
                     f"Collection {req.collection_id!r} does not exist"
                 )
-            dest = sanitize_dest(req.dest or coll.description or coll.id)
+            # Use the collection id, never its (long) description, for the
+            # dir name / manifest collection_name -- a Collection has no name
+            # field. Mirrors the runtime create_mount path.
+            dest = sanitize_dest(req.dest or coll.id)
             if dest in seen_dests:
                 raise ConflictError(
                     f"Multiple mounts resolve to the same directory {dest!r}"
@@ -544,7 +547,7 @@ async def create_workspace(
             extra_files += await expand_collection(service, req.collection_id, dest)
             base = await build_base_snapshot(service, req.collection_id)
             mount_records.append(
-                (req.collection_id, coll.description or coll.id, dest, base)
+                (req.collection_id, coll.id, dest, base)
             )
         overrides = overrides.model_copy(update={"files": extra_files})
 

--- a/primer/workspace/local/workspace.py
+++ b/primer/workspace/local/workspace.py
@@ -652,6 +652,30 @@ class LocalWorkspace(Workspace):
 
         await asyncio.to_thread(_append)
 
+    async def write_state_file(self, relative_path: str, content: bytes) -> None:
+        """Overwrite ``<root>/<relative_path>`` (root-contained).
+
+        The privileged, guard-free sibling of :meth:`append_state_line`: mount
+        bookkeeping (``.state/mounts.json``) lives inside the reserved ``.state``
+        tree that the public :meth:`write_file` refuses to mutate, so it needs
+        an overwrite that bypasses ``_refuse_reserved`` while still staying
+        within the workspace root.
+        """
+        root_resolved = self._root.resolve()
+        candidate = (root_resolved / relative_path).resolve()
+        try:
+            candidate.relative_to(root_resolved)
+        except ValueError as exc:
+            raise BadRequestError(
+                f"state path resolves outside workspace: {relative_path!r}"
+            ) from exc
+
+        def _write() -> None:
+            candidate.parent.mkdir(parents=True, exist_ok=True)
+            candidate.write_bytes(content)
+
+        await asyncio.to_thread(_write)
+
     async def aclose(self) -> None:
         """End any non-ENDED sessions, then release backend resources."""
         async with self._lock:

--- a/primer/workspace/mount_manifest.py
+++ b/primer/workspace/mount_manifest.py
@@ -53,7 +53,12 @@ async def load_manifest(ws) -> MountManifest:
 
 async def save_manifest(ws, manifest: MountManifest) -> None:
     payload = manifest.model_dump_json(indent=2).encode("utf-8")
-    await ws.write_file(MANIFEST_PATH, payload)
+    # MANIFEST_PATH lives under the reserved ``.state`` tree, which the public
+    # ``write_file`` refuses to mutate. Persist through the privileged
+    # ``write_state_file`` (sibling of ``append_state_line``) so the sidecar
+    # can actually be written on the real local/sandbox backends -- the public
+    # path only ever worked against permissive in-memory test fakes.
+    await ws.write_state_file(MANIFEST_PATH, payload)
 
 
 def find_by_collection(m: MountManifest, collection_id: str) -> MountEntry | None:

--- a/primer/workspace/sandbox/workspace.py
+++ b/primer/workspace/sandbox/workspace.py
@@ -449,15 +449,36 @@ class SandboxWorkspace(Workspace):
         info = await self._sandbox.stat(target)
         if info is None:
             raise NotFoundError(f"{path!r} not found")
-        # The sandbox delete is recursive; guard non-empty directories
-        # behind the recursive flag to match the local backend's contract.
-        if info.kind == "dir" and not recursive:
+        if info.kind == "dir":
             children = await self._sandbox.list_dir(target)
-            if children:
+            if children and not recursive:
                 raise BadRequestError(
                     f"directory {path!r} is not empty; pass recursive=true "
                     f"to delete it and its contents"
                 )
+            # The runtime ``delete`` op removes a single file or an EMPTY
+            # directory only -- it is NOT recursive, so a non-empty dir 500s.
+            # Empty the tree child-first so every delete lands on a leaf file
+            # or an already-emptied directory.
+            await self._delete_tree(target)
+        else:
+            await self._sandbox.delete(target)
+
+    async def _delete_tree(self, target: str) -> None:
+        """Depth-first delete of everything under ``target`` then ``target``.
+
+        Compensates for the non-recursive runtime ``delete`` op. ``target`` is
+        an absolute sandbox path; children are re-anchored from each entry's
+        basename (``list_dir`` returns absolute paths on the real runtime and
+        basenames on the fake -- taking the leaf handles both).
+        """
+        for fs in await self._sandbox.list_dir(target):
+            name = fs.path.rsplit("/", 1)[-1]
+            child = f"{target}/{name}"
+            if fs.kind == "dir":
+                await self._delete_tree(child)
+            else:
+                await self._sandbox.delete(child)
         await self._sandbox.delete(target)
 
     async def file_info(self, path: str) -> FileEntry:
@@ -582,6 +603,19 @@ class SandboxWorkspace(Workspace):
             line = line + b"\n"
         path = f"{self._workspace_root}/{relative_path}"
         await self._sandbox.append_file(path, line)
+
+    async def write_state_file(self, relative_path: str, content: bytes) -> None:
+        """Overwrite ``<workspace_root>/<relative_path>`` via the sandbox.
+
+        Privileged, guard-free sibling of :meth:`append_state_line`: the mount
+        sidecar (``.state/mounts.json``) lives under the reserved ``.state``
+        tree that the public :meth:`write_file` refuses to mutate, so it is
+        written straight through the sandbox rather than the guarded facade.
+        ``_resolve_path`` still rejects ``..``/absolute escapes (keeping the
+        write inside the workspace root); only ``_refuse_reserved`` is skipped.
+        """
+        target = self._resolve_path(relative_path)
+        await self._sandbox.write_file(target, content)
 
     async def aclose(self) -> None:
         """Tear down every live session. Errors from any one session must

--- a/tests/api/test_workspace_create_mounts.py
+++ b/tests/api/test_workspace_create_mounts.py
@@ -305,16 +305,22 @@ async def test_create_workspace_duplicate_collection_id_in_mounts_is_409(
 
 @pytest.mark.asyncio
 async def test_create_workspace_duplicate_dest_in_mounts_is_409(client, template_id):
-    """Two collections whose (default) sanitized dest collide -- descriptions
-    'Docs' and 'docs' both sanitize to 'docs'."""
-    a = await _make_empty_collection(client, "kb-dup-a", "Docs")
-    b = await _make_empty_collection(client, "kb-dup-b", "docs")
+    """Two mounts targeting the same dest dir collide -> 409.
+
+    (Previously this relied on two descriptions both sanitizing to 'docs';
+    dest now derives from the collection id, not the description, so the
+    collision is exercised explicitly via a shared ``dest``.)"""
+    a = await _make_empty_collection(client, "kb-dup-a", "Collection A")
+    b = await _make_empty_collection(client, "kb-dup-b", "Collection B")
 
     r = await client.post(
         "/v1/workspaces",
         json={
             "template_id": template_id,
-            "mounts": [{"collection_id": a}, {"collection_id": b}],
+            "mounts": [
+                {"collection_id": a, "dest": "shared"},
+                {"collection_id": b, "dest": "shared"},
+            ],
         },
     )
     assert r.status_code == 409, r.text

--- a/tests/api/test_workspace_files_studio.py
+++ b/tests/api/test_workspace_files_studio.py
@@ -163,6 +163,15 @@ class _FakeWorkspace:
         self._files[path] = content
         self._mtimes[path] = datetime.now(timezone.utc)
 
+    async def write_state_file(self, relative_path, content):
+        # Privileged .state overwrite (the real backends bypass the
+        # reserved-tree guard here). The in-memory fake stores it alongside
+        # normal files so read_file / load_manifest can round-trip it.
+        if "\x00" in relative_path:
+            raise BadRequestError("null byte in path")
+        self._files[relative_path] = content
+        self._mtimes[relative_path] = datetime.now(timezone.utc)
+
     async def make_dir(self, path):
         if "\x00" in path:
             raise BadRequestError("null byte in path")

--- a/tests/api/test_workspace_mounts.py
+++ b/tests/api/test_workspace_mounts.py
@@ -243,6 +243,24 @@ async def test_import_mounts_collection(client, wsr) -> None:
 
 
 @pytest.mark.asyncio
+async def test_import_defaults_name_and_dest_to_collection_id(client, wsr) -> None:
+    # Regression: a Collection has no name field. The manifest collection_name
+    # and the default dest must be the id, NEVER the (long) description
+    # ("test collection") -- that conflation polluted the Studio UI + manifest.
+    wid = await _setup_workspace(client, wsr)
+    coll_id = await _setup_collection(client)  # description="test collection"
+    r = await client.post(
+        f"/v1/workspaces/{wid}/mounts",
+        json={"collection_id": coll_id},  # no dest -> should default to the id
+    )
+    assert r.status_code == 201, r.text
+    body = r.json()
+    assert body["collection_name"] == coll_id
+    assert body["collection_name"] != "test collection"
+    assert body["dest"] == coll_id
+
+
+@pytest.mark.asyncio
 async def test_import_missing_collection_404(client, wsr) -> None:
     wid = await _setup_workspace(client, wsr)
     r = await client.post(

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -238,6 +238,14 @@ class _FakeWorkspace:
             raise BadRequestError("null byte in path")
         self._files[path] = content
 
+    async def write_state_file(self, relative_path, content):
+        # Privileged .state overwrite (real backends bypass the reserved-tree
+        # guard here). The in-memory fake stores it like any other file so
+        # read_file / load_manifest can round-trip the mount manifest.
+        if "\x00" in relative_path:
+            raise BadRequestError("null byte in path")
+        self._files[relative_path] = content
+
     async def append_message_line(self, session_id, line):
         # WorkspaceIO write surface used by WorkspaceMessageWriter: wake_session
         # persists a USER_INPUT record to messages.jsonl on steer/invoke.

--- a/tests/ui/test_studio_collection_mount.py
+++ b/tests/ui/test_studio_collection_mount.py
@@ -120,6 +120,16 @@ def test_mount_action_present_and_posts() -> None:
     assert "/collections?limit=200" in src
 
 
+def test_mount_select_labels_use_collection_id_not_description() -> None:
+    # Regression: the dropdown rendered `{c.description || c.id}`, dumping each
+    # collection's long description into the <option>. Collections have no name
+    # field, so the option label must be the id.
+    src = _src()
+    assert "{c.description || c.id}" not in src
+    assert ">{c.id}</option>" in src
+    assert "defaults to the collection id" in src
+
+
 def test_mount_header_button_in_files_header_group() -> None:
     # The button must live inside the Files-header action group (alongside
     # New file / Upload / New folder / Refresh), not just anywhere in the

--- a/tests/ui/test_workspace_create_mount_select.py
+++ b/tests/ui/test_workspace_create_mount_select.py
@@ -53,6 +53,14 @@ def test_checkbox_row_has_test_id() -> None:
     assert 'data-testid="create-mount-collection"' in modal
 
 
+def test_mount_checkbox_labels_use_collection_id_not_description() -> None:
+    # Regression: the multi-select rendered `{c.description || c.id}`, blowing
+    # the modal open with full collection descriptions. Render the id instead.
+    modal = _modal_src()
+    assert "{c.description || c.id}" not in modal
+    assert '<span className="mono">{c.id}</span>' in modal
+
+
 def test_bundle_transpiles_with_workspace_create_mount_select() -> None:
     from primer.api._jsx_bundle import build_jsx_bundle
 

--- a/tests/workspace/sandbox/test_sandbox_recursive_delete.py
+++ b/tests/workspace/sandbox/test_sandbox_recursive_delete.py
@@ -1,0 +1,75 @@
+"""Regression for the "Delete failed" 500 on the k8s/sandbox backend.
+
+The runtime ``delete`` op removes a single file or an EMPTY directory only --
+it is NOT recursive, so ``SandboxWorkspace.delete_file(recursive=True)`` used
+to hand a non-empty directory straight to it and 500. ``_delete_tree`` now
+empties the tree child-first so every ``delete`` lands on a leaf.
+
+Uses a stub sandbox whose ``delete`` faithfully refuses a non-empty directory
+(mirroring the real runtime); the ``FakeSandbox`` can't reproduce the bug
+because its ``delete`` does ``shutil.rmtree``.
+"""
+from __future__ import annotations
+
+import types
+
+import pytest
+
+from primer.model.except_ import BadRequestError
+from primer.workspace.sandbox.workspace import SandboxWorkspace
+
+
+class _NonRecursiveSandbox:
+    """Deletes a file or an *empty* dir; raises on a non-empty dir."""
+
+    def __init__(self) -> None:
+        # absolute path -> "dir" | "file"
+        self.tree: dict[str, str] = {
+            "/w/d": "dir",
+            "/w/d/sub": "dir",
+            "/w/d/sub/f1.txt": "file",
+            "/w/d/f2.txt": "file",
+        }
+        self.deleted: list[str] = []
+
+    async def list_dir(self, path: str):
+        prefix = path.rstrip("/") + "/"
+        return [
+            types.SimpleNamespace(path=p, kind=kind)
+            for p, kind in self.tree.items()
+            if p.startswith(prefix) and "/" not in p[len(prefix):]
+        ]
+
+    async def delete(self, path: str) -> None:
+        kind = self.tree.get(path)
+        assert kind is not None, f"delete of missing path {path!r}"
+        if kind == "dir":
+            prefix = path.rstrip("/") + "/"
+            if any(p != path and p.startswith(prefix) for p in self.tree):
+                raise OSError(f"directory not empty: {path}")
+        del self.tree[path]
+        self.deleted.append(path)
+
+
+async def test_delete_tree_empties_children_before_each_dir() -> None:
+    stub = _NonRecursiveSandbox()
+    ws = SandboxWorkspace.__new__(SandboxWorkspace)
+    ws._sandbox = stub  # type: ignore[attr-defined]
+
+    await ws._delete_tree("/w/d")
+
+    # Nothing left behind, and no "directory not empty" error was raised.
+    assert stub.tree == {}
+    # Depth-first: a directory is only deleted after its descendants.
+    assert stub.deleted.index("/w/d/sub/f1.txt") < stub.deleted.index("/w/d/sub")
+    assert stub.deleted.index("/w/d/sub") < stub.deleted.index("/w/d")
+    assert stub.deleted[-1] == "/w/d"
+
+
+async def test_write_state_file_rejects_root_escape() -> None:
+    # The privileged .state write must still stay inside the workspace root
+    # (_resolve_path rejects ``..``/absolute); only _refuse_reserved is skipped.
+    ws = SandboxWorkspace.__new__(SandboxWorkspace)
+    ws._workspace_root = "/workspace"  # type: ignore[attr-defined]
+    with pytest.raises(BadRequestError):
+        await ws.write_state_file("../evil.json", b"x")

--- a/tests/workspace/test_mount_manifest.py
+++ b/tests/workspace/test_mount_manifest.py
@@ -19,6 +19,11 @@ class FakeWS:
     async def write_file(self, path, content):
         assert isinstance(content, bytes)
         self.files[path] = content
+    async def write_state_file(self, path, content):
+        # Privileged .state write used by save_manifest (real backends bypass
+        # the reserved-tree guard here; the fake just stores it like any file).
+        assert isinstance(content, bytes)
+        self.files[path] = content
 
 
 def _entry(cid="collection-a", dest="a", mid="wsmnt-1"):

--- a/tests/workspace/test_mount_state_write.py
+++ b/tests/workspace/test_mount_state_write.py
@@ -1,0 +1,58 @@
+"""Regression: the mount manifest (`.state/mounts.json`) lives under the
+reserved ``.state`` tree, which the public ``write_file`` refuses to mutate.
+
+The original ``save_manifest`` used ``write_file`` and therefore raised
+``BadRequestError`` ("refusing to mutate path inside reserved tree") on every
+mount against the REAL local/sandbox backends — the bug only hid because the
+in-memory test fakes never enforced the reserved-tree guard. These tests run
+against a real ``LocalWorkspaceBackend`` so the guard is live.
+"""
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from primer.model.except_ import BadRequestError
+from primer.workspace import LocalWorkspaceBackend
+from primer.workspace import mount_manifest as mm
+from tests.workspace.test_local import _template
+
+
+@pytest.fixture
+async def ws(tmp_path):
+    backend = LocalWorkspaceBackend(tmp_path / "root")
+    await backend.initialize()
+    return await backend.create(_template())
+
+
+async def test_write_file_still_refuses_reserved_state(ws) -> None:
+    # The public guard must stay intact -- only the privileged path may write.
+    with pytest.raises(BadRequestError):
+        await ws.write_file(".state/mounts.json", b"x")
+
+
+async def test_write_state_file_bypasses_guard_and_roundtrips(ws) -> None:
+    payload = b'{"version": 1, "mounts": []}'
+    await ws.write_state_file(".state/mounts.json", payload)
+    assert await ws.read_file(".state/mounts.json") == payload
+
+
+async def test_write_state_file_rejects_root_escape(ws) -> None:
+    with pytest.raises(BadRequestError):
+        await ws.write_state_file("../evil.json", b"x")
+
+
+async def test_save_manifest_roundtrips_through_real_backend(ws) -> None:
+    entry = mm.MountEntry(
+        mount_id="wsmnt-abc123",
+        collection_id="kb-1",
+        collection_name="kb-1",
+        dest="kb-1",
+        mounted_at=datetime.now(timezone.utc),
+        base=[],
+    )
+    await mm.save_manifest(ws, mm.add_mount(mm.MountManifest(), entry))
+    loaded = await mm.load_manifest(ws)
+    assert [e.mount_id for e in loaded.mounts] == ["wsmnt-abc123"]
+    assert loaded.mounts[0].collection_name == "kb-1"

--- a/ui/components/studio-sidebar.jsx
+++ b/ui/components/studio-sidebar.jsx
@@ -890,12 +890,12 @@ function ST_MountCollectionModal({ wid, onClose, onMounted, pushToast }) {
         >
           <option value="">Select a collection…</option>
           {items.map(function (c) {
-            return <option key={c.id} value={c.id}>{c.description || c.id}</option>;
+            return <option key={c.id} value={c.id} title={c.description || undefined}>{c.id}</option>;
           })}
         </select>
       </div>
       <div className="field">
-        <label className="field-label">Directory name <span className="hint">optional — defaults to the collection name</span></label>
+        <label className="field-label">Directory name <span className="hint">optional — defaults to the collection id</span></label>
         <input
           className="input mono"
           style={{ width: "100%" }}

--- a/ui/components/workspaces.jsx
+++ b/ui/components/workspaces.jsx
@@ -433,10 +433,11 @@ function WS_NewWorkspaceModal({ onClose, pushToast }) {
             <label
               key={c.id}
               data-testid="create-mount-collection"
+              title={c.description || undefined}
               style={{ display: "flex", gap: 8, alignItems: "center", padding: "2px 0" }}
             >
               <input type="checkbox" checked={mountSel.has(c.id)} onChange={() => toggleMount(c.id)} />
-              <span className="mono">{c.description || c.id}</span>
+              <span className="mono">{c.id}</span>
             </label>
           ))}
         </div>


### PR DESCRIPTION
## Summary

Found by dogfooding the Collection↔Workspace mount feature on a k8s-backed instance — mounting failed every time, the collection pickers were unreadable, and deleting a mounted folder 500'd. Four distinct bugs:

### 1. Mount always failed — `.state/mounts.json` write refused
`save_manifest` wrote the manifest through the public `write_file`, but both backends' `_refuse_reserved` guard rejects any write into the reserved `.state` tree (reads are unguarded, which is why *loads* silently worked and *saves* always threw `BadRequestError`). The in-memory test fakes never enforced the guard, so it passed CI but failed on every real backend.
**Fix:** added a privileged `write_state_file` to the local + sandbox backends (mirrors the existing `append_state_line`); `save_manifest` uses it. The sandbox variant resolves through `_resolve_path`, so it still rejects `..`/absolute root escapes.

### 2. Collection *description* rendered as its *name*
The `Collection` model has **no `name` field** — only `id` (short, e.g. `agent-engineering`) and a long `description`. The Studio dropdown, the new-workspace multiselect, and both mount routers all fell back to `description`, dumping paragraphs into the UI and the manifest.
**Fix:** use `coll.id` everywhere for the label / dir name / manifest `collection_name`; the description is now a hover `title` only.

### 3. "Path already exists" on retry
`create_mount` created the dest dir + files *before* `save_manifest`; when the manifest write threw (bug #1), the dir was left behind, so the retry tripped the dest-exists guard.
**Fix:** best-effort rollback of the dest dir on any failure (never masks the original error).

### 4. "Delete failed" (500) detaching / deleting a mounted folder
The k8s runtime's `delete` op is **not recursive** (it removes a file or an *empty* dir), so `delete_file(recursive=True)` handed it a non-empty dir and 500'd. This affected *all* recursive deletes on the sandbox backend, not just mounts.
**Fix:** `delete_file` now empties the tree child-first (`_delete_tree`) so every delete lands on a leaf; the runtime was confirmed to delete files + empty dirs fine.

## Tests
- New: real-`LocalWorkspace` manifest persistence (catches the `.state` guard that fakes hid); sandbox recursive-delete against a faithful non-recursive stub; sandbox root-escape rejection; `collection_name`/`dest` default to `id`; UI source-string assertions on both pickers.
- Updated three in-memory workspace test fakes to implement `write_state_file`; corrected a dup-dest test that had encoded the description-collision bug.
- **141 passed, 0 failures** (run single-process, core-pinned).

## Reviewed
Independent code-review pass; all findings addressed (the missed third test fake, sandbox containment guard, rollback error-masking, stale doc wording).

## Not covered
Can't be verified end-to-end against the live instance without shipping — the instance runs the released 0.3.0 image. The four *bugs* were reproduced live against that image; the fix rides on the next release.
