### PR TITLE
fix: session event-log clobber, registry 500 on missing row, stale adapter after reconnect

### DIFF
--- a/primer/agent/workspace_executor.py
+++ b/primer/agent/workspace_executor.py
@@ -119,19 +119,33 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
         return await self._read_messages_jsonl()
 
     async def _persist_turn(self, turn_messages: list[Message]) -> None:
-        """Append ``turn_messages`` to ``messages.jsonl`` via ``commit_state``."""
-        new_text = await self._appended_jsonl(turn_messages)
-        excerpt = _summary_excerpt_from_messages(turn_messages)
-        sid_short = self._session.session_id[-12:]
-        if excerpt:
-            subject = f"turn[{sid_short}]: {excerpt}"
-        else:
-            subject = f"turn[{sid_short}]: assistant turn"
-        await self._session.commit_state(
-            summary=subject,
-            op="message",
-            files={"messages.jsonl": new_text},
-        )
+        """Append ``turn_messages`` to ``messages.jsonl`` via ``commit_state``.
+
+        This is itself a read-modify-rewrite: ``_appended_jsonl`` reads the
+        current file and ``commit_state`` writes the whole thing back. The
+        session's messages lock is held across BOTH so a concurrent writer
+        (an ``append_instruction`` steer, or a streamed event row) cannot
+        land in the read->rewrite gap and be silently truncated by the
+        rewrite (see arch-review batch 1, MEDIUM-1).
+
+        Lock order is ``messages_lock -> _commit_lock`` (commit_state takes
+        the latter internally), matching every other acquirer, and nothing
+        inside this critical section appends to messages.jsonl, so the
+        non-reentrant lock cannot be re-taken by this task.
+        """
+        async with self._session.messages_lock:
+            new_text = await self._appended_jsonl(turn_messages)
+            excerpt = _summary_excerpt_from_messages(turn_messages)
+            sid_short = self._session.session_id[-12:]
+            if excerpt:
+                subject = f"turn[{sid_short}]: {excerpt}"
+            else:
+                subject = f"turn[{sid_short}]: assistant turn"
+            await self._session.commit_state(
+                summary=subject,
+                op="message",
+                files={"messages.jsonl": new_text},
+            )
 
     async def inject_resume_messages(
         self, messages: list[Message],
@@ -163,17 +177,33 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
         Git history naturally preserves the pre-compaction snapshot --
         anyone inspecting ``.state/sessions/<id>/`` can ``git show``
         the previous commit to recover the original messages.
+
+        The messages lock is held across the rewrite so it cannot interleave
+        with a concurrent O_APPEND event row or another full-file rewriter.
+
+        NOTE (arch-review batch 1, MEDIUM-1): unlike ``_persist_turn`` this
+        hook does NOT contain its own read -- ``compacted`` is derived from
+        the snapshot ``AgentExecutor.invoke`` took at ``_load_history``,
+        which is separated from this rewrite by the compaction LLM call.
+        Locking only the rewrite therefore does not make compaction atomic
+        against a steer that arrives mid-compaction: that steer is appended
+        after the snapshot and is dropped by this rewrite. Closing that
+        window would mean holding the lock across the summarisation call
+        (stalling every append for its duration) or reconciling the file's
+        tail against the snapshot, neither of which belongs in this fix --
+        it is called out in the review notes instead.
         """
         new_jsonl = (
             "\n".join(m.model_dump_json() for m in compacted) + "\n"
             if compacted
             else ""
         )
-        await self._session.commit_state(
-            summary=f"{self._session.session_id}: compaction",
-            op="message",
-            files={"messages.jsonl": new_jsonl},
-        )
+        async with self._session.messages_lock:
+            await self._session.commit_state(
+                summary=f"{self._session.session_id}: compaction",
+                op="message",
+                files={"messages.jsonl": new_jsonl},
+            )
 
     async def _ensure_artifact_dir(self) -> None:
         """Best-effort create ``<workspace_root>/artifacts/<session_id>/``.

--- a/primer/api/registries/provider_registry.py
+++ b/primer/api/registries/provider_registry.py
@@ -621,6 +621,29 @@ class ProviderRegistry:
         self._embedder_factory = _build_default_embedder_factory(rate_limiter=rate_limiter)
         self._cross_encoder_factory = _build_default_cross_encoder_factory(rate_limiter=rate_limiter)
 
+    def _flush_caches_local(self) -> None:
+        """Drop every cached adapter WITHOUT closing it.
+
+        Invoked (synchronously) when an invalidation subscription
+        reconnects: a NOTIFY dropped during the LISTEN blip may have left
+        a stale adapter (e.g. a rotated API key) cached, so treat all
+        cached adapters as potentially stale and force reconstruction on
+        the next ``get_*``. This mirrors the cache-clearing half of
+        :meth:`aclose` (minus the ``aclose()`` calls).
+
+        No lock is taken: the reconnect hook runs synchronously in the
+        bus supervisor task, and clearing dicts has no ``await`` points,
+        so no coroutine can observe a half-cleared state. We deliberately
+        do NOT ``aclose()`` the dropped adapters -- one may still be in
+        use by an in-flight request, and closing its transport out from
+        under it would break that request; dropping the cache entry alone
+        is enough to force a fresh build next time.
+        """
+        self._llm_cache.clear()
+        self._embedder_cache.clear()
+        self._cross_encoder_cache.clear()
+        self._toolset_cache.clear()
+
     async def bind_invalidation_bus(self, bus: InvalidationBus) -> None:
         """Wire the registry's cache eviction to the bus. Idempotent."""
         if self._invalidation_bus is not None:
@@ -641,17 +664,34 @@ class ProviderRegistry:
         async def _tool(key: str) -> None:
             await self._invalidate_toolset_local(key)
 
+        # Every topic shares one broadcast channel, so a reconnect on any
+        # subscription means invalidations on ALL topics may have been
+        # dropped during the blip. Flush every cache on any reconnect --
+        # over-invalidation (an extra rebuild) is safe; a stale adapter
+        # (e.g. a rotated API key) cached until restart is not.
         self._invalidation_subs.append(
-            await bus.subscribe(InvalidationTopic.LLM_PROVIDER, _llm)
+            await bus.subscribe(
+                InvalidationTopic.LLM_PROVIDER, _llm,
+                on_reconnect=self._flush_caches_local,
+            )
         )
         self._invalidation_subs.append(
-            await bus.subscribe(InvalidationTopic.EMBEDDING_PROVIDER, _embed)
+            await bus.subscribe(
+                InvalidationTopic.EMBEDDING_PROVIDER, _embed,
+                on_reconnect=self._flush_caches_local,
+            )
         )
         self._invalidation_subs.append(
-            await bus.subscribe(InvalidationTopic.CROSS_ENCODER_PROVIDER, _cross)
+            await bus.subscribe(
+                InvalidationTopic.CROSS_ENCODER_PROVIDER, _cross,
+                on_reconnect=self._flush_caches_local,
+            )
         )
         self._invalidation_subs.append(
-            await bus.subscribe(InvalidationTopic.TOOLSET, _tool)
+            await bus.subscribe(
+                InvalidationTopic.TOOLSET, _tool,
+                on_reconnect=self._flush_caches_local,
+            )
         )
 
     # ---- Lifecycle --------------------------------------------------------

--- a/primer/api/registries/provider_registry.py
+++ b/primer/api/registries/provider_registry.py
@@ -380,6 +380,13 @@ class ProviderRegistry:
         self._cross_encoder_cache: dict[str, CrossEncoder] = {}
         self._toolset_cache: dict[str, ToolsetProvider] = {}
         self._lock = asyncio.Lock()
+        # Bumped by every cache flush. Each ``get_*`` samples it before the
+        # storage await and refuses to cache the adapter it built if the
+        # value moved while it was suspended -- that adapter was built from
+        # a row read BEFORE the flush, so caching it would resurrect exactly
+        # the staleness the flush exists to clear (see arch-review batch 1,
+        # MEDIUM-2).
+        self._cache_generation = 0
         self._invalidation_bus: InvalidationBus | None = None
         self._invalidation_subs: list[InvalidationSubscription] = []
 
@@ -390,13 +397,15 @@ class ProviderRegistry:
             cached = self._llm_cache.get(provider_id)
             if cached is not None:
                 return cached
+            generation = self._cache_generation
             row = await self._sp.get_storage(LLMProvider).get(provider_id)
             if row is None:
                 raise NotFoundError(
                     f"LLMProvider {provider_id!r} does not exist"
                 )
             adapter = self._llm_factory(row)
-            self._llm_cache[provider_id] = adapter
+            if self._cache_generation == generation:
+                self._llm_cache[provider_id] = adapter
             return adapter
 
     async def get_embedder(self, provider_id: str) -> Embedder:
@@ -404,13 +413,15 @@ class ProviderRegistry:
             cached = self._embedder_cache.get(provider_id)
             if cached is not None:
                 return cached
+            generation = self._cache_generation
             row = await self._sp.get_storage(EmbeddingProvider).get(provider_id)
             if row is None:
                 raise NotFoundError(
                     f"EmbeddingProvider {provider_id!r} does not exist"
                 )
             adapter = self._embedder_factory(row)
-            self._embedder_cache[provider_id] = adapter
+            if self._cache_generation == generation:
+                self._embedder_cache[provider_id] = adapter
             return adapter
 
     async def get_cross_encoder(self, provider_id: str) -> CrossEncoder:
@@ -418,13 +429,15 @@ class ProviderRegistry:
             cached = self._cross_encoder_cache.get(provider_id)
             if cached is not None:
                 return cached
+            generation = self._cache_generation
             row = await self._sp.get_storage(CrossEncoderProvider).get(provider_id)
             if row is None:
                 raise NotFoundError(
                     f"CrossEncoderProvider {provider_id!r} does not exist"
                 )
             adapter = self._cross_encoder_factory(row)
-            self._cross_encoder_cache[provider_id] = adapter
+            if self._cache_generation == generation:
+                self._cross_encoder_cache[provider_id] = adapter
             return adapter
 
     async def get_toolset(self, toolset_id: str) -> ToolsetProvider:
@@ -491,13 +504,15 @@ class ProviderRegistry:
             cached = self._toolset_cache.get(toolset_id)
             if cached is not None:
                 return cached
+            generation = self._cache_generation
             row = await self._sp.get_storage(Toolset).get(toolset_id)
             if row is None:
                 raise NotFoundError(
                     f"Toolset {toolset_id!r} does not exist"
                 )
             adapter = self._toolset_factory(row)
-            self._toolset_cache[toolset_id] = adapter
+            if self._cache_generation == generation:
+                self._toolset_cache[toolset_id] = adapter
             return adapter
 
     # ---- Invalidation (private local helpers) ----------------------------
@@ -638,7 +653,18 @@ class ProviderRegistry:
         use by an in-flight request, and closing its transport out from
         under it would break that request; dropping the cache entry alone
         is enough to force a fresh build next time.
+
+        Because no lock is taken, this CAN land while a ``get_*`` is
+        suspended at its storage await (``get_*`` holds ``self._lock``
+        across that await, which does not exclude this hook). That get
+        would then re-populate the cache with an adapter built from a
+        pre-flush row, leaving the stale adapter cached until restart --
+        the exact bug the flush exists to fix. Bumping the generation
+        makes any such in-flight get skip its cache insert (it still
+        returns its adapter to its caller, whose request completes
+        normally); the next get rebuilds from a post-flush row.
         """
+        self._cache_generation += 1
         self._llm_cache.clear()
         self._embedder_cache.clear()
         self._cross_encoder_cache.clear()

--- a/primer/api/registries/semantic_search_registry.py
+++ b/primer/api/registries/semantic_search_registry.py
@@ -86,6 +86,12 @@ class SemanticSearchRegistry:
 
         # Slow path: resolve + construct + initialize OUTSIDE the lock.
         row = await self._storage.get(ssp_id)
+        if row is None:
+            from primer.model.except_ import NotFoundError
+
+            raise NotFoundError(
+                f"semantic search provider {ssp_id!r} does not exist"
+            )
         provider = self._factory(row)
         await provider.initialize()
 

--- a/primer/bus/in_memory.py
+++ b/primer/bus/in_memory.py
@@ -13,6 +13,7 @@ Not safe across processes. The production app uses
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import Any
 
@@ -90,9 +91,17 @@ class InMemoryEventBus(EventBus):
         for sub in self._subscribers:
             await sub._queue.put(event)
 
-    def subscribe(self) -> _InMemorySubscription:
+    def subscribe(
+        self,
+        *,
+        on_reconnect: "Callable[[], None] | None" = None,
+    ) -> _InMemorySubscription:
         if self._closed:
             raise RuntimeError("subscribe on closed InMemoryEventBus")
+        # The in-memory bus has no droppable transport, so it never
+        # reconnects and never calls ``on_reconnect``. The parameter
+        # exists only to satisfy the EventBus contract.
+        del on_reconnect
         sub = _InMemorySubscription(self)
         self._subscribers.append(sub)
         return sub

--- a/primer/bus/postgres.py
+++ b/primer/bus/postgres.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import asyncio
 import json
 import logging
+from collections.abc import Callable
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Any
 
@@ -325,18 +326,34 @@ class PostgresEventBus(EventBus):
                 body,
             )
 
-    def subscribe(self) -> _PostgresSubscription:
+    def subscribe(
+        self,
+        *,
+        on_reconnect: Callable[[], None] | None = None,
+    ) -> _PostgresSubscription:
         if self._closed:
             raise RuntimeError("subscribe on closed PostgresEventBus")
 
-        def _bump_reconnects() -> None:
+        def _on_reconnect() -> None:
+            # Always bump the bus's own reconnect metric, then fan out to
+            # the caller's hook (if any). The caller's callback must never
+            # break the supervisor's reconnect loop, so its exceptions are
+            # logged and swallowed.
             self._listen_reconnects_total += 1
+            if on_reconnect is not None:
+                try:
+                    on_reconnect()
+                except Exception:  # noqa: BLE001 -- never break the loop
+                    logger.exception(
+                        "PostgresEventBus: subscribe on_reconnect hook raised; "
+                        "continuing",
+                    )
 
         sub = _PostgresSubscription(
             acquire=self._storage.pool.acquire,
             release=self._storage.pool.release,
             reconnect_seconds=self._reconnect_seconds,
-            on_reconnect=_bump_reconnects,
+            on_reconnect=_on_reconnect,
             on_close=self._unsubscribe,
         )
         sub._start()

--- a/primer/coordinator/in_memory.py
+++ b/primer/coordinator/in_memory.py
@@ -148,7 +148,13 @@ class InMemoryInvalidationBus(InvalidationBus):
         self,
         topic: InvalidationTopic,
         handler: Callable[[str], Awaitable[None]],
+        *,
+        on_reconnect: Callable[[], None] | None = None,
     ) -> InvalidationSubscription:
+        # In-process pub/sub has no droppable transport, so it never
+        # reconnects and never fires ``on_reconnect``. Accepted only to
+        # satisfy the InvalidationBus contract.
+        del on_reconnect
         async with self._lock:
             self._handlers[topic].append(handler)
         return _InMemoryInvalidationSubscription(self, topic, handler)

--- a/primer/coordinator/postgres.py
+++ b/primer/coordinator/postgres.py
@@ -205,11 +205,16 @@ class _PostgresInvalidationSubscription(InvalidationSubscription):
         bus: "EventBus",
         topic: "InvalidationTopic",
         handler: Callable[[str], Awaitable[None]],
+        on_reconnect: Callable[[], None] | None = None,
     ) -> None:
         self._bus = bus
         self._topic = topic
         self._handler = handler
-        self._sub = bus.subscribe()
+        # Thread the caller's reconnect hook down to the EventBus
+        # subscription: LISTEN/NOTIFY drops events across a reconnect, so
+        # this fires when the transport comes back and the subscriber
+        # needs to treat its cached invalidation state as stale.
+        self._sub = bus.subscribe(on_reconnect=on_reconnect)
         self._task: asyncio.Task = asyncio.create_task(
             self._run(),
             name=f"invalidation-sub-{topic.value}",
@@ -273,8 +278,12 @@ class PostgresInvalidationBus(InvalidationBus):
         self,
         topic: "InvalidationTopic",
         handler: Callable[[str], Awaitable[None]],
+        *,
+        on_reconnect: Callable[[], None] | None = None,
     ) -> _PostgresInvalidationSubscription:
-        return _PostgresInvalidationSubscription(self._bus, topic, handler)
+        return _PostgresInvalidationSubscription(
+            self._bus, topic, handler, on_reconnect,
+        )
 
 
 # ---------------------------------------------------------------------------

--- a/primer/int/coordinator.py
+++ b/primer/int/coordinator.py
@@ -107,7 +107,20 @@ class InvalidationBus(ABC):
         self,
         topic: InvalidationTopic,
         handler: Callable[[str], Awaitable[None]],
-    ) -> InvalidationSubscription: ...
+        *,
+        on_reconnect: Callable[[], None] | None = None,
+    ) -> InvalidationSubscription:
+        """Subscribe ``handler`` to ``topic``.
+
+        ``on_reconnect`` is invoked (synchronously) whenever the
+        underlying transport re-establishes a dropped connection. Since
+        the broadcast is not durable across a reconnect, invalidations
+        emitted during the blip are lost; subscribers that cache the
+        invalidated state use this hook to flush it wholesale (treat
+        everything as potentially stale). Impls without a droppable
+        transport never call it.
+        """
+        ...
 
 
 @dataclass

--- a/primer/int/event_bus.py
+++ b/primer/int/event_bus.py
@@ -18,6 +18,7 @@ inject the right one via the app lifespan.
 from __future__ import annotations
 
 from abc import ABC, abstractmethod
+from collections.abc import Callable
 from dataclasses import dataclass
 from datetime import datetime
 from typing import Any
@@ -89,7 +90,11 @@ class EventBus(ABC):
         """
 
     @abstractmethod
-    def subscribe(self) -> "EventSubscription":
+    def subscribe(
+        self,
+        *,
+        on_reconnect: "Callable[[], None] | None" = None,
+    ) -> "EventSubscription":
         """Subscribe to ALL events on the bus.
 
         Returns an :class:`EventSubscription` async-iterator the
@@ -103,6 +108,14 @@ class EventBus(ABC):
         for both shipped impls is broadcast — the worker pool's
         resumable-flip is idempotent (``mark_resumable``'s atomic
         UPDATE-WITH-WHERE means duplicate flips are no-ops).
+
+        ``on_reconnect`` is invoked (synchronously) each time the
+        subscription re-establishes a dropped transport. Because
+        LISTEN/NOTIFY is not durable across a reconnect, any events
+        emitted during the blip are lost; callers that cache
+        broadcast state use this hook to treat that state as
+        potentially stale. Impls without a droppable transport (the
+        in-memory bus) never call it.
         """
 
 

--- a/primer/workspace/local/state.py
+++ b/primer/workspace/local/state.py
@@ -99,6 +99,13 @@ class LocalStateRepo:
         self._workspace_id = workspace_id
         self._subprocess_timeout_seconds = subprocess_timeout_seconds
         self._commit_lock = asyncio.Lock()
+        # Serialises the messages.jsonl read->rewrite window (session
+        # instruction appends) against O_APPEND event-row writes
+        # (``Workspace.append_message_line``). Both paths acquire this so a
+        # streamed event row can never land in the read->rewrite gap and be
+        # truncated by the full-file rewrite. Distinct from ``_commit_lock``
+        # (which the rewrite still takes internally) to avoid re-entrancy.
+        self._messages_lock = asyncio.Lock()
         # session_id -> agent_id, populated on create_session and on
         # init scan. The commit-trailer assembler uses this so callers
         # don't have to thread agent_id through every commit call.
@@ -115,6 +122,16 @@ class LocalStateRepo:
     def workspace_id(self) -> str:
         """The workspace id stamped into every commit's trailer."""
         return self._workspace_id
+
+    @property
+    def messages_lock(self) -> asyncio.Lock:
+        """Mutual-exclusion lock for messages.jsonl append vs. rewrite.
+
+        Acquired by :meth:`Workspace.append_message_line` (the O_APPEND
+        event-row writer) and by the session's instruction append across
+        its read->rewrite window, so the two never interleave.
+        """
+        return self._messages_lock
 
     async def initialize(self) -> None:
         """Open / initialise the repo. Idempotent.

--- a/primer/workspace/local/state.py
+++ b/primer/workspace/local/state.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import AbstractAsyncContextManager
 from datetime import datetime
 from pathlib import Path
 
@@ -38,6 +39,7 @@ from primer.model.workspace_session import (
     WaitingState,
 )
 from primer.model.workspace import CommitInfo, Op
+from primer.session.mutation_lock import KeyedLock
 from primer.workspace.state_helpers import (
     TRAILER_AGENT as _TRAILER_AGENT,
     TRAILER_CALL as _TRAILER_CALL,
@@ -100,12 +102,19 @@ class LocalStateRepo:
         self._subprocess_timeout_seconds = subprocess_timeout_seconds
         self._commit_lock = asyncio.Lock()
         # Serialises the messages.jsonl read->rewrite window (session
-        # instruction appends) against O_APPEND event-row writes
-        # (``Workspace.append_message_line``). Both paths acquire this so a
-        # streamed event row can never land in the read->rewrite gap and be
+        # instruction appends, the executor's turn persist) against O_APPEND
+        # event-row writes (``Workspace.append_message_line``). Every writer
+        # acquires this so a row can never land in a read->rewrite gap and be
         # truncated by the full-file rewrite. Distinct from ``_commit_lock``
         # (which the rewrite still takes internally) to avoid re-entrancy.
-        self._messages_lock = asyncio.Lock()
+        #
+        # Keyed by session id: messages.jsonl is per-session
+        # (``sessions/<id>/messages.jsonl``), so two sessions never write the
+        # same file and must not contend. A single per-repo lock would make
+        # one session's event-row flush wait on another session's git commit,
+        # stalling an unrelated turn (the flush runs inline in the worker's
+        # turn task).
+        self._messages_locks = KeyedLock()
         # session_id -> agent_id, populated on create_session and on
         # init scan. The commit-trailer assembler uses this so callers
         # don't have to thread agent_id through every commit call.
@@ -123,15 +132,20 @@ class LocalStateRepo:
         """The workspace id stamped into every commit's trailer."""
         return self._workspace_id
 
-    @property
-    def messages_lock(self) -> asyncio.Lock:
-        """Mutual-exclusion lock for messages.jsonl append vs. rewrite.
+    def messages_lock(self, session_id: str) -> AbstractAsyncContextManager[None]:
+        """Mutual exclusion for one session's messages.jsonl writers.
 
         Acquired by :meth:`Workspace.append_message_line` (the O_APPEND
-        event-row writer) and by the session's instruction append across
-        its read->rewrite window, so the two never interleave.
+        event-row writer) and by every full-file rewriter across its
+        read->rewrite window (the session's instruction append, the
+        workspace executor's turn persist / compaction rewrite), so the
+        two never interleave.
+
+        Keyed by ``session_id`` so only writers to the SAME
+        ``sessions/<id>/messages.jsonl`` contend; unrelated sessions
+        proceed in parallel. Use as ``async with repo.messages_lock(sid):``.
         """
-        return self._messages_lock
+        return self._messages_locks.acquire(session_id)
 
     async def initialize(self) -> None:
         """Open / initialise the repo. Idempotent.

--- a/primer/workspace/local/workspace.py
+++ b/primer/workspace/local/workspace.py
@@ -675,7 +675,11 @@ class LocalWorkspace(Workspace):
             with target.open("ab") as fh:
                 fh.write(line)
 
-        await asyncio.to_thread(_append)
+        # Serialise against the session's messages.jsonl read->rewrite
+        # window (AgentSession.append_instruction) so this O_APPEND event
+        # row cannot land in that gap and be truncated by the rewrite.
+        async with self._state.messages_lock:
+            await asyncio.to_thread(_append)
 
     async def append_state_line(self, relative_path: str, line: bytes) -> None:
         """Append ``line`` to ``<root>/<relative_path>``.

--- a/primer/workspace/local/workspace.py
+++ b/primer/workspace/local/workspace.py
@@ -675,10 +675,13 @@ class LocalWorkspace(Workspace):
             with target.open("ab") as fh:
                 fh.write(line)
 
-        # Serialise against the session's messages.jsonl read->rewrite
-        # window (AgentSession.append_instruction) so this O_APPEND event
-        # row cannot land in that gap and be truncated by the rewrite.
-        async with self._state.messages_lock:
+        # Serialise against this session's messages.jsonl read->rewrite
+        # windows (AgentSession.append_instruction, the executor's turn
+        # persist) so this O_APPEND event row cannot land in one of those
+        # gaps and be truncated by the rewrite. The lock is keyed by
+        # session id, so a flush for one session never waits on another
+        # session's commit.
+        async with self._state.messages_lock(session_id):
             await asyncio.to_thread(_append)
 
     async def append_state_line(self, relative_path: str, line: bytes) -> None:

--- a/primer/workspace/sandbox/state.py
+++ b/primer/workspace/sandbox/state.py
@@ -228,6 +228,12 @@ class SandboxStateRepo:
         self._state_path = state_path
         self._workspace_id = workspace_id
         self._commit_lock = asyncio.Lock()
+        # Serialises the messages.jsonl read->rewrite window (session
+        # instruction appends) against the append-file event-row writes
+        # (``Workspace.append_message_line``). Distinct from
+        # ``_commit_lock`` (which the rewrite still takes internally) to
+        # avoid re-entrancy. Mirrors LocalStateRepo._messages_lock.
+        self._messages_lock = asyncio.Lock()
         # session_id -> agent_id cache (populated by create_session /
         # initialize scan; used by commit() to resolve the agent trailer).
         self._agent_by_session: dict[str, str] = {}
@@ -239,6 +245,16 @@ class SandboxStateRepo:
     @property
     def state_path(self) -> str:
         return self._state_path
+
+    @property
+    def messages_lock(self) -> asyncio.Lock:
+        """Mutual-exclusion lock for messages.jsonl append vs. rewrite.
+
+        Acquired by :meth:`Workspace.append_message_line` and by the
+        session's instruction append across its read->rewrite window, so
+        the two never interleave. Mirrors ``LocalStateRepo.messages_lock``.
+        """
+        return self._messages_lock
 
     # ------------------------------------------------------------------
     # Version guard

--- a/primer/workspace/sandbox/state.py
+++ b/primer/workspace/sandbox/state.py
@@ -19,6 +19,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+from contextlib import AbstractAsyncContextManager
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
@@ -31,6 +32,7 @@ from primer.model.workspace_session import (
     SessionInfo,
     WaitingState,
 )
+from primer.session.mutation_lock import KeyedLock
 from primer.workspace.state_helpers import (
     TRAILER_AGENT as _TRAILER_AGENT,
     TRAILER_CALL as _TRAILER_CALL,
@@ -229,11 +231,12 @@ class SandboxStateRepo:
         self._workspace_id = workspace_id
         self._commit_lock = asyncio.Lock()
         # Serialises the messages.jsonl read->rewrite window (session
-        # instruction appends) against the append-file event-row writes
-        # (``Workspace.append_message_line``). Distinct from
-        # ``_commit_lock`` (which the rewrite still takes internally) to
-        # avoid re-entrancy. Mirrors LocalStateRepo._messages_lock.
-        self._messages_lock = asyncio.Lock()
+        # instruction appends, the executor's turn persist) against the
+        # append-file event-row writes (``Workspace.append_message_line``).
+        # Distinct from ``_commit_lock`` (which the rewrite still takes
+        # internally) to avoid re-entrancy. Keyed by session id so unrelated
+        # sessions never contend. Mirrors LocalStateRepo._messages_locks.
+        self._messages_locks = KeyedLock()
         # session_id -> agent_id cache (populated by create_session /
         # initialize scan; used by commit() to resolve the agent trailer).
         self._agent_by_session: dict[str, str] = {}
@@ -246,15 +249,15 @@ class SandboxStateRepo:
     def state_path(self) -> str:
         return self._state_path
 
-    @property
-    def messages_lock(self) -> asyncio.Lock:
-        """Mutual-exclusion lock for messages.jsonl append vs. rewrite.
+    def messages_lock(self, session_id: str) -> AbstractAsyncContextManager[None]:
+        """Mutual exclusion for one session's messages.jsonl writers.
 
-        Acquired by :meth:`Workspace.append_message_line` and by the
-        session's instruction append across its read->rewrite window, so
-        the two never interleave. Mirrors ``LocalStateRepo.messages_lock``.
+        Acquired by :meth:`Workspace.append_message_line` and by every
+        full-file rewriter across its read->rewrite window, so the two never
+        interleave. Keyed by ``session_id`` so unrelated sessions do not
+        contend. Mirrors ``LocalStateRepo.messages_lock``.
         """
-        return self._messages_lock
+        return self._messages_locks.acquire(session_id)
 
     # ------------------------------------------------------------------
     # Version guard

--- a/primer/workspace/sandbox/workspace.py
+++ b/primer/workspace/sandbox/workspace.py
@@ -589,11 +589,13 @@ class SandboxWorkspace(Workspace):
             f"{self._workspace_root}/{self._template.state_path}"
             f"/sessions/{session_id}/messages.jsonl"
         )
-        # Serialise against the session's messages.jsonl read->rewrite
-        # window (AgentSession.append_instruction). The default sandbox
-        # ``append_file`` is itself read-modify-write, so without this the
-        # event row could be truncated by a concurrent instruction rewrite.
-        async with self._state_repo.messages_lock:
+        # Serialise against this session's messages.jsonl read->rewrite
+        # windows (AgentSession.append_instruction, the executor's turn
+        # persist). The default sandbox ``append_file`` is itself
+        # read-modify-write, so without this the event row could be
+        # truncated by a concurrent rewrite. Keyed by session id, so a
+        # flush for one session never waits on another session's commit.
+        async with self._state_repo.messages_lock(session_id):
             await self._sandbox.append_file(path, line)
 
     async def append_state_line(self, relative_path: str, line: bytes) -> None:

--- a/primer/workspace/sandbox/workspace.py
+++ b/primer/workspace/sandbox/workspace.py
@@ -589,7 +589,12 @@ class SandboxWorkspace(Workspace):
             f"{self._workspace_root}/{self._template.state_path}"
             f"/sessions/{session_id}/messages.jsonl"
         )
-        await self._sandbox.append_file(path, line)
+        # Serialise against the session's messages.jsonl read->rewrite
+        # window (AgentSession.append_instruction). The default sandbox
+        # ``append_file`` is itself read-modify-write, so without this the
+        # event row could be truncated by a concurrent instruction rewrite.
+        async with self._state_repo.messages_lock:
+            await self._sandbox.append_file(path, line)
 
     async def append_state_line(self, relative_path: str, line: bytes) -> None:
         """Append ``line`` to ``<workspace_root>/<relative_path>``.

--- a/primer/workspace/session.py
+++ b/primer/workspace/session.py
@@ -414,7 +414,6 @@ class AgentSession:
                 queued_at=now,
             )
             message = Message(role="user", parts=[TextPart(text=content)])
-            new_messages_jsonl = await self._appended_messages_jsonl(message)
 
             # Updated session metadata: last_activity_at moves forward.
             updated_info = self._info.model_copy(
@@ -424,15 +423,26 @@ class AgentSession:
             excerpt = " ".join(content.split())
             if len(excerpt) > 60:
                 excerpt = excerpt[:59].rstrip() + "…"
-            await self._state.commit(
-                self.session_id,
-                summary=f"user[{sid_short}]: {excerpt}" if excerpt else f"user[{sid_short}]: user_instruction",
-                op="user_instruction",
-                files={
-                    "messages.jsonl": new_messages_jsonl,
-                    "session.json": updated_info.model_dump_json(indent=2),
-                },
-            )
+            # Hold the state repo's messages lock across BOTH the read
+            # (_appended_messages_jsonl) and the full-file rewrite (commit),
+            # so a concurrent event-row append (Workspace.append_message_line,
+            # a different task) cannot slip into the read->rewrite gap and be
+            # truncated. The rewrite still takes the repo's _commit_lock
+            # internally; messages_lock is a distinct lock so there is no
+            # re-entrancy, and the acquisition order (messages_lock ->
+            # _commit_lock) is never inverted by the appender (which takes
+            # messages_lock alone).
+            async with self._state.messages_lock:
+                new_messages_jsonl = await self._appended_messages_jsonl(message)
+                await self._state.commit(
+                    self.session_id,
+                    summary=f"user[{sid_short}]: {excerpt}" if excerpt else f"user[{sid_short}]: user_instruction",
+                    op="user_instruction",
+                    files={
+                        "messages.jsonl": new_messages_jsonl,
+                        "session.json": updated_info.model_dump_json(indent=2),
+                    },
+                )
             self._info = updated_info
             return instruction
 

--- a/primer/workspace/session.py
+++ b/primer/workspace/session.py
@@ -278,6 +278,24 @@ class AgentSession:
         """Markdown injected into the agent's system prompt at session start."""
         return _SYSTEM_PROMPT_TEMPLATE.format(session_id=self.session_id)
 
+    @property
+    def messages_lock(self) -> asyncio.Lock:
+        """Mutual-exclusion lock for this session's messages.jsonl writers.
+
+        Every writer that rewrites the WHOLE file from a snapshot it read
+        (this class's :meth:`append_instruction`, the workspace executor's
+        ``_persist_turn`` / ``_replace_compacted_head``) must hold this
+        across its read->rewrite window, and the O_APPEND event-row writer
+        (``Workspace.append_message_line``) must hold it across its append.
+        Otherwise a write landing in a rewriter's read->rewrite gap is
+        silently truncated by the rewrite.
+
+        Exposed on the session (rather than callers reaching into
+        ``_state``) so the keying of the underlying lock table stays an
+        implementation detail of the state repo.
+        """
+        return self._state.messages_lock
+
     # ---- Pause / end flag accessors (set by request_*; read by runtime) --
 
     @property
@@ -423,16 +441,16 @@ class AgentSession:
             excerpt = " ".join(content.split())
             if len(excerpt) > 60:
                 excerpt = excerpt[:59].rstrip() + "…"
-            # Hold the state repo's messages lock across BOTH the read
+            # Hold the session's messages lock across BOTH the read
             # (_appended_messages_jsonl) and the full-file rewrite (commit),
-            # so a concurrent event-row append (Workspace.append_message_line,
-            # a different task) cannot slip into the read->rewrite gap and be
-            # truncated. The rewrite still takes the repo's _commit_lock
-            # internally; messages_lock is a distinct lock so there is no
-            # re-entrancy, and the acquisition order (messages_lock ->
-            # _commit_lock) is never inverted by the appender (which takes
-            # messages_lock alone).
-            async with self._state.messages_lock:
+            # so a concurrent event-row append (Workspace.append_message_line)
+            # or a concurrent full-file rewriter (the executor's _persist_turn)
+            # cannot slip into the read->rewrite gap and be truncated. The
+            # rewrite still takes the repo's _commit_lock internally;
+            # messages_lock is a distinct lock so there is no re-entrancy, and
+            # the acquisition order (messages_lock -> _commit_lock) is never
+            # inverted by any other acquirer.
+            async with self.messages_lock:
                 new_messages_jsonl = await self._appended_messages_jsonl(message)
                 await self._state.commit(
                     self.session_id,

--- a/primer/workspace/session.py
+++ b/primer/workspace/session.py
@@ -26,6 +26,7 @@ import asyncio
 import json
 import logging
 import uuid
+from contextlib import AbstractAsyncContextManager
 from datetime import datetime, timezone
 from pathlib import Path, PurePosixPath
 from typing import TYPE_CHECKING, Literal
@@ -279,8 +280,8 @@ class AgentSession:
         return _SYSTEM_PROMPT_TEMPLATE.format(session_id=self.session_id)
 
     @property
-    def messages_lock(self) -> asyncio.Lock:
-        """Mutual-exclusion lock for this session's messages.jsonl writers.
+    def messages_lock(self) -> AbstractAsyncContextManager[None]:
+        """Mutual exclusion for THIS session's messages.jsonl writers.
 
         Every writer that rewrites the WHOLE file from a snapshot it read
         (this class's :meth:`append_instruction`, the workspace executor's
@@ -290,11 +291,12 @@ class AgentSession:
         Otherwise a write landing in a rewriter's read->rewrite gap is
         silently truncated by the rewrite.
 
-        Exposed on the session (rather than callers reaching into
-        ``_state``) so the keying of the underlying lock table stays an
-        implementation detail of the state repo.
+        Returns a fresh context manager on each access; use it as
+        ``async with session.messages_lock:``. The repo's lock table is
+        keyed by session id, so writers to OTHER sessions never contend --
+        the key is supplied here so callers cannot key it inconsistently.
         """
-        return self._state.messages_lock
+        return self._state.messages_lock(self.session_id)
 
     # ---- Pause / end flag accessors (set by request_*; read by runtime) --
 

--- a/tests/agent/test_workspace_executor.py
+++ b/tests/agent/test_workspace_executor.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 import shutil
 from collections.abc import AsyncIterator
 from pathlib import Path
@@ -390,5 +391,122 @@ class TestSandboxStateRepoParity:
         finally:
             # Restore the real repo so aclose()'s status commit works.
             session._state = real_state  # type: ignore[assignment]
+            await session.aclose()
+            await backend.aclose()
+
+
+# ===========================================================================
+# messages.jsonl rewrite races (arch-review batch 1, MEDIUM-1)
+# ===========================================================================
+
+
+class TestPersistTurnInstructionRace:
+    """A steer must survive a concurrent ``_persist_turn``.
+
+    ``_persist_turn`` is itself read-modify-rewrite: ``_appended_jsonl``
+    snapshots messages.jsonl and ``commit_state`` rewrites the whole file
+    from that snapshot. ``AgentSession.append_instruction`` does the same.
+    Without serialisation an instruction committed inside the turn's
+    read->rewrite gap is silently truncated by the turn's rewrite -- the
+    user's steer is permanently lost. Both paths hold the session's
+    ``messages_lock`` across their window so the steer survives.
+    """
+
+    @pytest.mark.asyncio
+    async def test_instruction_survives_concurrent_persist_turn(
+        self, tmp_path: Path
+    ) -> None:
+        backend, workspace, session = await _build_session(tmp_path)
+        try:
+            llm = _FakeLLM(
+                scripts=[
+                    [
+                        TextDelta(text="assistant-turn-text", index=0),
+                        Done(stop_reason="stop", raw_reason="stop"),
+                    ]
+                ]
+            )
+            mgr = ToolExecutionManager.for_workspace(
+                toolset_providers={}, session=session
+            )
+            executor = WorkspaceAgentExecutor(
+                agent=_agent(),
+                llm=llm,  # type: ignore[arg-type]
+                llm_model=_model(),
+                tool_manager=mgr,
+                session=session,
+            )
+
+            rel = f"sessions/{session.session_id}/messages.jsonl"
+            real_read = workspace.state_repo.read_state_file
+            real_persist = executor._persist_turn
+            steer_started = asyncio.Event()
+            steer_tasks: list[asyncio.Task] = []
+            in_persist = False
+            fired = False
+
+            async def _do_steer() -> None:
+                # Signal that the steer coroutine has begun, then append.
+                # Under the fix this blocks on messages_lock until the turn's
+                # rewrite releases it; without the fix it commits straight
+                # into the read->rewrite gap and is then overwritten.
+                steer_started.set()
+                await session.append_instruction("steer me")
+
+            async def hooked_read(path: str):
+                nonlocal fired
+                # Let _persist_turn take its snapshot FIRST, then hold the gap
+                # open so the concurrent steer commits after that snapshot.
+                # If the turn is not serialised, its rewrite drops the steer.
+                result = await real_read(path)
+                if in_persist and path == rel and not fired:
+                    fired = True
+                    steer_tasks.append(asyncio.create_task(_do_steer()))
+                    await steer_started.wait()
+                    # Give the (broken) unserialised steer time to commit, or
+                    # the (fixed) serialised steer time to block on the lock.
+                    await asyncio.sleep(0.05)
+                return result
+
+            async def hooked_persist(turn_messages) -> None:
+                # Arm the read hook only for the reads _persist_turn itself
+                # makes, so the interleave lands in exactly the window under
+                # test (not _load_history's or _fetch_last_assistant_text's).
+                nonlocal in_persist
+                in_persist = True
+                try:
+                    await real_persist(turn_messages)
+                finally:
+                    in_persist = False
+
+            workspace.state_repo.read_state_file = hooked_read  # type: ignore[assignment]
+            executor._persist_turn = hooked_persist  # type: ignore[assignment]
+            try:
+                await _drain(
+                    executor.invoke(
+                        [Message(role="user", parts=[TextPart(text="hi")])]
+                    )
+                )
+            finally:
+                workspace.state_repo.read_state_file = real_read  # type: ignore[assignment]
+            await asyncio.gather(*steer_tasks)
+
+            content = (
+                workspace.root
+                / workspace.template.state_path
+                / "sessions"
+                / session.session_id
+                / "messages.jsonl"
+            ).read_bytes()
+            # The steer committed inside the turn's read->rewrite window must
+            # survive the rewrite.
+            assert b"steer me" in content, content
+            # ...and the turn the executor persisted must also be present.
+            assert b"assistant-turn-text" in content, content
+            # ...along with the original instruction that seeded the file.
+            assert b"hello" in content, content
+            # The interleave actually occurred (no vacuous pass).
+            assert fired is True
+        finally:
             await session.aclose()
             await backend.aclose()

--- a/tests/api/test_provider_registry.py
+++ b/tests/api/test_provider_registry.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 from unittest.mock import AsyncMock, MagicMock
 
@@ -259,3 +260,83 @@ class TestAclose:
         await registry.aclose()
         llm_adapter.aclose.assert_awaited_once()
         emb_adapter.aclose.assert_awaited_once()
+
+
+class TestFlushDuringInFlightGet:
+    """A reconnect flush must not be undone by an in-flight ``get_*``.
+
+    ``get_*`` holds ``registry._lock`` across the storage await, but
+    ``_flush_caches_local`` (the subscription's ``on_reconnect`` hook) takes
+    no lock, so it lands while a get is suspended. The get then resumes and
+    inserts an adapter built from a PRE-flush row, re-caching the stale
+    adapter (e.g. a rotated API key) until restart -- the exact bug the
+    flush exists to fix. A generation counter makes the in-flight get skip
+    its cache insert (see arch-review batch 1, MEDIUM-2).
+    """
+
+    @pytest.mark.asyncio
+    async def test_flush_during_suspended_get_does_not_recache_stale(
+        self,
+    ) -> None:
+        sp = _FakeStorageProvider()
+        await sp.get_storage(LLMProvider).create(_make_llm_provider())
+
+        stale = MagicMock(name="stale")
+        stale.aclose = AsyncMock()
+        fresh = MagicMock(name="fresh")
+        fresh.aclose = AsyncMock()
+        built: list[Any] = []
+
+        def _factory(row: LLMProvider):
+            adapter = stale if not built else fresh
+            built.append(adapter)
+            return adapter
+
+        registry = ProviderRegistry(sp, llm_factory=_factory)
+
+        storage = sp.get_storage(LLMProvider)
+        real_get = storage.get
+        suspended = asyncio.Event()
+        release = asyncio.Event()
+
+        async def _hooked_get(id: str):
+            row = await real_get(id)
+            # Suspend INSIDE get_llm's storage await, holding registry._lock.
+            suspended.set()
+            await release.wait()
+            return row
+
+        storage.get = _hooked_get  # type: ignore[assignment]
+        task = asyncio.create_task(registry.get_llm("anthropic-1"))
+        await suspended.wait()
+
+        # The subscription's reconnect hook fires while the get is suspended.
+        registry._flush_caches_local()
+
+        release.set()
+        adapter = await task
+
+        # The in-flight caller still gets a usable adapter back: its request
+        # must complete, not fail, just because a flush raced it.
+        assert adapter is stale
+        # ...but the pre-flush adapter must NOT be left in the cache.
+        assert registry._llm_cache == {}
+
+        # The next get rebuilds from a post-flush row and caches normally.
+        storage.get = real_get  # type: ignore[assignment]
+        assert await registry.get_llm("anthropic-1") is fresh
+        assert registry._llm_cache["anthropic-1"] is fresh
+
+    @pytest.mark.asyncio
+    async def test_get_without_racing_flush_still_caches(self) -> None:
+        """The generation guard must not break the ordinary caching path."""
+        sp = _FakeStorageProvider()
+        await sp.get_storage(LLMProvider).create(_make_llm_provider())
+        adapter = MagicMock()
+        adapter.aclose = AsyncMock()
+        registry = ProviderRegistry(sp, llm_factory=lambda p: adapter)
+
+        first = await registry.get_llm("anthropic-1")
+        assert registry._llm_cache["anthropic-1"] is adapter
+        # Second get is served from cache (no rebuild).
+        assert await registry.get_llm("anthropic-1") is first

--- a/tests/api/test_semantic_search_registry.py
+++ b/tests/api/test_semantic_search_registry.py
@@ -105,6 +105,32 @@ async def test_registry_get_missing_row_raises_not_found():
         await reg.get_provider("missing")
 
 
+class _NoneReturningStorage:
+    """Storage stand-in that returns ``None`` for a missing id.
+
+    Mirrors the real ``Storage.get`` contract (a dangling/bogus id
+    resolves to ``None`` rather than raising), which the sibling
+    registries (artifact, web-search) all model. The other stub in this
+    file *raises* on a miss, which masked the registry's missing
+    None-guard -- so this stub is what exercises it.
+    """
+
+    async def get(self, entity_id: str, *, principal=None):
+        return None
+
+
+@pytest.mark.asyncio
+async def test_registry_get_none_row_raises_not_found_not_attribute_error():
+    """A None row from storage must surface NotFoundError, not the
+    AttributeError the factory would raise dereferencing ``None``."""
+    reg = SemanticSearchRegistry(
+        storage=_NoneReturningStorage(),
+        factory=lambda r: _StubProvider(r),
+    )
+    with pytest.raises(NotFoundError):
+        await reg.get_provider("ssp-dangling")
+
+
 @pytest.mark.asyncio
 async def test_registry_aclose_closes_all_cached():
     storage = _StubStorage({"a": _make_row("a"), "b": _make_row("b")})

--- a/tests/bus/test_postgres_reconnect.py
+++ b/tests/bus/test_postgres_reconnect.py
@@ -15,7 +15,10 @@ import json
 
 import pytest
 
+from primer.api.registries.provider_registry import ProviderRegistry
 from primer.bus.postgres import PostgresEventBus, YIELD_EVENTS_CHANNEL
+from primer.coordinator.postgres import PostgresInvalidationBus
+from primer.int.coordinator import InvalidationTopic
 
 pytestmark = pytest.mark.asyncio
 
@@ -124,6 +127,65 @@ async def test_reconnect_after_connection_drop():
         assert event.event_key == "ask_user:2"
     finally:
         await sub.aclose()
+        await bus.aclose()
+
+
+class _StubAdapter:
+    """Sentinel cache entry with an awaitable aclose (never expected to
+    run once the reconnect flush drops it)."""
+
+    async def aclose(self) -> None:  # pragma: no cover - defensive
+        return None
+
+
+async def test_invalidation_reconnect_flushes_registry_caches():
+    """A dropped-then-reconnected invalidation subscription must flush the
+    ProviderRegistry caches wholesale.
+
+    LISTEN/NOTIFY is not durable across a reconnect, so an invalidation
+    NOTIFY (e.g. a rotated API key) emitted during the blip is lost and
+    would otherwise leave a stale adapter cached until restart. The
+    ``on_reconnect`` hook threaded bus -> invalidation-sub -> registry
+    treats every cached adapter as potentially stale on reconnect.
+    """
+    pool = _FakePool()
+    bus = PostgresEventBus(_FakeStorage(pool), reconnect_seconds=0.01)
+    await bus.initialize()
+    inv_bus = PostgresInvalidationBus(bus)
+    registry = ProviderRegistry(storage_provider=object())
+    await registry.bind_invalidation_bus(inv_bus)
+    try:
+        # bind creates one EventBus subscription per topic (4), each on its
+        # own LISTEN connection. Wait until all are listening.
+        await _wait_for(
+            lambda: sum(1 for c in pool.conns if c.listened) >= 4
+        )
+
+        # Seed every cache so we can observe the wholesale flush.
+        registry._llm_cache["llm-1"] = _StubAdapter()
+        registry._embedder_cache["emb-1"] = _StubAdapter()
+        registry._cross_encoder_cache["ce-1"] = _StubAdapter()
+        registry._toolset_cache["ts-1"] = _StubAdapter()
+
+        # Drop one subscription's connection -> that supervisor reconnects
+        # on a fresh conn and fires on_reconnect -> registry cache flush.
+        first = pool.conns[0]
+        first.drop()
+
+        await _wait_for(
+            lambda: (
+                not registry._llm_cache
+                and not registry._embedder_cache
+                and not registry._cross_encoder_cache
+                and not registry._toolset_cache
+            )
+        )
+        # The bus also counted the reconnect (shared metric still bumps).
+        assert bus.metrics_snapshot()[
+            "primer_yield_bus_listen_reconnects_total"
+        ] >= 1
+    finally:
+        await registry.aclose()
         await bus.aclose()
 
 

--- a/tests/workspace/test_local.py
+++ b/tests/workspace/test_local.py
@@ -975,6 +975,80 @@ class TestAppendMessageLine:
         assert path.read_bytes() == batch
 
 
+class TestMessagesJsonlAppendRewriteRace:
+    """Event-row O_APPEND must not be clobbered by an instruction rewrite.
+
+    ``AgentSession.append_instruction`` reads messages.jsonl, appends the
+    user message, and rewrites the whole file. ``append_message_line``
+    O_APPENDs a session event row. Without serialisation, an event row
+    appended into the read->rewrite gap is truncated by the rewrite. Both
+    paths acquire ``state_repo.messages_lock`` so the streamed row
+    survives (see arch-review batch 1, Fix 2).
+    """
+
+    async def test_event_append_survives_instruction_rewrite(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        assert isinstance(ws, LocalWorkspace)
+        session = await ws.start_session(
+            _binding(), id="sess-race", instructions="hello"
+        )
+        sid = session.session_id
+        rel = f"sessions/{sid}/messages.jsonl"
+        event_line = b'{"seq":99,"kind":"assistant_token","text":"streamed-event"}\n'
+
+        real_read = ws.state_repo.read_state_file
+        append_started = asyncio.Event()
+        append_tasks: list[asyncio.Task] = []
+        fired = False
+
+        async def _do_append() -> None:
+            # Signal that the appender coroutine has begun, then perform the
+            # O_APPEND. Under the fix this call blocks on messages_lock until
+            # the rewrite releases it; without the fix it writes straight
+            # into the read->rewrite gap.
+            append_started.set()
+            await ws.append_message_line(sid, event_line)
+
+        async def hooked_read(path: str):
+            nonlocal fired
+            # Snapshot the file as the rewrite sees it FIRST (pre-append),
+            # then open the read->rewrite gap so a concurrent event append
+            # lands after this snapshot. The rewrite will write back this
+            # snapshot -- if the appender is not serialised, its row is lost.
+            result = await real_read(path)
+            if path == rel and not fired:
+                fired = True
+                append_tasks.append(asyncio.create_task(_do_append()))
+                await append_started.wait()
+                # Give the (broken) unserialised append time to reach disk,
+                # or the (fixed) serialised append time to block on the lock.
+                await asyncio.sleep(0.05)
+            return result
+
+        # Shadow the shared state repo's read with the interleaving hook.
+        ws.state_repo.read_state_file = hooked_read  # type: ignore[assignment]
+        try:
+            await session.append_instruction("steer me")
+        finally:
+            ws.state_repo.read_state_file = real_read  # type: ignore[assignment]
+        await asyncio.gather(*append_tasks)
+
+        content = (
+            ws.root / ws.template.state_path / "sessions" / sid / "messages.jsonl"
+        ).read_bytes()
+        # The streamed event row appended into the read->rewrite window must
+        # survive the full-file rewrite.
+        assert b"streamed-event" in content, content
+        # ...and the steering instruction rewrite must also be present.
+        assert b"steer me" in content, content
+        # ...along with the original instruction that seeded the file.
+        assert b"hello" in content, content
+        # The rewrite ran (interleave actually occurred).
+        assert fired is True
+
+
 class TestDiagnosticExec:
     """LocalWorkspace.diagnostic_exec runs a shell command rooted at the
     workspace path and returns stdout/stderr/exit_code/duration."""

--- a/tests/workspace/test_local.py
+++ b/tests/workspace/test_local.py
@@ -1499,3 +1499,96 @@ class TestLocalWriteLocking:
         await asyncio.gather(exec_holder(), writer())
 
         assert order == ["write", "exec"]
+class TestMessagesLockIsPerSession:
+    """The messages lock must not couple unrelated sessions.
+
+    messages.jsonl is per-SESSION, so only writers to the same
+    ``sessions/<id>/messages.jsonl`` need to serialise. A per-repo
+    (per-workspace) lock would make session B's event-row flush wait on
+    session A's git commit -- and because the flush runs inline in the
+    worker's turn task, that stalls B's turn on unrelated work. The lock
+    is keyed by session id (see arch-review batch 1, MEDIUM-3).
+    """
+
+    async def test_distinct_sessions_do_not_block_each_other(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        ws = await provider.create(_template())
+        assert isinstance(ws, LocalWorkspace)
+        sess_a = await ws.start_session(
+            _binding(), id="sess-key-a", instructions="hello"
+        )
+        sess_b = await ws.start_session(
+            _binding(), id="sess-key-b", instructions="hello"
+        )
+
+        # Hold session A's messages lock, standing in for A's in-flight
+        # read->rewrite window (an append_instruction / turn commit).
+        async with ws.state_repo.messages_lock(sess_a.session_id):
+            # A DIFFERENT session's event-row flush must not wait on it.
+            await asyncio.wait_for(
+                ws.append_message_line(
+                    sess_b.session_id, b'{"seq":1,"kind":"done"}\n'
+                ),
+                timeout=2.0,
+            )
+
+            # ...while the SAME session's flush must still serialise: it
+            # blocks until A's window closes, so a bounded wait times out.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    ws.append_message_line(
+                        sess_a.session_id, b'{"seq":1,"kind":"done"}\n'
+                    ),
+                    timeout=0.2,
+                )
+
+        b_path = (
+            ws.root
+            / ws.template.state_path
+            / "sessions"
+            / sess_b.session_id
+            / "messages.jsonl"
+        )
+        assert b'{"seq":1,"kind":"done"}' in b_path.read_bytes()
+
+        # Once A's window closes, A's own append proceeds normally.
+        await asyncio.wait_for(
+            ws.append_message_line(
+                sess_a.session_id, b'{"seq":2,"kind":"done"}\n'
+            ),
+            timeout=2.0,
+        )
+        a_path = (
+            ws.root
+            / ws.template.state_path
+            / "sessions"
+            / sess_a.session_id
+            / "messages.jsonl"
+        )
+        assert b'{"seq":2,"kind":"done"}' in a_path.read_bytes()
+
+    async def test_same_session_key_shared_across_repo_and_session(
+        self, provider: LocalWorkspaceBackend
+    ) -> None:
+        """The session handle and the repo must resolve the SAME lock.
+
+        ``AgentSession.messages_lock`` keys the table by its own session
+        id; ``append_message_line`` keys it by the id it was handed. If the
+        two ever diverged the serialisation would silently do nothing.
+        """
+        ws = await provider.create(_template())
+        assert isinstance(ws, LocalWorkspace)
+        session = await ws.start_session(
+            _binding(), id="sess-key-same", instructions="hello"
+        )
+
+        async with session.messages_lock:
+            # The repo-keyed acquisition for the same session must block.
+            with pytest.raises(asyncio.TimeoutError):
+                await asyncio.wait_for(
+                    ws.append_message_line(
+                        session.session_id, b'{"seq":1,"kind":"done"}\n'
+                    ),
+                    timeout=0.2,
+                )


### PR DESCRIPTION
Fixes three findings from the platform architecture review (2026-07-17). Each was adversarially verified before any code was written, and each fix was reviewed afterwards - the review mandated three follow-ups, which are included here.

## 1. Concurrent writers silently truncated the session event log

`append_message_line` O_APPENDed event rows with **no lock**, while `AgentSession.append_instruction` did read -> modify -> **full-file git rewrite**. An event row appended into that window was permanently truncated.

**Impact:** steering a running agent - a common operation - silently destroyed transcript rows (the Messages tab, WS replay, and channel final-result derivation). LLM history was safe (`_commit_lock` serialises the two git-rewrite paths); the loss was bounded to `SessionMessageRecord` event rows.

The fix serialises appender against rewriter on **both** the local and sandbox backends (the sandbox `append_file` is read-modify-write, the same clobber shape).

Reusing `_commit_lock` would have **self-deadlocked every steer**, so a separate lock is used. Deadlock-freedom was then verified exhaustively: every acquirer enumerated, no re-entrancy, no order inversion - the global order is always `session._lock -> messages_lock -> _commit_lock`.

Review follow-ups included here:
- **The same symptom was still open through a different writer.** `_persist_turn` is itself read-modify-rewrite and `commit_state` took neither lock, so the worker could erase a concurrent steer. Now serialised.
- The lock is keyed **per session**, not per workspace, so one session's git commit no longer blocks another session's event flush (`append_message_line` was previously lock-free - this avoids a coupling regression).

## 2. A missing None guard turned a bad id into a 500

`SemanticSearchRegistry.get_provider` lacked the `if row is None: raise NotFoundError` guard its six sibling registries all have, so a bogus or dangling `search_provider_id` raised `AttributeError` -> HTTP 500 instead of 404 (reachable via the knowledge routes).

Note: the pre-existing test passed *for the wrong reason* - its stub raised instead of returning `None`, so it never exercised the guard. The new test closes that.

## 3. A dropped NOTIFY left a stale adapter cached forever

Postgres LISTEN/NOTIFY is not durable, the invalidation subscription passed no `on_reconnect`, and the registry caches have no TTL. A NOTIFY lost during a reconnect blip left a stale adapter (for example a rotated API key) cached until process restart. Now the caches flush on reconnect.

Review follow-up included here: an in-flight `get_*` holds the lock **across** its storage await, so a flush landing mid-get was undone by the post-await cache insert - resurrecting the exact bug the flush exists to fix. A generation counter now suppresses that insert.

## Known residuals (deliberately not fixed here)

- **A steer issued during compaction can still be lost.** `_replace_compacted_head` is not the same shape as `_persist_turn` - it has no read; its input comes from `_load_history`, separated from the rewrite by the compaction LLM call. A lock cannot close that window; it needs tail/snapshot reconciliation, which is a design decision rather than a fix.
- **Compaction wipes the event log unconditionally**, independent of any concurrency: the compaction rewrite drops all seq/kind rows. This looks pre-existing and possibly intentional - it wants a ruling before anyone "fixes" it.
- The racing caller in fix 3 still receives the stale-but-working adapter for that one request; subsequent gets are clean.
- Flushed adapters are not `aclose()`d (an in-flight request may hold one), unlike the normal invalidation path which does close them. The asymmetry is worth reconciling.

## Testing

Each fix has a test proven RED before the fix and GREEN after; the concurrency tests assert the interleave actually fired so they cannot pass vacuously. Targeted named-file runs only (130 + 142 + 59 passed). The broad suite runs in CI.

Held: no merge, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
