### PR TITLE
feat(ui): gate new-workspace mount picker behind a toggle + add search/pagination

### DIFF
--- a/tests/ui/test_workspace_create_mount_select.py
+++ b/tests/ui/test_workspace_create_mount_select.py
@@ -61,6 +61,37 @@ def test_mount_checkbox_labels_use_collection_id_not_description() -> None:
     assert '<span className="mono">{c.id}</span>' in modal
 
 
+def test_mount_picker_gated_behind_opt_in_toggle() -> None:
+    # The picker must only render after the "Mount collections" toggle is on,
+    # so the create form isn't cluttered by the full collection list by default.
+    modal = _modal_src()
+    assert 'data-testid="create-mount-toggle"' in modal
+    assert "mountEnabled" in modal
+    assert "setMountEnabled" in modal
+    assert "{mountEnabled && (" in modal
+    # ...and mounts are only submitted when the toggle is on.
+    assert "mountEnabled && mountSel.size" in modal
+
+
+def test_mount_picker_has_search_filter() -> None:
+    modal = _modal_src()
+    assert 'data-testid="create-mount-search"' in modal
+    assert "collSearch" in modal
+    assert "setCollSearch" in modal
+    assert "collFiltered" in modal
+    assert ".toLowerCase()" in modal  # case-insensitive filter by id
+
+
+def test_mount_picker_is_paginated() -> None:
+    modal = _modal_src()
+    assert 'data-testid="create-mount-pager"' in modal
+    assert "COLL_PAGE_SIZE" in modal
+    assert "collPage" in modal
+    assert "collSafePage" in modal
+    assert "collPageItems" in modal
+    assert "setCollPage(0)" in modal  # search resets to the first page
+
+
 def test_bundle_transpiles_with_workspace_create_mount_select() -> None:
     from primer.api._jsx_bundle import build_jsx_bundle
 

--- a/ui/components/workspaces.jsx
+++ b/ui/components/workspaces.jsx
@@ -340,6 +340,22 @@ function WS_NewWorkspaceModal({ onClose, pushToast }) {
     next.has(id) ? next.delete(id) : next.add(id);
     return next;
   });
+  // Mounting is opt-in: the picker only renders once this toggle is on, so the
+  // create form stays uncluttered for the common no-mount case. Search +
+  // pagination keep the list usable when there are many collections.
+  const [mountEnabled, setMountEnabled] = React.useState(false);
+  const [collSearch, setCollSearch] = React.useState("");
+  const [collPage, setCollPage] = React.useState(0);
+  const COLL_PAGE_SIZE = 8;
+  const collFiltered = collItems.filter(
+    (c) => c.id.toLowerCase().indexOf(collSearch.trim().toLowerCase()) !== -1
+  );
+  const collPageCount = Math.max(1, Math.ceil(collFiltered.length / COLL_PAGE_SIZE));
+  const collSafePage = Math.min(collPage, collPageCount - 1);
+  const collPageItems = collFiltered.slice(
+    collSafePage * COLL_PAGE_SIZE,
+    collSafePage * COLL_PAGE_SIZE + COLL_PAGE_SIZE,
+  );
 
   // Auto-pick the first template once it lands so a happy-path submission
   // doesn't need a manual selection if the server only has one template.
@@ -368,7 +384,7 @@ function WS_NewWorkspaceModal({ onClose, pushToast }) {
     if (!templateId) return;
     const body = { template_id: templateId };
     if (name.trim()) body.name = name.trim();
-    if (mountSel.size) body.mounts = Array.from(mountSel).map((id) => ({ collection_id: id }));
+    if (mountEnabled && mountSel.size) body.mounts = Array.from(mountSel).map((id) => ({ collection_id: id }));
     create.mutate(body);
   };
 
@@ -428,18 +444,59 @@ function WS_NewWorkspaceModal({ onClose, pushToast }) {
       </div>
       {collItems.length > 0 && (
         <div className="field">
-          <div className="field-label">Mount collections <span className="hint">optional</span></div>
-          {collItems.map((c) => (
-            <label
-              key={c.id}
-              data-testid="create-mount-collection"
-              title={c.description || undefined}
-              style={{ display: "flex", gap: 8, alignItems: "center", padding: "2px 0" }}
-            >
-              <input type="checkbox" checked={mountSel.has(c.id)} onChange={() => toggleMount(c.id)} />
-              <span className="mono">{c.id}</span>
-            </label>
-          ))}
+          <label
+            data-testid="create-mount-toggle"
+            style={{ display: "flex", gap: 8, alignItems: "center", cursor: "pointer" }}
+          >
+            <input
+              type="checkbox"
+              checked={mountEnabled}
+              onChange={(e) => setMountEnabled(e.target.checked)}
+            />
+            <span className="field-label" style={{ margin: 0 }}>Mount collections <span className="hint">optional</span></span>
+          </label>
+          {mountEnabled && (
+            <div style={{ border: "1px solid var(--border)", borderRadius: 6, overflow: "hidden", marginTop: 8 }}>
+              <div style={{ position: "relative", borderBottom: "1px solid var(--border)" }}>
+                <Icon name="search" size={13} className="icon" style={{ position: "absolute", left: 8, top: "50%", transform: "translateY(-50%)", opacity: 0.6 }} />
+                <input
+                  className="input mono"
+                  placeholder="Search collections…"
+                  value={collSearch}
+                  onChange={(e) => { setCollSearch(e.target.value); setCollPage(0); }}
+                  data-testid="create-mount-search"
+                  style={{ width: "100%", border: "none", borderRadius: 0, paddingLeft: 28 }}
+                />
+              </div>
+              <div style={{ maxHeight: 200, overflowY: "auto" }}>
+                {collPageItems.length === 0 ? (
+                  <div className="muted text-sm" style={{ padding: "10px 12px" }}>No matching collections.</div>
+                ) : collPageItems.map((c) => (
+                  <label
+                    key={c.id}
+                    data-testid="create-mount-collection"
+                    title={c.description || undefined}
+                    style={{ display: "flex", alignItems: "center", gap: 8, padding: "6px 12px", cursor: "pointer", fontSize: 12.5 }}
+                  >
+                    <input type="checkbox" checked={mountSel.has(c.id)} onChange={() => toggleMount(c.id)} />
+                    <span className="mono">{c.id}</span>
+                  </label>
+                ))}
+              </div>
+              <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", padding: "6px 10px", borderTop: "1px solid var(--border)", background: "var(--bg-2)" }}>
+                <span className="muted text-sm" data-testid="create-mount-selected-count">
+                  {mountSel.size} selected{collFiltered.length !== collItems.length ? ` · ${collFiltered.length} match` : ""}
+                </span>
+                {collPageCount > 1 && (
+                  <span data-testid="create-mount-pager" style={{ display: "inline-flex", alignItems: "center", gap: 8 }}>
+                    <Btn kind="ghost" disabled={collSafePage <= 0} onClick={() => setCollPage(collSafePage - 1)}>‹</Btn>
+                    <span className="muted text-sm">{collSafePage + 1}/{collPageCount}</span>
+                    <Btn kind="ghost" disabled={collSafePage >= collPageCount - 1} onClick={() => setCollPage(collSafePage + 1)}>›</Btn>
+                  </span>
+                )}
+              </div>
+            </div>
+          )}
         </div>
       )}
       <div className="banner banner-info" style={{ margin: 0, fontSize: 11.5 }}>


### PR DESCRIPTION
## Summary

Follow-up UX polish on the collection→workspace mount feature (#132). The New-workspace modal listed **every** collection as an always-visible flat checkbox column — cluttered by default and unusable once there are more than a handful of collections.

Two changes to `WS_NewWorkspaceModal` (`ui/components/workspaces.jsx`):

1. **Opt-in toggle** — the picker now renders only after a **"Mount collections"** checkbox is enabled (default **off**). The create form stays clean for the common no-mount case, and mounts are submitted only while the toggle is on (stale selections can't leak in).
2. **Search + pagination** — a search box filters collections by id (case-insensitive), results paginate at **8/page** with `‹ 1/N ›` controls, and a footer shows **"N selected · M match"** with the selection persisting across searches and pages (search resets to page 1).

Implemented by mirroring the **existing paginated multi-select idiom** from `channels.jsx` (the allowed-agents picker) — same search-icon input, scroll list, and pager — rather than a bespoke widget, so it's consistent with the rest of the console.

## Tests
- New UI source-string tests: toggle-gating (`create-mount-toggle`, `mountEnabled`, opt-in submit), search (`create-mount-search`, `collFiltered`), pagination (`create-mount-pager`, `COLL_PAGE_SIZE`, page reset).
- Babel transpile gate passes. **41 passed, 0 failures** (single-process, core-pinned).

## Notes
- Defaults (easy to change): page size 8; toggle off by default; internal `_internal_*` collections are still listed (searchable) — not hidden, since that wasn't requested.
- Not rendered in a browser here (the live instance runs the released image, not this branch); covered by the transpile gate + source tests.
