### PR TITLE
feat(agent): optional tool access during history compaction

### DIFF
--- a/primer/agent/base.py
+++ b/primer/agent/base.py
@@ -177,6 +177,7 @@ class _BaseAgentExecutor(ABC):
             history=history,
             new_messages=messages,
             last_known_input_tokens=self._last_input_tokens,
+            **self._compaction_tool_kwargs(),
         )
         if compacted is not None:
             await self._replace_compacted_head(compacted.new_messages)
@@ -211,6 +212,7 @@ class _BaseAgentExecutor(ABC):
                 llm=self._llm,
                 model=self._model,
                 history=history,
+                **self._compaction_tool_kwargs(),
             )
             await self._replace_compacted_head(forced.new_messages)
             history = forced.new_messages
@@ -364,6 +366,24 @@ class _BaseAgentExecutor(ABC):
                 )
 
         await asyncio.gather(*[_safe(s) for s in subs], return_exceptions=False)
+
+    def _compaction_tool_kwargs(self) -> dict[str, Any]:
+        """Extra kwargs for the compaction call when the agent opts into tool
+        access during compaction (``compaction_tool_access``); empty otherwise
+        so compaction stays a plain text-only summarisation.
+
+        ``event_sink=self._emit`` streams the compaction's tool-call/result
+        events to the live tap (the Studio activity rail) without persisting
+        them into the agent's history -- only the summary message the strategy
+        returns is persisted, via ``_replace_compacted_head``."""
+        if not getattr(self._agent, "compaction_tool_access", False):
+            return {}
+        return {
+            "tool_manager": self._tool_manager,
+            "event_sink": self._emit,
+            "max_tool_turns": self._agent.max_tool_turns,
+            "principal": self._principal,
+        }
 
 
 __all__ = ["_BaseAgentExecutor"]

--- a/primer/agent/compaction.py
+++ b/primer/agent/compaction.py
@@ -31,7 +31,7 @@ import json
 import logging
 from collections.abc import Sequence
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Protocol
 
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -41,23 +41,52 @@ from primer.model.chat import (
     AudioPart,
     DocumentPart,
     Error,
+    ExtendedEvent,
     ExtendedPart,
     ImagePart,
     Message,
     Part,
+    StreamEvent,
     TextDelta,
     TextPart,
+    Tool,
+    ToolCallEnd,
     ToolCallPart,
+    ToolCallStart,
     ToolResultPart,
     VideoPart,
+    _ExecutorToolResult,
+    output_to_message,
 )
 from primer.model.except_ import ServerError
 
 
 if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
     from primer.int.llm import LLM
     from primer.model.agent import Agent
     from primer.model.provider import LLMModel
+
+
+class CompactionToolExecutor(Protocol):
+    """The slice of ``ToolExecutionManager`` the compaction loop needs.
+
+    Duck-typed so the strategy stays decoupled from the executor layer and
+    is trivially fakeable in tests.
+    """
+
+    async def list_tools(self, *, principal: str | None = ...) -> list[Tool]: ...
+
+    async def execute(
+        self, call: ToolCallPart, *, principal: str | None = ...
+    ) -> ToolResultPart: ...
+
+
+# Fallback cap on the compaction tool loop when the agent sets no
+# ``max_tool_turns`` -- keeps an ill-behaved compaction prompt from looping
+# unbounded during an automatic, unattended step.
+DEFAULT_COMPACTION_TOOL_TURNS = 8
 
 
 logger = logging.getLogger(__name__)
@@ -225,8 +254,19 @@ class CompactionStrategy:
         history: list[Message],
         new_messages: list[Message],
         last_known_input_tokens: int | None = None,
+        tool_manager: "CompactionToolExecutor | None" = None,
+        event_sink: "Callable[[StreamEvent], Awaitable[None]] | None" = None,
+        max_tool_turns: int | None = None,
+        principal: str | None = None,
     ) -> CompactedTurn | None:
-        """Decide whether to compact; if so, do it. Returns ``None`` if not."""
+        """Decide whether to compact; if so, do it. Returns ``None`` if not.
+
+        When ``tool_manager`` is supplied (the agent has
+        ``compaction_tool_access`` on), the tier-2 summarisation call carries
+        the agent's tools and runs a bounded, ephemeral tool-use loop; tool
+        activity is streamed to ``event_sink`` but never enters the compacted
+        history. When it is ``None`` the call is plain text-only summarisation.
+        """
         before = max(
             self._estimate_tokens([*history, *new_messages]),
             last_known_input_tokens or 0,
@@ -263,6 +303,8 @@ class CompactionStrategy:
             pruned_count=pruned_count,
             before=before,
             agent=agent, llm=llm, model=model,
+            tool_manager=tool_manager, event_sink=event_sink,
+            max_tool_turns=max_tool_turns, principal=principal,
         )
 
     async def force_compact(
@@ -272,6 +314,10 @@ class CompactionStrategy:
         llm: "LLM",
         model: "LLMModel",
         history: list[Message],
+        tool_manager: "CompactionToolExecutor | None" = None,
+        event_sink: "Callable[[StreamEvent], Awaitable[None]] | None" = None,
+        max_tool_turns: int | None = None,
+        principal: str | None = None,
     ) -> CompactedTurn:
         """Mandatory compaction (used by hard-overflow recovery)."""
         before = self._estimate_tokens(history)
@@ -285,6 +331,8 @@ class CompactionStrategy:
             pruned_count=pruned_count,
             before=before,
             agent=agent, llm=llm, model=model,
+            tool_manager=tool_manager, event_sink=event_sink,
+            max_tool_turns=max_tool_turns, principal=principal,
         )
 
     async def _tier2(
@@ -296,6 +344,10 @@ class CompactionStrategy:
         agent: "Agent",
         llm: "LLM",
         model: "LLMModel",
+        tool_manager: "CompactionToolExecutor | None" = None,
+        event_sink: "Callable[[StreamEvent], Awaitable[None]] | None" = None,
+        max_tool_turns: int | None = None,
+        principal: str | None = None,
     ) -> CompactedTurn:
         """Run the full LLM-driven compaction pass and assemble the
         :class:`CompactedTurn` result. Shared by :meth:`maybe_compact`
@@ -306,6 +358,10 @@ class CompactionStrategy:
             agent=agent,
             llm=llm,
             model=model,
+            tool_manager=tool_manager,
+            event_sink=event_sink,
+            max_tool_turns=max_tool_turns,
+            principal=principal,
         )
         after = self._estimate_tokens(compacted_messages)
         return CompactedTurn(
@@ -445,6 +501,10 @@ class CompactionStrategy:
         agent: "Agent",
         llm: "LLM",
         model: "LLMModel",
+        tool_manager: "CompactionToolExecutor | None" = None,
+        event_sink: "Callable[[StreamEvent], Awaitable[None]] | None" = None,
+        max_tool_turns: int | None = None,
+        principal: str | None = None,
     ) -> tuple[list[Message], Message | None, int]:
         head, tail = tail_split(history, tail_turns=self.tail_turns)
         if not head:
@@ -473,6 +533,43 @@ class CompactionStrategy:
             ),
         ]
 
+        if tool_manager is None:
+            summary_text = await self._summarise_text_only(
+                summary_request, llm=llm, model=model,
+            )
+        else:
+            summary_text = await self._summarise_with_tools(
+                summary_request,
+                llm=llm,
+                model=model,
+                tool_manager=tool_manager,
+                event_sink=event_sink,
+                max_tool_turns=max_tool_turns,
+                principal=principal,
+            )
+
+        marker_ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        summary_msg = Message(
+            role="assistant",
+            parts=[
+                TextPart(
+                    text=(
+                        f"[earlier conversation compacted on {marker_ts}]\n\n"
+                        f"{summary_text}"
+                    )
+                )
+            ],
+        )
+        return [summary_msg, *tail], summary_msg, len(head)
+
+    async def _summarise_text_only(
+        self,
+        summary_request: list[Message],
+        *,
+        llm: "LLM",
+        model: "LLMModel",
+    ) -> str:
+        """Plain, tool-free summarisation (unchanged legacy path)."""
         text_buffers: list[str] = []
         async for event in llm.stream(
             model=model.name,
@@ -492,25 +589,144 @@ class CompactionStrategy:
         summary_text = "".join(text_buffers).strip()
         if not summary_text:
             raise ServerError("compaction produced empty summary text")
+        return summary_text
 
-        marker_ts = datetime.now(timezone.utc).isoformat(timespec="seconds")
-        summary_msg = Message(
-            role="assistant",
-            parts=[
-                TextPart(
-                    text=(
-                        f"[earlier conversation compacted on {marker_ts}]\n\n"
-                        f"{summary_text}"
-                    )
-                )
-            ],
+    async def _summarise_with_tools(
+        self,
+        summary_request: list[Message],
+        *,
+        llm: "LLM",
+        model: "LLMModel",
+        tool_manager: "CompactionToolExecutor",
+        event_sink: "Callable[[StreamEvent], Awaitable[None]] | None",
+        max_tool_turns: int | None,
+        principal: str | None,
+    ) -> str:
+        """Tool-enabled summarisation: a bounded, ephemeral tool-use loop.
+
+        The compaction prompt may instruct the model to call the agent's tools
+        (e.g. dump the compacted content to workspace files). Tool calls are
+        executed via ``tool_manager`` and their lifecycle events forwarded to
+        ``event_sink`` (surfaced as debug/activity events); the intermediate
+        assistant/tool messages are DISCARDED -- only the model's final text is
+        returned as the summary. An empty final text (e.g. the model spent its
+        turn writing files) falls back to a marker rather than erroring.
+        """
+        cap = (
+            max_tool_turns
+            if max_tool_turns is not None and max_tool_turns > 0
+            else DEFAULT_COMPACTION_TOOL_TURNS
         )
-        return [summary_msg, *tail], summary_msg, len(head)
+        tools = await tool_manager.list_tools(principal=principal)
+        messages = list(summary_request)
+        summary_text = ""
+        tool_round = 0
+        while True:
+            buffered: list[StreamEvent] = []
+            async for event in llm.stream(
+                model=model.name,
+                messages=messages,
+                temperature=0.0,
+                max_output_tokens=self.summary_max_tokens,
+                tools=tools,
+                tool_choice="auto",
+            ):
+                buffered.append(event)
+                if isinstance(event, (ToolCallStart, ToolCallEnd)):
+                    await self._sink(event_sink, event)
+                elif isinstance(event, Error) and event.fatal:
+                    raise ServerError(
+                        f"compaction LLM failed: {event.message}",
+                        code=event.code,
+                    )
+            try:
+                assistant_msg = output_to_message(buffered)
+            except ValueError:
+                # Empty / error-only stream -- nothing more to do.
+                break
+
+            tool_calls = [
+                p for p in assistant_msg.parts if isinstance(p, ToolCallPart)
+            ]
+            # Keep the last NON-EMPTY assistant text as the summary. A prompt
+            # that emits the summary first and only then dumps to files ends on
+            # tool-only (empty-text) rounds; without this guard that trailing
+            # empty round would clobber the real summary with the fallback.
+            round_text = "".join(
+                p.text for p in assistant_msg.parts if isinstance(p, TextPart)
+            ).strip()
+            if round_text:
+                summary_text = round_text
+            if not tool_calls:
+                break
+
+            tool_round += 1
+            if tool_round >= cap:
+                logger.warning(
+                    "compaction: reached tool-turn cap (%d); force-stopping "
+                    "the compaction tool loop", cap,
+                )
+                break
+
+            result_parts: list[ToolResultPart] = []
+            for call in tool_calls:
+                try:
+                    rp = await tool_manager.execute(call, principal=principal)
+                except Exception as exc:  # noqa: BLE001
+                    # INTENTIONAL divergence from the turn loop's contract
+                    # (loop.py / base.py re-raise AuthRequiredError + let
+                    # YieldToWorker propagate): compaction runs OUTSIDE the
+                    # turn's park/auth machinery, so propagating either would
+                    # corrupt park/resume state. Swallowing is safe -- the
+                    # approval gate raises YieldToWorker *before* dispatch, so
+                    # this fails closed (no un-approved side effect). Net effect:
+                    # auth/approval/yielding tools (ask_user, sleep, watch_files)
+                    # simply produce an error result during compaction and the
+                    # model moves on. Do NOT "harmonize" this to re-raise.
+                    # (CancelledError is a BaseException and still propagates.)
+                    rp = ToolResultPart(id=call.id, output=str(exc), error=True)
+                result_parts.append(rp)
+                await self._sink(
+                    event_sink,
+                    ExtendedEvent(
+                        extended=_ExecutorToolResult(
+                            call_id=rp.id, output=rp.output, error=rp.error,
+                        )
+                    ),
+                )
+            messages = messages + [
+                assistant_msg,
+                Message(role="tool", parts=result_parts),
+            ]
+
+        if not summary_text:
+            summary_text = (
+                "(compaction delegated the detail to tools -- the earlier "
+                "conversation was written out via the compaction tool calls; "
+                "see the compaction activity for what was produced.)"
+            )
+        return summary_text
+
+    @staticmethod
+    async def _sink(
+        event_sink: "Callable[[StreamEvent], Awaitable[None]] | None",
+        event: StreamEvent,
+    ) -> None:
+        """Forward a compaction tool event to the sink, swallowing sink errors
+        (observability must never break compaction)."""
+        if event_sink is None:
+            return
+        try:
+            await event_sink(event)
+        except Exception:  # noqa: BLE001
+            logger.debug("compaction: event_sink raised; ignoring", exc_info=True)
 
 
 __all__ = [
     "CompactedTurn",
     "CompactionStrategy",
+    "CompactionToolExecutor",
+    "DEFAULT_COMPACTION_TOOL_TURNS",
     "DEFAULT_CONTEXT_LIMIT",
     "MODEL_CONTEXT_FALLBACK",
     "lookup_context_length",

--- a/primer/agent/compaction_mixin.py
+++ b/primer/agent/compaction_mixin.py
@@ -22,8 +22,11 @@ from primer.model.chat import Message, Tool
 
 
 if TYPE_CHECKING:
-    from primer.agent.compaction import CompactionStrategy
+    from collections.abc import Awaitable, Callable
+
+    from primer.agent.compaction import CompactionStrategy, CompactionToolExecutor
     from primer.int.llm import LLM
+    from primer.model.chat import StreamEvent
 
 
 logger = logging.getLogger(__name__)
@@ -116,6 +119,10 @@ async def apply_compaction(
     compaction_prompt: str,
     model_name: str,
     context_length: int,
+    tool_manager: "CompactionToolExecutor | None" = None,
+    event_sink: "Callable[[StreamEvent], Awaitable[None]] | None" = None,
+    max_tool_turns: int | None = None,
+    principal: str | None = None,
 ) -> CompactionResult:
     """Run the :class:`CompactionStrategy` and assemble a :class:`CompactionResult`.
 
@@ -145,6 +152,10 @@ async def apply_compaction(
         agent=_AgentShim(),
         llm=llm,
         model=_ModelShim(),
+        tool_manager=tool_manager,
+        event_sink=event_sink,
+        max_tool_turns=max_tool_turns,
+        principal=principal,
     )
     summary_msg = compacted.summary_message
     summary_text = (
@@ -174,6 +185,10 @@ async def force_compact(
     compaction_prompt: str,
     model_name: str,
     context_length: int,
+    tool_manager: "CompactionToolExecutor | None" = None,
+    event_sink: "Callable[[StreamEvent], Awaitable[None]] | None" = None,
+    max_tool_turns: int | None = None,
+    principal: str | None = None,
 ) -> CompactionResult:
     """On-demand compaction -- bypasses the trigger check."""
     return await apply_compaction(
@@ -183,6 +198,10 @@ async def force_compact(
         compaction_prompt=compaction_prompt,
         model_name=model_name,
         context_length=context_length,
+        tool_manager=tool_manager,
+        event_sink=event_sink,
+        max_tool_turns=max_tool_turns,
+        principal=principal,
     )
 
 

--- a/primer/chat/executor.py
+++ b/primer/chat/executor.py
@@ -1182,6 +1182,17 @@ class ChatTurnRunner:
         else:
             compaction_prompt = DEFAULT_COMPACTION_PROMPT
             prompt_source = "default"
+        # Opt-in tool access during compaction (Agent.compaction_tool_access).
+        # event_sink is intentionally omitted for the chat path: a chat has no
+        # separate activity rail, and persisting compaction tool calls as chat
+        # rows would re-enter them into the next turn's history (defeating
+        # compaction). The tools still execute; their side effects persist.
+        tool_kwargs: dict = {}
+        if getattr(self._agent, "compaction_tool_access", False):
+            tool_kwargs = {
+                "tool_manager": self._tools,
+                "max_tool_turns": self._agent.max_tool_turns,
+            }
         result = await _mixin_apply_compaction(
             llm=self._llm,
             strategy=strategy,
@@ -1189,6 +1200,7 @@ class ChatTurnRunner:
             compaction_prompt=compaction_prompt,
             model_name=self._model.name,
             context_length=self._model.context_length,
+            **tool_kwargs,
         )
         next_seq = await self._next_seq_for_marker(chat)
         chat_msg = ChatMessage(

--- a/primer/model/agent.py
+++ b/primer/model/agent.py
@@ -171,6 +171,25 @@ class Agent(Describeable):
             "the runtime falls back to its default compaction prompt."
         ),
     )
+    compaction_tool_access: bool = Field(
+        default=False,
+        description=(
+            "When true, the agent's tools are registered on the LLM call "
+            "that performs history compaction, so a ``compaction_prompt`` can "
+            "instruct the model to call them -- e.g. dump the compacted "
+            "content to workspace files via the workspace tools (on a "
+            "workspace session the tool set already includes those). The tool "
+            "calls run in a bounded, ephemeral loop capped by "
+            ":attr:`max_tool_turns`; they surface as debug/activity events but "
+            "do NOT enter the agent's conversation history. The prompt should "
+            "make the model's FINAL message carry the summary text (a trailing "
+            "tool-only round yields a generic marker instead). Auth/approval/"
+            "yielding tools (ask_user, sleep, watch_files) do not function "
+            "during compaction -- they surface an error result and the model "
+            "moves on. Default false keeps compaction a plain text-only "
+            "summarisation."
+        ),
+    )
     response_format: dict[str, Any] | None = Field(
         default=None,
         description=(

--- a/tests/agent/test_compaction_tools.py
+++ b/tests/agent/test_compaction_tools.py
@@ -1,0 +1,223 @@
+"""Tool access during compaction (``Agent.compaction_tool_access``).
+
+Exercises ``CompactionStrategy``'s tier-2 tool-use loop directly with a
+scripted fake LLM + a fake tool manager -- no executor / workspace needed.
+"""
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from primer.agent.compaction import CompactionStrategy
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import (
+    Done,
+    ExtendedEvent,
+    Message,
+    StreamEvent,
+    TextDelta,
+    TextPart,
+    Tool,
+    ToolCallEnd,
+    ToolCallPart,
+    ToolCallStart,
+    ToolResultPart,
+)
+from primer.model.provider import LLMModel
+
+
+# --- fakes + helpers --------------------------------------------------------
+
+
+def _agent(**kw: Any) -> Agent:
+    return Agent(
+        id="researcher",
+        description="Research agent",
+        model=AgentModel(provider_id="openai-1", model_name="gpt-4o-mini"),
+        **kw,
+    )
+
+
+def _model(context_length: int = 1000) -> LLMModel:
+    return LLMModel(name="gpt-4o-mini", context_length=context_length)
+
+
+def _u(text: str) -> Message:
+    return Message(role="user", parts=[TextPart(text=text)])
+
+
+def _a(text: str) -> Message:
+    return Message(role="assistant", parts=[TextPart(text=text)])
+
+
+# 6 turns; with tail_turns=1 the head is non-empty so tier-2 summarisation runs.
+HISTORY = [m for i in range(1, 7) for m in (_u(f"q{i}"), _a(f"a{i}"))]
+
+
+class _ScriptedLLM:
+    """Yields a distinct scripted event list per ``stream()`` call."""
+
+    def __init__(self, rounds: list[list[StreamEvent]]) -> None:
+        self._rounds = list(rounds)
+        self.calls: list[dict[str, Any]] = []
+
+    def stream(
+        self, *, model: str, messages: list[Message], **kwargs: Any
+    ) -> AsyncIterator[StreamEvent]:
+        self.calls.append({"messages": list(messages), **kwargs})
+        script = (
+            self._rounds.pop(0)
+            if self._rounds
+            else [Done(stop_reason="stop", raw_reason="stop")]
+        )
+
+        async def _gen() -> AsyncIterator[StreamEvent]:
+            for ev in script:
+                yield ev
+
+        return _gen()
+
+
+class _FakeToolManager:
+    def __init__(self, *, raise_on: str | None = None) -> None:
+        self._raise_on = raise_on
+        self.executed: list[ToolCallPart] = []
+
+    async def list_tools(self, *, principal: str | None = None) -> list[Tool]:
+        return []  # the scripted LLM emits calls regardless of the catalogue
+
+    async def execute(
+        self, call: ToolCallPart, *, principal: str | None = None
+    ) -> ToolResultPart:
+        self.executed.append(call)
+        if self._raise_on and call.name == self._raise_on:
+            raise RuntimeError("boom")
+        return ToolResultPart(id=call.id, output=f"wrote {call.arguments}", error=False)
+
+
+def _tool_round(cid: str, name: str, args: dict) -> list[StreamEvent]:
+    return [
+        ToolCallStart(id=cid, name=name, index=0),
+        ToolCallEnd(id=cid, arguments=args, index=0),
+        Done(stop_reason="tool_use", raw_reason="tool_use"),
+    ]
+
+
+def _text_round(text: str) -> list[StreamEvent]:
+    return [TextDelta(text=text, index=0), Done(stop_reason="stop", raw_reason="stop")]
+
+
+def _strategy() -> CompactionStrategy:
+    return CompactionStrategy(tail_turns=1)
+
+
+async def _run(llm, tm, *, max_tool_turns=None, agent=None):
+    events: list[StreamEvent] = []
+
+    async def sink(ev: StreamEvent) -> None:
+        events.append(ev)
+
+    result = await _strategy().force_compact(
+        agent=agent or _agent(),
+        llm=llm,
+        model=_model(),
+        history=list(HISTORY),
+        tool_manager=tm,
+        event_sink=sink,
+        max_tool_turns=max_tool_turns,
+    )
+    return result, events
+
+
+def _summary_text(result) -> str:
+    assert result.summary_message is not None
+    return "".join(
+        p.text for p in result.summary_message.parts if isinstance(p, TextPart)
+    )
+
+
+# --- tests ------------------------------------------------------------------
+
+
+async def test_tool_call_executed_and_final_text_is_summary() -> None:
+    llm = _ScriptedLLM(
+        [
+            _tool_round("c1", "workspace__write", {"path": "dump.md"}),
+            _text_round("wrote the dump to dump.md"),
+        ]
+    )
+    tm = _FakeToolManager()
+    result, events = await _run(llm, tm)
+
+    assert [c.name for c in tm.executed] == ["workspace__write"]
+    assert "wrote the dump to dump.md" in _summary_text(result)
+    # The intermediate tool call/result must NOT leak into the compacted history.
+    assert not any(m.role == "tool" for m in result.new_messages)
+    assert not any(
+        isinstance(p, ToolCallPart)
+        for m in result.new_messages
+        for p in m.parts
+    )
+    # Tools were threaded to the LLM call, and the second call carried the
+    # tool result back (loop actually iterated).
+    assert "tools" in llm.calls[0]
+    assert len(llm.calls) == 2
+    # Tool activity surfaced to the sink.
+    assert any(isinstance(e, ToolCallStart) for e in events)
+    assert any(isinstance(e, ExtendedEvent) for e in events)
+
+
+async def test_no_tool_manager_is_text_only_unchanged() -> None:
+    llm = _ScriptedLLM([_text_round("plain summary")])
+    result = await _strategy().force_compact(
+        agent=_agent(), llm=llm, model=_model(), history=list(HISTORY),
+    )
+    assert "plain summary" in _summary_text(result)
+    # The text-only path passes no tools.
+    assert not llm.calls[0].get("tools")
+    assert len(llm.calls) == 1
+
+
+async def test_empty_final_text_falls_back_to_marker() -> None:
+    llm = _ScriptedLLM(
+        [
+            _tool_round("c1", "workspace__write", {"path": "x"}),
+            [Done(stop_reason="stop", raw_reason="stop")],  # no text at all
+        ]
+    )
+    result, _ = await _run(llm, _FakeToolManager())
+    assert "delegated the detail to tools" in _summary_text(result)
+
+
+async def test_tool_failure_is_fed_back_and_loop_continues() -> None:
+    llm = _ScriptedLLM(
+        [
+            _tool_round("c1", "workspace__write", {"path": "x"}),
+            _text_round("finished despite the tool error"),
+        ]
+    )
+    tm = _FakeToolManager(raise_on="workspace__write")
+    result, events = await _run(llm, tm)
+    assert "finished despite the tool error" in _summary_text(result)
+    # The failure surfaced as an error tool-result event, and the loop did not abort.
+    assert any(
+        isinstance(e, ExtendedEvent) and getattr(e.extended, "error", False)
+        for e in events
+    )
+
+
+def test_agent_flag_defaults_off_and_round_trips() -> None:
+    assert _agent().compaction_tool_access is False
+    assert _agent(compaction_tool_access=True).compaction_tool_access is True
+
+
+async def test_tool_turn_cap_enforced() -> None:
+    # Every round emits a tool call; without a cap this never terminates.
+    rounds = [_tool_round(f"c{i}", "workspace__write", {"n": i}) for i in range(10)]
+    llm = _ScriptedLLM(rounds)
+    tm = _FakeToolManager()
+    result, _ = await _run(llm, tm, max_tool_turns=2)
+    assert 1 <= len(tm.executed) <= 2  # bounded well below the 10 scripted rounds
+    assert result.summary_message is not None


### PR DESCRIPTION
## Summary

Adds a per-agent flag **`Agent.compaction_tool_access`** (default **off**). When on, the LLM call that performs **history compaction** carries the agent's full tool set and runs a **bounded, ephemeral tool-use loop** — so a customised `compaction_prompt` can instruct the model to call tools, e.g. **dump the compacted content to workspace files** so the full detail survives on disk instead of being lost to summarisation.

Generic across session types (per the brainstorm): on a **workspace** session the tool set already includes the workspace tools; on a **chat** session it's the agent's toolsets/MCP. No workspace special-casing.

## How it works
- `CompactionStrategy` tier-2 summarisation splits into `_summarise_text_only` (the legacy path, **unchanged** — still raises on empty) and `_summarise_with_tools` (the new bounded loop, reusing `output_to_message`). `tool_manager` / `event_sink` / `max_tool_turns` / `principal` thread through `maybe_compact` / `force_compact` / `_tier2` / `_full_compact` and the `compaction_mixin`.
- **Ephemeral:** the loop's intermediate tool-call/result messages are **discarded** — only the model's final text becomes the summary that replaces the head; the written files persist. Tool activity streams to `event_sink` (the executor's live tap → Studio **activity rail**) but never enters conversation history. (Compaction messages are never persisted; workspace event-log records are skipped on history reload; the chat path omits the sink to avoid chat-row re-entry.)
- `base.py` wires `event_sink=self._emit` when the flag is on (thread + workspace executors); the chat path passes the tools but omits the sink.
- **Bounded** by `agent.max_tool_turns` (fallback 8). A tool failure is fed back as an error result and the loop continues; the approval gate raises **before** dispatch, so gated tools fail closed during compaction.

## Reviewed
Independent code-review pass (read-only, no suite run) — **APPROVE**, no Critical/Important. Applied its two Minor items: retain the last *non-empty* summary text across rounds (so a trailing tool-only round can't clobber a real summary), and documented the intentional exception-handling divergence + the auth/approval/yielding-tools limitation on the `Agent` field.

## Tests
`tests/agent/test_compaction_tools.py` (new): tool call executed + result fed back + final text is the summary; intermediate messages excluded from history; no-tools path unchanged (regression); empty-final-text fallback; tool-failure fed back + loop continues; tool-turn cap enforced; flag defaults off. **183 passed** across `tests/agent/` + chat compaction + compact endpoints, single-process. ruff clean.

## Notes
- Default-off → compaction is **bit-for-bit unchanged** for every existing agent.
- Auth/approval/yielding tools (`ask_user`, `sleep`, `watch_files`) don't function during compaction (they surface an error result); documented on the field.
- Part of the held 0.4.0 release.
