### PR TITLE
fix: lost ask_user replies, orphaned workspaces, pool exhaustion, ignored lease TTL

### DIFF
--- a/primer/api/config.py
+++ b/primer/api/config.py
@@ -16,7 +16,7 @@ import os
 from pathlib import Path
 from typing import Literal
 
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, model_validator
 from pydantic_settings import (
     BaseSettings,
     PydanticBaseSettingsSource,
@@ -24,12 +24,31 @@ from pydantic_settings import (
     TomlConfigSettingsSource,
 )
 
-from primer.model.provider import SecretProviderConfig, StorageProviderConfig
+from primer.model.except_ import ConfigError
+from primer.model.provider import (
+    SecretProviderConfig,
+    StorageProviderConfig,
+    StorageProviderType,
+)
 from primer.model.scheduler import (
     RuntimeMode,
     SchedulerProviderConfig,
+    SchedulerProviderType,
     WorkerConfig,
 )
+
+
+# Headroom (extra pool connections beyond worker.concurrency) the Postgres
+# worker lane needs. Each in-flight turn pins one dedicated LISTEN connection
+# from the shared storage pool, and a handful of persistent LISTEN
+# connections live for the whole process (scheduler session_ready +
+# session_cancel, claim engine claim_ready, the yield-event listener, the
+# session/chat tick forwarders, the mcp-task bridge, and workspace watchers),
+# all on top of per-turn storage + rate-limiter acquires. This fixed margin
+# keeps ``pool.max_size`` above ``concurrency`` by enough that raised
+# concurrency cannot starve those persistent connections and block per-turn
+# acquires until PoolTimeout.
+_WORKER_POOL_HEADROOM = 8
 
 
 class ObservabilityConfig(BaseModel):
@@ -227,6 +246,54 @@ class AppConfig(BaseSettings):
             "False uses a human-readable single-line formatter."
         ),
     )
+
+    @model_validator(mode="after")
+    def _validate_worker_pool_headroom(self) -> "AppConfig":
+        """Reject a Postgres worker lane whose pool can't cover its concurrency.
+
+        When this process runs the worker pool on the Postgres scheduler/bus
+        lane, the PostgresClaimEngine + PostgresEventBus pin a dedicated
+        LISTEN connection per in-flight turn from the SAME storage pool that
+        serves per-turn storage + rate-limiter acquires, plus a handful of
+        persistent listeners. If ``db.config.pool.max_size`` is below
+        ``worker.concurrency + _WORKER_POOL_HEADROOM`` a busy process exhausts
+        the pool: acquires block for ``acquire_timeout`` (30s) then raise
+        PoolTimeout, stalling turns (arch review A-I2). Fail fast at startup
+        with a clear message instead of degrading silently under load.
+
+        The guard only fires on the Postgres lane with a Postgres storage
+        pool; the in-memory scheduler/bus (single-process / SQLite) has no
+        such pool and is unaffected.
+        """
+        runs_worker = self.runtime_mode in (
+            RuntimeMode.WORKER, RuntimeMode.API_PLUS_WORKER,
+        )
+        postgres_lane = (
+            self.scheduler is not None
+            and self.scheduler.provider == SchedulerProviderType.POSTGRES
+        )
+        db_is_postgres = (
+            self.db is not None
+            and self.db.provider == StorageProviderType.POSTGRES
+        )
+        if not (runs_worker and postgres_lane and db_is_postgres):
+            return self
+        pool = getattr(self.db.config, "pool", None)
+        if pool is None:
+            return self
+        required = self.worker.concurrency + _WORKER_POOL_HEADROOM
+        if pool.max_size < required:
+            raise ConfigError(
+                f"db.config.pool.max_size ({pool.max_size}) is too small for "
+                f"worker.concurrency ({self.worker.concurrency}) on the "
+                f"Postgres worker lane: each in-flight turn pins one LISTEN "
+                f"connection from the same pool plus ~{_WORKER_POOL_HEADROOM} "
+                f"persistent listeners, so db.config.pool.max_size must be "
+                f">= worker.concurrency + {_WORKER_POOL_HEADROOM} "
+                f"(= {required}). Raise db.config.pool.max_size or lower "
+                f"worker.concurrency."
+            )
+        return self
 
     @classmethod
     def settings_customise_sources(

--- a/primer/api/routers/tool_approval.py
+++ b/primer/api/routers/tool_approval.py
@@ -24,7 +24,7 @@ from primer.api.routers._crud import make_crud_router
 from primer.int.claim import ClaimEngine
 from primer.int.event_bus import EventBus
 from primer.model.except_ import ConflictError, NotFoundError
-from primer.session.yields import durably_mark_session_resumable
+from primer.session.yields import durably_wake_session
 from primer.model.workspace_session import WorkspaceSession
 from primer.model.storage import OffsetPage, OffsetPageResponse, OrderBy
 from primer.storage.q import Q
@@ -256,15 +256,21 @@ async def _publish_decision(
     event_bus: EventBus,
     session_storage,
     engine: ClaimEngine | None,
-) -> None:
+) -> bool:
     """Validate the decision, durably flip the row, then wake the bus.
 
     D-C2 fix: the operator decision is stamped onto the session row
     (``resume_event_payload`` + ``parked_status='resumable'`` + the claim
     lease re-armed) BEFORE the bus publish, so a decision is never lost when
-    the bus listener is down/reconnecting — LISTEN/NOTIFY is not durable but
+    the bus listener is down/reconnecting - LISTEN/NOTIFY is not durable but
     the row is, and the claim loop admits ``resumable`` rows without any bus.
     The publish that follows is a best-effort immediate wake only.
+
+    Uses :func:`durably_wake_session`, which acts on the flip helper's bool:
+    a guard-rejected row that is already ``resumable`` gets its claim lease
+    re-armed, so a retry after a half-applied flip (row stamped, lease lost)
+    repairs the row rather than accepting a decision the claim loop can never
+    act on. Returns True when this call advanced the row.
     """
     blob = _approval_blob_or_404(sess, id_str)
     yielded: dict = blob.get("yielded") or {}
@@ -279,7 +285,7 @@ async def _publish_decision(
     if not event_key:
         raise NotFoundError(f"{id_str!r} park is missing event_key")
     payload = {"decision": body.decision, "reason": body.reason}
-    await durably_mark_session_resumable(
+    did = await durably_wake_session(
         sess,
         event_key=event_key,
         payload=payload,
@@ -293,6 +299,7 @@ async def _publish_decision(
             "tool_approval decision publish failed for event_key=%r; durable "
             "flip already persisted, claim loop will recover", event_key,
         )
+    return did
 
 
 def make_tool_approval_router() -> APIRouter:

--- a/primer/api/routers/tool_approval.py
+++ b/primer/api/routers/tool_approval.py
@@ -13,6 +13,7 @@ from pydantic import BaseModel, Field
 from primer.api.deps import (
     get_approval_resolver,
     get_chat_storage,
+    get_claim_engine,
     get_event_bus,
     get_provider_registry,
     get_session_storage,
@@ -20,8 +21,10 @@ from primer.api.deps import (
 )
 from primer.api.errors import common_responses
 from primer.api.routers._crud import make_crud_router
+from primer.int.claim import ClaimEngine
 from primer.int.event_bus import EventBus
 from primer.model.except_ import ConflictError, NotFoundError
+from primer.session.yields import durably_mark_session_resumable
 from primer.model.workspace_session import WorkspaceSession
 from primer.model.storage import OffsetPage, OffsetPageResponse, OrderBy
 from primer.storage.q import Q
@@ -251,8 +254,18 @@ async def _publish_decision(
     id_str: str,
     body: ToolApprovalRespondBody,
     event_bus: EventBus,
+    session_storage,
+    engine: ClaimEngine | None,
 ) -> None:
-    """Validate and publish the operator decision onto the event bus."""
+    """Validate the decision, durably flip the row, then wake the bus.
+
+    D-C2 fix: the operator decision is stamped onto the session row
+    (``resume_event_payload`` + ``parked_status='resumable'`` + the claim
+    lease re-armed) BEFORE the bus publish, so a decision is never lost when
+    the bus listener is down/reconnecting — LISTEN/NOTIFY is not durable but
+    the row is, and the claim loop admits ``resumable`` rows without any bus.
+    The publish that follows is a best-effort immediate wake only.
+    """
     blob = _approval_blob_or_404(sess, id_str)
     yielded: dict = blob.get("yielded") or {}
     original: dict = (yielded.get("resume_metadata") or {}).get("original_call") or {}
@@ -265,10 +278,21 @@ async def _publish_decision(
     event_key: str | None = yielded.get("event_key")
     if not event_key:
         raise NotFoundError(f"{id_str!r} park is missing event_key")
-    await event_bus.publish(
-        event_key,
-        {"decision": body.decision, "reason": body.reason},
+    payload = {"decision": body.decision, "reason": body.reason}
+    await durably_mark_session_resumable(
+        sess,
+        event_key=event_key,
+        payload=payload,
+        session_storage=session_storage,
+        engine=engine,
     )
+    try:
+        await event_bus.publish(event_key, payload)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "tool_approval decision publish failed for event_key=%r; durable "
+            "flip already persisted, claim loop will recover", event_key,
+        )
 
 
 def make_tool_approval_router() -> APIRouter:
@@ -340,6 +364,7 @@ def make_tool_approval_router() -> APIRouter:
         body: Annotated[ToolApprovalRespondBody, Body()],
         session_storage=Depends(get_session_storage),
         event_bus: EventBus = Depends(get_event_bus),
+        engine: ClaimEngine | None = Depends(get_claim_engine),
     ) -> dict[str, str]:
         sess = await session_storage.get(session_id)
         await _publish_decision(
@@ -347,6 +372,8 @@ def make_tool_approval_router() -> APIRouter:
             id_str=session_id,
             body=body,
             event_bus=event_bus,
+            session_storage=session_storage,
+            engine=engine,
         )
         return {"status": "accepted"}
 

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -553,50 +553,71 @@ async def create_workspace(
 
     live = await registry.materialise(template=template, overrides=overrides)
 
-    if mount_records:
-        manifest = await mm.load_manifest(live)
-        for cid, cname, dest, base in mount_records:
-            if not base:
-                # Zero-document collection: expand_collection produced no
-                # FileMounts, so materialise() never created dest on disk.
-                # Create it explicitly (mirrors the runtime create_mount
-                # path in workspace_mounts.py) so GET /mounts doesn't 500 /
-                # show a phantom dir with no backing directory. Only do
-                # this when base is empty -- for non-empty collections the
-                # dir already exists from materialise, and make_dir on an
-                # existing dir raises.
-                await live.make_dir(dest)
-                await live.write_file(f"{dest}/.gitkeep", b"")
-            manifest = mm.add_mount(
-                manifest,
-                mm.MountEntry(
-                    mount_id=f"wsmnt-{uuid.uuid4().hex[:12]}",
-                    collection_id=cid,
-                    collection_name=cname,
-                    dest=dest,
-                    mounted_at=datetime.now(timezone.utc),
-                    base=base,
-                ),
-            )
-        await mm.save_manifest(live, manifest)
+    # materialise() has now created a live container/volume, but the durable
+    # WorkspaceRow is written LAST. Any failure in the mount work or the
+    # row-write in between would orphan that live instance: the probe loop is
+    # row-driven and there is no orphan sweep, so it would leak silently
+    # (arch review D-I1). Wrap everything after materialise so a failure best-
+    # effort tears the live workspace back down before re-raising the original
+    # error unchanged.
+    try:
+        if mount_records:
+            manifest = await mm.load_manifest(live)
+            for cid, cname, dest, base in mount_records:
+                if not base:
+                    # Zero-document collection: expand_collection produced no
+                    # FileMounts, so materialise() never created dest on disk.
+                    # Create it explicitly (mirrors the runtime create_mount
+                    # path in workspace_mounts.py) so GET /mounts doesn't 500 /
+                    # show a phantom dir with no backing directory. Only do
+                    # this when base is empty -- for non-empty collections the
+                    # dir already exists from materialise, and make_dir on an
+                    # existing dir raises.
+                    await live.make_dir(dest)
+                    await live.write_file(f"{dest}/.gitkeep", b"")
+                manifest = mm.add_mount(
+                    manifest,
+                    mm.MountEntry(
+                        mount_id=f"wsmnt-{uuid.uuid4().hex[:12]}",
+                        collection_id=cid,
+                        collection_name=cname,
+                        dest=dest,
+                        mounted_at=datetime.now(timezone.utc),
+                        base=base,
+                    ),
+                )
+            await mm.save_manifest(live, manifest)
 
-    row_id = body.id if body.id is not None else live.id
-    # Mark the row "running" immediately — materialise() returned a live
-    # handle, so the workspace IS up. The probe loop transitions from
-    # running <-> failed thereafter; without this initial mark the row
-    # would sit at the default "pending" forever and the probe skips it.
-    row = WorkspaceRow(
-        id=row_id,
-        name=body.name,
-        template_id=body.template_id,
-        provider_id=template.provider_id,
-        overrides=body.overrides,
-        created_at=datetime.now(timezone.utc),
-        phase="running",
-        runtime_meta=live.runtime_meta,
-        reply_binding=body.reply_binding,
-    )
-    await workspace_storage.create(row)
+        row_id = body.id if body.id is not None else live.id
+        # Mark the row "running" immediately — materialise() returned a live
+        # handle, so the workspace IS up. The probe loop transitions from
+        # running <-> failed thereafter; without this initial mark the row
+        # would sit at the default "pending" forever and the probe skips it.
+        row = WorkspaceRow(
+            id=row_id,
+            name=body.name,
+            template_id=body.template_id,
+            provider_id=template.provider_id,
+            overrides=body.overrides,
+            created_at=datetime.now(timezone.utc),
+            phase="running",
+            runtime_meta=live.runtime_meta,
+            reply_binding=body.reply_binding,
+        )
+        await workspace_storage.create(row)
+    except Exception:
+        # registry.destroy() is row-driven and the row does not exist yet, so
+        # tear down the backend instance directly. Best-effort: never let a
+        # cleanup failure mask the original error.
+        try:
+            backend = await registry.get_backend(template.provider_id)
+            await backend.destroy(live.id)
+        except Exception:
+            logger.exception(
+                "create_workspace: failed to roll back orphaned live "
+                "workspace %s after a post-materialise error", live.id,
+            )
+        raise
     return row
 
 

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -605,7 +605,16 @@ async def create_workspace(
             reply_binding=body.reply_binding,
         )
         await workspace_storage.create(row)
-    except Exception:
+    except BaseException:
+        # BaseException, not Exception: asyncio.CancelledError has been a
+        # BaseException since 3.8, so `except Exception` would skip the
+        # teardown on the single most likely way this block is entered -- a
+        # client disconnect during the slow materialise()+mount work cancels
+        # the request task, which would orphan the very live instance this
+        # rollback exists to reclaim (arch review D-I1). The bare `raise`
+        # re-raises the original exception with its traceback intact and
+        # preserves CancelledError's cancellation semantics.
+        #
         # registry.destroy() is row-driven and the row does not exist yet, so
         # tear down the backend instance directly. Best-effort: never let a
         # cleanup failure mask the original error.

--- a/primer/api/routers/yields.py
+++ b/primer/api/routers/yields.py
@@ -41,7 +41,7 @@ from primer.model.except_ import (
     ValidationError,
 )
 from primer.model.workspace_session import WorkspaceSession
-from primer.session.yields import durably_mark_session_resumable
+from primer.session.yields import durably_wake_session
 from primer.worker.yield_runtime import make_cancelled_payload
 
 
@@ -132,18 +132,24 @@ async def _durable_wake(
     session_storage,
     engine: ClaimEngine | None,
     event_bus: EventBus,
-) -> None:
+) -> bool:
     """Durably flip the parked row to resumable, then wake the bus.
 
     D-C2 fix: the durable flip (stamp ``resume_event_payload`` +
     ``parked_status='resumable'`` + re-arm the claim lease) happens FIRST so a
-    reply is never lost when the bus listener is down/reconnecting — LISTEN/
+    reply is never lost when the bus listener is down/reconnecting - LISTEN/
     NOTIFY is not durable, but the session row is, and the claim loop admits
     ``resumable`` rows without any bus. The bus publish that follows is only a
     best-effort immediate wake: durability is already guaranteed, so a bus
     hiccup must not fail an otherwise-accepted reply.
+
+    Uses :func:`durably_wake_session`, which acts on the flip helper's bool:
+    a guard-rejected row that is already ``resumable`` gets its claim lease
+    re-armed, so a retry after a half-applied flip (row stamped, lease lost)
+    repairs the row instead of handing back a 202 for a session the claim
+    loop can never pick up. Returns True when this call advanced the row.
     """
-    await durably_mark_session_resumable(
+    did = await durably_wake_session(
         session,
         event_key=event_key,
         payload=payload,
@@ -157,6 +163,7 @@ async def _durable_wake(
             "ask_user resume publish failed for event_key=%r; durable flip "
             "already persisted, claim loop will recover", event_key,
         )
+    return did
 
 
 # ===========================================================================

--- a/primer/api/routers/yields.py
+++ b/primer/api/routers/yields.py
@@ -31,8 +31,9 @@ from typing import Annotated, Any
 from fastapi import APIRouter, Body, Depends, Path
 from pydantic import BaseModel, Field
 
-from primer.api.deps import get_event_bus, get_session_storage
+from primer.api.deps import get_claim_engine, get_event_bus, get_session_storage
 from primer.api.errors import common_responses
+from primer.int.claim import ClaimEngine
 from primer.int.event_bus import EventBus
 from primer.model.except_ import (
     ConflictError,
@@ -40,6 +41,7 @@ from primer.model.except_ import (
     ValidationError,
 )
 from primer.model.workspace_session import WorkspaceSession
+from primer.session.yields import durably_mark_session_resumable
 from primer.worker.yield_runtime import make_cancelled_payload
 
 
@@ -120,6 +122,41 @@ def _graph_ask_user_dispatch(
             continue
         return entry
     return None
+
+
+async def _durable_wake(
+    *,
+    session: WorkspaceSession,
+    event_key: str,
+    payload: dict[str, Any],
+    session_storage,
+    engine: ClaimEngine | None,
+    event_bus: EventBus,
+) -> None:
+    """Durably flip the parked row to resumable, then wake the bus.
+
+    D-C2 fix: the durable flip (stamp ``resume_event_payload`` +
+    ``parked_status='resumable'`` + re-arm the claim lease) happens FIRST so a
+    reply is never lost when the bus listener is down/reconnecting — LISTEN/
+    NOTIFY is not durable, but the session row is, and the claim loop admits
+    ``resumable`` rows without any bus. The bus publish that follows is only a
+    best-effort immediate wake: durability is already guaranteed, so a bus
+    hiccup must not fail an otherwise-accepted reply.
+    """
+    await durably_mark_session_resumable(
+        session,
+        event_key=event_key,
+        payload=payload,
+        session_storage=session_storage,
+        engine=engine,  # type: ignore[arg-type]
+    )
+    try:
+        await event_bus.publish(event_key, payload)
+    except Exception:  # noqa: BLE001
+        logger.exception(
+            "ask_user resume publish failed for event_key=%r; durable flip "
+            "already persisted, claim loop will recover", event_key,
+        )
 
 
 # ===========================================================================
@@ -259,6 +296,7 @@ async def post_ask_user_respond(
     body: AskUserRespondBody = Body(...),
     session_storage=Depends(get_session_storage),
     event_bus: EventBus = Depends(get_event_bus),
+    engine: ClaimEngine | None = Depends(get_claim_engine),
 ) -> dict[str, str]:
     sess = await _load_session_or_404(session_storage, session_id)
     blob = _parked_blob(sess)
@@ -290,7 +328,14 @@ async def post_ask_user_respond(
                 raise NotFoundError(
                     f"Session {session_id!r} agent yield is missing event_key"
                 )
-            await event_bus.publish(ay_event_key, {"response": body.response})
+            await _durable_wake(
+                session=sess,
+                event_key=ay_event_key,
+                payload={"response": body.response},
+                session_storage=session_storage,
+                engine=engine,
+                event_bus=event_bus,
+            )
             return {"status": "accepted"}
         # A graph tool_call ask_user node: its prompt + schema live in
         # pending_dispatch; the wake key is the matching pending_toolcalls
@@ -316,7 +361,14 @@ async def post_ask_user_respond(
             raise NotFoundError(
                 f"Session {session_id!r} tool_call yield is missing event_key"
             )
-        await event_bus.publish(tc_event_key, {"response": body.response})
+        await _durable_wake(
+            session=sess,
+            event_key=tc_event_key,
+            payload={"response": body.response},
+            session_storage=session_storage,
+            engine=engine,
+            event_bus=event_bus,
+        )
         return {"status": "accepted"}
     if yielded.get("tool_name") != "ask_user":
         raise NotFoundError(
@@ -338,7 +390,14 @@ async def post_ask_user_respond(
         raise NotFoundError(
             f"Session {session_id!r} park is missing event_key"
         )
-    await event_bus.publish(event_key, {"response": body.response})
+    await _durable_wake(
+        session=sess,
+        event_key=event_key,
+        payload={"response": body.response},
+        session_storage=session_storage,
+        engine=engine,
+        event_bus=event_bus,
+    )
     return {"status": "accepted"}
 
 

--- a/primer/bus/listener.py
+++ b/primer/bus/listener.py
@@ -18,10 +18,11 @@ from __future__ import annotations
 import asyncio
 import logging
 
-from primer.int.claim import ClaimEngine, ClaimKind
+from primer.int.claim import ClaimEngine
 from primer.int.event_bus import EventBus
 from primer.int.storage import Storage
 from primer.model.storage import FieldRef, OffsetPage, Op, Predicate, Value
+from primer.session.yields import durably_mark_session_resumable
 
 
 logger = logging.getLogger(__name__)
@@ -83,42 +84,27 @@ class YieldEventListener:
         """Flip the given parked rows to resumable, stamping the payload +
         the specific key that fired, and re-arming the engine lease.
 
-        Multi-event parks (``parked_event_keys`` set) ACCUMULATE replies
-        into ``parked_state['resume_event_payloads']`` (keyed by the fired
-        tool_call_id) and may be advanced even from ``resumable`` - so a
-        second concurrent reply that arrives before the worker has drained
-        the first is preserved rather than dropped or overwriting it. The
-        worker drains the whole map. Single-event parks are unchanged
-        (singular ``resume_event_payload``, only advanced from ``parked``).
+        Delegates the per-row guarded flip to the shared
+        :func:`primer.session.yields.durably_mark_session_resumable` so the
+        listener and the REST reply handlers (which now perform the same
+        durable flip inline — arch review D-C2) can never diverge. Multi-event
+        parks (``parked_event_keys`` set) ACCUMULATE replies into
+        ``parked_state['resume_event_payloads']`` (keyed by the fired
+        tool_call_id) and may be advanced even from ``resumable``; single-event
+        parks stamp the singular ``resume_event_payload`` and only advance from
+        ``parked``.
         """
         flipped = 0
-        fired_tcid = event.event_key.rsplit(":", 1)[-1]
         for sess in rows:
-            is_multi = bool(sess.parked_event_keys)
-            allowed = ("parked", "resumable") if is_multi else ("parked",)
-            if sess.parked_status not in allowed:
-                continue
-            state = dict(sess.parked_state or {})
-            # Singular fields: kept for the single-event resume path + as a
-            # back-compat "last fired" hint.
-            state["resume_event_payload"] = dict(event.payload or {})
-            state["resume_event_key"] = event.event_key
-            if is_multi:
-                payloads = dict(state.get("resume_event_payloads") or {})
-                payloads[fired_tcid] = {
-                    "payload": dict(event.payload or {}),
-                    "event_key": event.event_key,
-                }
-                state["resume_event_payloads"] = payloads
-            updated = sess.model_copy(update={
-                "parked_status": "resumable",
-                "parked_state": state,
-            })
-            await self._storage.update(updated)
-            # Re-arm the engine lease (park dropped it). mark_resumable
-            # upserts a fresh claimable lease when none exists.
-            await self._engine.mark_resumable(ClaimKind.SESSION, sess.id)
-            flipped += 1
+            did = await durably_mark_session_resumable(
+                sess,
+                event_key=event.event_key,
+                payload=event.payload,
+                session_storage=self._storage,
+                engine=self._engine,
+            )
+            if did:
+                flipped += 1
         return flipped
 
     async def _handle_event(self, event) -> None:

--- a/primer/bus/listener.py
+++ b/primer/bus/listener.py
@@ -87,7 +87,7 @@ class YieldEventListener:
         Delegates the per-row guarded flip to the shared
         :func:`primer.session.yields.durably_mark_session_resumable` so the
         listener and the REST reply handlers (which now perform the same
-        durable flip inline — arch review D-C2) can never diverge. Multi-event
+        durable flip inline - arch review D-C2) can never diverge. Multi-event
         parks (``parked_event_keys`` set) ACCUMULATE replies into
         ``parked_state['resume_event_payloads']`` (keyed by the fired
         tool_call_id) and may be advanced even from ``resumable``; single-event

--- a/primer/claim/in_memory.py
+++ b/primer/claim/in_memory.py
@@ -28,11 +28,22 @@ class _LeaseRow:
 
 
 class InMemoryClaimEngine(ClaimEngine):
-    def __init__(self, *, adapters: dict[ClaimKind, ClaimAdapter]) -> None:
+    def __init__(
+        self,
+        *,
+        adapters: dict[ClaimKind, ClaimAdapter],
+        lease_ttl_seconds: int = 60,
+    ) -> None:
         self._adapters = adapters
         self._leases: dict[tuple[ClaimKind, str], _LeaseRow] = {}
         self._wake = asyncio.Event()
         self._notify_queue: asyncio.Queue[tuple[ClaimKind, str]] = asyncio.Queue()
+        # How long a claimed lease is valid before it is considered expired
+        # and reclaimable. Defaults to 60s for a standalone engine; the worker
+        # pool overrides it from WorkerConfig.lease_ttl_seconds at start() so
+        # the lease_ttl >= 2*heartbeat validator actually governs the engine
+        # (arch review A-I1).
+        self.lease_ttl_seconds = lease_ttl_seconds
 
     async def upsert(
         self, kind: ClaimKind, entity_id: str, *, priority: int = 100,
@@ -55,8 +66,6 @@ class InMemoryClaimEngine(ClaimEngine):
     async def delete_lease(self, kind: ClaimKind, entity_id: str) -> None:
         self._leases.pop((kind, entity_id), None)
 
-    LEASE_TTL = timedelta(seconds=60)
-
     async def claim_due(self, worker_id: str, *, max_count: int) -> list[Lease]:
         _tracer = _tracing.get_tracer("primer.claim")
         with _tracer.start_as_current_span("claim.due") as _span:
@@ -75,7 +84,7 @@ class InMemoryClaimEngine(ClaimEngine):
                 row.claimed_by = worker_id
                 row.claimed_at = now
                 row.last_heartbeat_at = now
-                row.expires_at = now + self.LEASE_TTL
+                row.expires_at = now + timedelta(seconds=self.lease_ttl_seconds)
                 lease = Lease(
                     kind=row.kind, entity_id=row.entity_id, claimed_by=worker_id,
                     claimed_at=now, expires_at=row.expires_at,
@@ -98,7 +107,7 @@ class InMemoryClaimEngine(ClaimEngine):
             row = self._leases.get((kind, entity_id))
             if row is not None and row.claimed_by == worker_id:
                 row.last_heartbeat_at = now
-                row.expires_at = now + self.LEASE_TTL
+                row.expires_at = now + timedelta(seconds=self.lease_ttl_seconds)
                 confirmed.append((kind, entity_id))
         return confirmed
 

--- a/primer/claim/postgres.py
+++ b/primer/claim/postgres.py
@@ -75,10 +75,17 @@ class PostgresClaimEngine(ClaimEngine):
         *,
         storage_provider: Any,
         adapters: dict[ClaimKind, ClaimAdapter],
+        lease_ttl_seconds: int = 60,
     ) -> None:
         self._storage = storage_provider
         self._adapters = adapters
         self._table = storage_provider.leases_table
+        # Lease TTL (seconds) fed into the claim_due + heartbeat SQL intervals.
+        # Defaults to 60s for a standalone engine; the worker pool overrides it
+        # from WorkerConfig.lease_ttl_seconds at start() so the
+        # lease_ttl >= 2*heartbeat validator actually governs the engine
+        # (arch review A-I1).
+        self.lease_ttl_seconds = lease_ttl_seconds
         # Build once; claim_due uses it on every call.
         self._claim_query = build_claim_query(
             adapters,
@@ -201,7 +208,9 @@ class PostgresClaimEngine(ClaimEngine):
                     self._claim_query,
                     max_count,
                     worker_id,
-                    "60",  # TTL in seconds (string cast to interval)
+                    # TTL in seconds (string cast to interval in the query,
+                    # $3). Configured via WorkerConfig.lease_ttl_seconds.
+                    str(self.lease_ttl_seconds),
                 )
             leases = [
                 Lease(
@@ -252,12 +261,14 @@ class PostgresClaimEngine(ClaimEngine):
             rows = await conn.fetch(
                 f"UPDATE {self._table}"
                 f"   SET last_heartbeat_at = now(),"
-                f"       expires_at = now() + interval '60 seconds'"
+                # TTL parameterised ($4) so the refreshed expiry uses the
+                # configured lease_ttl_seconds, not a hardcoded 60s.
+                f"       expires_at = now() + ($4 || ' seconds')::interval"
                 f" WHERE (kind, entity_id) IN"
                 f"       (SELECT * FROM UNNEST($1::text[], $2::text[]))"
                 f"   AND claimed_by = $3"
                 f" RETURNING kind, entity_id",
-                kinds, ids, worker_id,
+                kinds, ids, worker_id, str(self.lease_ttl_seconds),
             )
         return [(ClaimKind(r["kind"]), r["entity_id"]) for r in rows]
 

--- a/primer/session/yields.py
+++ b/primer/session/yields.py
@@ -107,6 +107,59 @@ async def durably_mark_session_resumable(
     return True
 
 
+async def durably_wake_session(
+    session: WorkspaceSession,
+    *,
+    event_key: str,
+    payload: dict[str, Any] | None,
+    session_storage: "Storage[WorkspaceSession]",
+    engine: "ClaimEngine | None",
+) -> bool:
+    """Durable flip for the REST reply handlers, repairing a missing lease.
+
+    :func:`durably_mark_session_resumable` writes twice and the two writes
+    CANNOT share a transaction (``mark_resumable`` acquires its own
+    connection). So a crash between them leaves the row ``resumable`` with
+    NO lease row - and ``claim_due`` JOINs the leases table, which makes the
+    session permanently unclaimable. The reply handlers must not report the
+    reply accepted in that state.
+
+    This wrapper ACTS on the helper's return value instead of discarding it:
+    a False return on a row whose ``parked_status`` is already ``resumable``
+    is exactly the fingerprint of that half-applied flip (the guard only
+    admits ``parked`` for a single-event park), so re-drive
+    ``mark_resumable`` - an idempotent upsert - to re-create the lease the
+    first attempt lost. When the lease is already healthy the upsert is a
+    harmless no-op, which is the common case for an ordinary double-reply.
+
+    A raising ``storage.update`` still propagates untouched: the caller must
+    NOT report a reply accepted when the durable stamp never landed.
+
+    Returns the underlying helper's bool (True when this call advanced the
+    row, False when the guard rejected it).
+    """
+    did = await durably_mark_session_resumable(
+        session,
+        event_key=event_key,
+        payload=payload,
+        session_storage=session_storage,
+        engine=engine,
+    )
+    if did or engine is None:
+        return did
+    if session.parked_status != "resumable":
+        # Guard rejected for some other reason (not a half-applied flip);
+        # there is no lease to repair.
+        return did
+    logger.info(
+        "Repairing claim lease for session %s: the row is already "
+        "'resumable' but the durable flip may not have re-armed its lease",
+        session.id,
+    )
+    await engine.mark_resumable(ClaimKind.SESSION, session.id)
+    return did
+
+
 @dataclass
 class RespondToYieldDeps:
     """Collaborators :func:`respond_to_yield` needs.
@@ -209,5 +262,6 @@ async def respond_to_yield(
 __all__ = [
     "RespondToYieldDeps",
     "durably_mark_session_resumable",
+    "durably_wake_session",
     "respond_to_yield",
 ]

--- a/primer/session/yields.py
+++ b/primer/session/yields.py
@@ -58,7 +58,7 @@ async def durably_mark_session_resumable(
     shared by the bus listener (``primer.bus.listener.YieldEventListener``,
     which reacts to a bus NOTIFY) and the REST reply handlers (which now
     perform it durably so a listener outage cannot silently drop an operator
-    reply — see arch review D-C2).
+    reply - see arch review D-C2).
 
     Steps, mirroring the listener's original ``_flip_rows`` write exactly:
 

--- a/primer/session/yields.py
+++ b/primer/session/yields.py
@@ -30,13 +30,81 @@ from __future__ import annotations
 
 import logging
 from dataclasses import dataclass
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
+from primer.int.claim import ClaimKind
 from primer.model.except_ import NotFoundError
 from primer.model.workspace_session import WorkspaceSession
 
+if TYPE_CHECKING:
+    from primer.int.claim import ClaimEngine
+    from primer.int.storage import Storage
+
 
 logger = logging.getLogger(__name__)
+
+
+async def durably_mark_session_resumable(
+    session: WorkspaceSession,
+    *,
+    event_key: str,
+    payload: dict[str, Any] | None,
+    session_storage: "Storage[WorkspaceSession]",
+    engine: "ClaimEngine | None",
+) -> bool:
+    """Guarded, durable ``parked -> resumable`` flip for one session row.
+
+    This is the single source of truth for the park->resumable transition,
+    shared by the bus listener (``primer.bus.listener.YieldEventListener``,
+    which reacts to a bus NOTIFY) and the REST reply handlers (which now
+    perform it durably so a listener outage cannot silently drop an operator
+    reply — see arch review D-C2).
+
+    Steps, mirroring the listener's original ``_flip_rows`` write exactly:
+
+    * Stamp the singular ``resume_event_payload`` / ``resume_event_key`` (the
+      single-event resume path + a "last fired" hint).
+    * For a MULTI-event park (``parked_event_keys`` set) also accumulate
+      ``resume_event_payloads[fired_tcid]`` so a second concurrent reply is
+      preserved rather than overwritten.
+    * ``storage.update`` the flipped row.
+    * Re-arm the claim lease via ``engine.mark_resumable`` (park dropped it)
+      so the claim loop re-claims the row WITHOUT relying on any bus. When no
+      engine is wired (e.g. the lightweight test app) the durable storage
+      flip still lands; the lease re-arm is simply skipped.
+
+    Idempotency (the listener may also process the NOTIFY): a single-event
+    park only advances from ``parked``, so a second flip is a no-op; a
+    multi-event park may advance from ``resumable`` and re-accumulates the
+    same ``fired_tcid`` with identical data. Returns True when the row was
+    advanced/accumulated, False when the guard rejected it.
+    """
+    is_multi = bool(session.parked_event_keys)
+    allowed = ("parked", "resumable") if is_multi else ("parked",)
+    if session.parked_status not in allowed:
+        return False
+    state = dict(session.parked_state or {})
+    # Singular fields: the single-event resume path + a "last fired" hint.
+    state["resume_event_payload"] = dict(payload or {})
+    state["resume_event_key"] = event_key
+    if is_multi:
+        fired_tcid = event_key.rsplit(":", 1)[-1]
+        payloads = dict(state.get("resume_event_payloads") or {})
+        payloads[fired_tcid] = {
+            "payload": dict(payload or {}),
+            "event_key": event_key,
+        }
+        state["resume_event_payloads"] = payloads
+    updated = session.model_copy(update={
+        "parked_status": "resumable",
+        "parked_state": state,
+    })
+    await session_storage.update(updated)
+    # Re-arm the engine lease (park dropped it). mark_resumable upserts a
+    # fresh claimable lease when none exists.
+    if engine is not None:
+        await engine.mark_resumable(ClaimKind.SESSION, session.id)
+    return True
 
 
 @dataclass
@@ -138,4 +206,8 @@ async def respond_to_yield(
     await deps.event_bus.publish(event_key, payload)
 
 
-__all__ = ["RespondToYieldDeps", "respond_to_yield"]
+__all__ = [
+    "RespondToYieldDeps",
+    "durably_mark_session_resumable",
+    "respond_to_yield",
+]

--- a/primer/worker/pool.py
+++ b/primer/worker/pool.py
@@ -131,6 +131,16 @@ class WorkerPool:
             self._scheduler.lease_ttl_seconds = self.config.lease_ttl_seconds  # type: ignore[attr-defined]
         except AttributeError:
             pass
+        # Tell the claim engine our lease TTL too, so its claim/heartbeat SQL
+        # (postgres) and lease expiry (in-memory) use the configured interval
+        # rather than a hardcoded 60s -- this is what makes the
+        # lease_ttl >= 2*heartbeat validator actually govern the engine (arch
+        # review A-I1). The ClaimEngine ABC doesn't mandate the attribute, so
+        # guard it the same way as the scheduler push above.
+        try:
+            self._engine.lease_ttl_seconds = self.config.lease_ttl_seconds  # type: ignore[attr-defined]
+        except AttributeError:
+            pass
         await self._scheduler.register_worker(
             worker_id=self._worker_id,
             host=socket.gethostname(),

--- a/tests/api/test_config.py
+++ b/tests/api/test_config.py
@@ -10,7 +10,9 @@ import yaml
 from pydantic import ValidationError
 
 from primer.api.config import AppConfig
+from primer.model.except_ import ConfigError
 from primer.model.provider import (
+    PoolConfig,
     PostgresConfig,
     SqliteConfig,
     StorageProviderConfig,
@@ -18,6 +20,7 @@ from primer.model.provider import (
 )
 from primer.model.scheduler import (
     InMemorySchedulerConfig,
+    PostgresSchedulerConfig,
     RuntimeMode,
     SchedulerProviderConfig,
     SchedulerProviderType,
@@ -205,3 +208,68 @@ class TestConfigExampleYaml:
             f"Expected db.provider='postgres', got {cfg.db.provider!r}. "
             "Update config.example.yaml to use the correct nested db block."
         )
+
+
+class TestWorkerPoolHeadroom:
+    """AppConfig rejects a Postgres worker lane whose pool can't cover
+    worker concurrency + the fixed LISTEN-connection headroom (A-I2)."""
+
+    @staticmethod
+    def _pg_config(
+        *,
+        concurrency: int,
+        max_size: int,
+        scheduler_provider: SchedulerProviderType = SchedulerProviderType.POSTGRES,
+        runtime_mode: RuntimeMode = RuntimeMode.API_PLUS_WORKER,
+    ) -> AppConfig:
+        sched_cfg = (
+            PostgresSchedulerConfig()
+            if scheduler_provider == SchedulerProviderType.POSTGRES
+            else InMemorySchedulerConfig()
+        )
+        return AppConfig(
+            runtime_mode=runtime_mode,
+            db=StorageProviderConfig(
+                provider=StorageProviderType.POSTGRES,
+                config=PostgresConfig(
+                    hostname="h", username="u", password="p", database="d",
+                    pool=PoolConfig(max_size=max_size),
+                ),
+            ),
+            scheduler=SchedulerProviderConfig(
+                provider=scheduler_provider, config=sched_cfg,
+            ),
+            worker=WorkerConfig(concurrency=concurrency),
+        )
+
+    def test_accepts_default_concurrency_and_pool(self) -> None:
+        # Default 8 concurrency, default 25 pool: 8 + 8 headroom = 16 <= 25.
+        cfg = self._pg_config(concurrency=8, max_size=25)
+        assert cfg.worker.concurrency == 8
+        assert cfg.db.config.pool.max_size == 25  # type: ignore[union-attr]
+
+    def test_rejects_high_concurrency_over_small_pool(self) -> None:
+        with pytest.raises(ConfigError) as exc:
+            self._pg_config(concurrency=64, max_size=25)
+        msg = str(exc.value)
+        # Names both fields, the offending values, and the required minimum.
+        assert "max_size" in msg
+        assert "concurrency" in msg
+        assert "25" in msg and "64" in msg
+        assert "72" in msg  # 64 + 8 headroom
+
+    def test_skips_when_scheduler_is_in_memory(self) -> None:
+        # A Postgres db but in-memory scheduler/bus pins no per-turn LISTEN
+        # connection, so the headroom guard does not apply.
+        cfg = self._pg_config(
+            concurrency=64, max_size=25,
+            scheduler_provider=SchedulerProviderType.IN_MEMORY,
+        )
+        assert cfg.worker.concurrency == 64
+
+    def test_skips_when_api_only(self) -> None:
+        # No worker pool runs in api-only mode, so no pool pressure.
+        cfg = self._pg_config(
+            concurrency=64, max_size=25, runtime_mode=RuntimeMode.API,
+        )
+        assert cfg.runtime_mode == RuntimeMode.API

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -8,6 +8,7 @@ fake backend. That keeps the tests cheap and isolated.
 
 from __future__ import annotations
 
+import asyncio
 import base64
 from datetime import datetime, timezone
 from typing import Any
@@ -21,6 +22,7 @@ from primer.api.registries import (
     ProviderRegistry,
     WorkspaceRegistry,
 )
+from primer.api.routers.workspaces import WorkspaceCreateBody, create_workspace
 from primer.model.except_ import (
     BadRequestError,
     ConflictError,
@@ -849,6 +851,65 @@ class TestWorkspaceRouter:
         # The orphaned live workspace was torn down...
         assert destroyed, "backend.destroy was not called on rollback"
         # ...and the backend holds no leaked instance.
+        assert await backend.list() == []
+
+    @pytest.mark.asyncio
+    async def test_create_rolls_back_live_workspace_on_cancellation(
+        self, client, wsr, sp
+    ) -> None:
+        """A client disconnect during the slow post-materialise work cancels
+        the request task, raising asyncio.CancelledError -- a BaseException
+        since 3.8, so an ``except Exception`` rollback would skip the teardown
+        and orphan the live instance, which is exactly the D-I1 harm this
+        rollback exists to prevent. The teardown must run, and the
+        CancelledError must still propagate (never be swallowed).
+
+        The handler is driven directly rather than over ``client``: Starlette's
+        BaseHTTPMiddleware absorbs a CancelledError raised inside the app and
+        re-raises RuntimeError("No response returned."), which would hide the
+        very propagation this test pins down.
+        """
+        await client.post(
+            "/v1/workspace_providers", json=_provider().model_dump(mode="json")
+        )
+        await client.post(
+            "/v1/workspace_templates", json=_template().model_dump(mode="json")
+        )
+
+        backend = await wsr.get_backend("local-1")
+        destroyed: list[str] = []
+        original_destroy = backend.destroy
+
+        async def _spy_destroy(workspace_id):
+            destroyed.append(workspace_id)
+            await original_destroy(workspace_id)
+
+        backend.destroy = _spy_destroy  # type: ignore[assignment]
+
+        # Stand in for the request task being cancelled mid-flight, after
+        # materialise() has already brought a live workspace up.
+        row_storage = sp.get_storage(Workspace)
+
+        async def _cancelled(_row):
+            raise asyncio.CancelledError()
+
+        row_storage.create = _cancelled  # type: ignore[assignment]
+
+        # CancelledError still propagates: swallowing it would break
+        # cancellation and leave the caller hanging.
+        with pytest.raises(asyncio.CancelledError):
+            await create_workspace(
+                body=WorkspaceCreateBody(template_id="tpl-1"),
+                # Only read by the mounts branch, which this body doesn't take.
+                request=None,  # type: ignore[arg-type]
+                workspace_storage=row_storage,
+                template_storage=sp.get_storage(WorkspaceTemplate),
+                provider_storage=sp.get_storage(WorkspaceProvider),
+                registry=wsr,
+            )
+
+        # ...and the teardown ran anyway, so nothing leaked.
+        assert destroyed, "backend.destroy was not called on cancellation"
         assert await backend.list() == []
 
     @pytest.mark.asyncio

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -33,6 +33,7 @@ from pydantic import SecretStr
 from primer.model.workspace import (
     FileEntry,
     LocalWorkspaceConfig,
+    Workspace,
     WorkspaceProvider,
     WorkspaceProviderType,
     WorkspaceRuntimeMeta,
@@ -804,6 +805,51 @@ class TestWorkspaceRouter:
         assert delete.status_code == 204
         get2 = await client.get(f"/v1/workspaces/{wid}")
         assert get2.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_create_rolls_back_live_workspace_when_row_write_fails(
+        self, client, wsr, sp
+    ) -> None:
+        """A failure AFTER materialise() (here: the durable row-write, the
+        last step) must tear the just-created live workspace back down rather
+        than orphan it, and the original error must still surface (arch review
+        D-I1)."""
+        await client.post(
+            "/v1/workspace_providers", json=_provider().model_dump(mode="json")
+        )
+        await client.post(
+            "/v1/workspace_templates", json=_template().model_dump(mode="json")
+        )
+
+        backend = await wsr.get_backend("local-1")
+        destroyed: list[str] = []
+        original_destroy = backend.destroy
+
+        async def _spy_destroy(workspace_id):
+            destroyed.append(workspace_id)
+            await original_destroy(workspace_id)
+
+        backend.destroy = _spy_destroy  # type: ignore[assignment]
+
+        # Force the LAST step (the durable row-write) to fail, after
+        # materialise() has already brought a live workspace up.
+        row_storage = sp.get_storage(Workspace)
+
+        async def _boom(_row):
+            raise RuntimeError("storage down")
+
+        row_storage.create = _boom  # type: ignore[assignment]
+
+        # The original error still surfaces exactly as before the rollback
+        # was added: create_workspace re-raises it unchanged, so it
+        # propagates out of the ASGI app just as it did with no try/except.
+        with pytest.raises(RuntimeError, match="storage down"):
+            await client.post("/v1/workspaces", json={"template_id": "tpl-1"})
+
+        # The orphaned live workspace was torn down...
+        assert destroyed, "backend.destroy was not called on rollback"
+        # ...and the backend holds no leaked instance.
+        assert await backend.list() == []
 
     @pytest.mark.asyncio
     async def test_name_on_create_and_rename(self, client) -> None:

--- a/tests/api/test_yields_durable_flip.py
+++ b/tests/api/test_yields_durable_flip.py
@@ -20,12 +20,37 @@ from datetime import UTC, datetime, timedelta
 
 import pytest
 
+from primer.int.claim import ClaimKind
 from primer.model.workspace_session import (
     AgentSessionBinding,
     SessionStatus,
     WorkspaceSession,
 )
 from primer.session.yields import durably_mark_session_resumable
+
+
+class _FlakyEngine:
+    """Minimal ClaimEngine stand-in that records the leases it upserts.
+
+    ``mark_resumable`` raises on its first ``fail_times`` calls, reproducing
+    the non-atomic flip: ``storage.update`` lands (row -> ``resumable``) but
+    the lease re-arm blows up, leaving NO lease row. ``claim_due`` JOINs the
+    leases table, so such a row is permanently unclaimable.
+    """
+
+    def __init__(self, *, fail_times: int = 1) -> None:
+        self.fail_times = fail_times
+        self.calls: list[tuple[ClaimKind, str]] = []
+        self.leases: set[tuple[ClaimKind, str]] = set()
+
+    async def mark_resumable(
+        self, kind: ClaimKind, entity_id: str, *, priority: int = 50,
+    ) -> None:
+        self.calls.append((kind, entity_id))
+        if self.fail_times > 0:
+            self.fail_times -= 1
+            raise RuntimeError("lease upsert down")
+        self.leases.add((kind, entity_id))
 
 
 def _make_ask_user_parked_session(
@@ -205,3 +230,111 @@ async def test_second_listener_style_flip_is_idempotent(app, client):
     after = await storage.get("d-idem")
     assert after.parked_status == "resumable"
     assert after.parked_state["resume_event_payload"] == {"response": "first"}
+
+
+@pytest.mark.asyncio
+async def test_ask_user_retry_repairs_lease_lost_by_a_half_applied_flip(
+    app, client,
+):
+    """The durable flip writes twice and cannot share a transaction: a
+    ``mark_resumable`` that raises after ``storage.update`` landed leaves the
+    row ``resumable`` with NO lease, which ``claim_due``'s JOIN makes
+    permanently unclaimable.
+
+    The first reply must NOT be reported accepted in that state, and a client
+    retry must REPAIR the missing lease rather than 202 a session that will
+    never resume.
+    """
+    sess = _make_ask_user_parked_session(session_id="d-rep", tool_call_id="tcr")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+    engine = _FlakyEngine(fail_times=1)
+    app.state.claim_engine = engine
+
+    # 1st reply: storage.update lands, the lease re-arm raises. The error
+    # propagates -- the caller must NOT get a 202 for an unclaimable session.
+    with pytest.raises(RuntimeError, match="lease upsert down"):
+        await client.post(
+            "/v1/sessions/d-rep/ask_user/respond",
+            json={"tool_call_id": "tcr", "response": "Ada"},
+        )
+
+    # The row is stamped + resumable, but stranded: no lease exists.
+    row = await storage.get("d-rep")
+    assert row.parked_status == "resumable"
+    assert row.parked_state["resume_event_payload"] == {"response": "Ada"}
+    assert (ClaimKind.SESSION, "d-rep") not in engine.leases
+
+    # 2nd reply (client retry): the flip guard rejects the already-resumable
+    # row, but the handler now ACTS on that False and re-drives the
+    # idempotent mark_resumable, repairing the lease before returning 202.
+    resp = await client.post(
+        "/v1/sessions/d-rep/ask_user/respond",
+        json={"tool_call_id": "tcr", "response": "Ada"},
+    )
+    assert resp.status_code == 202
+    assert (ClaimKind.SESSION, "d-rep") in engine.leases
+
+    # The retry repaired the lease without corrupting the stamped reply.
+    after = await storage.get("d-rep")
+    assert after.parked_status == "resumable"
+    assert after.parked_state["resume_event_payload"] == {"response": "Ada"}
+
+
+@pytest.mark.asyncio
+async def test_tool_approval_retry_repairs_lease_lost_by_a_half_applied_flip(
+    app, client,
+):
+    """The tool_approval decision path shares the same non-atomic flip, so it
+    must repair a lost lease on retry too."""
+    sess = _make_approval_parked_session(
+        session_id="d-aprep", tool_call_id="call-r",
+    )
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+    engine = _FlakyEngine(fail_times=1)
+    app.state.claim_engine = engine
+
+    with pytest.raises(RuntimeError, match="lease upsert down"):
+        await client.post(
+            "/v1/sessions/d-aprep/tool_approval/respond",
+            json={"tool_call_id": "call-r", "decision": "approved"},
+        )
+
+    row = await storage.get("d-aprep")
+    assert row.parked_status == "resumable"
+    assert (ClaimKind.SESSION, "d-aprep") not in engine.leases
+
+    resp = await client.post(
+        "/v1/sessions/d-aprep/tool_approval/respond",
+        json={"tool_call_id": "call-r", "decision": "approved"},
+    )
+    assert resp.status_code == 202
+    assert (ClaimKind.SESSION, "d-aprep") in engine.leases
+
+
+@pytest.mark.asyncio
+async def test_healthy_double_reply_still_repairs_idempotently(app, client):
+    """The repair is an idempotent upsert, so an ordinary double-reply (lease
+    already healthy) stays a harmless no-op that still returns 202."""
+    sess = _make_ask_user_parked_session(session_id="d-2x", tool_call_id="tc2x")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+    engine = _FlakyEngine(fail_times=0)
+    app.state.claim_engine = engine
+
+    first = await client.post(
+        "/v1/sessions/d-2x/ask_user/respond",
+        json={"tool_call_id": "tc2x", "response": "one"},
+    )
+    assert first.status_code == 202
+    assert (ClaimKind.SESSION, "d-2x") in engine.leases
+
+    second = await client.post(
+        "/v1/sessions/d-2x/ask_user/respond",
+        json={"tool_call_id": "tc2x", "response": "two"},
+    )
+    assert second.status_code == 202
+    # The guard still protects the first reply's payload from being clobbered.
+    after = await storage.get("d-2x")
+    assert after.parked_state["resume_event_payload"] == {"response": "one"}

--- a/tests/api/test_yields_durable_flip.py
+++ b/tests/api/test_yields_durable_flip.py
@@ -1,0 +1,207 @@
+"""Durable resume-flip in the reply handlers (arch review D-C2).
+
+The ``ask_user`` and ``tool_approval`` respond endpoints used to be
+bus-only: they published the reply on the event bus and returned 202 with
+NO durable write. The durable ``parked -> resumable`` stamp happened only
+in the bus listener, so a reply that landed while the listener was
+down/reconnecting was permanently lost (LISTEN/NOTIFY is not durable) and
+the park later timed out "unanswered".
+
+These tests wire the app WITHOUT any :class:`YieldEventListener`, so the
+bus publish is a genuine no-op (nothing consumes it). If the handler still
+flips + stamps the row, the durability fix is doing its job. They also
+prove the flip survives a publish that raises (best-effort wake) and is
+idempotent under a second, listener-style flip.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+from primer.session.yields import durably_mark_session_resumable
+
+
+def _make_ask_user_parked_session(
+    *, session_id: str, tool_call_id: str,
+) -> WorkspaceSession:
+    now = datetime.now(UTC)
+    ek = f"ask_user:{session_id}:{tool_call_id}"
+    sess = WorkspaceSession(
+        id=session_id,
+        workspace_id="ws-x",
+        binding=AgentSessionBinding(kind="agent", agent_id="ag-x"),
+        status=SessionStatus.RUNNING,
+        created_at=now,
+    )
+    sess.parked_status = "parked"
+    sess.parked_event_key = ek
+    sess.parked_until = now + timedelta(seconds=600)
+    sess.parked_at = now
+    sess.parked_state = {
+        "schema_version": 1,
+        "tool_call_id": tool_call_id,
+        "yielded": {
+            "tool_name": "ask_user",
+            "event_key": ek,
+            "timeout": 600.0,
+            "resume_metadata": {
+                "prompt": "name?",
+                "response_schema": None,
+                "tool_call_id": tool_call_id,
+                "parked_at_iso": now.isoformat(),
+            },
+        },
+        "llm_messages": [],
+        "turn_no": 1,
+        "started_at": now.isoformat(),
+        "resume_event_payload": None,
+    }
+    return sess
+
+
+def _make_approval_parked_session(
+    *, session_id: str, tool_call_id: str,
+) -> WorkspaceSession:
+    now = datetime.now(UTC)
+    ek = f"tool_approval:{session_id}:{tool_call_id}"
+    return WorkspaceSession(
+        id=session_id,
+        workspace_id="ws",
+        binding=AgentSessionBinding(kind="agent", agent_id="agt"),
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        parked_status="parked",
+        parked_at=now,
+        parked_event_key=ek,
+        parked_state={
+            "tool_call_id": tool_call_id,
+            "yielded": {
+                "tool_name": "_approval",
+                "event_key": ek,
+                "resume_metadata": {
+                    "original_call": {
+                        "id": tool_call_id,
+                        "name": "delete_workspace",
+                        "arguments": {"id": "ws-x"},
+                    },
+                },
+            },
+            "parked_at_iso": now.isoformat(),
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_ask_user_respond_flips_row_without_listener(app, client):
+    """No listener is wired, so the bus publish is a no-op; the row must
+    still be flipped + stamped by the handler's own durable write."""
+    sess = _make_ask_user_parked_session(session_id="d-a1", tool_call_id="tc1")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.post(
+        "/v1/sessions/d-a1/ask_user/respond",
+        json={"tool_call_id": "tc1", "response": "Alice"},
+    )
+    assert resp.status_code == 202
+
+    row = await storage.get("d-a1")
+    assert row is not None
+    # Flipped durably by the handler, even though nothing consumed the bus.
+    assert row.parked_status == "resumable"
+    assert row.parked_state["resume_event_payload"] == {"response": "Alice"}
+    assert row.parked_state["resume_event_key"] == "ask_user:d-a1:tc1"
+
+
+@pytest.mark.asyncio
+async def test_ask_user_respond_flips_even_when_publish_raises(app, client):
+    """The bus publish is best-effort: a raising publish must not fail the
+    reply nor lose the durable flip."""
+    sess = _make_ask_user_parked_session(session_id="d-a2", tool_call_id="tc2")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    async def _boom(key, payload):  # noqa: ANN001
+        raise RuntimeError("bus down")
+
+    original = app.state.event_bus.publish
+    app.state.event_bus.publish = _boom
+    try:
+        resp = await client.post(
+            "/v1/sessions/d-a2/ask_user/respond",
+            json={"tool_call_id": "tc2", "response": "Bob"},
+        )
+        assert resp.status_code == 202
+    finally:
+        app.state.event_bus.publish = original
+
+    row = await storage.get("d-a2")
+    assert row is not None
+    assert row.parked_status == "resumable"
+    assert row.parked_state["resume_event_payload"] == {"response": "Bob"}
+
+
+@pytest.mark.asyncio
+async def test_tool_approval_respond_flips_row_without_listener(app, client):
+    """The tool_approval decision publisher must also stamp the row durably
+    before the (unconsumed) bus publish."""
+    sess = _make_approval_parked_session(
+        session_id="d-ap1", tool_call_id="call-1",
+    )
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.post(
+        "/v1/sessions/d-ap1/tool_approval/respond",
+        json={"tool_call_id": "call-1", "decision": "approved"},
+    )
+    assert resp.status_code == 202
+
+    row = await storage.get("d-ap1")
+    assert row is not None
+    assert row.parked_status == "resumable"
+    assert row.parked_state["resume_event_payload"] == {
+        "decision": "approved",
+        "reason": None,
+    }
+
+
+@pytest.mark.asyncio
+async def test_second_listener_style_flip_is_idempotent(app, client):
+    """After the handler's durable flip, a second (listener-style) flip of
+    the same single-event park is a guard-rejected no-op — it must not
+    corrupt the already-stamped payload."""
+    sess = _make_ask_user_parked_session(session_id="d-idem", tool_call_id="tcx")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.post(
+        "/v1/sessions/d-idem/ask_user/respond",
+        json={"tool_call_id": "tcx", "response": "first"},
+    )
+    assert resp.status_code == 202
+
+    row = await storage.get("d-idem")
+    assert row.parked_status == "resumable"
+    assert row.parked_state["resume_event_payload"] == {"response": "first"}
+
+    # Listener-style replay for the same key: the guard rejects a
+    # single-event park that is already resumable, so nothing changes.
+    did = await durably_mark_session_resumable(
+        row,
+        event_key="ask_user:d-idem:tcx",
+        payload={"response": "second"},
+        session_storage=storage,
+        engine=None,
+    )
+    assert did is False
+    after = await storage.get("d-idem")
+    assert after.parked_status == "resumable"
+    assert after.parked_state["resume_event_payload"] == {"response": "first"}

--- a/tests/api/test_yields_durable_flip.py
+++ b/tests/api/test_yields_durable_flip.py
@@ -201,7 +201,7 @@ async def test_tool_approval_respond_flips_row_without_listener(app, client):
 @pytest.mark.asyncio
 async def test_second_listener_style_flip_is_idempotent(app, client):
     """After the handler's durable flip, a second (listener-style) flip of
-    the same single-event park is a guard-rejected no-op — it must not
+    the same single-event park is a guard-rejected no-op - it must not
     corrupt the already-stamped payload."""
     sess = _make_ask_user_parked_session(session_id="d-idem", tool_call_id="tcx")
     storage = app.state.storage_provider.get_storage(WorkspaceSession)

--- a/tests/claim/test_in_memory_engine.py
+++ b/tests/claim/test_in_memory_engine.py
@@ -138,6 +138,43 @@ async def test_mark_resumable_lowers_priority_and_wakes():
 
 
 @pytest.mark.asyncio
+async def test_default_lease_ttl_is_60_seconds():
+    engine = InMemoryClaimEngine(adapters={})
+    assert engine.lease_ttl_seconds == 60
+    await engine.upsert(ClaimKind.CHAT, "c1")
+    before = datetime.now(UTC)
+    [lease] = await engine.claim_due("worker-A", max_count=1)
+    assert lease.expires_at is not None
+    assert lease.expires_at >= before + timedelta(seconds=59)
+
+
+@pytest.mark.asyncio
+async def test_claim_due_honors_custom_lease_ttl():
+    # A custom lease_ttl_seconds must drive the claimed lease's expiry
+    # (A-I1: the configured TTL now actually reaches the engine).
+    engine = InMemoryClaimEngine(adapters={}, lease_ttl_seconds=5)
+    await engine.upsert(ClaimKind.CHAT, "c1")
+    before = datetime.now(UTC)
+    [lease] = await engine.claim_due("worker-A", max_count=1)
+    after = datetime.now(UTC)
+    assert lease.expires_at is not None
+    assert before + timedelta(seconds=5) <= lease.expires_at <= after + timedelta(seconds=5)
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_honors_custom_lease_ttl():
+    engine = InMemoryClaimEngine(adapters={}, lease_ttl_seconds=5)
+    await engine.upsert(ClaimKind.CHAT, "c1")
+    await engine.claim_due("worker-A", max_count=1)
+    before = datetime.now(UTC)
+    await engine.heartbeat("worker-A", [(ClaimKind.CHAT, "c1")])
+    after = datetime.now(UTC)
+    exp = engine._leases[(ClaimKind.CHAT, "c1")].expires_at
+    assert exp is not None
+    assert before + timedelta(seconds=5) <= exp <= after + timedelta(seconds=5)
+
+
+@pytest.mark.asyncio
 async def test_watch_ready_yields_on_upsert():
     engine = InMemoryClaimEngine(adapters={})
     gen = engine.watch_ready()

--- a/tests/claim/test_postgres_engine.py
+++ b/tests/claim/test_postgres_engine.py
@@ -815,7 +815,7 @@ async def test_claim_due_on_fresh_schema_ensures_entity_tables(pg_storage):
 
 
 # ---------------------------------------------------------------------------
-# Lease-TTL threading — no live database (records the bound params)
+# Lease-TTL threading - no live database (records the bound params)
 # ---------------------------------------------------------------------------
 
 

--- a/tests/claim/test_postgres_engine.py
+++ b/tests/claim/test_postgres_engine.py
@@ -812,3 +812,85 @@ async def test_claim_due_on_fresh_schema_ensures_entity_tables(pg_storage):
         for t in ("chat", "harness", "trigger", "sessions"):
             reg = await conn.fetchval("SELECT to_regclass($1)", f"{schema}.{t}")
             assert reg is not None, f"entity table {t!r} was not ensured"
+
+
+# ---------------------------------------------------------------------------
+# Lease-TTL threading — no live database (records the bound params)
+# ---------------------------------------------------------------------------
+
+
+class _RecordingConn:
+    """Minimal asyncpg-conn stand-in that records fetch() calls."""
+
+    def __init__(self) -> None:
+        self.fetch_calls: list[tuple[str, tuple]] = []
+
+    async def fetch(self, query, *args):
+        self.fetch_calls.append((query, args))
+        return []
+
+    async def execute(self, query, *args):
+        return "OK"
+
+
+class _RecordingPool:
+    def __init__(self, conn: _RecordingConn) -> None:
+        self._conn = conn
+
+    def acquire(self):
+        conn = self._conn
+
+        class _Ctx:
+            async def __aenter__(self_inner):
+                return conn
+
+            async def __aexit__(self_inner, *exc):
+                return False
+
+        return _Ctx()
+
+
+class _RecordingSP:
+    def __init__(self, conn: _RecordingConn) -> None:
+        self.pool = _RecordingPool(conn)
+        self.leases_table = '"primer"."leases"'
+        self.schema = "primer"
+
+
+@pytest.mark.asyncio
+async def test_claim_due_binds_configured_lease_ttl():
+    # A-I1: the configured lease TTL must be the $3 interval passed to the
+    # claim query, not a hardcoded "60".
+    conn = _RecordingConn()
+    engine = PostgresClaimEngine(
+        storage_provider=_RecordingSP(conn), adapters={}, lease_ttl_seconds=15,
+    )
+    await engine.claim_due("worker-A", max_count=5)
+    assert conn.fetch_calls, "claim_due did not run a fetch"
+    _query, args = conn.fetch_calls[-1]
+    assert args == (5, "worker-A", "15")
+
+
+@pytest.mark.asyncio
+async def test_heartbeat_binds_configured_lease_ttl():
+    conn = _RecordingConn()
+    engine = PostgresClaimEngine(
+        storage_provider=_RecordingSP(conn), adapters={}, lease_ttl_seconds=15,
+    )
+    await engine.heartbeat("worker-A", [(ClaimKind.CHAT, "c1")])
+    assert conn.fetch_calls, "heartbeat did not run a fetch"
+    query, args = conn.fetch_calls[-1]
+    # TTL threaded as the last ($4) param; no hardcoded 60s literal remains.
+    assert args[-1] == "15"
+    assert "'60 seconds'" not in query
+    assert "$4" in query
+
+
+@pytest.mark.asyncio
+async def test_default_lease_ttl_is_60_seconds():
+    conn = _RecordingConn()
+    engine = PostgresClaimEngine(storage_provider=_RecordingSP(conn), adapters={})
+    assert engine.lease_ttl_seconds == 60
+    await engine.claim_due("worker-A", max_count=1)
+    _query, args = conn.fetch_calls[-1]
+    assert args[-1] == "60"

--- a/tests/claim/test_worker_pool_integration.py
+++ b/tests/claim/test_worker_pool_integration.py
@@ -263,3 +263,31 @@ async def test_engine_bus_loop_wakes_claim_loop_on_upsert():
     assert elapsed < 5.0, (
         f"dispatch took {elapsed:.2f}s — bus wakeup didn't work"
     )
+
+
+@pytest.mark.asyncio
+async def test_pool_pushes_lease_ttl_to_engine():
+    """The worker pool threads WorkerConfig.lease_ttl_seconds onto the claim
+    engine at start() so the lease_ttl >= 2*heartbeat validator actually
+    governs the engine, not a hardcoded 60s (A-I1)."""
+    engine = InMemoryClaimEngine(adapters={})
+    assert engine.lease_ttl_seconds == 60  # standalone default
+
+    pool = WorkerPool(
+        config=WorkerConfig(
+            concurrency=2,
+            heartbeat_interval_seconds=5,
+            lease_ttl_seconds=45,  # 45 >= 2 * 5, and != the 60s default
+            poll_interval_seconds=0.1,
+        ),
+        scheduler=_NullScheduler(),
+        storage=None,               # type: ignore[arg-type]
+        workspace_registry=None,    # type: ignore[arg-type]
+        provider_registry=None,     # type: ignore[arg-type]
+        engine=engine,
+    )
+    await pool.start()
+    try:
+        assert engine.lease_ttl_seconds == 45
+    finally:
+        await pool.drain_and_stop(timeout=2.0)


### PR DESCRIPTION
Fixes four findings from the platform architecture review (2026-07-17). Each was adversarially verified before any code was written, and each fix was reviewed afterwards - the review found two holes **in the fixes themselves**, which are fixed here.

## 1. A reply that arrived while the listener was down was lost forever

`ask_user` respond and the tool-approval decision were **bus-only publishes** with no durable write. The durable flip (stamp `resume_event_payload`, set `parked_status='resumable'`) happened only inside the bus listener. Postgres LISTEN/NOTIFY is not durable, so a reply arriving while the listener was down or reconnecting was dropped - and since parked rows are excluded from claim eligibility, the park later timed out as **"unanswered" despite a real answer existing**.

The handlers now perform the same durable flip themselves *before* returning, and the publish becomes a best-effort wake. The claim lane already admits `resumable` rows without the bus, so recovery no longer depends on a NOTIFY arriving.

The flip is idempotent (a single-event park only advances from `parked`, so the listener replaying the NOTIFY is a guard-rejected no-op), and a failing durable write propagates rather than returning 202 - it never accepts a reply it did not persist.

Review follow-up included here: the flip is two writes that cannot share a transaction (`mark_resumable` acquires its own connection). If the row update succeeded and the lease write failed, the session became `resumable` **with no lease** - permanently unclaimable - and the retry hit the guard, returned `False`, which the caller **ignored**, returning 202 for a session that would never resume. The caller now acts on that result and re-drives the idempotent lease upsert.

## 2. A failed workspace create orphaned a live container forever

`create_workspace` provisioned the backend before writing the DB row, with no rollback. Any failure after `materialise()` left a live container and volume with no row - and the startup probe is row-driven, so nothing ever reaped it.

Review follow-up included here: the first fix used `except Exception`, which does **not** catch `CancelledError` (a `BaseException`). A **client disconnect** during a slow materialise therefore still orphaned the workspace - exactly the harm the fix exists to prevent. Now `BaseException` with a bare `raise`; teardown stays best-effort so it cannot mask the original error.

## 3. Raising worker concurrency silently exhausted the connection pool

Every in-flight turn pins a dedicated Postgres LISTEN connection for its cancel-watcher, but `concurrency` (up to 128) was never validated against pool `max_size` (default 25). Past ~25 concurrent turns, turns block 30s on pool acquire and then fail - contention rather than graceful backpressure. A startup validator now rejects that configuration, naming both fields and the required headroom. Gated to the Postgres worker lane only.

## 4. The lease TTL config was silently ignored

Both claim engines hardcoded a 60s lease while `WorkerConfig.lease_ttl_seconds` only reached the legacy scheduler, making the `lease_ttl >= 2*heartbeat` validator vacuous for the engines.

This also fixes a real inconsistency: the pool already pushed 30s to the scheduler while the engines held 60s, and reclaim gates on the **leases** table - so the scheduler considered a worker dead at 30s while its lease survived to 60s.

**Release note:** at defaults the effective engine lease moves 60s -> 30s. This is safe (heartbeat is 10s, so 30s tolerates two missed beats and satisfies the project's own invariant), but stall tolerance narrows - three consecutive heartbeat failures now reach expiry instead of five. Operators can raise `lease_ttl_seconds` (cap 300).

## Known residuals (deliberately not fixed here)

- **The resume flip is still not atomic.** The repair covers a client retry; a half-applied flip whose client never retries stays stranded. Closing it properly needs a reconciliation sweep, or threading a connection through `mark_resumable` - an interface change.
- The **cancel** endpoint and the service-layer `respond_to_yield` still publish bus-only. Neither is a regression, the shared helper now exists so it is mechanical, and a lost cancel degrades gracefully (the park sweeper cancels anyway, which is the caller's intent).
- Multi-event parks with the listener down: two concurrent replies can each write from the same snapshot and lose one. Narrower than the bug fixed here, and still strictly better than bus-only, where both were lost.

## Testing

Each fix has a test proven RED before the fix. The lease-repair tests carry a **negative control** - disabling the repair makes them fail, so they cannot pass vacuously. Targeted named-file runs only (114 passed / 21 skipped; the skips are live-Postgres). The broad suite runs in CI.

Caveat: the `CancelledError` test drives the handler directly, because Starlette's `BaseHTTPMiddleware` absorbs `CancelledError` and re-raises `RuntimeError("No response returned.")`. The fix is sound (teardown runs before the exception escapes), but a true end-to-end disconnect test needs a live server.

Held: no merge, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
