### PR TITLE
test(auth): de-flake OIDC tamper test (base64 last-char malleability)

### DIFF
--- a/tests/auth/test_oidc.py
+++ b/tests/auth/test_oidc.py
@@ -165,8 +165,18 @@ class TestState:
     def test_tampered_token_rejects(self):
         secret = "s" * 32
         token = oidc.sign_state({"a": 1}, secret)
-        # Flip the last character (part of the HMAC signature suffix).
-        tampered = token[:-1] + ("a" if token[-1] != "a" else "b")
+        # Corrupt the signature. NB: flipping the *last* base64 char is flaky
+        # (~6%) -- base64's final char carries "don't-care" low bits, so the
+        # flip can decode to the SAME signature bytes and the HMAC still
+        # verifies. Flip the FIRST char of the signature segment instead: a
+        # leading base64 char's 6 bits are all significant, so the decoded
+        # bytes always change and the tamper is always rejected.
+        sig_start = token.rindex(".") + 1
+        tampered = (
+            token[:sig_start]
+            + ("a" if token[sig_start] != "a" else "b")
+            + token[sig_start + 1:]
+        )
         assert oidc.verify_state(tampered, secret, 60) is None
 
     def test_expired_token_rejects(self):


### PR DESCRIPTION
## Problem
The `main` CI "Unit sweep" [failed intermittently](https://github.com/primerhq/primer/actions/runs/29290033986) on `tests/auth/test_oidc.py::test_tampered_token_rejects`:
```
>       assert oidc.verify_state(tampered, secret, 60) is None
E       AssertionError: assert {'a': 1} is None
```
(The many "Event loop is closed" annotations are async-teardown noise cascading from the one real failure.) Unrelated to the mount/UI PRs that triggered the run.

## Root cause
The test tampers by flipping the token's **last** base64 character. But `sign_state` uses `itsdangerous` (dot-separated base64url segments), and a base64 string's final character carries **don't-care low bits** — for a 20-byte HMAC-SHA1 signature the last char has 2 such bits, so ~1/16 of signatures have a last char whose flip-to-`a` decodes to the **same** bytes. The HMAC still verifies, the tamper goes undetected, and the assertion fails.

Measured over 4000 distinct signatures: **258/4000 (6.5%)** undetected — matching an intermittent CI failure. (It hid locally at first because `sign_state` is deterministic per-second, so a tight loop re-signs the *same* token.)

## Fix
Flip the **first** character of the signature segment instead. A leading base64 char's 6 bits are all significant, so the decoded signature always changes and the tamper is always rejected. Measured: **0/4000**.

Test-only change; no release impact. `tests/auth/test_oidc.py`: 37 passed.