### PR TITLE
feat(ui): surface compaction_tool_access as a toggle in the agent form

### DIFF
--- a/tests/ui/test_agent_compaction_help.py
+++ b/tests/ui/test_agent_compaction_help.py
@@ -12,3 +12,26 @@ def test_help_text_present() -> None:
     src = JSX.read_text(encoding="utf-8")
     assert "Leave blank to use the default prompt" in src
     assert "preserve system context" in src
+
+
+def test_compaction_tool_access_toggle_present() -> None:
+    src = JSX.read_text(encoding="utf-8")
+    # State + request body are wired.
+    assert "compactionToolAccess" in src
+    assert "setCompactionToolAccess" in src
+    assert "compaction_tool_access: compactionToolAccess" in src
+    # Rendered as a sliding toggle switch (role="switch"), not a checkbox.
+    assert "function AG_Toggle(" in src
+    assert 'role="switch"' in src
+    assert 'testid="na-compaction-tool-access"' in src
+    assert "Tool access during compaction" in src
+
+
+def test_agents_bundle_transpiles() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    ui_dir = JSX.resolve().parents[1]
+    build_jsx_bundle.cache_clear()
+    etag, body = build_jsx_bundle(ui_dir)
+    assert etag and body, "bundle did not build (Babel/vendor missing?)"
+    assert "/* === components/agents.jsx === */" in body.decode("utf-8")

--- a/ui/components/agents.jsx
+++ b/ui/components/agents.jsx
@@ -294,6 +294,51 @@ function AgentsPage({ onOpen, pushToast }) {
 }
 
 // ============================================================================
+// AG_Toggle — sliding switch, mirrors CH_Toggle (channels.jsx) / SSO_Toggle.
+// ============================================================================
+
+function AG_Toggle({ checked, onChange, label, help, disabled, testid }) {
+  return (
+    <label
+      style={{
+        display: "flex", alignItems: "flex-start", gap: 10,
+        cursor: disabled ? "default" : "pointer", opacity: disabled ? 0.5 : 1,
+      }}
+    >
+      <button
+        type="button"
+        role="switch"
+        aria-checked={checked}
+        disabled={disabled}
+        data-testid={testid}
+        onClick={() => !disabled && onChange(!checked)}
+        style={{
+          flex: "0 0 auto", width: 34, height: 20, borderRadius: 999,
+          border: "1px solid var(--border)", padding: 0, marginTop: 1,
+          background: checked ? "var(--accent)" : "var(--bg-2)",
+          position: "relative", cursor: disabled ? "default" : "pointer",
+          transition: "background 0.12s ease",
+        }}
+      >
+        <span
+          style={{
+            position: "absolute", top: 1, left: checked ? 15 : 1,
+            width: 16, height: 16, borderRadius: "50%",
+            background: checked ? "var(--accent-fg)" : "var(--text-3)",
+            transition: "left 0.12s ease",
+          }}
+        />
+      </button>
+      <span style={{ fontSize: 12.5, lineHeight: 1.4 }}>
+        {label}
+        {help && <span className="muted"> — {help}</span>}
+      </span>
+    </label>
+  );
+}
+
+
+// ============================================================================
 // New agent modal
 // ============================================================================
 
@@ -335,6 +380,7 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
   const [modelName, setModelName] = React.useState(existing?.model?.model_name || "");
   const [systemPrompt, setSystemPrompt] = React.useState(_joinPrompt(existing?.system_prompt));
   const [compactionPrompt, setCompactionPrompt] = React.useState(_joinPrompt(existing?.compaction_prompt));
+  const [compactionToolAccess, setCompactionToolAccess] = React.useState(existing?.compaction_tool_access ?? false);
   // selectedScopedIds is a Set so toggles are O(1); persisted as a
   // sorted list at submit time for stable JSON.
   const [selectedScopedIds, setSelectedScopedIds] = React.useState(_initialTools);
@@ -520,6 +566,7 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
       tools,
       system_prompt: systemPrompt ? [systemPrompt] : [],
       compaction_prompt: compactionPrompt ? [compactionPrompt] : [],
+      compaction_tool_access: compactionToolAccess,
     };
     if (temperature !== "" && !Number.isNaN(+temperature)) {
       body.temperature = Number(temperature);
@@ -872,6 +919,15 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
               Leave blank to use the default prompt (recommended unless your agent has a domain-specific compaction need).
               The default is designed to preserve system context, recent turns, and pending tool calls.
             </p>
+          </div>
+          <div className="field">
+            <AG_Toggle
+              checked={compactionToolAccess}
+              onChange={setCompactionToolAccess}
+              testid="na-compaction-tool-access"
+              label="Tool access during compaction"
+              help="let the compaction prompt call this agent's tools while summarising — e.g. dump the compacted content to workspace files. Runs in a bounded, ephemeral loop; the tool calls don't enter conversation history. Leave off for plain text-only compaction."
+            />
           </div>
           <div className="field">
             <label className="field-label" htmlFor="na-temperature">


### PR DESCRIPTION
The `Agent.compaction_tool_access` flag merged in #136, but its UI control landed on the branch **after** #136 was merged, so it never reached `main` — the flag was only settable via the API.

This adds the control: a sliding toggle (`AG_Toggle`, mirroring the existing `CH_Toggle`/`SSO_Toggle` — `role="switch"` + `aria-checked`) in the **New/Edit agent → Advanced** tab, right under the Compaction prompt, bound to the create/edit body.

- `ui/components/agents.jsx`: `AG_Toggle` component + state + request-body field + the control.
- `tests/ui/test_agent_compaction_help.py`: asserts the toggle wiring + a whole-bundle transpile gate. 3 pass (single-process).

Completes the compaction-tools feature end-to-end for 0.4.0.