### PR TITLE
feat(llm): aggregated chat models - grouped providers with failover

### DIFF
--- a/docs/dev/architecture/provider-pattern.md
+++ b/docs/dev/architecture/provider-pattern.md
@@ -135,6 +135,9 @@ LLM adapters (`primer/llm/`, re-exported from `primer.llm`):
 - `OpenRouterLLM` (`openrouter.py`) is a thin OpenRouter specialisation adding `HTTP-Referer` / `X-Title` attribution headers. Importable but not in `__all__`.
 - `AnthropicLLM` (`anthropic.py`) wraps `AsyncAnthropic`.
 - `GeminiLLM` (`gemini.py`) and `OllamaLLM` (`ollama.py`).
+- The `aggregated` LLM provider is a config-only variant: it holds no
+  connection config of its own and instead wraps peer providers by id,
+  resolving them lazily through the registry at call time.
 
 The three OpenAI-family adapters share `primer/llm/_openai_common.py` (sampling-param builder) and `primer/llm/_openai_compat.py` (Chat Completions streaming compat). `count_tokens` is backed by per-provider tokenizers under `primer/llm/_tokenizer/` (anthropic, gemini, hf, openai, char_fallback); `_trace.py` holds the `trace_llm_io` debug-dump helper.
 

--- a/docs/dev/subsystems/model-providers.md
+++ b/docs/dev/subsystems/model-providers.md
@@ -112,6 +112,75 @@ stateDiagram-v2
     Error --> [*]
 ```
 
+### Aggregated LLM provider
+
+`LLMProviderType.AGGREGATED` ("aggregated") is a config-only provider that
+wraps a pool of other LLM providers behind one chat interface. Its
+`AggregatedLLMConfig` carries:
+
+- `members`: an ordered list of `(provider_id, model_name)` pairs, deduped
+  on the pair preserving first-seen order (min length 1). Each member must
+  reference an existing NON-aggregated provider; existence is checked at
+  resolve time, not at write time.
+- `strategy`: `sequential` (always start at members[0]) or `round_robin`
+  (rotate the starting member once per call; per-process, load-spreading).
+- `failover_point`: `before_first_token` (default; never re-emits tokens)
+  or `mid_stream` (opt-in; may duplicate already-shown tokens).
+- `failover_on`: `transient` (rate-limit / 5xx / timeout / network) or
+  `transient_and_config` (default; also auth / bad-request).
+
+The aggregated provider still carries `models` - the virtual model name(s)
+an agent selects. `stream(model=<virtual>)` dispatches to each member using
+that member's own `model_name`; the virtual name is not forwarded
+downstream.
+
+**Two failover channels.** A member surfaces a failure two ways, and the
+aggregated adapter handles each:
+
+- Connect phase (before the first event): the member RAISES a typed
+  exception. Matched by class - the reliable channel.
+- Mid-stream (after at least one event): the member usually YIELDS a
+  terminal `Error(fatal=True)`, but a mid-stream timeout is RAISED instead.
+  The adapter inspects the FIRST event before forwarding anything, so a
+  first-event fatal error fails over without emitting tokens. Yielded errors
+  carry a `code` that is often null for transient failures, so yielded-error
+  eligibility is best-effort by code (known timeout codes and null are
+  always eligible; other codes are eligible only under
+  `transient_and_config`).
+
+**The commit point is the first event of any kind.** The failover window
+closes at the first event the member yields, including a `StreamStart`. In
+practice rate-limit and auth failures RAISE at connect, before any event,
+so they fail over cleanly; a fatal error that arrives only after the first
+event is surfaced (default mode) rather than retried.
+
+**Class coarsening on the yielded channel.** Because the classify_*
+functions erase the exception class to `code=null` for rate-limit, server,
+auth, and network failures, the yielded channel cannot honor the
+`transient` policy's "exclude auth" guarantee: a null-code fatal error is
+treated as eligible under either policy. This is safe because the
+yielded-error failover window ends before any token is emitted, and auth
+failures also RAISE at connect (where the class is preserved and `transient`
+correctly excludes them). The all-members-failed error is an aggregated
+`RateLimitError` whose message lists each member and its failure class;
+that per-member class summary is the coarsened record of what went wrong.
+
+**Safety constraint.** Clean failover is only possible before the first
+non-terminal event reaches the subscriber; retrying after partial output
+was streamed would re-emit shown tokens. That is why `before_first_token`
+is the default. Under `mid_stream`, both a yielded fatal eligible Error and
+a raised eligible exception (e.g. a mid-stream timeout) after tokens were
+shown restart on the next member, and the already-streamed tokens may be
+duplicated in the output; this is the documented trade-off of the mode.
+
+**No nesting.** A member that resolves to another aggregated provider (or
+to itself) is rejected at resolve time with `BadRequestError`.
+
+**Ownership.** Downstream adapters are owned and cached by the
+`ProviderRegistry`; `AggregatedLLM.aclose()` is a no-op. Members resolve
+lazily per `stream` call through the registry, so editing a member is
+picked up transparently on the next call.
+
 ## 6. Lifecycle
 
 An adapter is built lazily by `ProviderRegistry` on first lookup of a provider row, cached under the row id, and dropped (with `aclose()`) when the row is invalidated. A single `stream()` call walks the validate, translate, acquire, iterate, classify sequence below. Pre-stream exceptions are classified and re-raised; once the iterator has opened, mid-stream exceptions are classified and yielded as a terminal `Error(fatal=True)` so the consumer's `async for` always closes cleanly.
@@ -149,6 +218,11 @@ sequenceDiagram
 ```
 
 Embedders follow the mirror flow: validate model, map every `EmbeddingPart` to its input type before acquiring the lease (so unsupported parts fast-fail without holding a slot), acquire, call the SDK, classify exceptions, and translate the response into `EmbedResponse`. The local `HuggingFaceEmbedder` and `HuggingFaceCrossEncoder` differ only in that the SDK call is a synchronous `SentenceTransformer.encode` / `.predict` wrapped in `asyncio.to_thread` so the event loop is never blocked by weight loading.
+
+- Aggregated providers resolve members lazily per call via
+  `ProviderRegistry.get_llm`, so a member edit (which invalidates that
+  member's own cache entry) is picked up on the next aggregated call with
+  no cross-invalidation wiring.
 
 ## 7. Persistence
 

--- a/primectl/tests/test_aggregated_llm_roundtrip.py
+++ b/primectl/tests/test_aggregated_llm_roundtrip.py
@@ -1,0 +1,57 @@
+"""primectl forwards an aggregated LLMProvider manifest body verbatim."""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from pathlib import Path
+
+import httpx
+from typer.testing import CliRunner
+
+from primectl.main import app
+
+runner = CliRunner()
+
+
+def test_create_aggregated_llm_provider_posts_spec_verbatim(
+    mock_session, tmp_path: Path,
+):
+    seen = {}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        seen["method"] = request.method
+        seen["path"] = request.url.path
+        seen["body"] = json.loads(request.content)
+        return httpx.Response(201, json={"id": "agg1"})
+
+    mock_session.set_handler(handler)
+
+    spec = {
+        "id": "agg1",
+        "provider": "aggregated",
+        "config": {
+            "members": [
+                {"provider_id": "p1", "model_name": "m1"},
+                {"provider_id": "p2", "model_name": "m2"},
+            ],
+            "strategy": "round_robin",
+            "failover_point": "before_first_token",
+            "failover_on": "transient_and_config",
+        },
+        "models": [{"name": "virtual-1", "context_length": 200000}],
+        "limits": {"max_concurrency": 4},
+    }
+    manifest = tmp_path / "agg.yaml"
+    # JSON is valid YAML; indent it two spaces so it nests under `spec:`.
+    manifest.write_text(
+        "kind: llm_provider\nspec:\n"
+        + textwrap.indent(json.dumps(spec, indent=2), "  ")
+        + "\n"
+    )
+
+    result = runner.invoke(app, ["create", "-f", str(manifest)], obj=mock_session.session)
+    assert result.exit_code == 0, result.output
+    assert seen["method"] == "POST"
+    assert seen["path"] == "/v1/llm_providers"
+    assert seen["body"] == spec   # nested config forwarded untouched

--- a/primer/api/registries/provider_registry.py
+++ b/primer/api/registries/provider_registry.py
@@ -41,6 +41,7 @@ def _build_default_llm_factory(
     *,
     rate_limiter: "RateLimiter | None" = None,
     trace_llm_io: bool = False,
+    resolve_member: "Callable[[str], Any] | None" = None,
 ) -> Callable[[LLMProvider], LLM]:
     """Build the default ``llm_factory`` closure.
 
@@ -48,6 +49,8 @@ def _build_default_llm_factory(
     participate in the global concurrency limiter. ``None`` causes each
     adapter to fall back to a local :class:`~primer.coordinator.in_memory.InMemoryRateLimiter`.
     ``trace_llm_io`` controls whether prompt messages are included in spans.
+    ``resolve_member`` is threaded into the aggregated LLM provider so its
+    members resolve lazily through the caller's own ``get_llm``.
     """
     def _factory(provider: LLMProvider) -> LLM:  # pragma: no cover
         match provider.provider:
@@ -81,6 +84,15 @@ def _build_default_llm_factory(
                 return OpenRouterLLM(
                     provider, rate_limiter=rate_limiter, trace_llm_io=trace_llm_io,
                 )
+            case LLMProviderType.AGGREGATED:
+                from primer.llm.aggregated import AggregatedLLM
+                if resolve_member is None:
+                    raise ConfigError(
+                        "aggregated LLM provider requires a member resolver; "
+                        "the ProviderRegistry must build its llm_factory with "
+                        "resolve_member=self.get_llm",
+                    )
+                return AggregatedLLM(provider, resolve_member=resolve_member)
             case _:
                 raise ConfigError(
                     f"unknown LLM provider type {provider.provider!r}"
@@ -313,6 +325,7 @@ class ProviderRegistry:
         self._llm_factory = llm_factory or _build_default_llm_factory(
             rate_limiter=rate_limiter,
             trace_llm_io=trace_llm_io,
+            resolve_member=self.get_llm,
         )
         self._embedder_factory = embedder_factory or _build_default_embedder_factory(
             rate_limiter=rate_limiter,
@@ -603,6 +616,7 @@ class ProviderRegistry:
         self._rate_limiter = rate_limiter
         self._llm_factory = _build_default_llm_factory(
             rate_limiter=rate_limiter, trace_llm_io=self._trace_llm_io,
+            resolve_member=self.get_llm,
         )
         self._embedder_factory = _build_default_embedder_factory(rate_limiter=rate_limiter)
         self._cross_encoder_factory = _build_default_cross_encoder_factory(rate_limiter=rate_limiter)

--- a/primer/llm/__init__.py
+++ b/primer/llm/__init__.py
@@ -4,10 +4,18 @@ Each adapter subclasses :class:`primer.int.LLM` and implements the
 streaming chat interface against one provider's SDK.
 """
 
+from primer.llm.aggregated import AggregatedLLM
 from primer.llm.anthropic import AnthropicLLM
 from primer.llm.gemini import GeminiLLM
 from primer.llm.ollama import OllamaLLM
 from primer.llm.openchat import OpenChatLLM
 from primer.llm.openresponses import OpenResponsesLLM
 
-__all__ = ["AnthropicLLM", "GeminiLLM", "OllamaLLM", "OpenChatLLM", "OpenResponsesLLM"]
+__all__ = [
+    "AggregatedLLM",
+    "AnthropicLLM",
+    "GeminiLLM",
+    "OllamaLLM",
+    "OpenChatLLM",
+    "OpenResponsesLLM",
+]

--- a/primer/llm/aggregated.py
+++ b/primer/llm/aggregated.py
@@ -1,0 +1,317 @@
+"""Aggregated chat-model adapter.
+
+Wraps an ordered pool of downstream (provider_id, model_name) members
+behind one LLM interface. On a rate-limited / unavailable member the
+adapter fails over to the next member. Members are resolved LAZILY on
+each ``stream`` call through the ``resolve_member`` callable (which the
+ProviderRegistry binds to its own ``get_llm``), so member edits and
+cache invalidations are picked up transparently and no build-time cycle
+is created.
+
+Two failover channels, mirroring the real adapters:
+
+* Connect phase (before the first event): the member's ``stream``
+  RAISES a typed exception (RateLimitError, ServerError, ...). Matched
+  by class - the reliable channel.
+* Mid-stream (after >= 1 event): the member usually YIELDS a terminal
+  ``Error(fatal=True)`` (whose ``code`` is often ``None`` for transient
+  errors, so eligibility is best-effort by code - see
+  ``_yielded_eligible``), but a mid-stream timeout is RAISED instead
+  (ProviderTimeoutError). In ``MID_STREAM`` mode both a yielded fatal
+  eligible Error and a raised eligible exception restart on the next
+  member (already-shown tokens may duplicate); in ``BEFORE_FIRST_TOKEN``
+  mode a post-commit failure is surfaced/propagated (never re-emit).
+
+Ownership: downstream LLMs are owned/cached by the ProviderRegistry.
+``AggregatedLLM.aclose`` is a no-op.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from collections.abc import AsyncIterator, Awaitable, Callable, Iterable
+from typing import Any
+
+from pydantic import BaseModel
+
+from primer.int.llm import LLM
+from primer.model.chat import Error as ChatError
+from primer.model.chat import Message, StreamEvent, Tool, ToolChoice
+from primer.model.except_ import (
+    AuthenticationError,
+    BadRequestError,
+    ConfigError,
+    NetworkError,
+    NotFoundError,
+    ProviderError,
+    ProviderTimeoutError,
+    RateLimitError,
+    ServerError,
+)
+from primer.model.provider import (
+    AggregatedLLMConfig,
+    AggregatedMember,
+    FailoverClasses,
+    FailoverPoint,
+    LLMProvider,
+    RoutingStrategy,
+)
+
+
+logger = logging.getLogger(__name__)
+
+
+# RAISED-exception eligibility (the reliable connect-phase channel).
+_TRANSIENT_EXC: tuple[type[BaseException], ...] = (
+    RateLimitError,
+    ServerError,
+    ProviderTimeoutError,
+    NetworkError,
+)
+_CONFIG_EXC: tuple[type[BaseException], ...] = (
+    AuthenticationError,
+    BadRequestError,
+)
+
+# YIELDED-error eligibility. DEFENSIVE ONLY: every current adapter RAISES
+# its timeouts mid-stream (ProviderTimeoutError - openchat.py:284,
+# anthropic.py:760), so these codes never actually arrive on a yielded
+# Error today. They are matched here so the policy stays correct if an
+# adapter ever starts yielding a timeout instead of raising it. Every
+# other transient/server/rate-limit/auth/network error classifies with
+# code=None (see primer/common/anthropic_errors.py and primer/llm/ollama.py).
+_TRANSIENT_CODES: frozenset[str] = frozenset({
+    "stream_timeout",
+    "generation_timeout",
+    "connect_timeout",
+})
+
+
+def _exc_eligible(exc: BaseException, failover_on: FailoverClasses) -> bool:
+    if isinstance(exc, _TRANSIENT_EXC):
+        return True
+    if failover_on == FailoverClasses.TRANSIENT_AND_CONFIG and isinstance(exc, _CONFIG_EXC):
+        return True
+    return False
+
+
+def _yielded_eligible(code: str | None, failover_on: FailoverClasses) -> bool:
+    """Best-effort eligibility for a YIELDED fatal Error, keyed on ``code``.
+
+    - a known timeout code -> eligible under either policy.
+    - ``None`` -> eligible under either policy. Rate-limit, server, network,
+      AND auth all classify with code=None in every classifier family
+      (anthropic_errors.py, ollama.py, and the OpenAI-compatible
+      classifiers), and a code-less bad-request is itself config-eligible,
+      so None is treated as eligible. NOTE: this means the yielded channel
+      CANNOT honor the TRANSIENT policy's "exclude auth" guarantee - an auth
+      error that surfaced as a yielded fatal Error would fail over even
+      under TRANSIENT. This is safe because the yielded-error failover
+      window closes before any token is emitted downstream (auth failures
+      also RAISE at connect in practice, where the class IS preserved).
+    - any other (non-null) code appears only on bad-request (provider code)
+      or OpenAI-native mid-stream errors -> config-eligible, i.e. matched
+      only under TRANSIENT_AND_CONFIG.
+    """
+    if code in _TRANSIENT_CODES or code is None:
+        return True
+    return failover_on == FailoverClasses.TRANSIENT_AND_CONFIG
+
+
+async def _safe_aclose(agen: AsyncIterator[StreamEvent]) -> None:
+    aclose = getattr(agen, "aclose", None)
+    if aclose is None:
+        return
+    try:
+        await aclose()
+    except Exception:  # noqa: BLE001 -- best-effort cleanup of an abandoned stream
+        pass
+
+
+class AggregatedLLM(LLM):
+    """Virtual chat model that fails over across an ordered member pool."""
+
+    def __init__(
+        self,
+        provider: LLMProvider,
+        *,
+        resolve_member: Callable[[str], Awaitable[LLM]],
+    ) -> None:
+        self._provider = provider
+        assert isinstance(provider.config, AggregatedLLMConfig)
+        self._config: AggregatedLLMConfig = provider.config
+        self._resolve = resolve_member
+        self._cursor = 0
+        self._cursor_lock = asyncio.Lock()
+
+    async def list_models(self) -> Iterable[str]:
+        # Mirrors every other adapter: return the stored row's static
+        # model list (the virtual name(s)), not a live probe.
+        return [m.name for m in self._provider.models]
+
+    async def _member_order(self) -> list[AggregatedMember]:
+        members = self._config.members
+        if self._config.strategy == RoutingStrategy.SEQUENTIAL:
+            return list(members)
+        n = len(members)
+        async with self._cursor_lock:
+            start = self._cursor
+            self._cursor = (self._cursor + 1) % n
+        return [members[(start + i) % n] for i in range(n)]
+
+    def _log_failover(self, member: AggregatedMember, reason: str) -> None:
+        logger.info(
+            "aggregated-llm %s: member %s (model=%s) failing over: %s",
+            self._provider.id, member.provider_id, member.model_name, reason,
+        )
+
+    async def stream(
+        self,
+        *,
+        model: str,
+        messages: list[Message],
+        temperature: float | None = None,
+        top_p: float | None = None,
+        max_output_tokens: int | None = None,
+        stop: list[str] | None = None,
+        response_format: type[BaseModel] | dict[str, Any] | None = None,
+        tools: list[Tool] | None = None,
+        tool_choice: ToolChoice | None = None,
+        extended: dict[str, Any] | None = None,
+    ) -> AsyncIterator[StreamEvent]:
+        cfg = self._config
+        errors: list[str] = []
+        for member in await self._member_order():
+            try:
+                llm = await self._resolve(member.provider_id)
+            except NotFoundError:
+                errors.append(f"{member.provider_id}: not found")
+                self._log_failover(member, "provider row not found")
+                continue
+            if isinstance(llm, AggregatedLLM):
+                raise BadRequestError(
+                    f"aggregated LLM provider {self._provider.id!r} member "
+                    f"{member.provider_id!r} resolves to another aggregated "
+                    f"provider; nesting/self-reference is not allowed",
+                )
+            agen = llm.stream(
+                model=member.model_name,
+                messages=messages,
+                temperature=temperature,
+                top_p=top_p,
+                max_output_tokens=max_output_tokens,
+                stop=stop,
+                response_format=response_format,
+                tools=tools,
+                tool_choice=tool_choice,
+                extended=extended,
+            )
+            # The per-member ``finally`` is the single cleanup point: it
+            # acloses ``agen`` on EVERY exit path - failover-continue, a
+            # surfaced/propagated exception, normal completion (return), AND
+            # consumer abandonment (a GeneratorExit thrown into this async
+            # generator at a ``yield`` while ``agen`` is still open). Without
+            # it, an abandoned downstream stream would leak its rate-limiter
+            # slot (openchat.py:245, anthropic.py:708) - fatal for
+            # max_concurrency:1 backends. aclose on an exhausted/already-closed
+            # generator is a harmless no-op, so this subsumes per-path aclose.
+            failed_over = False
+            try:
+                # --- connect phase: pull the first event ---
+                try:
+                    first = await agen.__anext__()
+                except StopAsyncIteration:
+                    errors.append(f"{member.provider_id}: empty stream")
+                    self._log_failover(member, "empty stream")
+                    continue
+                except (ProviderError, NetworkError) as exc:
+                    if _exc_eligible(exc, cfg.failover_on):
+                        errors.append(f"{member.provider_id}: {type(exc).__name__}")
+                        self._log_failover(member, f"connect {type(exc).__name__}: {exc}")
+                        continue
+                    raise
+                # --- first event in hand ---
+                if (
+                    isinstance(first, ChatError)
+                    and first.fatal
+                    and _yielded_eligible(first.code, cfg.failover_on)
+                ):
+                    errors.append(f"{member.provider_id}: first-event Error code={first.code}")
+                    self._log_failover(member, f"first-event Error code={first.code}")
+                    continue
+                # commit to this member: nothing has been yielded downstream yet.
+                yield first
+                # --- stream the rest ---
+                try:
+                    async for ev in agen:
+                        if (
+                            cfg.failover_point == FailoverPoint.MID_STREAM
+                            and isinstance(ev, ChatError)
+                            and ev.fatal
+                            and _yielded_eligible(ev.code, cfg.failover_on)
+                        ):
+                            errors.append(f"{member.provider_id}: mid-stream Error code={ev.code}")
+                            self._log_failover(
+                                member,
+                                f"mid-stream YIELDED Error code={ev.code} (tokens may duplicate)",
+                            )
+                            failed_over = True
+                            break
+                        yield ev
+                except (ProviderError, NetworkError) as exc:
+                    # Mid-stream RAISED failure (e.g. ProviderTimeoutError,
+                    # openchat.py:284 / anthropic.py:760). We already committed
+                    # tokens, so only MID_STREAM may restart on the next member;
+                    # BEFORE_FIRST_TOKEN cannot fail over post-commit -> propagate.
+                    if (
+                        cfg.failover_point == FailoverPoint.MID_STREAM
+                        and _exc_eligible(exc, cfg.failover_on)
+                    ):
+                        errors.append(f"{member.provider_id}: mid-stream {type(exc).__name__}")
+                        self._log_failover(
+                            member,
+                            f"mid-stream RAISED {type(exc).__name__} (tokens may duplicate)",
+                        )
+                        failed_over = True
+                    else:
+                        raise
+                if failed_over:
+                    continue
+                return  # stream completed on this member (success or surfaced error)
+            finally:
+                await _safe_aclose(agen)
+        raise RateLimitError(
+            f"all {len(errors)} aggregated members failed: {'; '.join(errors)}",
+        )
+
+    async def count_tokens(
+        self,
+        *,
+        model: str,
+        messages: list[Message],
+        tools: list[Tool] | None = None,
+    ) -> int:
+        # Best-effort: delegate to the first resolvable member. Token
+        # counts across members differ; documented.
+        for member in self._config.members:
+            try:
+                llm = await self._resolve(member.provider_id)
+            except NotFoundError:
+                continue
+            if isinstance(llm, AggregatedLLM):
+                continue
+            return await llm.count_tokens(
+                model=member.model_name, messages=messages, tools=tools,
+            )
+        raise ConfigError(
+            f"aggregated LLM provider {self._provider.id!r} has no resolvable "
+            f"member for count_tokens",
+        )
+
+    async def aclose(self) -> None:
+        # No-op: the ProviderRegistry owns downstream adapter lifecycles.
+        return
+
+
+__all__ = ["AggregatedLLM"]

--- a/primer/llm/aggregated.py
+++ b/primer/llm/aggregated.py
@@ -300,6 +300,10 @@ class AggregatedLLM(LLM):
             except NotFoundError:
                 continue
             if isinstance(llm, AggregatedLLM):
+                # INTENTIONAL divergence from stream()'s hard BadRequestError
+                # on a nested/self-referential member: count_tokens is a
+                # best-effort hot-path estimate, so we skip and try the next
+                # member rather than raising strict validation here.
                 continue
             return await llm.count_tokens(
                 model=member.model_name, messages=messages, tools=tools,

--- a/primer/model/provider.py
+++ b/primer/model/provider.py
@@ -72,7 +72,11 @@ from primer.model.providers.embedding import (  # noqa: F401
     OpenAIEmbeddingFlavor,
 )
 from primer.model.providers.llm import (  # noqa: F401
+    AggregatedLLMConfig,
+    AggregatedMember,
     AnthropicConfig,
+    FailoverClasses,
+    FailoverPoint,
     GoogleConfig,
     LLMModel,
     LLMProvider,
@@ -83,6 +87,7 @@ from primer.model.providers.llm import (  # noqa: F401
     OpenResponsesConfig,
     OpenResponsesFlavor,
     OpenRouterConfig,
+    RoutingStrategy,
 )
 from primer.model.providers.secret import (  # noqa: F401
     EnvSecretConfig,
@@ -120,6 +125,8 @@ from primer.model.providers.vector import (  # noqa: F401
 )
 
 __all__ = [
+    "AggregatedLLMConfig",
+    "AggregatedMember",
     "AnthropicConfig",
     "ArtifactStorageProvider",
     "ArtifactStorageProviderType",
@@ -131,6 +138,8 @@ __all__ = [
     "EmbeddingProvider",
     "EmbeddingProviderType",
     "EnvSecretConfig",
+    "FailoverClasses",
+    "FailoverPoint",
     "FilesystemArtifactConfig",
     "GoogleConfig",
     "HttpConfig",
@@ -156,6 +165,7 @@ __all__ = [
     "PgVectorScaleConfig",
     "PoolConfig",
     "PostgresConfig",
+    "RoutingStrategy",
     "S3ArtifactConfig",
     "SecretProviderConfig",
     "SecretProviderType",

--- a/primer/model/providers/llm.py
+++ b/primer/model/providers/llm.py
@@ -7,10 +7,19 @@ Gemini connection shape) and is also reused by the embedding family.
 
 from __future__ import annotations
 
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import ClassVar
 
-from pydantic import BaseModel, ConfigDict, Field, HttpUrl, PositiveInt, SecretStr, model_validator
+from pydantic import (
+    BaseModel,
+    ConfigDict,
+    Field,
+    HttpUrl,
+    PositiveInt,
+    SecretStr,
+    field_validator,
+    model_validator,
+)
 
 from primer.model.common import Identifiable
 from primer.model.providers._shared import Limits, _HttpApiKeyConfig
@@ -29,6 +38,7 @@ class LLMProviderType(str, Enum):
     ANTHROPIC = "anthropic"
     OLLAMA = "ollama"
     OPENROUTER = "openrouter"
+    AGGREGATED = "aggregated"
 
 
 class OpenResponsesFlavor(str, Enum):
@@ -226,6 +236,67 @@ class OpenRouterConfig(BaseModel):
     )
 
 
+class RoutingStrategy(StrEnum):
+    """How the aggregated adapter picks the member to try first."""
+
+    SEQUENTIAL = "sequential"      # fixed priority queue: always start at members[0]
+    ROUND_ROBIN = "round_robin"    # rotate the start position once per stream call
+
+
+class FailoverPoint(StrEnum):
+    """When the aggregated adapter is still allowed to fail over."""
+
+    BEFORE_FIRST_TOKEN = "before_first_token"  # default; never re-emits tokens
+    MID_STREAM = "mid_stream"                  # opt-in; may duplicate already-shown tokens
+
+
+class FailoverClasses(StrEnum):
+    """Which error classes are eligible to trigger failover."""
+
+    TRANSIENT = "transient"                        # rate-limit / 5xx / timeout / network
+    TRANSIENT_AND_CONFIG = "transient_and_config"  # + auth / bad-request (mirrors web-search)
+
+
+class AggregatedMember(BaseModel):
+    """One downstream chat model in an aggregated pool.
+
+    References an existing NON-aggregated LLMProvider by id and one of its
+    model names. Existence is NOT validated here (config-time cannot see
+    other rows); it is checked at resolve time in AggregatedLLM.
+    """
+
+    provider_id: str = Field(..., min_length=1)
+    model_name: str = Field(..., min_length=1)
+
+
+class AggregatedLLMConfig(BaseModel):
+    """Config for an ``aggregated`` LLMProvider: an ordered member pool
+    plus routing/failover policy. ``members`` is deduped on the
+    ``(provider_id, model_name)`` pair preserving first-seen order.
+    ``max_attempts`` is implicitly ``len(members)`` (each member tried once).
+    """
+
+    members: list[AggregatedMember] = Field(..., min_length=1)
+    strategy: RoutingStrategy = RoutingStrategy.SEQUENTIAL
+    failover_point: FailoverPoint = FailoverPoint.BEFORE_FIRST_TOKEN
+    failover_on: FailoverClasses = FailoverClasses.TRANSIENT_AND_CONFIG
+
+    @field_validator("members")
+    @classmethod
+    def _dedupe_preserve_order(
+        cls, v: list[AggregatedMember]
+    ) -> list[AggregatedMember]:
+        seen: set[tuple[str, str]] = set()
+        out: list[AggregatedMember] = []
+        for m in v:
+            key = (m.provider_id, m.model_name)
+            if key in seen:
+                continue
+            seen.add(key)
+            out.append(m)
+        return out
+
+
 class LLMModel(BaseModel):
     """A single LLM model exposed by a provider."""
 
@@ -269,6 +340,7 @@ class LLMProvider(Identifiable):
         | AnthropicConfig
         | OllamaConfig
         | OpenRouterConfig
+        | AggregatedLLMConfig
     ) = Field(
         ...,
         description="Backend-specific connection configuration; must match ``provider``.",
@@ -308,6 +380,7 @@ class LLMProvider(Identifiable):
             LLMProviderType.ANTHROPIC: AnthropicConfig,
             LLMProviderType.OLLAMA: OllamaConfig,
             LLMProviderType.OPENROUTER: OpenRouterConfig,
+            LLMProviderType.AGGREGATED: AggregatedLLMConfig,
         }.get(provider_enum)
         if config_cls is None:
             return data

--- a/tests/_support/mock_llm.py
+++ b/tests/_support/mock_llm.py
@@ -12,7 +12,7 @@ from typing import Any
 
 from starlette.applications import Starlette
 from starlette.requests import Request
-from starlette.responses import JSONResponse, StreamingResponse
+from starlette.responses import JSONResponse, Response, StreamingResponse
 from starlette.routing import Route
 
 
@@ -33,6 +33,10 @@ class Rule:
     # gated one. Real providers always mint unique ids, so this only matters
     # for the scripted mock.
     emit_tool_call_id: str | None = None
+    # When >= 400, the chat handler returns a JSON error with this status
+    # instead of a streamed 200 (lets a scenario model force e.g. a 429).
+    emit_status: int = 200
+    emit_error_message: str | None = None
 
     def matches(self, req: dict[str, Any]) -> bool:
         msgs = req.get("messages", [])
@@ -121,10 +125,19 @@ def build_app(registry: ScriptRegistry) -> Starlette:
             }
         )
 
-    async def chat(req: Request) -> StreamingResponse:
+    async def chat(req: Request) -> Response:
         body = await req.json()
         model = body.get("model", "scripted:default")
         rule = registry.resolve(body)
+
+        if rule.emit_status >= 400:
+            return JSONResponse(
+                {"error": {
+                    "message": rule.emit_error_message or "scripted error",
+                    "type": "rate_limit_error" if rule.emit_status == 429 else "error",
+                }},
+                status_code=rule.emit_status,
+            )
 
         async def gen():
             yield _chunk(model, {"role": "assistant"})

--- a/tests/agent/test_aggregated_runtime.py
+++ b/tests/agent/test_aggregated_runtime.py
@@ -1,0 +1,78 @@
+"""_resolve_agent_runtime resolves an aggregated provider + virtual model."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import SecretStr
+
+from primer.agent.invoke import _resolve_agent_runtime
+from primer.api.registries.provider_registry import ProviderRegistry
+from primer.llm.aggregated import AggregatedLLM
+from primer.model.agent import Agent, AgentModel
+from primer.model.provider import (
+    AggregatedLLMConfig,
+    AggregatedMember,
+    AnthropicConfig,
+    Limits,
+    LLMModel,
+    LLMProvider,
+    LLMProviderType,
+)
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    async def get(self, id: str):
+        return self._data.get(id)
+
+    async def create(self, entity):
+        self._data[entity.id] = entity
+        return entity
+
+
+class _FakeStorageProvider:
+    def __init__(self) -> None:
+        self._stores: dict[type, _FakeStorage] = {}
+
+    def get_storage(self, model_class: type) -> _FakeStorage:
+        return self._stores.setdefault(model_class, _FakeStorage())
+
+
+@pytest.mark.asyncio
+async def test_resolves_aggregated_runtime_and_virtual_model():
+    sp = _FakeStorageProvider()
+    await sp.get_storage(LLMProvider).create(
+        LLMProvider(
+            id="member-1", provider=LLMProviderType.ANTHROPIC,
+            models=[LLMModel(name="claude-x", context_length=200000)],
+            config=AnthropicConfig(api_key=SecretStr("sk-x")),
+            limits=Limits(max_concurrency=4),
+        )
+    )
+    await sp.get_storage(LLMProvider).create(
+        LLMProvider(
+            id="agg-1", provider=LLMProviderType.AGGREGATED,
+            models=[LLMModel(name="virtual-1", context_length=200000)],
+            config=AggregatedLLMConfig(members=[
+                AggregatedMember(provider_id="member-1", model_name="claude-x"),
+            ]),
+            limits=Limits(max_concurrency=4),
+        )
+    )
+    await sp.get_storage(Agent).create(
+        Agent(
+            id="ag-1", description="test agent",
+            model=AgentModel(provider_id="agg-1", model_name="virtual-1"),
+        )
+    )
+    registry = ProviderRegistry(sp)
+
+    agent, llm, llm_model = await _resolve_agent_runtime(
+        "ag-1", storage_provider=sp, provider_registry=registry,
+    )
+    assert isinstance(llm, AggregatedLLM)
+    assert llm_model.name == "virtual-1"   # virtual name matched on the agg row

--- a/tests/api/test_aggregated_llm_provider.py
+++ b/tests/api/test_aggregated_llm_provider.py
@@ -168,3 +168,72 @@ class AggregatedMemberStub:
 
     async def aclose(self) -> None:
         return
+
+
+class TestAggregatedRest:
+    def _body(self, **overrides):
+        body = {
+            "id": "agg-rest",
+            "provider": "aggregated",
+            "config": {
+                "members": [{"provider_id": "member-x", "model_name": "m"}],
+                "strategy": "sequential",
+                "failover_point": "before_first_token",
+                "failover_on": "transient_and_config",
+            },
+            "models": [{"name": "virtual-1", "context_length": 200000}],
+            "limits": {"max_concurrency": 4},
+        }
+        body.update(overrides)
+        return body
+
+    @pytest.mark.asyncio
+    async def test_create_with_nonexistent_member_is_accepted(self, client):
+        # Member existence is a deep check done at resolve, not at write.
+        r = await client.post("/v1/llm_providers", json=self._body())
+        assert r.status_code in (200, 201), r.text
+        await client.delete("/v1/llm_providers/agg-rest")
+
+    @pytest.mark.asyncio
+    async def test_create_with_empty_members_is_422(self, client):
+        body = self._body(id="agg-empty")
+        body["config"]["members"] = []
+        r = await client.post("/v1/llm_providers", json=body)
+        assert r.status_code == 422, r.text
+        # RFC7807 envelope.
+        assert r.headers["content-type"].startswith("application/problem+json") \
+            or "type" in r.json()
+
+    @pytest.mark.asyncio
+    async def test_get_models_returns_virtual_names(
+        self, client, fake_provider_registry
+    ):
+        r = await client.post("/v1/llm_providers", json=self._body(id="agg-models"))
+        assert r.status_code in (200, 201), r.text
+
+        # The client fixture's ProviderRegistry is built with a generic
+        # `object()` stub llm_factory (tests/api/conftest.py) so ordinary
+        # CRUD tests don't need real provider adapters. Swap in a real
+        # AggregatedLLM wired with the registry's own get_llm resolver --
+        # same as production's default factory -- to exercise the actual
+        # GET /{id}/models -> list_models() path.
+        def _factory(row):
+            return AggregatedLLM(row, resolve_member=fake_provider_registry.get_llm)
+        fake_provider_registry._llm_factory = _factory  # type: ignore[attr-defined]
+
+        rm = await client.get("/v1/llm_providers/agg-models/models")
+        assert rm.status_code == 200, rm.text
+        assert rm.json()["models"] == ["virtual-1"]
+        await client.delete("/v1/llm_providers/agg-models")
+
+    @pytest.mark.asyncio
+    async def test_discover_models_400_for_aggregated(self, client):
+        r = await client.post(
+            "/v1/llm_providers/_discover_models",
+            json={
+                "provider": "aggregated",
+                "config": {"members": [{"provider_id": "p", "model_name": "m"}]},
+            },
+        )
+        assert r.status_code == 400, r.text
+        assert "discovery is not supported" in r.text.lower()

--- a/tests/api/test_aggregated_llm_provider.py
+++ b/tests/api/test_aggregated_llm_provider.py
@@ -1,0 +1,170 @@
+"""Registry wiring + REST behavior for the aggregated LLM provider."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+from pydantic import SecretStr
+
+from primer.api.registries.provider_registry import ProviderRegistry
+from primer.llm.aggregated import AggregatedLLM
+from primer.model.chat import Done, StreamEvent
+from primer.model.except_ import BadRequestError
+from primer.model.provider import (
+    AggregatedLLMConfig,
+    AggregatedMember,
+    AnthropicConfig,
+    Limits,
+    LLMModel,
+    LLMProvider,
+    LLMProviderType,
+)
+
+
+class _FakeStorage:
+    def __init__(self) -> None:
+        self._data: dict[str, Any] = {}
+
+    async def get(self, id: str):
+        return self._data.get(id)
+
+    async def create(self, entity):
+        self._data[entity.id] = entity
+        return entity
+
+    async def update(self, entity):
+        self._data[entity.id] = entity
+        return entity
+
+    async def delete(self, id: str) -> None:
+        self._data.pop(id, None)
+
+
+class _FakeStorageProvider:
+    def __init__(self) -> None:
+        self._stores: dict[type, _FakeStorage] = {}
+
+    def get_storage(self, model_class: type) -> _FakeStorage:
+        return self._stores.setdefault(model_class, _FakeStorage())
+
+    async def initialize(self) -> None:
+        return
+
+    async def aclose(self) -> None:
+        return
+
+
+def _member_row(pid: str) -> LLMProvider:
+    return LLMProvider(
+        id=pid,
+        provider=LLMProviderType.ANTHROPIC,
+        models=[LLMModel(name="claude-x", context_length=200000)],
+        config=AnthropicConfig(api_key=SecretStr("sk-x")),
+        limits=Limits(max_concurrency=4),
+    )
+
+
+def _agg_row(agg_id: str, members: list[AggregatedMember]) -> LLMProvider:
+    return LLMProvider(
+        id=agg_id,
+        provider=LLMProviderType.AGGREGATED,
+        models=[LLMModel(name="virtual-1", context_length=200000)],
+        config=AggregatedLLMConfig(members=members),
+        limits=Limits(max_concurrency=4),
+    )
+
+
+@pytest.mark.asyncio
+async def test_factory_builds_aggregated_llm_via_default_resolver():
+    sp = _FakeStorageProvider()
+    await sp.get_storage(LLMProvider).create(_member_row("member-1"))
+    await sp.get_storage(LLMProvider).create(
+        _agg_row("agg-1", [AggregatedMember(provider_id="member-1", model_name="claude-x")])
+    )
+    # DEFAULT factory (no llm_factory injected) so resolve_member=self.get_llm wired.
+    registry = ProviderRegistry(sp)
+    adapter = await registry.get_llm("agg-1")
+    assert isinstance(adapter, AggregatedLLM)
+
+
+@pytest.mark.asyncio
+async def test_nested_member_raises_bad_request_at_resolve():
+    sp = _FakeStorageProvider()
+    # agg-2 points at agg-1 (another aggregated provider) -> nesting.
+    await sp.get_storage(LLMProvider).create(_member_row("member-1"))
+    await sp.get_storage(LLMProvider).create(
+        _agg_row("agg-1", [AggregatedMember(provider_id="member-1", model_name="claude-x")])
+    )
+    await sp.get_storage(LLMProvider).create(
+        _agg_row("agg-2", [AggregatedMember(provider_id="agg-1", model_name="virtual-1")])
+    )
+    registry = ProviderRegistry(sp)
+    outer = await registry.get_llm("agg-2")
+    with pytest.raises(BadRequestError, match="nesting"):
+        [ev async for ev in outer.stream(model="virtual-1", messages=[])]
+
+
+@pytest.mark.asyncio
+async def test_self_reference_raises_bad_request():
+    sp = _FakeStorageProvider()
+    await sp.get_storage(LLMProvider).create(
+        _agg_row("agg-1", [AggregatedMember(provider_id="agg-1", model_name="virtual-1")])
+    )
+    registry = ProviderRegistry(sp)
+    agg = await registry.get_llm("agg-1")
+    with pytest.raises(BadRequestError, match="nesting|self-reference"):
+        [ev async for ev in agg.stream(model="virtual-1", messages=[])]
+
+
+@pytest.mark.asyncio
+async def test_member_edit_is_picked_up_lazily_per_call():
+    # A stub adapter whose stream records a version tag so we can prove the
+    # aggregated adapter re-resolves the member after invalidation.
+    class _Stub(AggregatedMemberStub):
+        pass
+
+    sp = _FakeStorageProvider()
+    await sp.get_storage(LLMProvider).create(_member_row("member-1"))
+    await sp.get_storage(LLMProvider).create(
+        _agg_row("agg-1", [AggregatedMember(provider_id="member-1", model_name="claude-x")])
+    )
+
+    versions = {"member-1": 0}
+
+    def factory(row: LLMProvider):
+        if row.provider == LLMProviderType.AGGREGATED:
+            from primer.llm.aggregated import AggregatedLLM as _Agg
+            return _Agg(row, resolve_member=registry.get_llm)
+        return AggregatedMemberStub(version=versions[row.id])
+
+    registry = ProviderRegistry(sp, llm_factory=factory)
+    agg = await registry.get_llm("agg-1")
+
+    ev1 = [e async for e in agg.stream(model="virtual-1", messages=[])]
+    assert ev1[0].raw_reason == "v0"
+
+    versions["member-1"] = 1
+    await registry.invalidate_llm("member-1")
+
+    ev2 = [e async for e in agg.stream(model="virtual-1", messages=[])]
+    assert ev2[0].raw_reason == "v1"  # re-resolved member picked up the edit
+
+
+class AggregatedMemberStub:
+    """Minimal LLM stub whose Done.raw_reason encodes a version tag."""
+
+    def __init__(self, *, version: int = 0) -> None:
+        self._version = version
+
+    async def list_models(self):
+        return ["claude-x"]
+
+    async def count_tokens(self, *, model, messages, tools=None) -> int:
+        return 1
+
+    async def stream(self, *, model, messages, **kwargs) -> "StreamEvent":
+        yield Done(stop_reason="stop", raw_reason=f"v{self._version}")
+
+    async def aclose(self) -> None:
+        return

--- a/tests/e2e/test_aggregated_llm_journey.py
+++ b/tests/e2e/test_aggregated_llm_journey.py
@@ -1,0 +1,143 @@
+"""E2E: an aggregated LLM provider fails over from a 429 member to a live one.
+
+Runs only under PRIMER_RUN_E2E=1 (see tests/e2e/conftest.py). Locally verify
+collection with --collect-only; CI runs it.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+
+import httpx
+import pytest
+
+from tests._support.mock_llm import Rule
+
+
+def _ws_headers(client: httpx.AsyncClient) -> list[tuple[str, str]]:
+    """Forward the authenticated client's session cookie onto the WS
+    handshake (mirrors tests/e2e/test_bus_tasks_and_chat_ws.py)."""
+    pairs = [f"{c.name}={c.value}" for c in client.cookies.jar]
+    if not pairs:
+        return []
+    return [("Cookie", "; ".join(pairs))]
+
+
+@pytest.mark.asyncio
+async def test_aggregated_fails_over_from_429_member(
+    client: httpx.AsyncClient, mock_llm, unique_suffix: str,
+):
+    import websockets
+
+    registry, base_url = mock_llm
+    # Two scenario models on the shared mock: one always 429, one serves.
+    registry.register("agg:429", [Rule(emit_status=429, emit_error_message="429")])
+    registry.register("agg:ok", [Rule(emit_text="served-by-member-2")])
+
+    # One openchat provider (points at the mock) exposing both scenario models.
+    member_pid = f"agg-member-{unique_suffix}"
+    r = await client.post("/v1/llm_providers", json={
+        "id": member_pid,
+        "provider": "openchat",
+        "models": [
+            {"name": "agg:429", "context_length": 8192},
+            {"name": "agg:ok", "context_length": 8192},
+        ],
+        "config": {"url": base_url, "flavor": "lmstudio"},
+        "limits": {"max_concurrency": 4},
+    })
+    assert r.status_code in (200, 201), r.text
+
+    # Aggregated provider: member[0] = 429 model, member[1] = ok model.
+    agg_pid = f"agg-{unique_suffix}"
+    r = await client.post("/v1/llm_providers", json={
+        "id": agg_pid,
+        "provider": "aggregated",
+        "config": {
+            "members": [
+                {"provider_id": member_pid, "model_name": "agg:429"},
+                {"provider_id": member_pid, "model_name": "agg:ok"},
+            ],
+            "strategy": "sequential",
+            "failover_point": "before_first_token",
+            "failover_on": "transient_and_config",
+        },
+        "models": [{"name": "agg-virtual", "context_length": 8192}],
+        "limits": {"max_concurrency": 4},
+    })
+    assert r.status_code in (200, 201), r.text
+
+    # Agent bound to the aggregated virtual model.
+    agent_id = f"agg-agent-{unique_suffix}"
+    r = await client.post("/v1/agents", json={
+        "id": agent_id,
+        "description": "aggregated failover probe",
+        "model": {"provider_id": agg_pid, "model_name": "agg-virtual"},
+        "tools": [],
+        "system_prompt": ["aggregated failover probe"],
+    })
+    assert r.status_code in (200, 201), r.text
+
+    cleanup_urls = [
+        f"/v1/agents/{agent_id}",
+        f"/v1/llm_providers/{agg_pid}",
+        f"/v1/llm_providers/{member_pid}",
+    ]
+    try:
+        # Drive one chat turn over WS (mirror
+        # tests/e2e/test_bus_tasks_and_chat_ws.py's create-chat +
+        # websocket_connect + receive loop). Assert the assistant text is
+        # served by member[1] after member[0] fails over on connect (429).
+        r = await client.post("/v1/chats", json={"agent_id": agent_id})
+        assert r.status_code == 201, r.text
+        cid = r.json()["id"]
+        cleanup_urls.insert(0, f"/v1/chats/{cid}")
+
+        http_url = str(client.base_url).rstrip("/")
+        ws_origin = http_url.replace("http://", "ws://").replace(
+            "https://", "wss://"
+        )
+        ws_url = f"{ws_origin}/v1/chats/{cid}/ws"
+
+        assistant_text = ""
+        saw_done = False
+        async with websockets.connect(
+            ws_url, max_size=None, additional_headers=_ws_headers(client),
+        ) as ws:
+            # Spec §6.4: initial ``usage`` frame after accept().
+            initial = json.loads(await asyncio.wait_for(ws.recv(), timeout=10.0))
+            assert initial["kind"] == "usage", initial
+            await ws.send(json.dumps(
+                {"kind": "user_message", "content": "hello"}
+            ))
+            deadline = asyncio.get_event_loop().time() + 30.0
+            while not saw_done:
+                remaining = deadline - asyncio.get_event_loop().time()
+                assert remaining > 0, "chat turn did not reach a 'done' frame"
+                frame = json.loads(
+                    await asyncio.wait_for(ws.recv(), timeout=remaining)
+                )
+                kind = frame.get("kind")
+                if kind == "assistant_token":
+                    assistant_text += frame.get("delta") or ""
+                elif kind == "done":
+                    saw_done = True
+
+        assert assistant_text == "served-by-member-2", assistant_text
+
+        # CRUD RFC7807: an empty members list is 422.
+        bad = await client.post("/v1/llm_providers", json={
+            "id": f"agg-bad-{unique_suffix}",
+            "provider": "aggregated",
+            "config": {"members": []},
+            "models": [{"name": "v", "context_length": 8192}],
+            "limits": {"max_concurrency": 4},
+        })
+        assert bad.status_code == 422, bad.text
+    finally:
+        for url in cleanup_urls:
+            try:
+                await client.delete(url)
+            except Exception:  # noqa: BLE001
+                pass

--- a/tests/llm/test_aggregated.py
+++ b/tests/llm/test_aggregated.py
@@ -1,0 +1,311 @@
+"""Unit tests for AggregatedLLM (fake-LLM async generators; no SDK/network)."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+
+import pytest
+
+from primer.int.llm import LLM
+from primer.llm.aggregated import AggregatedLLM
+from primer.model.chat import (
+    Done,
+    Error as ChatError,
+    StreamStart,
+    StreamEvent,
+    TextDelta,
+)
+from primer.model.except_ import (
+    AuthenticationError,
+    BadRequestError,
+    ConfigError,
+    NotFoundError,
+    ProviderTimeoutError,
+    RateLimitError,
+    ServerError,
+)
+from primer.model.provider import (
+    AggregatedLLMConfig,
+    AggregatedMember,
+    FailoverClasses,
+    FailoverPoint,
+    Limits,
+    LLMModel,
+    LLMProvider,
+    LLMProviderType,
+    RoutingStrategy,
+)
+
+
+class _FakeLLM(LLM):
+    """Scripted downstream LLM.
+
+    ``events`` is the list yielded once the stream opens. ``connect_exc``,
+    if set, is raised on the first ``__anext__`` (connect phase). ``mid_exc``,
+    if set, is RAISED after all ``events`` are yielded (models a mid-stream
+    raise, e.g. ProviderTimeoutError - anthropic.py:760, openchat.py:284).
+    ``record`` (a list) captures each ``model=`` the adapter was asked to
+    stream. ``stream_closed`` flips True when the stream generator is
+    finalized (normal exhaustion OR GeneratorExit from ``aclose``); ``yielded``
+    counts events actually pulled, so an abandonment test can prove the
+    downstream stream was cut short and cleaned up.
+    """
+
+    def __init__(self, *, events=None, connect_exc=None, mid_exc=None,
+                 record=None, name="fake"):
+        self._events = events or []
+        self._connect_exc = connect_exc
+        self._mid_exc = mid_exc
+        self._record = record
+        self._name = name
+        self.closed = False
+        self.stream_closed = False
+        self.yielded = 0
+
+    async def list_models(self):
+        return [self._name]
+
+    async def count_tokens(self, *, model, messages, tools=None) -> int:
+        return 7
+
+    async def stream(self, *, model, messages, **kwargs) -> AsyncIterator[StreamEvent]:
+        if self._record is not None:
+            self._record.append(model)
+        if self._connect_exc is not None:
+            raise self._connect_exc
+        try:
+            for ev in self._events:
+                self.yielded += 1
+                yield ev
+            if self._mid_exc is not None:
+                raise self._mid_exc
+        finally:
+            # Runs on normal exhaustion AND on GeneratorExit thrown by
+            # ``agen.aclose()`` when the aggregated stream is abandoned.
+            self.stream_closed = True
+
+    async def aclose(self) -> None:
+        self.closed = True
+
+
+def _row(config: AggregatedLLMConfig) -> LLMProvider:
+    return LLMProvider(
+        id="agg-1",
+        provider=LLMProviderType.AGGREGATED,
+        models=[LLMModel(name="virtual-1", context_length=200000)],
+        config=config,
+        limits=Limits(max_concurrency=4),
+    )
+
+
+def _resolver(mapping: dict[str, LLM]):
+    async def resolve(pid: str) -> LLM:
+        if pid not in mapping:
+            raise NotFoundError(f"LLMProvider {pid!r} does not exist")
+        return mapping[pid]
+    return resolve
+
+
+_MSG = []  # empty message list is fine for the fakes
+
+
+async def _drain(agen) -> list[StreamEvent]:
+    return [ev async for ev in agen]
+
+
+@pytest.mark.asyncio
+async def test_connect_raise_fails_over_to_next_member():
+    good = _FakeLLM(events=[StreamStart(model="m2"), TextDelta(text="hi", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    bad = _FakeLLM(connect_exc=RateLimitError("429"))
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="bad", model_name="m1"),
+        AggregatedMember(provider_id="good", model_name="m2"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert any(isinstance(e, TextDelta) for e in events)
+    assert isinstance(events[-1], Done)
+
+
+@pytest.mark.asyncio
+async def test_first_event_error_fails_over_no_tokens_emitted():
+    # Realistic: real classifiers emit code=None for a rate-limit that
+    # surfaces as a YIELDED fatal Error (anthropic_errors.py, ollama.py).
+    # code=None is eligible under either policy.
+    bad = _FakeLLM(events=[ChatError(fatal=True, code=None, message="429")])
+    good = _FakeLLM(events=[StreamStart(model="m2"), TextDelta(text="ok", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="bad", model_name="m1"),
+        AggregatedMember(provider_id="good", model_name="m2"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    # No Error from the failed member reached the subscriber.
+    assert not any(isinstance(e, ChatError) for e in events)
+    assert any(isinstance(e, TextDelta) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_first_event_error_with_hypothetical_transient_code_fails_over():
+    # Hypothetical: no current adapter emits a non-null transient code on a
+    # yielded Error, but if one did, a config-eligible code fails over under
+    # the default TRANSIENT_AND_CONFIG. Kept as the one non-null-code case.
+    bad = _FakeLLM(events=[ChatError(fatal=True, code="rate_limit", message="429")])
+    good = _FakeLLM(events=[TextDelta(text="ok", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="bad", model_name="m1"),
+        AggregatedMember(provider_id="good", model_name="m2"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert any(isinstance(e, TextDelta) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_stream_start_then_error_surfaces_no_failover():
+    # PINNED DECISION A: the commit point is the FIRST event of ANY kind
+    # (StreamStart counts). Member[0] yields StreamStart then a fatal Error;
+    # since StreamStart already committed, the Error SURFACES in the default
+    # BEFORE_FIRST_TOKEN mode - no failover to member[1].
+    bad = _FakeLLM(events=[StreamStart(model="m1"),
+                           ChatError(fatal=True, code=None, message="boom")])
+    good = _FakeLLM(events=[TextDelta(text="SHOULD-NOT-APPEAR", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="bad", model_name="m1"),
+        AggregatedMember(provider_id="good", model_name="m2"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert isinstance(events[0], StreamStart)
+    assert isinstance(events[-1], ChatError)
+    assert not any(isinstance(e, TextDelta) for e in events)  # member[1] never ran
+
+
+@pytest.mark.asyncio
+async def test_abandoned_stream_closes_downstream_generator():
+    # IMPORTANT: on consumer abandonment (task cancellation / client
+    # disconnect) the aggregated stream's per-member ``finally`` must aclose
+    # the downstream generator so its rate-limiter slot is released.
+    good = _FakeLLM(events=[StreamStart(model="m"), TextDelta(text="a", index=0),
+                            TextDelta(text="b", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(members=[AggregatedMember(provider_id="good", model_name="m")])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"good": good}))
+    agen = agg.stream(model="virtual-1", messages=_MSG)
+    first = await agen.__anext__()          # StreamStart committed
+    assert isinstance(first, StreamStart)
+    await agen.aclose()                     # consumer abandons the stream
+    assert good.stream_closed is True       # downstream generator finalized
+    assert good.yielded < 4                 # member stream was cut short
+
+
+@pytest.mark.asyncio
+async def test_token_then_error_before_first_token_surfaces_error_no_failover():
+    # Member[0] commits (a token) then yields a fatal Error. In the default
+    # BEFORE_FIRST_TOKEN mode the error is surfaced; no failover, no dup.
+    bad = _FakeLLM(events=[TextDelta(text="partial", index=0),
+                           ChatError(fatal=True, code=None, message="429")])
+    good = _FakeLLM(events=[TextDelta(text="SHOULD-NOT-APPEAR", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="bad", model_name="m1"),
+        AggregatedMember(provider_id="good", model_name="m2"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert [e.text for e in events if isinstance(e, TextDelta)] == ["partial"]
+    assert isinstance(events[-1], ChatError)
+
+
+@pytest.mark.asyncio
+async def test_all_members_fail_raises_aggregated_rate_limit():
+    a = _FakeLLM(connect_exc=RateLimitError("429 a"))
+    b = _FakeLLM(connect_exc=ServerError("500 b"))
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="a", model_name="m"),
+        AggregatedMember(provider_id="b", model_name="m"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"a": a, "b": b}))
+    with pytest.raises(RateLimitError, match="all 2 aggregated members failed"):
+        await _drain(agg.stream(model="virtual-1", messages=_MSG))
+
+
+@pytest.mark.asyncio
+async def test_not_found_member_is_skipped():
+    good = _FakeLLM(events=[TextDelta(text="ok", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="missing", model_name="m1"),
+        AggregatedMember(provider_id="good", model_name="m2"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert any(isinstance(e, TextDelta) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_non_eligible_exception_propagates_unchanged():
+    # ConfigError is neither ProviderError nor NetworkError -> propagate.
+    bad = _FakeLLM(connect_exc=ConfigError("boom"))
+    cfg = AggregatedLLMConfig(members=[AggregatedMember(provider_id="bad", model_name="m")])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad}))
+    with pytest.raises(ConfigError, match="boom"):
+        await _drain(agg.stream(model="virtual-1", messages=_MSG))
+
+
+@pytest.mark.asyncio
+async def test_stream_maps_virtual_model_to_each_member_model_name():
+    record: list[str] = []
+    good = _FakeLLM(events=[Done(stop_reason="stop", raw_reason="stop")], record=record)
+    cfg = AggregatedLLMConfig(members=[AggregatedMember(provider_id="good", model_name="member-model")])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"good": good}))
+    await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    # The incoming virtual name is NOT forwarded; the member's own model is.
+    assert record == ["member-model"]
+
+
+@pytest.mark.asyncio
+async def test_list_models_returns_virtual_names():
+    cfg = AggregatedLLMConfig(members=[AggregatedMember(provider_id="p", model_name="m")])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({}))
+    assert list(await agg.list_models()) == ["virtual-1"]
+
+
+@pytest.mark.asyncio
+async def test_count_tokens_delegates_to_first_resolvable_member():
+    good = _FakeLLM(name="g")
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="missing", model_name="m1"),
+        AggregatedMember(provider_id="good", model_name="m2"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"good": good}))
+    assert await agg.count_tokens(model="virtual-1", messages=_MSG) == 7
+
+
+@pytest.mark.asyncio
+async def test_aclose_is_noop_does_not_close_members():
+    good = _FakeLLM()
+    cfg = AggregatedLLMConfig(members=[AggregatedMember(provider_id="good", model_name="m")])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"good": good}))
+    await agg.aclose()
+    assert good.closed is False
+
+
+@pytest.mark.asyncio
+async def test_failover_is_logged(caplog):
+    bad = _FakeLLM(connect_exc=RateLimitError("429"))
+    good = _FakeLLM(events=[Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="bad", model_name="m1"),
+        AggregatedMember(provider_id="good", model_name="m2"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    with caplog.at_level(logging.INFO, logger="primer.llm.aggregated"):
+        await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert any("failing over" in r.message or "failing over" in r.getMessage()
+               for r in caplog.records)

--- a/tests/llm/test_aggregated.py
+++ b/tests/llm/test_aggregated.py
@@ -447,3 +447,178 @@ async def test_round_robin_cursor_is_concurrency_safe():
     served = sorted(k for k, calls in records.items() if calls)
     assert served == sorted(str(i) for i in range(n))
     assert all(len(calls) == 1 for calls in records.values())
+
+
+# --- MID_STREAM failover mode (Task 4: regression-pin, expected to pass) ---
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_restarts_on_next_member_with_dup():
+    # Member[0] commits a token then yields a fatal eligible Error mid-stream.
+    # With MID_STREAM, the adapter restarts on member[1]; the "partial" token
+    # was already yielded (documented duplication).
+    bad = _FakeLLM(events=[
+        TextDelta(text="partial", index=0),
+        ChatError(fatal=True, code=None, message="mid-stream 429"),
+    ])
+    good = _FakeLLM(events=[
+        TextDelta(text="partial", index=0),
+        TextDelta(text=" full", index=0),
+        Done(stop_reason="stop", raw_reason="stop"),
+    ])
+    cfg = AggregatedLLMConfig(
+        failover_point=FailoverPoint.MID_STREAM,
+        members=[
+            AggregatedMember(provider_id="bad", model_name="m1"),
+            AggregatedMember(provider_id="good", model_name="m2"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    texts = [e.text for e in events if isinstance(e, TextDelta)]
+    # "partial" appears twice (member[0] then member[1] restart) -> duplication.
+    assert texts == ["partial", "partial", " full"]
+    assert isinstance(events[-1], Done)
+    # The failed member's Error never reached the subscriber.
+    assert not any(isinstance(e, ChatError) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_before_first_token_does_not_restart_on_mid_stream_error():
+    # Same script, default BEFORE_FIRST_TOKEN: no restart, error surfaced.
+    bad = _FakeLLM(events=[
+        TextDelta(text="partial", index=0),
+        ChatError(fatal=True, code=None, message="mid-stream 429"),
+    ])
+    good = _FakeLLM(events=[TextDelta(text="unused", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(
+        failover_point=FailoverPoint.BEFORE_FIRST_TOKEN,
+        members=[
+            AggregatedMember(provider_id="bad", model_name="m1"),
+            AggregatedMember(provider_id="good", model_name="m2"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    texts = [e.text for e in events if isinstance(e, TextDelta)]
+    assert texts == ["partial"]
+    assert isinstance(events[-1], ChatError)
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_raised_timeout_restarts_under_mid_stream():
+    # Mid-stream timeouts are RAISED, not yielded (openchat.py:284,
+    # anthropic.py:760). Under MID_STREAM an eligible raised exception after
+    # commit restarts on the next member.
+    bad = _FakeLLM(
+        events=[StreamStart(model="m1"), TextDelta(text="partial", index=0)],
+        mid_exc=ProviderTimeoutError("stalled", code="stream_timeout"),
+    )
+    good = _FakeLLM(events=[TextDelta(text="served", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(
+        failover_point=FailoverPoint.MID_STREAM,
+        members=[
+            AggregatedMember(provider_id="bad", model_name="m1"),
+            AggregatedMember(provider_id="good", model_name="m2"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    texts = [e.text for e in events if isinstance(e, TextDelta)]
+    assert texts == ["partial", "served"]      # restarted after the raised timeout
+    assert isinstance(events[-1], Done)
+
+
+@pytest.mark.asyncio
+async def test_before_first_token_propagates_raised_mid_stream_timeout():
+    # In the default mode a post-commit RAISED failure cannot fail over
+    # (would re-emit) -> it propagates.
+    from primer.model.except_ import ProviderTimeoutError as _PTE
+    bad = _FakeLLM(
+        events=[StreamStart(model="m1"), TextDelta(text="partial", index=0)],
+        mid_exc=_PTE("stalled", code="stream_timeout"),
+    )
+    good = _FakeLLM(events=[Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(
+        failover_point=FailoverPoint.BEFORE_FIRST_TOKEN,
+        members=[
+            AggregatedMember(provider_id="bad", model_name="m1"),
+            AggregatedMember(provider_id="good", model_name="m2"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    with pytest.raises(_PTE):
+        await _drain(agg.stream(model="virtual-1", messages=_MSG))
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_failover_closes_abandoned_downstream():
+    # The failed-over member's generator must be aclosed (rate-limiter slot).
+    bad = _FakeLLM(events=[
+        TextDelta(text="partial", index=0),
+        ChatError(fatal=True, code=None, message="mid-stream 429"),
+        TextDelta(text="never", index=0),
+    ])
+    good = _FakeLLM(events=[Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(
+        failover_point=FailoverPoint.MID_STREAM,
+        members=[
+            AggregatedMember(provider_id="bad", model_name="m1"),
+            AggregatedMember(provider_id="good", model_name="m2"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert bad.stream_closed is True
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_non_eligible_yielded_error_surfaces_no_restart():
+    # A non-null, non-timeout code (e.g. bad-request) is config-eligible only,
+    # so under FailoverClasses.TRANSIENT it is NOT eligible even in MID_STREAM
+    # mode -> the Error surfaces to the subscriber; member[1] never runs.
+    bad = _FakeLLM(events=[
+        TextDelta(text="partial", index=0),
+        ChatError(fatal=True, code="invalid_request_error", message="bad request mid-stream"),
+    ])
+    good = _FakeLLM(events=[TextDelta(text="SHOULD-NOT-APPEAR", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(
+        failover_point=FailoverPoint.MID_STREAM,
+        failover_on=FailoverClasses.TRANSIENT,
+        members=[
+            AggregatedMember(provider_id="bad", model_name="m1"),
+            AggregatedMember(provider_id="good", model_name="m2"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    texts = [e.text for e in events if isinstance(e, TextDelta)]
+    assert texts == ["partial"]                # no restart, no duplication
+    assert isinstance(events[-1], ChatError)    # the error surfaced, not raised
+
+
+@pytest.mark.asyncio
+async def test_mid_stream_non_eligible_raised_error_propagates_no_restart():
+    # AuthenticationError is config-eligible only; under FailoverClasses.
+    # TRANSIENT it is NOT eligible even in MID_STREAM mode -> the raised
+    # exception propagates instead of restarting on member[1].
+    bad = _FakeLLM(
+        events=[StreamStart(model="m1"), TextDelta(text="partial", index=0)],
+        mid_exc=AuthenticationError("401 mid-stream"),
+    )
+    good = _FakeLLM(events=[TextDelta(text="SHOULD-NOT-APPEAR", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(
+        failover_point=FailoverPoint.MID_STREAM,
+        failover_on=FailoverClasses.TRANSIENT,
+        members=[
+            AggregatedMember(provider_id="bad", model_name="m1"),
+            AggregatedMember(provider_id="good", model_name="m2"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    with pytest.raises(AuthenticationError):
+        await _drain(agg.stream(model="virtual-1", messages=_MSG))

--- a/tests/llm/test_aggregated.py
+++ b/tests/llm/test_aggregated.py
@@ -309,3 +309,141 @@ async def test_failover_is_logged(caplog):
         await _drain(agg.stream(model="virtual-1", messages=_MSG))
     assert any("failing over" in r.message or "failing over" in r.getMessage()
                for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_empty_stream_member_is_treated_as_failure():
+    # Member[0]'s stream ends immediately (StopAsyncIteration on the first
+    # fetch) -> recorded as a member failure and failover proceeds to
+    # member[1] (aggregated.py:224-227).
+    empty = _FakeLLM(events=[])
+    good = _FakeLLM(events=[TextDelta(text="ok", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(members=[
+        AggregatedMember(provider_id="empty", model_name="m1"),
+        AggregatedMember(provider_id="good", model_name="m2"),
+    ])
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"empty": empty, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert any(isinstance(e, TextDelta) for e in events)
+    assert isinstance(events[-1], Done)
+
+
+@pytest.mark.asyncio
+async def test_sequential_always_starts_at_member_zero():
+    records = {"a": [], "b": []}
+    a = _FakeLLM(events=[Done(stop_reason="stop", raw_reason="stop")], record=records["a"], name="a")
+    b = _FakeLLM(events=[Done(stop_reason="stop", raw_reason="stop")], record=records["b"], name="b")
+    cfg = AggregatedLLMConfig(
+        strategy=RoutingStrategy.SEQUENTIAL,
+        members=[
+            AggregatedMember(provider_id="a", model_name="ma"),
+            AggregatedMember(provider_id="b", model_name="mb"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"a": a, "b": b}))
+    for _ in range(3):
+        await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    # Member[0] served every call; member[1] never reached.
+    assert len(records["a"]) == 3
+    assert len(records["b"]) == 0
+
+
+@pytest.mark.asyncio
+async def test_round_robin_rotates_starting_member():
+    records = {"a": [], "b": [], "c": []}
+
+    def mk(k):
+        return _FakeLLM(events=[Done(stop_reason="stop", raw_reason="stop")],
+                        record=records[k], name=k)
+
+    a, b, c = mk("a"), mk("b"), mk("c")
+    cfg = AggregatedLLMConfig(
+        strategy=RoutingStrategy.ROUND_ROBIN,
+        members=[
+            AggregatedMember(provider_id="a", model_name="ma"),
+            AggregatedMember(provider_id="b", model_name="mb"),
+            AggregatedMember(provider_id="c", model_name="mc"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"a": a, "b": b, "c": c}))
+    for _ in range(3):
+        await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    # Each call commits to its start member, so each member served exactly once.
+    assert len(records["a"]) == 1
+    assert len(records["b"]) == 1
+    assert len(records["c"]) == 1
+
+
+@pytest.mark.asyncio
+async def test_transient_only_propagates_auth_error():
+    # failover_on=TRANSIENT: an AuthenticationError is NOT eligible -> propagate.
+    bad = _FakeLLM(connect_exc=AuthenticationError("401"))
+    good = _FakeLLM(events=[Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(
+        failover_on=FailoverClasses.TRANSIENT,
+        members=[
+            AggregatedMember(provider_id="bad", model_name="m1"),
+            AggregatedMember(provider_id="good", model_name="m2"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    with pytest.raises(AuthenticationError):
+        await _drain(agg.stream(model="virtual-1", messages=_MSG))
+
+
+@pytest.mark.asyncio
+async def test_transient_and_config_fails_over_auth_error():
+    bad = _FakeLLM(connect_exc=AuthenticationError("401"))
+    good = _FakeLLM(events=[TextDelta(text="ok", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    cfg = AggregatedLLMConfig(
+        failover_on=FailoverClasses.TRANSIENT_AND_CONFIG,
+        members=[
+            AggregatedMember(provider_id="bad", model_name="m1"),
+            AggregatedMember(provider_id="good", model_name="m2"),
+        ],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver({"bad": bad, "good": good}))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert any(isinstance(e, TextDelta) for e in events)
+
+
+def test_yielded_eligibility_policy():
+    from primer.llm.aggregated import _yielded_eligible
+    # timeout code + None -> eligible under both policies.
+    for policy in (FailoverClasses.TRANSIENT, FailoverClasses.TRANSIENT_AND_CONFIG):
+        assert _yielded_eligible("stream_timeout", policy) is True
+        assert _yielded_eligible(None, policy) is True
+    # a non-null, non-timeout code (bad-request / OpenAI native) -> config only.
+    assert _yielded_eligible("invalid_request_error", FailoverClasses.TRANSIENT) is False
+    assert _yielded_eligible("invalid_request_error", FailoverClasses.TRANSIENT_AND_CONFIG) is True
+
+
+@pytest.mark.asyncio
+async def test_round_robin_cursor_is_concurrency_safe():
+    # N concurrent stream calls must each get a distinct start member (a clean
+    # rotation with no cursor races), exercising _cursor_lock for real.
+    import asyncio
+
+    n = 6
+    records = {str(i): [] for i in range(n)}
+
+    def mk(k):
+        return _FakeLLM(events=[Done(stop_reason="stop", raw_reason="stop")],
+                        record=records[k], name=k)
+
+    fakes = {str(i): mk(str(i)) for i in range(n)}
+    cfg = AggregatedLLMConfig(
+        strategy=RoutingStrategy.ROUND_ROBIN,
+        members=[AggregatedMember(provider_id=str(i), model_name=f"m{i}") for i in range(n)],
+    )
+    agg = AggregatedLLM(_row(cfg), resolve_member=_resolver(fakes))
+    await asyncio.gather(*[
+        _drain(agg.stream(model="virtual-1", messages=_MSG)) for _ in range(n)
+    ])
+    # Each member was the committed start member exactly once (a full rotation
+    # with no duplicates), proving the cursor advanced atomically per call.
+    served = sorted(k for k, calls in records.items() if calls)
+    assert served == sorted(str(i) for i in range(n))
+    assert all(len(calls) == 1 for calls in records.values())

--- a/tests/model/test_provider_aggregated.py
+++ b/tests/model/test_provider_aggregated.py
@@ -1,0 +1,95 @@
+"""Schema tests for the aggregated LLM provider type and config."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from primer.model.provider import (
+    AggregatedLLMConfig,
+    AggregatedMember,
+    FailoverClasses,
+    FailoverPoint,
+    LLMProvider,
+    LLMProviderType,
+    RoutingStrategy,
+)
+
+
+class TestEnumValues:
+    def test_provider_type_value_is_stable(self):
+        assert LLMProviderType.AGGREGATED.value == "aggregated"
+
+    def test_strategy_values(self):
+        assert RoutingStrategy.SEQUENTIAL.value == "sequential"
+        assert RoutingStrategy.ROUND_ROBIN.value == "round_robin"
+
+    def test_failover_point_values(self):
+        assert FailoverPoint.BEFORE_FIRST_TOKEN.value == "before_first_token"
+        assert FailoverPoint.MID_STREAM.value == "mid_stream"
+
+    def test_failover_classes_values(self):
+        assert FailoverClasses.TRANSIENT.value == "transient"
+        assert FailoverClasses.TRANSIENT_AND_CONFIG.value == "transient_and_config"
+
+
+class TestAggregatedLLMConfig:
+    def test_defaults(self):
+        cfg = AggregatedLLMConfig(
+            members=[AggregatedMember(provider_id="p1", model_name="m1")],
+        )
+        assert cfg.strategy == RoutingStrategy.SEQUENTIAL
+        assert cfg.failover_point == FailoverPoint.BEFORE_FIRST_TOKEN
+        assert cfg.failover_on == FailoverClasses.TRANSIENT_AND_CONFIG
+
+    def test_empty_members_raises(self):
+        with pytest.raises(ValidationError):
+            AggregatedLLMConfig(members=[])
+
+    def test_dedupes_pairs_preserving_order(self):
+        cfg = AggregatedLLMConfig(
+            members=[
+                AggregatedMember(provider_id="p1", model_name="a"),
+                AggregatedMember(provider_id="p1", model_name="b"),
+                AggregatedMember(provider_id="p1", model_name="a"),  # dup
+                AggregatedMember(provider_id="p2", model_name="a"),
+            ],
+        )
+        assert [(m.provider_id, m.model_name) for m in cfg.members] == [
+            ("p1", "a"), ("p1", "b"), ("p2", "a"),
+        ]
+
+    def test_same_provider_different_model_is_not_a_dup(self):
+        cfg = AggregatedLLMConfig(
+            members=[
+                AggregatedMember(provider_id="p1", model_name="a"),
+                AggregatedMember(provider_id="p1", model_name="b"),
+            ],
+        )
+        assert len(cfg.members) == 2
+
+
+class TestLLMProviderAggregatedDispatch:
+    def _body(self, **overrides):
+        body = {
+            "id": "agg-1",
+            "provider": "aggregated",
+            "config": {
+                "members": [{"provider_id": "p1", "model_name": "m1"}],
+                "strategy": "round_robin",
+            },
+            "models": [{"name": "virtual-1", "context_length": 200000}],
+            "limits": {"max_concurrency": 4},
+        }
+        body.update(overrides)
+        return body
+
+    def test_coerce_selects_aggregated_config(self):
+        row = LLMProvider.model_validate(self._body())
+        assert isinstance(row.config, AggregatedLLMConfig)
+        assert row.config.strategy == RoutingStrategy.ROUND_ROBIN
+        assert row.config.members[0].provider_id == "p1"
+
+    def test_models_required_min_length_one(self):
+        with pytest.raises(ValidationError):
+            LLMProvider.model_validate(self._body(models=[]))

--- a/tests/toolset/test_system.py
+++ b/tests/toolset/test_system.py
@@ -480,6 +480,45 @@ class TestLLMProviderTools:
         assert json.loads(result.output)["type"] == "validation-error"
 
 
+class TestAggregatedLLMProviderTool:
+    @pytest.mark.asyncio
+    async def test_create_aggregated_llm_provider_roundtrips(
+        self, system_toolset
+    ) -> None:
+        body = {
+            "id": "agg-tool-1",
+            "provider": "aggregated",
+            "config": {
+                "members": [
+                    {"provider_id": "p1", "model_name": "m1"},
+                    {"provider_id": "p2", "model_name": "m2"},
+                ],
+                "strategy": "round_robin",
+                "failover_point": "before_first_token",
+                "failover_on": "transient_and_config",
+            },
+            "models": [{"name": "virtual-1", "context_length": 200000}],
+            "limits": {"max_concurrency": 4},
+        }
+        result = await system_toolset.call(
+            tool_name="create_llm_provider", arguments={"entity": body}
+        )
+        assert not result.is_error, result.output
+        created = json.loads(result.output)
+        assert created["id"] == "agg-tool-1"
+        assert created["provider"] == "aggregated"
+        # The aggregated config survived model_validate untouched.
+        assert created["config"]["strategy"] == "round_robin"
+        assert created["config"]["members"] == body["config"]["members"]
+
+        # Read back through get_llm_provider.
+        got = await system_toolset.call(
+            tool_name="get_llm_provider", arguments={"id": "agg-tool-1"}
+        )
+        assert not got.is_error
+        assert json.loads(got.output)["config"]["failover_on"] == "transient_and_config"
+
+
 # ===========================================================================
 # Cascade invalidation
 # ===========================================================================

--- a/tests/ui/test_providers_aggregated.py
+++ b/tests/ui/test_providers_aggregated.py
@@ -1,0 +1,37 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SRC = UI / "components" / "providers.jsx"
+
+
+def _src() -> str:
+    return SRC.read_text(encoding="utf-8")
+
+
+def test_aggregated_provider_type_registered() -> None:
+    src = _src()
+    assert "aggregated:" in src          # new key under PROVIDER_KINDS_FIELDS.llm
+    assert "Aggregated" in src           # human label
+
+
+def test_aggregated_member_editor_and_controls_present() -> None:
+    src = _src()
+    assert "PR_AggregatedEditor" in src
+    assert "PR_Toggle" in src
+    # Strategy / failover-point toggles use the role="switch" idiom.
+    assert 'role="switch"' in src
+    # Enum string values must match the backend StrEnums exactly.
+    for token in ("round_robin", "sequential", "before_first_token",
+                  "mid_stream", "transient", "transient_and_config"):
+        assert token in src
+    # Member shape fields.
+    assert "provider_id" in src and "model_name" in src
+
+
+def test_providers_jsx_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    code = b._transform(_src(), "components/providers.jsx")
+    assert code and "PROVIDER_KINDS_FIELDS" in code

--- a/ui/components/providers.jsx
+++ b/ui/components/providers.jsx
@@ -16,6 +16,7 @@ const VENDOR_COLORS = {
   huggingface: "var(--amber)",
   openresponses: "var(--green)",
   openchat: "var(--green)",
+  aggregated: "var(--blue)",
 };
 
 // kind prop ("llm" / "embedding" / "rerank") -> URL segment + REST plural +
@@ -162,6 +163,17 @@ const PROVIDER_KINDS_FIELDS = {
       // component in Task 5.2 to render the richer variant.
       pickerVariant: "openrouter",
     },
+    aggregated: {
+      label: "Aggregated",
+      variant: "aggregated",
+      config: [], // config is built by PR_AggregatedEditor, not ConfigField
+      discoverable: false,
+      suggestedModels: [],
+      modelFields: [
+        { key: "name", label: "Virtual model name", flex: 2 },
+        { key: "context_length", label: "Context length", type: "number", flex: 1, min: 1 },
+      ],
+    },
   },
   embedding: {
     openai: {
@@ -237,6 +249,17 @@ const OPENROUTER_SLUG_RE = /^[a-z0-9-]+\/[a-z0-9._-]+(:[a-z0-9-]+)?$/;
 // bound for almost every OpenRouter-routed model in 2026; the operator
 // can always tighten it in the per-row inputs below the picker.
 const OPENROUTER_DEFAULT_LLM_CONTEXT = 128000;
+
+// Default shape for the "aggregated" provider's config - mirrors the
+// backend's AggregatedLLMConfig field defaults exactly (primer/model/
+// providers/llm.py: RoutingStrategy.SEQUENTIAL, FailoverPoint.
+// BEFORE_FIRST_TOKEN, FailoverClasses.TRANSIENT_AND_CONFIG).
+const AGG_CONFIG_DEFAULT = {
+  members: [],
+  strategy: "sequential",
+  failover_point: "before_first_token",
+  failover_on: "transient_and_config",
+};
 
 // ============================================================================
 // Top-level page — list view vs detail view dispatched on the router's id.
@@ -578,11 +601,105 @@ function OpenRouterModelPicker({ discovered, selected, onSelect, onDeselect }) {
 }
 
 // ============================================================================
+// PR_Toggle - verbatim mirror of SSO_Toggle (ui/components/sso_admin.jsx:56-94).
+// ============================================================================
+
+function PR_Toggle({ checked, onChange, label, help, disabled, testid }) {
+  return (
+    <label style={{ display: "flex", alignItems: "flex-start", gap: 10,
+      cursor: disabled ? "default" : "pointer", opacity: disabled ? 0.5 : 1 }}>
+      <button type="button" role="switch" aria-checked={checked} disabled={disabled}
+        data-testid={testid} onClick={() => !disabled && onChange(!checked)}
+        style={{ flex: "0 0 auto", width: 34, height: 20, borderRadius: 999,
+          border: "1px solid var(--border)", padding: 0, marginTop: 1,
+          background: checked ? "var(--accent)" : "var(--bg-2)", position: "relative",
+          cursor: disabled ? "default" : "pointer", transition: "background 0.12s ease" }}>
+        <span style={{ position: "absolute", top: 1, left: checked ? 15 : 1, width: 16,
+          height: 16, borderRadius: "50%", background: checked ? "var(--accent-fg)" : "var(--text-3)",
+          transition: "left 0.12s ease" }} />
+      </button>
+      <span style={{ fontSize: 12.5, lineHeight: 1.4 }}>
+        {label}{help && <span className="muted"> - {help}</span>}
+      </span>
+    </label>
+  );
+}
+
+// ============================================================================
+// PR_AggregatedEditor - ordered member picker + strategy/failover toggles for
+// the "aggregated" LLM provider variant. Mirrors WSP_AggregatedEditor
+// (ui/components/web_search.jsx:704-765) but the member shape here is richer
+// ({provider_id, model_name} rather than a bare provider id) since aggregated
+// LLM members each pin a specific upstream model.
+// ============================================================================
+
+function PR_AggregatedEditor({ value, onChange, candidates }) {
+  // value: { members: [{provider_id, model_name}], strategy, failover_point, failover_on }
+  const v = value || {};
+  const members = v.members || [];
+  const set = (patch) => onChange({ ...v, ...patch });
+  const setMember = (i, patch) =>
+    set({ members: members.map((m, j) => (j === i ? { ...m, ...patch } : m)) });
+  const move = (i, d) => {
+    const j = i + d;
+    if (j < 0 || j >= members.length) return;
+    const next = members.slice();
+    [next[i], next[j]] = [next[j], next[i]];
+    set({ members: next });
+  };
+  const remove = (i) => set({ members: members.filter((_, j) => j !== i) });
+  const add = () => set({ members: [...members, { provider_id: "", model_name: "" }] });
+  const modelsFor = (pid) => (candidates.find((c) => c.id === pid)?.models || []).map((m) => m.name);
+  return (
+    <div className="field">
+      <label className="field-label">Members (ordered; failover walks top to bottom)</label>
+      {members.map((m, i) => (
+        <div key={i} style={{ display: "flex", gap: 6, marginTop: 4, alignItems: "center" }}>
+          <span className="mono muted">#{i + 1}</span>
+          <select className="select" value={m.provider_id}
+            onChange={(e) => setMember(i, { provider_id: e.target.value, model_name: "" })}>
+            <option value="">select provider…</option>
+            {candidates.map((c) => <option key={c.id} value={c.id}>{c.id}</option>)}
+          </select>
+          <select className="select" value={m.model_name}
+            onChange={(e) => setMember(i, { model_name: e.target.value })}>
+            <option value="">select model…</option>
+            {modelsFor(m.provider_id).map((n) => <option key={n} value={n}>{n}</option>)}
+          </select>
+          <Btn size="sm" kind="ghost" onClick={() => move(i, -1)} title="Up">↑</Btn>
+          <Btn size="sm" kind="ghost" onClick={() => move(i, 1)} title="Down">↓</Btn>
+          <Btn size="sm" kind="ghost" onClick={() => remove(i)} title="Remove">×</Btn>
+        </div>
+      ))}
+      <div style={{ marginTop: 6 }}>
+        <Btn size="sm" onClick={add}>Add member</Btn>
+      </div>
+      <div style={{ marginTop: 10, display: "grid", gap: 8 }}>
+        <PR_Toggle checked={(v.strategy || "sequential") === "round_robin"}
+          onChange={(on) => set({ strategy: on ? "round_robin" : "sequential" })}
+          label="Round-robin" help="rotate the starting member per call (off = sequential)" />
+        <PR_Toggle checked={(v.failover_point || "before_first_token") === "mid_stream"}
+          onChange={(on) => set({ failover_point: on ? "mid_stream" : "before_first_token" })}
+          label="Mid-stream failover" help="may duplicate already-shown tokens (off = before first token)" />
+        <div className="field">
+          <label className="field-label">Failover on</label>
+          <select className="select" value={v.failover_on || "transient_and_config"}
+            onChange={(e) => set({ failover_on: e.target.value })} style={{ width: "100%" }}>
+            <option value="transient">transient</option>
+            <option value="transient_and_config">transient_and_config</option>
+          </select>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ============================================================================
 // Create modal — provider-pattern with rich per-provider controls.
 // ============================================================================
 
 function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToast, existing }) {
-  const { apiFetch, useMutation } = window.primerApi;
+  const { apiFetch, useMutation, useResource } = window.primerApi;
   const _push = pushToast || (() => {});
   const fieldKind = _normKind(kindProp);
   const providers = PROVIDER_KINDS_FIELDS[fieldKind] || {};
@@ -623,6 +740,26 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
   // just "openrouter"). For other providers discovery still flows into
   // `models` directly via the legacy onSuccess branch below.
   const [discovered, setDiscovered] = React.useState([]);
+  // Config for the "aggregated" variant's dedicated sub-editor - not part
+  // of the generic ConfigField-driven configValues map (def.config is []
+  // for aggregated; see PROVIDER_KINDS_FIELDS.llm.aggregated above).
+  const [aggConfig, setAggConfig] = React.useState(() => {
+    if (isEdit && existing?.provider === "aggregated") {
+      return { ...AGG_CONFIG_DEFAULT, ...(existing?.config || {}) };
+    }
+    return { ...AGG_CONFIG_DEFAULT };
+  });
+  // Candidate members for the aggregated picker: existing NON-aggregated
+  // LLM providers (an aggregated member must resolve to a real upstream
+  // adapter - nesting is rejected server-side at resolve time).
+  const llmProvidersRes = useResource(
+    "providers:agg-member-candidates",
+    (signal) => apiFetch("GET", "/llm_providers?limit=200", null, { signal }),
+    { pollMs: null },
+  );
+  const llmCandidates = (llmProvidersRes.data?.items ?? []).filter(
+    (p) => p.provider !== "aggregated"
+  );
   const [maxConcurrency, setMaxConcurrency] = React.useState(
     existing?.limits?.max_concurrency ?? 1
   );
@@ -667,6 +804,7 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
     setModels([]);
     setDiscovered([]);
     setFieldErrors({});
+    setAggConfig({ ...AGG_CONFIG_DEFAULT });
   }, [provider]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const def = providers[provider];
@@ -793,7 +931,7 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
       // can autogenerate.
       ...(isEdit ? { id: existing.id } : (id ? { id } : {})),
       provider,
-      config: cleanConfig(),
+      config: def?.variant === "aggregated" ? aggConfig : cleanConfig(),
       models: cleanModels(),
       limits: {
         max_concurrency: Number(maxConcurrency) || 1,
@@ -820,6 +958,9 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
     // `models: [{}]` and the API rejected it with a 422 on models.0.name.
     && models.every((m) => def?.modelFields.every((f) => f.optional || String(m[f.key] ?? "").trim() !== ""))
     && def?.config.every((f) => !f.required || (configValues[f.key] != null && configValues[f.key] !== ""))
+    && ((def?.variant !== "aggregated")
+      || (aggConfig.members.length >= 1
+        && aggConfig.members.every((m) => m.provider_id && m.model_name)))
     && !create.loading;
 
   return (
@@ -870,15 +1011,23 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
         {fieldErrors["body.provider"] && <div className="field-help" style={{ color: "var(--red)" }}>{fieldErrors["body.provider"]}</div>}
       </div>
 
-      {def && def.config.map((f) => (
-        <ConfigField
-          key={f.key}
-          field={f}
-          value={configValues[f.key] ?? ""}
-          onChange={(v) => setConfigValues((cv) => ({ ...cv, [f.key]: v }))}
-          error={fieldErrors[`body.config.${f.key}`]}
+      {def && def.variant === "aggregated" ? (
+        <PR_AggregatedEditor
+          value={aggConfig}
+          onChange={setAggConfig}
+          candidates={llmCandidates}
         />
-      ))}
+      ) : (
+        def && def.config.map((f) => (
+          <ConfigField
+            key={f.key}
+            field={f}
+            value={configValues[f.key] ?? ""}
+            onChange={(v) => setConfigValues((cv) => ({ ...cv, [f.key]: v }))}
+            error={fieldErrors[`body.config.${f.key}`]}
+          />
+        ))
+      )}
 
       <div className="field">
         <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>


### PR DESCRIPTION
## What

**Aggregated Chat Models**: group models from the same or different providers behind one chat interface, so a 429 / quota failure on one model automatically retries on the next member. Agents select the virtual model like any other provider.

- New `LLMProviderType.AGGREGATED` with `members: [(provider_id, model_name), ...]` (ordered, deduped), `strategy` (`sequential` fixed priority | `round_robin` rotating start), `failover_point` (`before_first_token` default | `mid_stream` opt-in), `failover_on` (`transient` | `transient_and_config` default).
- `AggregatedLLM(LLM)` adapter: lazy per-call member resolution through the registry (member edits are picked up without recreating the aggregate); failover across BOTH error channels (raised connect-phase typed exceptions AND first-event yielded `Error(fatal)`); commit point = the first event of any kind (so the default mode never re-emits tokens); `try/finally` downstream cleanup on every exit path including consumer abandonment; all-members-failed raises an aggregated `RateLimitError` carrying a per-member failure summary.
- Nesting (an aggregated member inside an aggregate) is rejected at stream time; the console never offers aggregated providers as members.
- `aclose()` is a no-op by design: the registry owns downstream adapter lifecycles.

## Semantics worth knowing (documented in docs/dev/subsystems/model-providers.md)

- The failover window closes at the first streamed event. In practice rate-limit / auth failures raise at connect, before any event.
- Mid-stream failover (opt-in) may re-emit already-streamed tokens.
- On the yielded channel the provider classifiers erase the error class (`code=None`), so under the `transient` policy a first-event yielded auth error still fails over. That is safe because no tokens have been emitted; the raised channel (the real-world auth path) is policy-gated correctly.
- All-fail raises `RateLimitError` regardless of the underlying classes (class coarsening); the message carries the per-member detail.

## Surfaces (Definition of Done)

Backend + registry wiring / console form (ordered member picker, strategy + failover toggles) / system-tools parity (generic schema-driven CRUD, test-pinned) / docs (model-providers + provider-pattern) / unit (44+ tests including adversarial failover pins) / e2e (CI-gated 429-failover journey; the mock LLM gained an additive, back-compatible error-injection path) / primectl parity (schema-driven, test-pinned).

## Review trail

12 tasks, each implemented and independently reviewed. The plan itself was adversarially reviewed before execution, which caught that the provider classifiers erase the error class - that reshaped the eligibility rules. Final whole-branch review verdict: **READY**, zero Critical/Important. Two optional coverage follow-ups noted by reviewers (a negative provider/config coercion test; an all-duplicates-members edge test) - non-blocking.

## Testing

Targeted suites green per task (named-file runs). The broad suite and the gated e2e run in CI - deliberately not run locally.

Held: no merge, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
