### PR TITLE
feat(ui): show workspace name (id) in the Studio selector

### DIFF
--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -145,6 +145,18 @@ def test_workspace_selector_uses_workspaces_resource() -> None:
     assert "useResource" in src
 
 
+def test_workspace_selector_trigger_shows_name_with_id() -> None:
+    src = _studio_src()
+    # The trigger prefers the user-defined name with the id in brackets,
+    # e.g. "main (ws-abc123)", falling back to the bare id.
+    assert "var curWs = items.find(" in src
+    assert 'curWs && curWs.name ? curWs.name + " (" + wid + ")" : wid' in src
+    # ...and the label (not the bare {wid}) is what the trigger renders, with a
+    # matching title for the full value on hover.
+    assert "title={wsLabel}" in src
+    assert ">{wsLabel}</span>" in src
+
+
 def test_studio_registered_in_index_after_workspace_tap() -> None:
     order = _index_order()
     assert "components/studio.jsx" in order

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -499,6 +499,12 @@ function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, term
     { pollMs: 5000 }
   );
   var items = Array.isArray(workspaces.data && workspaces.data.items) ? workspaces.data.items : [];
+  // Selector label: prefer the workspace's user-defined name with the id in
+  // brackets, e.g. "main (ws-abc123)". Falls back to the bare id when the
+  // workspace has no name, or before the list has loaded / for a deep-linked
+  // wid not (yet) in the list.
+  var curWs = items.find(function (w) { return w.id === wid; });
+  var wsLabel = curWs && curWs.name ? curWs.name + " (" + wid + ")" : wid;
 
   // Close the dropdown on Escape or outside click.
   React.useEffect(function () {
@@ -539,7 +545,7 @@ function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, term
         onClick={function (e) { e.stopPropagation(); setMenuOpen(function (o) { return !o; }); }}
       >
         <span style={{ width: 14, height: 14, borderRadius: 4, background: "var(--accent-dim)", border: "1px solid var(--accent-border)" }} />
-        <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 180 }}>{wid}</span>
+        <span title={wsLabel} style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", maxWidth: 180 }}>{wsLabel}</span>
         <span style={{ color: "var(--text-3)" }}>▾</span>
         {menuOpen && (
           <div className="st-ws-menu" data-testid="workspace-menu" onClick={function (e) { e.stopPropagation(); }}>


### PR DESCRIPTION
The top-left Studio workspace selector trigger displayed the bare workspace **id** even when the workspace had a user-defined **name** (the dropdown menu rows already preferred the name).

Now the trigger shows `name (id)` when a name exists (e.g. `main (ws-6cc715700e7f4966)`), falling back to the bare id when the workspace is unnamed, or before the workspaces list has loaded / for a deep-linked wid not yet in the list. A `title` attribute carries the full value for hover (the trigger ellipsis-clips at 180px).

- `ui/components/studio.jsx`: compute the current workspace from the already-loaded list; trigger label + title.
- Menu rows unchanged (already `name || id`).
- Test: `tests/ui/test_studio_shell.py` source-string assertion + the studio transpile gate. 23 passed (single-process).