### PR TITLE
fix: webhook deliveries lost on crash, boot chat scan, redundant auth COUNT

### DIFF
--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -28,6 +28,7 @@ from primer.api._app_lifespan_phases import (
     recover_chats,
     recover_ic_bootstrap,
     recover_sessions,
+    recover_webhook_deliveries,
     run_first_boot_bootstrap,
     sample_claim_queue_depth,
     seed_default_artifact_provider,
@@ -615,6 +616,22 @@ def _make_lifespan(config: AppConfig):
         # that match.
         if claim_engine is not None:
             await recover_chats(claim_engine, storage_provider)
+
+        # --- Webhook delivery recovery on startup --------------------------
+        # The webhook endpoint persists a pending WebhookDelivery row before
+        # its fire-and-forget BackgroundTask dispatches. A crash between the
+        # 202 and dispatch completion leaves the row 'pending' and the
+        # delivery lost (senders never retry a 202). Re-dispatch stale
+        # pending rows via the same _dispatch_webhook path. Runs regardless
+        # of claim_engine (fresh-session subs need it, but plain webhook
+        # subs do not); the dispatcher tolerates a None claim_engine.
+        await recover_webhook_deliveries(
+            storage_provider,
+            event_bus,
+            claim_engine,
+            scheduler,
+            workspace_registry,
+        )
 
         # --- Observability: claim queue-depth sampler ----------------------
         # Runs every 10s when the claim engine is Postgres-backed and

--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -625,13 +625,19 @@ def _make_lifespan(config: AppConfig):
         # pending rows via the same _dispatch_webhook path. Runs regardless
         # of claim_engine (fresh-session subs need it, but plain webhook
         # subs do not); the dispatcher tolerates a None claim_engine.
-        await recover_webhook_deliveries(
+        # The sweep is one-shot, so rows still inside the grace window when it
+        # runs would otherwise wait for the NEXT boot (possibly never). It
+        # hands back a single task that re-checks exactly those ids once they
+        # clear the window; we own it and cancel it on teardown so it cannot
+        # outlive the app.
+        _webhook_recheck_task = await recover_webhook_deliveries(
             storage_provider,
             event_bus,
             claim_engine,
             scheduler,
             workspace_registry,
         )
+        app.state.webhook_recovery_recheck_task = _webhook_recheck_task
 
         # --- Observability: claim queue-depth sampler ----------------------
         # Runs every 10s when the claim engine is Postgres-backed and
@@ -925,6 +931,19 @@ def _make_lifespan(config: AppConfig):
                         pass
                 except Exception:
                     logger.exception("claim_depth_task teardown failed")
+            # Sleeping until its grace-skipped ids clear the window. Anything
+            # it had not re-fired yet stays pending for the next boot's sweep.
+            if _webhook_recheck_task is not None:
+                try:
+                    _webhook_recheck_task.cancel()
+                    try:
+                        await _webhook_recheck_task
+                    except asyncio.CancelledError:
+                        pass
+                except Exception:
+                    logger.exception(
+                        "webhook_recheck_task teardown failed"
+                    )
             if event_bus is not None:
                 try:
                     await event_bus.aclose()

--- a/primer/api/_app_lifespan_phases.py
+++ b/primer/api/_app_lifespan_phases.py
@@ -261,7 +261,7 @@ async def recover_webhook_deliveries(
     ``_dispatch_webhook`` path.
 
     Idempotency: the ``fire_id`` gate in ``fire_trigger`` does NOT dedupe a
-    webhook re-fire — ``fire_trigger`` recomputes a fresh wall-clock
+    webhook re-fire - ``fire_trigger`` recomputes a fresh wall-clock
     ``fired_at`` for every webhook call (``scheduled_for=None``), so each
     dispatch derives a different ``fire_id`` and ``last_fired_id`` never
     matches. The durable ``WebhookDelivery.status`` IS the dedupe: only
@@ -294,7 +294,7 @@ async def recover_webhook_deliveries(
             )
             _items = list(_page.items)
             for _row in _items:
-                # Skip rows younger than the grace window — they may be an
+                # Skip rows younger than the grace window - they may be an
                 # in-flight dispatch from THIS process's early startup.
                 if _row.created_at.timestamp() > _cutoff:
                     continue
@@ -320,7 +320,7 @@ async def recover_webhook_deliveries(
             _offset += 200
         if _refired:
             logger.info(
-                "lifespan: webhook recovery — re-dispatched %d stale "
+                "lifespan: webhook recovery - re-dispatched %d stale "
                 "pending delivery(ies) from persisted state", _refired,
             )
     except Exception:  # noqa: BLE001 -- never break startup

--- a/primer/api/_app_lifespan_phases.py
+++ b/primer/api/_app_lifespan_phases.py
@@ -258,10 +258,22 @@ async def recover_chats(claim_engine, storage_provider) -> None:
 # the claim machine (primer/claim/) so exactly one process owns each delivery,
 # which needs a new ClaimKind + adapter + a consumer loop that heartbeats
 # through a long dispatch; that is a follow-up, not a constant. Meanwhile the
-# default is raised well clear of a typical dispatch. A larger value only
-# delays recovery of a genuinely dropped delivery (already bounded by the boot
-# cadence), so prefer one on deployments with slow fresh-session dispatches or
-# long rolling-deploy drains.
+# default is raised well clear of a typical dispatch.
+#
+# THE TRADE (read this before changing the value): the boot sweep is ONE-SHOT.
+# A row still inside the grace band when the sweep runs is NOT re-fired by that
+# pass, and nothing re-runs the sweep - so such a row is not "bounded by the
+# boot cadence": on a stable deployment the next boot may be weeks away, or
+# never. To make the bound real, recover_webhook_deliveries schedules a single
+# delayed re-check of the ids it grace-skipped, which fires once the youngest
+# of them clears the window. Recovery latency for a dropped delivery is
+# therefore at most this window (re-check) rather than unbounded (next boot),
+# and the value is a straight duplicate-suppression-vs-recovery-latency trade:
+# larger suppresses more spurious re-fires of a live sibling's slow dispatch
+# and defers a genuinely dropped delivery by up to that long. Raise it on
+# deployments with slow fresh-session dispatches or long rolling-deploy drains;
+# if the re-check task is lost (process exits before it fires) the row falls
+# back to the next boot's sweep.
 _WEBHOOK_DELIVERY_GRACE_SECS = float(
     os.environ.get("PRIMER_WEBHOOK_RECOVERY_GRACE_SECS", "300")
 )
@@ -384,13 +396,65 @@ async def _dispatch_recovered_deliveries(
     return _refired
 
 
-async def recover_webhook_deliveries(
+async def _recheck_grace_skipped_deliveries(
+    _ids: list[str],
+    _delay: float,
+    _storage,
     storage_provider,
     event_bus,
     claim_engine,
     scheduler,
     workspace_registry,
 ) -> None:
+    """Re-check deliveries the boot sweep skipped for the grace window.
+
+    The sweep is one-shot, so without this a row younger than the cutoff at
+    boot is never revisited by this process and waits for the NEXT boot -
+    which on a stable deployment may never come. Sleeping until the youngest
+    skipped row clears the window turns the grace into a genuine upper bound
+    on recovery latency.
+
+    One sleep and one pass, not a poll: every id is past the window by the
+    time this runs, so there is nothing left to wait for afterwards. The task
+    is owned and cancelled by the lifespan, so it cannot outlive the app.
+    """
+    from datetime import datetime, timezone as _tz
+
+    try:
+        await asyncio.sleep(_delay)
+        # Recompute against the clock we woke on, not the sweep's cutoff.
+        _cutoff = (
+            datetime.now(_tz.utc).timestamp() - _WEBHOOK_DELIVERY_GRACE_SECS
+        )
+        _refired = await _dispatch_recovered_deliveries(
+            _ids,
+            _storage,
+            _cutoff,
+            storage_provider,
+            event_bus,
+            claim_engine,
+            scheduler,
+            workspace_registry,
+        )
+        if _refired:
+            logger.info(
+                "lifespan: webhook recovery - re-dispatched %d delivery(ies) "
+                "that were inside the grace window at boot", _refired,
+            )
+    except asyncio.CancelledError:
+        # Shutdown. Anything still pending falls to the next boot's sweep.
+        raise
+    except Exception:  # noqa: BLE001 -- a background task must not die loudly
+        logger.exception("lifespan: webhook grace re-check failed")
+
+
+async def recover_webhook_deliveries(
+    storage_provider,
+    event_bus,
+    claim_engine,
+    scheduler,
+    workspace_registry,
+) -> asyncio.Task | None:
     """Re-dispatch inbound webhook deliveries the previous process dropped.
 
     The webhook endpoint persists a ``WebhookDelivery`` row (status
@@ -415,6 +479,13 @@ async def recover_webhook_deliveries(
     process, or its done/failed marking keeps failing) is abandoned at
     ``_WEBHOOK_DELIVERY_MAX_ATTEMPTS`` and marked ``failed`` rather than
     re-fired on every boot forever.
+
+    Rows still inside the grace window when the sweep runs are not re-fired
+    by this one-shot pass. Returns a single ``asyncio.Task`` that re-checks
+    exactly those ids once they clear the window (``None`` when there are
+    none). The caller OWNS that task and must cancel it on shutdown, so the
+    grace is a real bound on recovery latency rather than a deferral to the
+    next boot.
     """
     try:
         from datetime import datetime, timezone as _tz
@@ -450,6 +521,11 @@ async def recover_webhook_deliveries(
         # OOM in the mass-crash case. _dispatch_recovered_deliveries re-reads
         # each id right before dispatching it.
         _stale_ids: list[str] = []
+        # Ids skipped for the grace window, plus the wall-clock instant the
+        # youngest of them clears it. The re-check task below waits for that
+        # instant, so one pass suffices for all of them.
+        _grace_ids: list[str] = []
+        _grace_deadline = 0.0
         _offset = 0
         while True:
             _page = await _storage.find(
@@ -457,12 +533,19 @@ async def recover_webhook_deliveries(
                 _OffsetPage(offset=_offset, length=_WEBHOOK_RECOVERY_PAGE_SIZE),
             )
             _items = list(_page.items)
-            # Skip rows younger than the grace window - they may be an
-            # in-flight dispatch from a live process.
-            _stale_ids.extend(
-                _row.id for _row in _items
-                if _row.created_at.timestamp() <= _cutoff
-            )
+            for _row in _items:
+                _created = _row.created_at.timestamp()
+                if _created <= _cutoff:
+                    _stale_ids.append(_row.id)
+                else:
+                    # Younger than the grace window - it may be a live
+                    # process's in-flight dispatch, so leave it to the
+                    # re-check rather than racing it now.
+                    _grace_ids.append(_row.id)
+                    _grace_deadline = max(
+                        _grace_deadline,
+                        _created + _WEBHOOK_DELIVERY_GRACE_SECS,
+                    )
             # Advance on the UNFILTERED page length: the grace filter above is
             # applied in Python, so a page can be wholly grace-skipped while
             # more pages remain. Terminating on the filtered count would end
@@ -487,8 +570,39 @@ async def recover_webhook_deliveries(
                 "lifespan: webhook recovery - re-dispatched %d stale "
                 "pending delivery(ies) from persisted state", _refired,
             )
+
+        if not _grace_ids:
+            return None
+        # Wait only until the YOUNGEST grace-skipped row clears the window;
+        # every older one has cleared it by then, so a single pass drains the
+        # set and the task ends. Clamped to the window: a row dated in the
+        # future (clock skew) must not stretch the wait past it, and a
+        # deadline already in the past means fire straight away.
+        _delay = min(
+            max(_grace_deadline - datetime.now(_tz.utc).timestamp(), 0.0),
+            _WEBHOOK_DELIVERY_GRACE_SECS,
+        )
+        logger.info(
+            "lifespan: webhook recovery - %d pending delivery(ies) are inside "
+            "the %.0fs grace window; re-checking them in %.0fs",
+            len(_grace_ids), _WEBHOOK_DELIVERY_GRACE_SECS, _delay,
+        )
+        return asyncio.create_task(
+            _recheck_grace_skipped_deliveries(
+                _grace_ids,
+                _delay,
+                _storage,
+                storage_provider,
+                event_bus,
+                claim_engine,
+                scheduler,
+                workspace_registry,
+            ),
+            name="webhook-recovery-grace-recheck",
+        )
     except Exception:  # noqa: BLE001 -- never break startup
         logger.exception("lifespan: webhook recovery failed")
+        return None
 
 
 async def recover_ic_bootstrap(storage_provider) -> None:

--- a/primer/api/_app_lifespan_phases.py
+++ b/primer/api/_app_lifespan_phases.py
@@ -274,9 +274,32 @@ async def recover_chats(claim_engine, storage_provider) -> None:
 # deployments with slow fresh-session dispatches or long rolling-deploy drains;
 # if the re-check task is lost (process exits before it fires) the row falls
 # back to the next boot's sweep.
-_WEBHOOK_DELIVERY_GRACE_SECS = float(
-    os.environ.get("PRIMER_WEBHOOK_RECOVERY_GRACE_SECS", "300")
-)
+_WEBHOOK_DELIVERY_GRACE_SECS_DEFAULT = 300.0
+
+
+def _read_webhook_grace_secs() -> float:
+    """Parse the grace override, falling back to the default.
+
+    This runs at IMPORT time, so an unparseable value must not raise: a
+    typo'd PRIMER_WEBHOOK_RECOVERY_GRACE_SECS would otherwise propagate out
+    of the import and take the whole API down at boot. A bad override is an
+    operator mistake worth shouting about, not a reason to refuse to start.
+    """
+    _raw = os.environ.get("PRIMER_WEBHOOK_RECOVERY_GRACE_SECS")
+    if _raw is None:
+        return _WEBHOOK_DELIVERY_GRACE_SECS_DEFAULT
+    try:
+        return float(_raw)
+    except (TypeError, ValueError):
+        logger.warning(
+            "PRIMER_WEBHOOK_RECOVERY_GRACE_SECS=%r is not a number; "
+            "falling back to the %.0fs default",
+            _raw, _WEBHOOK_DELIVERY_GRACE_SECS_DEFAULT,
+        )
+        return _WEBHOOK_DELIVERY_GRACE_SECS_DEFAULT
+
+
+_WEBHOOK_DELIVERY_GRACE_SECS = _read_webhook_grace_secs()
 
 # Page size for the recovery sweep's scan of pending rows. Bounded by the
 # OffsetPage contract (length is 1..200).

--- a/primer/api/_app_lifespan_phases.py
+++ b/primer/api/_app_lifespan_phases.py
@@ -246,6 +246,15 @@ _WEBHOOK_DELIVERY_GRACE_SECS = 30.0
 # OffsetPage contract (length is 1..200).
 _WEBHOOK_RECOVERY_PAGE_SIZE = 200
 
+# Poison-pill cap: give up on a delivery after this many dispatch attempts.
+# WebhookDelivery.attempts counts attempts STARTED (the endpoint records its
+# own BackgroundTask as attempt 1; the sweep below bumps the count BEFORE
+# re-dispatching), so a row whose dispatch hard-crashes the process, or whose
+# done/failed marking keeps failing, still advances the counter. Without the
+# cap such a row is re-fired on EVERY subsequent boot forever, each time
+# spawning duplicate chats/sessions. 3 leaves room for two crash recoveries.
+_WEBHOOK_DELIVERY_MAX_ATTEMPTS = 3
+
 
 async def recover_webhook_deliveries(
     storage_provider,
@@ -273,6 +282,11 @@ async def recover_webhook_deliveries(
     ``done``/``failed``, so a ``done`` row is never re-dispatched. Delivery
     is therefore at-least-once (a crash in the delivered-but-not-yet-marked
     window can double-deliver), matching the endpoint's best-effort marking.
+
+    A row that survives repeated re-fires (its dispatch keeps killing the
+    process, or its done/failed marking keeps failing) is abandoned at
+    ``_WEBHOOK_DELIVERY_MAX_ATTEMPTS`` and marked ``failed`` rather than
+    re-fired on every boot forever.
     """
     try:
         from datetime import datetime, timezone as _tz
@@ -322,6 +336,43 @@ async def recover_webhook_deliveries(
 
         _refired = 0
         for _row in _stale:
+            # Poison-pill cap: a row that keeps coming back (its dispatch
+            # kills the process, or _finalize_delivery's update keeps failing
+            # and is swallowed) must not be re-fired forever. Give up loudly.
+            if _row.attempts >= _WEBHOOK_DELIVERY_MAX_ATTEMPTS:
+                logger.error(
+                    "webhook recovery: delivery %s exhausted %d attempts; "
+                    "marking failed and giving up",
+                    _row.id, _row.attempts,
+                )
+                try:
+                    await _storage.update(_row.model_copy(update={
+                        "status": "failed",
+                        "completed_at": datetime.now(_tz.utc),
+                    }))
+                except Exception:
+                    logger.exception(
+                        "webhook recovery: could not mark exhausted delivery "
+                        "%s failed", _row.id,
+                    )
+                continue
+            # Record the attempt BEFORE dispatching. Counting it afterwards
+            # would never count the cases the cap exists for: a dispatch that
+            # hard-crashes the process, or a finalize that keeps failing,
+            # never reaches a post-hoc increment.
+            try:
+                _row = await _storage.update(
+                    _row.model_copy(update={"attempts": _row.attempts + 1})
+                )
+            except Exception:
+                # Cannot account for this attempt, so do not take it: firing
+                # uncounted is exactly the unbounded re-fire the cap removes.
+                # The row stays pending and a later boot can retry it.
+                logger.exception(
+                    "webhook recovery: could not record an attempt for %s; "
+                    "skipping it this sweep", _row.id,
+                )
+                continue
             try:
                 await _dispatch_webhook(
                     _row.trigger_id,

--- a/primer/api/_app_lifespan_phases.py
+++ b/primer/api/_app_lifespan_phases.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from pathlib import Path
 
 from primer.api.config import AppConfig
@@ -240,7 +241,30 @@ async def recover_chats(claim_engine, storage_provider) -> None:
         logger.exception("lifespan: chat recovery failed")
 
 
-_WEBHOOK_DELIVERY_GRACE_SECS = 30.0
+# Grace window: only pending rows OLDER than this are re-fired. It is the only
+# thing separating a re-fire from a live sibling's in-flight dispatch.
+#
+# MULTI-PROCESS RE-FIRE HAZARD (known, bounded, NOT eliminated): every API
+# process runs this phase on boot and takes no claim or lock on a delivery. On
+# a rolling deploy the booting replica re-fires the draining replica's still
+# pending rows whenever their dispatch outlives this window - and an
+# agent_fresh_session dispatch (workspace + session creation) plausibly exceeds
+# the old 30s default. Unlike recover_sessions / recover_chats, whose
+# idempotent lease re-arms are harmless to repeat, this phase has real external
+# side effects (it spawns chats/sessions), so a spurious re-fire is a duplicate
+# delivery rather than a no-op.
+#
+# A window only NARROWS that race. Closing it means routing recovery through
+# the claim machine (primer/claim/) so exactly one process owns each delivery,
+# which needs a new ClaimKind + adapter + a consumer loop that heartbeats
+# through a long dispatch; that is a follow-up, not a constant. Meanwhile the
+# default is raised well clear of a typical dispatch. A larger value only
+# delays recovery of a genuinely dropped delivery (already bounded by the boot
+# cadence), so prefer one on deployments with slow fresh-session dispatches or
+# long rolling-deploy drains.
+_WEBHOOK_DELIVERY_GRACE_SECS = float(
+    os.environ.get("PRIMER_WEBHOOK_RECOVERY_GRACE_SECS", "300")
+)
 
 # Page size for the recovery sweep's scan of pending rows. Bounded by the
 # OffsetPage contract (length is 1..200).

--- a/primer/api/_app_lifespan_phases.py
+++ b/primer/api/_app_lifespan_phases.py
@@ -242,6 +242,10 @@ async def recover_chats(claim_engine, storage_provider) -> None:
 
 _WEBHOOK_DELIVERY_GRACE_SECS = 30.0
 
+# Page size for the recovery sweep's scan of pending rows. Bounded by the
+# OffsetPage contract (length is 1..200).
+_WEBHOOK_RECOVERY_PAGE_SIZE = 200
+
 
 async def recover_webhook_deliveries(
     storage_provider,
@@ -285,39 +289,56 @@ async def recover_webhook_deliveries(
             _Q(WebhookDelivery).where("status", "pending").build()
         )
         _cutoff = datetime.now(_tz.utc).timestamp() - _WEBHOOK_DELIVERY_GRACE_SECS
-        _refired = 0
+
+        # Collect the whole stale set BEFORE dispatching any of it.
+        # _dispatch_webhook flips its row 'pending' -> 'done'/'failed', which
+        # MUTATES the very predicate this query pages over. Dispatching inside
+        # the paging loop therefore shrinks the result set under the cursor and
+        # silently skips rows: with 500 stale rows, offset=0 drains 1-200 and
+        # marks them done, leaving 201-500 as the pending set, so the next read
+        # at offset=200 returns 401-500 and rows 201-400 are never dispatched
+        # (they stay pending until some future boot) - worst exactly in the
+        # mass-crash case this phase exists for. Collecting first keeps the
+        # paging stable over an unchanging set, and is simpler to reason about
+        # than re-querying offset=0 until drained while tracking grace-skipped
+        # ids to keep a fresh row from looping forever.
+        _stale: list[WebhookDelivery] = []
         _offset = 0
         while True:
             _page = await _storage.find(
                 _pending_predicate,
-                _OffsetPage(offset=_offset, length=200),
+                _OffsetPage(offset=_offset, length=_WEBHOOK_RECOVERY_PAGE_SIZE),
             )
             _items = list(_page.items)
-            for _row in _items:
-                # Skip rows younger than the grace window - they may be an
-                # in-flight dispatch from THIS process's early startup.
-                if _row.created_at.timestamp() > _cutoff:
-                    continue
-                try:
-                    await _dispatch_webhook(
-                        _row.trigger_id,
-                        _row.extra_context,
-                        storage_provider,
-                        event_bus,
-                        claim_engine,
-                        scheduler,
-                        workspace_registry,
-                        delivery_id=_row.id,
-                    )
-                    _refired += 1
-                except Exception:
-                    logger.exception(
-                        "webhook recovery: re-dispatch failed for %s",
-                        _row.id,
-                    )
-            if len(_items) < 200:
+            # Skip rows younger than the grace window - they may be an
+            # in-flight dispatch from a live process.
+            _stale.extend(
+                _row for _row in _items
+                if _row.created_at.timestamp() <= _cutoff
+            )
+            if len(_items) < _WEBHOOK_RECOVERY_PAGE_SIZE:
                 break
-            _offset += 200
+            _offset += _WEBHOOK_RECOVERY_PAGE_SIZE
+
+        _refired = 0
+        for _row in _stale:
+            try:
+                await _dispatch_webhook(
+                    _row.trigger_id,
+                    _row.extra_context,
+                    storage_provider,
+                    event_bus,
+                    claim_engine,
+                    scheduler,
+                    workspace_registry,
+                    delivery_id=_row.id,
+                )
+                _refired += 1
+            except Exception:
+                logger.exception(
+                    "webhook recovery: re-dispatch failed for %s",
+                    _row.id,
+                )
         if _refired:
             logger.info(
                 "lifespan: webhook recovery - re-dispatched %d stale "

--- a/primer/api/_app_lifespan_phases.py
+++ b/primer/api/_app_lifespan_phases.py
@@ -195,22 +195,31 @@ async def recover_chats(claim_engine, storage_provider) -> None:
         from primer.int.claim import ClaimKind as _ClaimKind
         from primer.model.chats import Chat as _Chat
         from primer.model.storage import OffsetPage as _OffsetPage
+        from primer.storage.q import Q as _Q
 
         _chats_storage = storage_provider.get_storage(_Chat)
+        # Push the eligibility filter into the query (mirrors session
+        # recovery above) instead of list()-ing every chat and dropping
+        # non-matching rows in Python: at scale that loads the entire chat
+        # history into memory. ChatClaimAdapter only accepts rows with
+        # status='active' AND turn_status in {claimable, running}, so we
+        # re-arm exactly those. The new chat.(status,turn_status) B-tree
+        # index keeps the scan cheap.
+        _chat_predicate = (
+            _Q(_Chat)
+            .where("status", "active")
+            .where_in("turn_status", ["claimable", "running"])
+            .build()
+        )
         _recovered_chats = 0
         _chat_offset = 0
         while True:
-            _page = await _chats_storage.list(
-                _OffsetPage(offset=_chat_offset, length=200)
+            _page = await _chats_storage.find(
+                _chat_predicate,
+                _OffsetPage(offset=_chat_offset, length=200),
             )
             _items = list(_page.items)
             for _chat in _items:
-                # Skip anything the adapter wouldn't accept.
-                if getattr(_chat, "status", None) != "active":
-                    continue
-                _ts = getattr(_chat, "turn_status", None)
-                if _ts not in ("claimable", "running"):
-                    continue
                 try:
                     await claim_engine.upsert(_ClaimKind.CHAT, _chat.id)
                     _recovered_chats += 1

--- a/primer/api/_app_lifespan_phases.py
+++ b/primer/api/_app_lifespan_phases.py
@@ -240,6 +240,93 @@ async def recover_chats(claim_engine, storage_provider) -> None:
         logger.exception("lifespan: chat recovery failed")
 
 
+_WEBHOOK_DELIVERY_GRACE_SECS = 30.0
+
+
+async def recover_webhook_deliveries(
+    storage_provider,
+    event_bus,
+    claim_engine,
+    scheduler,
+    workspace_registry,
+) -> None:
+    """Re-dispatch inbound webhook deliveries the previous process dropped.
+
+    The webhook endpoint persists a ``WebhookDelivery`` row (status
+    ``pending``) BEFORE returning 202 and BEFORE its in-process
+    ``BackgroundTask`` dispatches the trigger. If the process died between
+    the 202 and dispatch completion the row stays ``pending`` forever and
+    the delivery is lost (senders never retry a 202). Scan for ``pending``
+    rows older than a small grace window and re-run the SAME
+    ``_dispatch_webhook`` path.
+
+    Idempotency: the ``fire_id`` gate in ``fire_trigger`` does NOT dedupe a
+    webhook re-fire — ``fire_trigger`` recomputes a fresh wall-clock
+    ``fired_at`` for every webhook call (``scheduled_for=None``), so each
+    dispatch derives a different ``fire_id`` and ``last_fired_id`` never
+    matches. The durable ``WebhookDelivery.status`` IS the dedupe: only
+    ``pending`` rows are re-fired and ``_dispatch_webhook`` flips the row to
+    ``done``/``failed``, so a ``done`` row is never re-dispatched. Delivery
+    is therefore at-least-once (a crash in the delivered-but-not-yet-marked
+    window can double-deliver), matching the endpoint's best-effort marking.
+    """
+    try:
+        from datetime import datetime, timezone as _tz
+
+        from primer.api.routers.webhooks import _dispatch_webhook
+        from primer.model.storage import OffsetPage as _OffsetPage
+        from primer.model.webhook_delivery import WebhookDelivery
+        from primer.storage.q import Q as _Q
+
+        _storage = storage_provider.get_storage(WebhookDelivery)
+        # status is filtered in SQL; the created_at grace is applied in
+        # Python because a datetime is not a JSON-scalar predicate value.
+        _pending_predicate = (
+            _Q(WebhookDelivery).where("status", "pending").build()
+        )
+        _cutoff = datetime.now(_tz.utc).timestamp() - _WEBHOOK_DELIVERY_GRACE_SECS
+        _refired = 0
+        _offset = 0
+        while True:
+            _page = await _storage.find(
+                _pending_predicate,
+                _OffsetPage(offset=_offset, length=200),
+            )
+            _items = list(_page.items)
+            for _row in _items:
+                # Skip rows younger than the grace window — they may be an
+                # in-flight dispatch from THIS process's early startup.
+                if _row.created_at.timestamp() > _cutoff:
+                    continue
+                try:
+                    await _dispatch_webhook(
+                        _row.trigger_id,
+                        _row.extra_context,
+                        storage_provider,
+                        event_bus,
+                        claim_engine,
+                        scheduler,
+                        workspace_registry,
+                        delivery_id=_row.id,
+                    )
+                    _refired += 1
+                except Exception:
+                    logger.exception(
+                        "webhook recovery: re-dispatch failed for %s",
+                        _row.id,
+                    )
+            if len(_items) < 200:
+                break
+            _offset += 200
+        if _refired:
+            logger.info(
+                "lifespan: webhook recovery — re-dispatched %d stale "
+                "pending delivery(ies) from persisted state", _refired,
+            )
+    except Exception:  # noqa: BLE001 -- never break startup
+        logger.exception("lifespan: webhook recovery failed")
+
+
 async def recover_ic_bootstrap(storage_provider) -> None:
     """Internal-collections bootstrap recovery.
 

--- a/primer/api/_app_lifespan_phases.py
+++ b/primer/api/_app_lifespan_phases.py
@@ -280,6 +280,110 @@ _WEBHOOK_RECOVERY_PAGE_SIZE = 200
 _WEBHOOK_DELIVERY_MAX_ATTEMPTS = 3
 
 
+async def _dispatch_recovered_deliveries(
+    _ids: list[str],
+    _storage,
+    _cutoff: float,
+    storage_provider,
+    event_bus,
+    claim_engine,
+    scheduler,
+    workspace_registry,
+) -> int:
+    """Re-read each collected id and dispatch the ones still eligible.
+
+    Takes ids rather than rows on purpose. The sweep that collects them can
+    span an unbounded number of pending rows, and each row carries its
+    ``extra_context.webhook_body`` (up to the endpoint's 1 MB cap), so
+    holding the whole collected set as rows is a boot-path OOM in exactly
+    the mass-crash case recovery exists for. Ids bound that to strings.
+
+    Re-reading also makes every check act on FRESH state: a live sibling may
+    have finalized a row between collection and dispatch, and the re-read
+    row's ``status`` / ``attempts`` reflect that, so the sweep skips it
+    instead of re-firing a delivery someone else already made.
+
+    Returns the number of deliveries actually re-dispatched.
+    """
+    from datetime import datetime, timezone as _tz
+
+    from primer.api.routers.webhooks import _dispatch_webhook
+
+    _refired = 0
+    for _id in _ids:
+        try:
+            _row = await _storage.get(_id)
+        except Exception:
+            logger.exception(
+                "webhook recovery: could not re-read delivery %s; "
+                "skipping it this sweep", _id,
+            )
+            continue
+        # Gone, or finalized by a live sibling between collection and now.
+        # Either way it is not ours to re-fire.
+        if _row is None or _row.status != "pending":
+            continue
+        # Re-check the grace window against the fresh row: a row that was
+        # stale at collection time is still stale now, but the re-check pass
+        # below reuses this helper with a recomputed cutoff.
+        if _row.created_at.timestamp() > _cutoff:
+            continue
+        # Poison-pill cap: a row that keeps coming back (its dispatch
+        # kills the process, or _finalize_delivery's update keeps failing
+        # and is swallowed) must not be re-fired forever. Give up loudly.
+        if _row.attempts >= _WEBHOOK_DELIVERY_MAX_ATTEMPTS:
+            logger.error(
+                "webhook recovery: delivery %s exhausted %d attempts; "
+                "marking failed and giving up",
+                _row.id, _row.attempts,
+            )
+            try:
+                await _storage.update(_row.model_copy(update={
+                    "status": "failed",
+                    "completed_at": datetime.now(_tz.utc),
+                }))
+            except Exception:
+                logger.exception(
+                    "webhook recovery: could not mark exhausted delivery "
+                    "%s failed", _row.id,
+                )
+            continue
+        # Record the attempt BEFORE dispatching. Counting it afterwards
+        # would never count the cases the cap exists for: a dispatch that
+        # hard-crashes the process, or a finalize that keeps failing,
+        # never reaches a post-hoc increment.
+        try:
+            _row = await _storage.update(
+                _row.model_copy(update={"attempts": _row.attempts + 1})
+            )
+        except Exception:
+            # Cannot account for this attempt, so do not take it: firing
+            # uncounted is exactly the unbounded re-fire the cap removes.
+            # The row stays pending and a later boot can retry it.
+            logger.exception(
+                "webhook recovery: could not record an attempt for %s; "
+                "skipping it this sweep", _row.id,
+            )
+            continue
+        try:
+            await _dispatch_webhook(
+                _row.trigger_id,
+                _row.extra_context,
+                storage_provider,
+                event_bus,
+                claim_engine,
+                scheduler,
+                workspace_registry,
+                delivery_id=_row.id,
+            )
+            _refired += 1
+        except Exception:
+            logger.exception(
+                "webhook recovery: re-dispatch failed for %s", _row.id,
+            )
+    return _refired
+
+
 async def recover_webhook_deliveries(
     storage_provider,
     event_bus,
@@ -315,7 +419,6 @@ async def recover_webhook_deliveries(
     try:
         from datetime import datetime, timezone as _tz
 
-        from primer.api.routers.webhooks import _dispatch_webhook
         from primer.model.storage import OffsetPage as _OffsetPage
         from primer.model.webhook_delivery import WebhookDelivery
         from primer.storage.q import Q as _Q
@@ -328,7 +431,7 @@ async def recover_webhook_deliveries(
         )
         _cutoff = datetime.now(_tz.utc).timestamp() - _WEBHOOK_DELIVERY_GRACE_SECS
 
-        # Collect the whole stale set BEFORE dispatching any of it.
+        # Collect the whole stale set BEFORE dispatching any of it, as IDS.
         # _dispatch_webhook flips its row 'pending' -> 'done'/'failed', which
         # MUTATES the very predicate this query pages over. Dispatching inside
         # the paging loop therefore shrinks the result set under the cursor and
@@ -340,7 +443,13 @@ async def recover_webhook_deliveries(
         # paging stable over an unchanging set, and is simpler to reason about
         # than re-querying offset=0 until drained while tracking grace-skipped
         # ids to keep a fresh row from looping forever.
-        _stale: list[WebhookDelivery] = []
+        #
+        # Ids, not rows: the pending set is unbounded (rows leave 'pending'
+        # only via dispatch and the table is never pruned) and every row
+        # carries its webhook_body, so holding the collected rows is a boot
+        # OOM in the mass-crash case. _dispatch_recovered_deliveries re-reads
+        # each id right before dispatching it.
+        _stale_ids: list[str] = []
         _offset = 0
         while True:
             _page = await _storage.find(
@@ -350,70 +459,29 @@ async def recover_webhook_deliveries(
             _items = list(_page.items)
             # Skip rows younger than the grace window - they may be an
             # in-flight dispatch from a live process.
-            _stale.extend(
-                _row for _row in _items
+            _stale_ids.extend(
+                _row.id for _row in _items
                 if _row.created_at.timestamp() <= _cutoff
             )
+            # Advance on the UNFILTERED page length: the grace filter above is
+            # applied in Python, so a page can be wholly grace-skipped while
+            # more pages remain. Terminating on the filtered count would end
+            # the sweep early; paging on len(_items) is also what makes this
+            # loop unable to run forever (a short page always ends it).
             if len(_items) < _WEBHOOK_RECOVERY_PAGE_SIZE:
                 break
             _offset += _WEBHOOK_RECOVERY_PAGE_SIZE
 
-        _refired = 0
-        for _row in _stale:
-            # Poison-pill cap: a row that keeps coming back (its dispatch
-            # kills the process, or _finalize_delivery's update keeps failing
-            # and is swallowed) must not be re-fired forever. Give up loudly.
-            if _row.attempts >= _WEBHOOK_DELIVERY_MAX_ATTEMPTS:
-                logger.error(
-                    "webhook recovery: delivery %s exhausted %d attempts; "
-                    "marking failed and giving up",
-                    _row.id, _row.attempts,
-                )
-                try:
-                    await _storage.update(_row.model_copy(update={
-                        "status": "failed",
-                        "completed_at": datetime.now(_tz.utc),
-                    }))
-                except Exception:
-                    logger.exception(
-                        "webhook recovery: could not mark exhausted delivery "
-                        "%s failed", _row.id,
-                    )
-                continue
-            # Record the attempt BEFORE dispatching. Counting it afterwards
-            # would never count the cases the cap exists for: a dispatch that
-            # hard-crashes the process, or a finalize that keeps failing,
-            # never reaches a post-hoc increment.
-            try:
-                _row = await _storage.update(
-                    _row.model_copy(update={"attempts": _row.attempts + 1})
-                )
-            except Exception:
-                # Cannot account for this attempt, so do not take it: firing
-                # uncounted is exactly the unbounded re-fire the cap removes.
-                # The row stays pending and a later boot can retry it.
-                logger.exception(
-                    "webhook recovery: could not record an attempt for %s; "
-                    "skipping it this sweep", _row.id,
-                )
-                continue
-            try:
-                await _dispatch_webhook(
-                    _row.trigger_id,
-                    _row.extra_context,
-                    storage_provider,
-                    event_bus,
-                    claim_engine,
-                    scheduler,
-                    workspace_registry,
-                    delivery_id=_row.id,
-                )
-                _refired += 1
-            except Exception:
-                logger.exception(
-                    "webhook recovery: re-dispatch failed for %s",
-                    _row.id,
-                )
+        _refired = await _dispatch_recovered_deliveries(
+            _stale_ids,
+            _storage,
+            _cutoff,
+            storage_provider,
+            event_bus,
+            claim_engine,
+            scheduler,
+            workspace_registry,
+        )
         if _refired:
             logger.info(
                 "lifespan: webhook recovery - re-dispatched %d stale "

--- a/primer/api/middleware/auth.py
+++ b/primer/api/middleware/auth.py
@@ -238,12 +238,15 @@ class AuthMiddleware:
     async def _find_by_hash(self, storage_provider, token_hash: str):
         """Look up an ApiToken by its sha256 hash. Returns the row or None."""
         from primer.model.api_token import ApiToken
-        from primer.model.storage import OffsetPage, Op
+        from primer.model.storage import CursorPage, Op
         from primer.storage.q import Q
 
         storage = storage_provider.get_storage(ApiToken)
         predicate = Q(ApiToken).where_op("token_hash", Op.EQ, token_hash).build()
-        page = await storage.find(predicate, OffsetPage(offset=0, length=1))
+        # CursorPage, not OffsetPage: the offset path issues an extra
+        # COUNT(*) on every bearer-authenticated request (to populate the
+        # page total we never read); the keyset cursor path issues none.
+        page = await storage.find(predicate, CursorPage(length=1))
         items = list(page.items)
         return items[0] if items else None
 

--- a/primer/api/routers/webhooks.py
+++ b/primer/api/routers/webhooks.py
@@ -135,6 +135,13 @@ async def _finalize_delivery(
     Never raises: durability marking is advisory and must not turn a
     successful dispatch into a logged failure (or vice versa). A missing
     row (create failed earlier) is tolerated silently.
+
+    Deliberately does NOT touch ``attempts``: that counts attempts STARTED
+    and is written by whoever starts one (the endpoint on create, startup
+    recovery before each re-dispatch). Incrementing here would both
+    double-count every recovered attempt and, because this marking is
+    swallowed on failure, fail to count the very cases the attempt cap
+    guards against.
     """
     from primer.model.webhook_delivery import WebhookDelivery
 
@@ -146,7 +153,6 @@ async def _finalize_delivery(
         await storage.update(row.model_copy(update={
             "status": "done" if ok else "failed",
             "completed_at": datetime.now(timezone.utc),
-            "attempts": row.attempts + 1,
         }))
     except Exception:  # noqa: BLE001 -- advisory marking, never fatal
         logger.debug(
@@ -330,6 +336,10 @@ async def receive_webhook(
             extra_context=extra_context,
             status="pending",
             created_at=fired_at,
+            # The BackgroundTask queued below is attempt 1. Recording it here
+            # (before it runs) is what lets the recovery sweep's attempt cap
+            # bound a delivery whose dispatch keeps killing the process.
+            attempts=1,
         ))
         delivery_persisted = True
     except ConflictError:

--- a/primer/api/routers/webhooks.py
+++ b/primer/api/routers/webhooks.py
@@ -24,8 +24,12 @@ Payload delivery:
   which merges it into the fire_context. Dispatchers and payload
   templates can reference ``webhook_body``, ``webhook_headers``,
   ``webhook_query``, and ``webhook_method``.
-- Dispatch is fire-and-forget via a BackgroundTask; the 202 is returned
-  immediately.
+- A durable ``WebhookDelivery`` row (status ``pending``) is written
+  BEFORE the 202 is returned; the BackgroundTask dispatches immediately
+  and marks the row ``done``/``failed``. A crash between the 202 and
+  dispatch completion leaves the row ``pending``, and startup recovery
+  re-dispatches stale pending rows (senders never retry a 202). Delivery
+  is therefore at-least-once rather than fire-and-forget.
 """
 
 from __future__ import annotations
@@ -116,6 +120,34 @@ def _verify_hmac(secret: str, body: bytes, sig_header: str | None) -> bool:
     return hmac.compare_digest(candidate, expected)
 
 
+async def _finalize_delivery(
+    storage_provider: Any, delivery_id: str, *, ok: bool
+) -> None:
+    """Best-effort flip of a WebhookDelivery row to done/failed.
+
+    Never raises: durability marking is advisory and must not turn a
+    successful dispatch into a logged failure (or vice versa). A missing
+    row (create failed earlier) is tolerated silently.
+    """
+    from primer.model.webhook_delivery import WebhookDelivery
+
+    try:
+        storage = storage_provider.get_storage(WebhookDelivery)
+        row = await storage.get(delivery_id)
+        if row is None:
+            return
+        await storage.update(row.model_copy(update={
+            "status": "done" if ok else "failed",
+            "completed_at": datetime.now(timezone.utc),
+            "attempts": row.attempts + 1,
+        }))
+    except Exception:  # noqa: BLE001 -- advisory marking, never fatal
+        logger.debug(
+            "webhook delivery finalize failed for %s", delivery_id,
+            exc_info=True,
+        )
+
+
 async def _dispatch_webhook(
     trigger_id: str,
     extra_context: dict,
@@ -124,6 +156,8 @@ async def _dispatch_webhook(
     claim_engine: Any = None,
     scheduler: Any = None,
     workspace_registry: Any = None,
+    *,
+    delivery_id: str | None = None,
 ) -> None:
     """Background task: fire subscriptions for a received webhook.
 
@@ -134,7 +168,14 @@ async def _dispatch_webhook(
     ``auto_start=True`` session: a ``claim_engine=None`` there flips the
     session to RUNNING but never claims it, hanging it forever (now a
     loud ConfigError at create time rather than a silent hang).
+
+    When ``delivery_id`` names a persisted :class:`WebhookDelivery` row,
+    the row is marked done/failed after the dispatch completes (best
+    effort). This is the same code path startup recovery re-runs for a
+    stale ``pending`` row, so both the live fire and the crash-recovery
+    fire share one dispatch implementation.
     """
+    ok = False
     try:
         dispatch_deps = DispatchDeps(
             storage_provider=storage_provider,
@@ -155,8 +196,11 @@ async def _dispatch_webhook(
             result.fire_id,
             len(result.results),
         )
+        ok = True
     except Exception:
         logger.exception("webhook dispatch failed for trigger %s", trigger_id)
+    if delivery_id is not None:
+        await _finalize_delivery(storage_provider, delivery_id, ok=ok)
 
 
 # ---------------------------------------------------------------------------
@@ -246,6 +290,42 @@ async def receive_webhook(
         "webhook_method": request.method,
     }
 
+    # Durability: persist a pending WebhookDelivery BEFORE returning 202
+    # and BEFORE the fire-and-forget BackgroundTask. A crash between the
+    # 202 and dispatch completion leaves this row 'pending'; startup
+    # recovery re-dispatches stale pending rows (senders never retry a
+    # 202). The row id IS the delivery/fire id, so a duplicate inbound
+    # for the same instant collides on the primary key and is deduped.
+    # Best effort: if the write fails we still dispatch (behaviour then
+    # matches the old fire-and-forget path — no worse than before).
+    from primer.model.except_ import ConflictError
+    from primer.model.webhook_delivery import WebhookDelivery
+
+    delivery_persisted = False
+    try:
+        await sp.get_storage(WebhookDelivery).create(WebhookDelivery(
+            id=delivery_id,
+            trigger_id=trigger.id,
+            extra_context=extra_context,
+            status="pending",
+            created_at=fired_at,
+        ))
+        delivery_persisted = True
+    except ConflictError:
+        # Same fire_id already recorded (duplicate inbound in the same
+        # millisecond); the first request owns the dispatch. Do not
+        # re-dispatch — return the accepted 202 idempotently.
+        logger.info(
+            "webhook delivery %s already recorded; treating as duplicate",
+            delivery_id,
+        )
+        return {"delivery_id": delivery_id, "status": "accepted"}
+    except Exception:
+        logger.exception(
+            "webhook delivery persist failed for %s; dispatching without "
+            "durability", delivery_id,
+        )
+
     # Fire and forget. Resolve the live claim_engine / scheduler /
     # workspace_registry from app.state HERE (request scope, where app.state
     # is reachable) and thread them into the background task. The
@@ -268,6 +348,7 @@ async def receive_webhook(
         claim_engine,
         scheduler,
         workspace_registry,
+        delivery_id=delivery_id if delivery_persisted else None,
     )
 
     return {"delivery_id": delivery_id, "status": "accepted"}

--- a/primer/api/routers/webhooks.py
+++ b/primer/api/routers/webhooks.py
@@ -30,6 +30,12 @@ Payload delivery:
   dispatch completion leaves the row ``pending``, and startup recovery
   re-dispatches stale pending rows (senders never retry a 202). Delivery
   is therefore at-least-once rather than fire-and-forget.
+- At-least-once is NOT idempotent. Every inbound POST gets its own
+  delivery row and its own dispatch, so a sender that retries a POST
+  fires the trigger a second time, and a recovery re-fire can
+  double-deliver when the process died after dispatching but before
+  marking the row. Suppressing genuine duplicates would require a
+  sender-supplied idempotency key to dedupe on; that is out of scope.
 """
 
 from __future__ import annotations
@@ -41,6 +47,7 @@ import time
 from collections import defaultdict
 from datetime import datetime, timezone
 from typing import Any
+from uuid import uuid4
 
 from fastapi import APIRouter, BackgroundTasks, HTTPException, Request
 
@@ -281,7 +288,14 @@ async def receive_webhook(
         body_str = ""
 
     fired_at = datetime.now(timezone.utc)
-    delivery_id = make_fire_id(trigger.id, fired_at)
+    # The row id must be unique PER REQUEST. It used to be the bare fire_id
+    # (``fire-{trigger_id}-{ms}``), which keys on (trigger, arrival
+    # millisecond) and correlates with NEITHER the sender nor the payload:
+    # two DISTINCT events for one trigger in the same millisecond collided on
+    # the primary key, and the loser was silently accepted without dispatching
+    # (losing its body outright). Keep the fire_id as a readable correlation
+    # prefix and append a random suffix so distinct requests never collide.
+    delivery_id = f"{make_fire_id(trigger.id, fired_at)}-{uuid4().hex[:8]}"
 
     extra_context = {
         "webhook_body": body_str,
@@ -294,8 +308,15 @@ async def receive_webhook(
     # and BEFORE the fire-and-forget BackgroundTask. A crash between the
     # 202 and dispatch completion leaves this row 'pending'; startup
     # recovery re-dispatches stale pending rows (senders never retry a
-    # 202). The row id IS the delivery/fire id, so a duplicate inbound
-    # for the same instant collides on the primary key and is deduped.
+    # 202).
+    #
+    # This does NOT make the endpoint idempotent. Every inbound POST gets
+    # its own row and its own dispatch, so a genuine duplicate (a sender
+    # retrying seconds later) lands a different fire_id, hits no conflict,
+    # and fires the trigger again. Delivery is at-least-once; real
+    # duplicate suppression would need a sender-supplied idempotency key
+    # to dedupe on, which is out of scope.
+    #
     # Best effort: if the write fails we still dispatch (behaviour then
     # matches the old fire-and-forget path - no worse than before).
     from primer.model.except_ import ConflictError
@@ -312,14 +333,15 @@ async def receive_webhook(
         ))
         delivery_persisted = True
     except ConflictError:
-        # Same fire_id already recorded (duplicate inbound in the same
-        # millisecond); the first request owns the dispatch. Do not
-        # re-dispatch - return the accepted 202 idempotently.
-        logger.info(
-            "webhook delivery %s already recorded; treating as duplicate",
-            delivery_id,
+        # Not expected now that ids carry a random suffix. Treat it as the
+        # best-effort persist failure it is and dispatch anyway: returning
+        # an "accepted" 202 without dispatching would drop the delivery,
+        # which is the exact silent loss this durability path exists to
+        # eliminate.
+        logger.exception(
+            "webhook delivery %s conflicted on create; dispatching without "
+            "durability", delivery_id,
         )
-        return {"delivery_id": delivery_id, "status": "accepted"}
     except Exception:
         logger.exception(
             "webhook delivery persist failed for %s; dispatching without "

--- a/primer/api/routers/webhooks.py
+++ b/primer/api/routers/webhooks.py
@@ -297,7 +297,7 @@ async def receive_webhook(
     # 202). The row id IS the delivery/fire id, so a duplicate inbound
     # for the same instant collides on the primary key and is deduped.
     # Best effort: if the write fails we still dispatch (behaviour then
-    # matches the old fire-and-forget path — no worse than before).
+    # matches the old fire-and-forget path - no worse than before).
     from primer.model.except_ import ConflictError
     from primer.model.webhook_delivery import WebhookDelivery
 
@@ -314,7 +314,7 @@ async def receive_webhook(
     except ConflictError:
         # Same fire_id already recorded (duplicate inbound in the same
         # millisecond); the first request owns the dispatch. Do not
-        # re-dispatch — return the accepted 202 idempotently.
+        # re-dispatch - return the accepted 202 idempotently.
         logger.info(
             "webhook delivery %s already recorded; treating as duplicate",
             delivery_id,

--- a/primer/model/webhook_delivery.py
+++ b/primer/model/webhook_delivery.py
@@ -76,7 +76,15 @@ class WebhookDelivery(Identifiable):
     attempts: int = Field(
         default=0,
         ge=0,
-        description="Number of dispatch attempts (incremented per dispatch).",
+        description=(
+            "Dispatch attempts STARTED for this delivery. Written by whoever "
+            "starts one: the endpoint creates the row with 1 (its "
+            "BackgroundTask) and startup recovery bumps it BEFORE each "
+            "re-dispatch, so an attempt that crashes the process is still "
+            "counted. Recovery abandons the row (marks it 'failed') once it "
+            "reaches the attempt cap, which stops a poison-pill delivery from "
+            "re-firing on every boot forever."
+        ),
     )
 
 

--- a/primer/model/webhook_delivery.py
+++ b/primer/model/webhook_delivery.py
@@ -63,7 +63,7 @@ class WebhookDelivery(Identifiable):
     )
     status: WebhookDeliveryStatus = Field(
         default="pending",
-        description="pending → done/failed. Recovery re-fires stale 'pending'.",
+        description="pending -> done/failed. Recovery re-fires stale 'pending'.",
     )
     created_at: datetime = Field(
         ...,

--- a/primer/model/webhook_delivery.py
+++ b/primer/model/webhook_delivery.py
@@ -1,4 +1,4 @@
-"""WebhookDelivery model — durable record of an inbound webhook fire.
+"""WebhookDelivery model - durable record of an inbound webhook fire.
 
 A row is written by the public webhook endpoint (``POST /v1/webhooks/{token}``)
 BEFORE it returns 202 and BEFORE the in-process ``BackgroundTask`` dispatches
@@ -10,9 +10,9 @@ endpoint, so a duplicate inbound request for the same logical instant collides
 on the primary key and is naturally idempotent at the storage layer.
 
 Lifecycle:
-- ``pending``  — created; dispatch not yet confirmed complete.
-- ``done``     — the background dispatch finished (best-effort mark).
-- ``failed``   — the background dispatch raised (best-effort mark).
+- ``pending``  - created; dispatch not yet confirmed complete.
+- ``done``     - the background dispatch finished (best-effort mark).
+- ``failed``   - the background dispatch raised (best-effort mark).
 
 Startup recovery re-dispatches ``pending`` rows older than a small grace
 window (their owning process died before marking them), giving inbound
@@ -36,7 +36,7 @@ class WebhookDelivery(Identifiable):
     """Persisted record of one inbound webhook fire.
 
     ``id`` is the endpoint-computed ``fire_id`` (never auto-generated), so
-    the model carries no ``_id_prefix`` — callers always supply the id.
+    the model carries no ``_id_prefix`` - callers always supply the id.
     """
 
     trigger_id: str = Field(

--- a/primer/model/webhook_delivery.py
+++ b/primer/model/webhook_delivery.py
@@ -5,9 +5,17 @@ BEFORE it returns 202 and BEFORE the in-process ``BackgroundTask`` dispatches
 the trigger. Without this durable marker a crash between the 202 and dispatch
 completion permanently loses the delivery (senders do not retry a 202).
 
-The row ``id`` is the ``fire_id`` (``fire-{trigger_id}-{ms}``) computed by the
-endpoint, so a duplicate inbound request for the same logical instant collides
-on the primary key and is naturally idempotent at the storage layer.
+The row ``id`` is the endpoint's ``fire_id`` (``fire-{trigger_id}-{ms}``) plus a
+random per-request suffix, so every inbound request gets its own row. The bare
+fire_id is NOT usable as the id: it keys on (trigger, arrival millisecond) and
+correlates with neither the sender nor the payload, so two distinct events for
+one trigger in the same millisecond collided on the primary key and the second
+was dropped.
+
+Delivery is at-least-once and NOT idempotent for duplicate POSTs: a sender
+retrying seconds later gets a different fire_id and fires the trigger again.
+Deduping genuine duplicates would require a sender-supplied idempotency key,
+which is out of scope.
 
 Lifecycle:
 - ``pending``  - created; dispatch not yet confirmed complete.
@@ -35,8 +43,9 @@ WebhookDeliveryStatus = Literal["pending", "done", "failed"]
 class WebhookDelivery(Identifiable):
     """Persisted record of one inbound webhook fire.
 
-    ``id`` is the endpoint-computed ``fire_id`` (never auto-generated), so
-    the model carries no ``_id_prefix`` - callers always supply the id.
+    ``id`` is endpoint-computed (``fire_id`` + a random per-request suffix)
+    and never auto-generated, so the model carries no ``_id_prefix`` -
+    callers always supply the id.
     """
 
     trigger_id: str = Field(

--- a/primer/model/webhook_delivery.py
+++ b/primer/model/webhook_delivery.py
@@ -1,0 +1,74 @@
+"""WebhookDelivery model — durable record of an inbound webhook fire.
+
+A row is written by the public webhook endpoint (``POST /v1/webhooks/{token}``)
+BEFORE it returns 202 and BEFORE the in-process ``BackgroundTask`` dispatches
+the trigger. Without this durable marker a crash between the 202 and dispatch
+completion permanently loses the delivery (senders do not retry a 202).
+
+The row ``id`` is the ``fire_id`` (``fire-{trigger_id}-{ms}``) computed by the
+endpoint, so a duplicate inbound request for the same logical instant collides
+on the primary key and is naturally idempotent at the storage layer.
+
+Lifecycle:
+- ``pending``  — created; dispatch not yet confirmed complete.
+- ``done``     — the background dispatch finished (best-effort mark).
+- ``failed``   — the background dispatch raised (best-effort mark).
+
+Startup recovery re-dispatches ``pending`` rows older than a small grace
+window (their owning process died before marking them), giving inbound
+webhooks at-least-once delivery instead of fire-and-forget.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime
+from typing import Any, Literal
+
+from pydantic import Field
+
+from primer.model.common import Identifiable
+
+
+WebhookDeliveryStatus = Literal["pending", "done", "failed"]
+
+
+class WebhookDelivery(Identifiable):
+    """Persisted record of one inbound webhook fire.
+
+    ``id`` is the endpoint-computed ``fire_id`` (never auto-generated), so
+    the model carries no ``_id_prefix`` — callers always supply the id.
+    """
+
+    trigger_id: str = Field(
+        ...,
+        min_length=1,
+        description="Trigger whose subscriptions this delivery dispatches.",
+    )
+    extra_context: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Snapshot of the fire_context extras the endpoint captured "
+            "(webhook_body / webhook_headers / webhook_query / "
+            "webhook_method), replayed verbatim on re-dispatch."
+        ),
+    )
+    status: WebhookDeliveryStatus = Field(
+        default="pending",
+        description="pending → done/failed. Recovery re-fires stale 'pending'.",
+    )
+    created_at: datetime = Field(
+        ...,
+        description="When the endpoint accepted the webhook (the fire instant).",
+    )
+    completed_at: datetime | None = Field(
+        default=None,
+        description="When the dispatch was marked done/failed; None while pending.",
+    )
+    attempts: int = Field(
+        default=0,
+        ge=0,
+        description="Number of dispatch attempts (incremented per dispatch).",
+    )
+
+
+__all__ = ["WebhookDelivery", "WebhookDeliveryStatus"]

--- a/primer/storage/postgres.py
+++ b/primer/storage/postgres.py
@@ -495,6 +495,17 @@ _HOT_FIELD_INDEXES: dict[str, list[tuple[str, bool, str]]] = {
     "sessions": [
         ("status", False, "((data->>'status'))"),
     ],
+    "chat": [
+        # Startup chat recovery filters status='active' AND turn_status IN
+        # (claimable, running); a composite expression index serves that
+        # combined predicate. Table name is the lowercased class name
+        # ("chat", not "chats") -- see _table_name_for / ChatClaimAdapter.
+        (
+            "status_turn",
+            False,
+            "((data->>'status'), (data->>'turn_status'))",
+        ),
+    ],
     "channel": [
         (
             "provider_external",

--- a/primer/storage/postgres.py
+++ b/primer/storage/postgres.py
@@ -516,6 +516,17 @@ _HOT_FIELD_INDEXES: dict[str, list[tuple[str, bool, str]]] = {
     "useridentity": [
         ("provider_subject_uniq", True, "((data->>'provider_id'), (data->>'subject'))"),
     ],
+    "webhookdelivery": [
+        # Startup webhook recovery filters status='pending' on every boot;
+        # without this the sweep seq-scans every delivery ever received (and
+        # OffsetPage adds a COUNT(*) per page over that scan). Table name is
+        # the lowercased class name -- see _table_name_for.
+        #
+        # NOTE: delivery rows are never pruned, so this table grows with
+        # lifetime webhook volume. The index keeps the boot sweep off a full
+        # scan, but a retention/prune policy is still owed as a follow-up.
+        ("status", False, "((data->>'status'))"),
+    ],
 }
 
 

--- a/tests/api/middleware/test_auth_bearer.py
+++ b/tests/api/middleware/test_auth_bearer.py
@@ -139,6 +139,37 @@ async def test_cookie_path_unchanged(client):
 
 
 @pytest.mark.asyncio
+async def test_find_by_hash_uses_cursor_page_no_count():
+    """The bearer lookup must page via CursorPage, not OffsetPage.
+
+    The offset path issues an extra COUNT(*) on every bearer-authenticated
+    request (E-I2); the keyset cursor path issues none. Assert the page
+    type the storage receives so the COUNT can't silently regress.
+    """
+    from primer.api.middleware.auth import AuthMiddleware
+    from primer.model.storage import CursorPage, CursorPageResponse
+
+    seen_pages: list = []
+
+    class _SpyTokenStorage:
+        async def find(self, predicate, page, *, order_by=None):
+            seen_pages.append(page)
+            return CursorPageResponse(next_cursor=None, items=[])
+
+    class _SpyProvider:
+        def get_storage(self, model_class):
+            return _SpyTokenStorage()
+
+    mw = AuthMiddleware(app=None)
+    result = await mw._find_by_hash(_SpyProvider(), "a" * 64)
+
+    assert result is None
+    assert len(seen_pages) == 1
+    assert isinstance(seen_pages[0], CursorPage)
+    assert seen_pages[0].length == 1
+
+
+@pytest.mark.asyncio
 async def test_bearer_updates_last_used_at(client, fake_storage_provider):
     user = await _seeded_user(fake_storage_provider)
     plaintext = mint_plaintext()

--- a/tests/api/test_chat_recovery_filter.py
+++ b/tests/api/test_chat_recovery_filter.py
@@ -1,0 +1,98 @@
+"""Unit test for SQL-filtered chat recovery (E-I1).
+
+``recover_chats`` must push the eligibility filter into the storage query
+(status='active' AND turn_status IN {claimable, running}) via ``find()``
+instead of listing every chat and filtering in Python via ``list()``.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timezone
+
+import pytest
+
+from primer.model.storage import (
+    FieldRef,
+    OffsetPageResponse,
+    Op,
+    Predicate,
+    Value,
+)
+
+
+class _SpyChatStorage:
+    """Records find()/list() calls; returns the seeded items from find()."""
+
+    def __init__(self, items):
+        self._items = items
+        self.find_calls: list = []
+        self.list_calls: list = []
+
+    async def find(self, predicate, page, *, order_by=None):
+        self.find_calls.append((predicate, page))
+        return OffsetPageResponse(
+            offset=0, length=len(self._items),
+            total=len(self._items), items=self._items,
+        )
+
+    async def list(self, page, *, order_by=None):
+        self.list_calls.append(page)
+        return OffsetPageResponse(offset=0, length=0, total=0, items=[])
+
+
+class _SpyStorageProvider:
+    def __init__(self, storage):
+        self._storage = storage
+
+    def get_storage(self, model_class):
+        return self._storage
+
+
+class _SpyClaimEngine:
+    def __init__(self):
+        self.upserts: list = []
+
+    async def upsert(self, kind, entity_id):
+        self.upserts.append((kind, entity_id))
+
+
+def _leaf_comparisons(node) -> list[tuple[str, Op, object]]:
+    """Flatten an AND/OR predicate tree into its leaf comparisons."""
+    if isinstance(node, Predicate) and node.op in (Op.AND, Op.OR):
+        return _leaf_comparisons(node.left) + _leaf_comparisons(node.right)
+    assert isinstance(node, Predicate)
+    assert isinstance(node.left, FieldRef)
+    assert isinstance(node.right, Value)
+    return [(node.left.name, node.op, node.right.value)]
+
+
+@pytest.mark.asyncio
+async def test_recover_chats_uses_filtered_find_not_list():
+    """recover_chats must push status/turn_status into a find() predicate
+    (E-I1), never scan the whole table via list()."""
+    from primer.api._app_lifespan_phases import recover_chats
+    from primer.int.claim import ClaimKind
+    from primer.model.chats import Chat
+
+    chat = Chat(
+        id="chat-1", agent_id="agent-1",
+        created_at=datetime.now(timezone.utc),
+        status="active", turn_status="claimable",
+    )
+    spy_storage = _SpyChatStorage([chat])
+    provider = _SpyStorageProvider(spy_storage)
+    claim_engine = _SpyClaimEngine()
+
+    await recover_chats(claim_engine, provider)
+
+    # find() used, list() never touched.
+    assert len(spy_storage.find_calls) == 1
+    assert spy_storage.list_calls == []
+
+    predicate, _page = spy_storage.find_calls[0]
+    leaves = _leaf_comparisons(predicate)
+    assert ("status", Op.EQ, "active") in leaves
+    assert ("turn_status", Op.IN, ["claimable", "running"]) in leaves
+
+    # The returned row is re-armed on the claim engine.
+    assert claim_engine.upserts == [(ClaimKind.CHAT, "chat-1")]

--- a/tests/api/test_webhook_delivery_recovery.py
+++ b/tests/api/test_webhook_delivery_recovery.py
@@ -56,6 +56,48 @@ async def test_recover_webhook_redispatches_stale_pending(fake_storage_provider)
 
 
 @pytest.mark.asyncio
+async def test_recover_webhook_redispatches_every_row_across_pages(
+    fake_storage_provider,
+):
+    """EVERY stale pending row is dispatched exactly once, even when the
+    stale set spans more than one page.
+
+    Regression: the sweep used to dispatch inside the paging loop, and each
+    dispatch flips its row out of the 'pending' set being paged - mutating
+    the predicate mid-page. With 250 rows and a 200-row page, offset=0 drained
+    rows 0-199, which left only 50 pending; the next query at offset=200 then
+    landed past the end and returned nothing, silently skipping rows 200-249.
+    """
+    from primer.api._app_lifespan_phases import recover_webhook_deliveries
+
+    stale = datetime.now(timezone.utc) - timedelta(minutes=5)
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    total = 250  # deliberately > the 200-row recovery page size
+    for i in range(total):
+        await storage.create(WebhookDelivery(
+            id=f"fire-{i:04d}", trigger_id=f"trig-{i}",
+            extra_context={}, status="pending", created_at=stale,
+        ))
+
+    dispatched: list[str] = []
+
+    async def _spy(*args, delivery_id=None, **kwargs):
+        # Mimic the real dispatcher: it finalizes the row, which removes it
+        # from the 'pending' set the recovery query pages over.
+        dispatched.append(delivery_id)
+        row = await storage.get(delivery_id)
+        await storage.update(row.model_copy(update={"status": "done"}))
+
+    with patch("primer.api.routers.webhooks._dispatch_webhook", _spy):
+        await recover_webhook_deliveries(
+            fake_storage_provider, None, None, None, None
+        )
+
+    assert len(dispatched) == total, f"only {len(dispatched)}/{total} dispatched"
+    assert sorted(dispatched) == sorted(f"fire-{i:04d}" for i in range(total))
+
+
+@pytest.mark.asyncio
 async def test_recover_webhook_noop_when_no_pending(fake_storage_provider):
     """No pending rows → dispatcher never called."""
     from primer.api._app_lifespan_phases import recover_webhook_deliveries

--- a/tests/api/test_webhook_delivery_recovery.py
+++ b/tests/api/test_webhook_delivery_recovery.py
@@ -23,7 +23,7 @@ async def test_recover_webhook_redispatches_stale_pending(fake_storage_provider)
     from primer.api._app_lifespan_phases import recover_webhook_deliveries
 
     now = datetime.now(timezone.utc)
-    stale = now - timedelta(minutes=5)
+    stale = now - timedelta(hours=1)
     storage = fake_storage_provider.get_storage(WebhookDelivery)
     await storage.create(WebhookDelivery(
         id="fire-stale", trigger_id="trig-1",
@@ -70,7 +70,7 @@ async def test_recover_webhook_redispatches_every_row_across_pages(
     """
     from primer.api._app_lifespan_phases import recover_webhook_deliveries
 
-    stale = datetime.now(timezone.utc) - timedelta(minutes=5)
+    stale = datetime.now(timezone.utc) - timedelta(hours=1)
     storage = fake_storage_provider.get_storage(WebhookDelivery)
     total = 250  # deliberately > the 200-row recovery page size
     for i in range(total):
@@ -111,7 +111,7 @@ async def test_recover_webhook_gives_up_at_the_attempt_cap(fake_storage_provider
         recover_webhook_deliveries,
     )
 
-    stale = datetime.now(timezone.utc) - timedelta(minutes=5)
+    stale = datetime.now(timezone.utc) - timedelta(hours=1)
     storage = fake_storage_provider.get_storage(WebhookDelivery)
     await storage.create(WebhookDelivery(
         id="fire-poison", trigger_id="trig-poison", extra_context={},
@@ -142,6 +142,27 @@ async def test_recover_webhook_gives_up_at_the_attempt_cap(fake_storage_provider
     assert (await storage.get("fire-under-cap")).attempts == (
         _WEBHOOK_DELIVERY_MAX_ATTEMPTS
     )
+
+
+def test_grace_window_is_configurable_and_clears_a_slow_dispatch():
+    """The grace window is the only guard against re-firing a live sibling's
+    in-flight dispatch, so its default must clear a slow fresh-session
+    dispatch (workspace + session creation), and operators must be able to
+    raise it without a code change.
+    """
+    import importlib
+
+    from primer.api import _app_lifespan_phases as phases
+
+    assert phases._WEBHOOK_DELIVERY_GRACE_SECS >= 300
+
+    with patch.dict(
+        "os.environ", {"PRIMER_WEBHOOK_RECOVERY_GRACE_SECS": "900"}
+    ):
+        reloaded = importlib.reload(phases)
+        assert reloaded._WEBHOOK_DELIVERY_GRACE_SECS == 900.0
+    # Restore the module-level default for any later import of it.
+    importlib.reload(phases)
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_webhook_delivery_recovery.py
+++ b/tests/api/test_webhook_delivery_recovery.py
@@ -330,7 +330,7 @@ def test_grace_window_is_configurable_and_clears_a_slow_dispatch():
 
 @pytest.mark.asyncio
 async def test_recover_webhook_noop_when_no_pending(fake_storage_provider):
-    """No pending rows → dispatcher never called."""
+    """No pending rows -> dispatcher never called."""
     from primer.api._app_lifespan_phases import recover_webhook_deliveries
 
     dispatch_spy = AsyncMock()

--- a/tests/api/test_webhook_delivery_recovery.py
+++ b/tests/api/test_webhook_delivery_recovery.py
@@ -1,0 +1,70 @@
+"""Unit tests for ``recover_webhook_deliveries`` (D-C1 durability).
+
+The webhook endpoint persists a pending ``WebhookDelivery`` row before its
+fire-and-forget dispatch. Startup recovery re-dispatches stale ``pending``
+rows the previous process dropped, and leaves ``done`` / fresh ``pending``
+rows alone.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from primer.model.webhook_delivery import WebhookDelivery
+
+
+@pytest.mark.asyncio
+async def test_recover_webhook_redispatches_stale_pending(fake_storage_provider):
+    """A stale pending row is re-dispatched via _dispatch_webhook; a done
+    row and a fresh pending row are not."""
+    from primer.api._app_lifespan_phases import recover_webhook_deliveries
+
+    now = datetime.now(timezone.utc)
+    stale = now - timedelta(minutes=5)
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    await storage.create(WebhookDelivery(
+        id="fire-stale", trigger_id="trig-1",
+        extra_context={"webhook_body": "hi"},
+        status="pending", created_at=stale,
+    ))
+    await storage.create(WebhookDelivery(
+        id="fire-done", trigger_id="trig-2",
+        extra_context={}, status="done", created_at=stale,
+        completed_at=stale,
+    ))
+    await storage.create(WebhookDelivery(
+        id="fire-fresh", trigger_id="trig-3",
+        extra_context={}, status="pending", created_at=now,
+    ))
+
+    dispatch_spy = AsyncMock()
+    with patch(
+        "primer.api.routers.webhooks._dispatch_webhook", dispatch_spy
+    ):
+        await recover_webhook_deliveries(
+            fake_storage_provider, None, None, None, None
+        )
+
+    assert dispatch_spy.await_count == 1
+    args, kwargs = dispatch_spy.await_args
+    assert args[0] == "trig-1"                 # trigger_id
+    assert args[1] == {"webhook_body": "hi"}   # extra_context
+    assert kwargs["delivery_id"] == "fire-stale"
+
+
+@pytest.mark.asyncio
+async def test_recover_webhook_noop_when_no_pending(fake_storage_provider):
+    """No pending rows → dispatcher never called."""
+    from primer.api._app_lifespan_phases import recover_webhook_deliveries
+
+    dispatch_spy = AsyncMock()
+    with patch(
+        "primer.api.routers.webhooks._dispatch_webhook", dispatch_spy
+    ):
+        await recover_webhook_deliveries(
+            fake_storage_provider, None, None, None, None
+        )
+    assert dispatch_spy.await_count == 0

--- a/tests/api/test_webhook_delivery_recovery.py
+++ b/tests/api/test_webhook_delivery_recovery.py
@@ -98,6 +98,55 @@ async def test_recover_webhook_redispatches_every_row_across_pages(
 
 
 @pytest.mark.asyncio
+async def test_recover_webhook_skips_a_row_finalized_after_collection(
+    fake_storage_provider,
+):
+    """A row finalized between collection and dispatch is NOT re-fired.
+
+    The sweep collects ids and re-reads each one immediately before
+    dispatching it, so a live sibling that finalizes a row mid-sweep is
+    observed rather than raced: the re-read row is no longer 'pending' and
+    the sweep skips it instead of duplicating the delivery.
+    """
+    from primer.api._app_lifespan_phases import recover_webhook_deliveries
+
+    stale = datetime.now(timezone.utc) - timedelta(hours=1)
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    for _id in ("fire-a", "fire-sibling", "fire-b"):
+        await storage.create(WebhookDelivery(
+            id=_id, trigger_id=f"trig-{_id}", extra_context={},
+            status="pending", created_at=stale,
+        ))
+
+    dispatched: list[str] = []
+
+    async def _spy(*args, delivery_id=None, **kwargs):
+        dispatched.append(delivery_id)
+        # While dispatching the first row, a "live sibling" finalizes another
+        # row that this sweep already collected the id of.
+        if delivery_id == "fire-a":
+            row = await storage.get("fire-sibling")
+            await storage.update(row.model_copy(update={"status": "done"}))
+        row = await storage.get(delivery_id)
+        await storage.update(row.model_copy(update={"status": "done"}))
+
+    with patch("primer.api.routers.webhooks._dispatch_webhook", _spy):
+        await recover_webhook_deliveries(
+            fake_storage_provider, None, None, None, None
+        )
+
+    assert "fire-sibling" not in dispatched, (
+        "a row finalized after collection was re-fired"
+    )
+    assert sorted(dispatched) == ["fire-a", "fire-b"]
+    # The sibling keeps the status its finaliser set, and the sweep never
+    # charged it an attempt.
+    sibling = await storage.get("fire-sibling")
+    assert sibling.status == "done"
+    assert sibling.attempts == 0
+
+
+@pytest.mark.asyncio
 async def test_recover_webhook_gives_up_at_the_attempt_cap(fake_storage_provider):
     """A row at the attempt cap is marked failed and NOT re-fired.
 

--- a/tests/api/test_webhook_delivery_recovery.py
+++ b/tests/api/test_webhook_delivery_recovery.py
@@ -98,6 +98,53 @@ async def test_recover_webhook_redispatches_every_row_across_pages(
 
 
 @pytest.mark.asyncio
+async def test_recover_webhook_gives_up_at_the_attempt_cap(fake_storage_provider):
+    """A row at the attempt cap is marked failed and NOT re-fired.
+
+    Without the cap a poison-pill row (its dispatch hard-crashes the process,
+    or _finalize_delivery's swallowed update never marks it) stays pending and
+    is re-fired on EVERY subsequent boot forever, each time spawning duplicate
+    chats/sessions.
+    """
+    from primer.api._app_lifespan_phases import (
+        _WEBHOOK_DELIVERY_MAX_ATTEMPTS,
+        recover_webhook_deliveries,
+    )
+
+    stale = datetime.now(timezone.utc) - timedelta(minutes=5)
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    await storage.create(WebhookDelivery(
+        id="fire-poison", trigger_id="trig-poison", extra_context={},
+        status="pending", created_at=stale,
+        attempts=_WEBHOOK_DELIVERY_MAX_ATTEMPTS,
+    ))
+    await storage.create(WebhookDelivery(
+        id="fire-under-cap", trigger_id="trig-ok", extra_context={},
+        status="pending", created_at=stale,
+        attempts=_WEBHOOK_DELIVERY_MAX_ATTEMPTS - 1,
+    ))
+
+    dispatch_spy = AsyncMock()
+    with patch("primer.api.routers.webhooks._dispatch_webhook", dispatch_spy):
+        await recover_webhook_deliveries(
+            fake_storage_provider, None, None, None, None
+        )
+
+    # The exhausted row is abandoned, not re-fired.
+    assert dispatch_spy.await_count == 1
+    assert dispatch_spy.await_args.kwargs["delivery_id"] == "fire-under-cap"
+    poisoned = await storage.get("fire-poison")
+    assert poisoned.status == "failed"
+    assert poisoned.completed_at is not None
+
+    # The under-cap row is re-fired, and its attempt is recorded BEFORE the
+    # dispatch so an attempt that kills the process still counts.
+    assert (await storage.get("fire-under-cap")).attempts == (
+        _WEBHOOK_DELIVERY_MAX_ATTEMPTS
+    )
+
+
+@pytest.mark.asyncio
 async def test_recover_webhook_noop_when_no_pending(fake_storage_provider):
     """No pending rows → dispatcher never called."""
     from primer.api._app_lifespan_phases import recover_webhook_deliveries

--- a/tests/api/test_webhook_delivery_recovery.py
+++ b/tests/api/test_webhook_delivery_recovery.py
@@ -315,13 +315,17 @@ def test_grace_window_is_configurable_and_clears_a_slow_dispatch():
 
     assert phases._WEBHOOK_DELIVERY_GRACE_SECS >= 300
 
-    with patch.dict(
-        "os.environ", {"PRIMER_WEBHOOK_RECOVERY_GRACE_SECS": "900"}
-    ):
-        reloaded = importlib.reload(phases)
-        assert reloaded._WEBHOOK_DELIVERY_GRACE_SECS == 900.0
-    # Restore the module-level default for any later import of it.
-    importlib.reload(phases)
+    try:
+        with patch.dict(
+            "os.environ", {"PRIMER_WEBHOOK_RECOVERY_GRACE_SECS": "900"}
+        ):
+            reloaded = importlib.reload(phases)
+            assert reloaded._WEBHOOK_DELIVERY_GRACE_SECS == 900.0
+    finally:
+        # Restore the module-level default for any later import of it. Must
+        # be unconditional: a failing assertion above would otherwise leave
+        # the module at GRACE=900 and silently skew every later test.
+        importlib.reload(phases)
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_webhook_delivery_recovery.py
+++ b/tests/api/test_webhook_delivery_recovery.py
@@ -281,6 +281,28 @@ async def test_recover_webhook_gives_up_at_the_attempt_cap(fake_storage_provider
     )
 
 
+def test_a_bad_grace_override_does_not_break_the_import():
+    """A non-numeric override falls back to the default instead of raising.
+
+    The value is parsed at import time, so letting ValueError escape means a
+    typo'd env var takes the entire API down at boot.
+    """
+    import importlib
+
+    from primer.api import _app_lifespan_phases as phases
+
+    try:
+        with patch.dict(
+            "os.environ", {"PRIMER_WEBHOOK_RECOVERY_GRACE_SECS": "not-a-number"}
+        ):
+            reloaded = importlib.reload(phases)
+            assert reloaded._WEBHOOK_DELIVERY_GRACE_SECS == (
+                reloaded._WEBHOOK_DELIVERY_GRACE_SECS_DEFAULT
+            )
+    finally:
+        importlib.reload(phases)
+
+
 def test_grace_window_is_configurable_and_clears_a_slow_dispatch():
     """The grace window is the only guard against re-firing a live sibling's
     in-flight dispatch, so its default must clear a slow fresh-session

--- a/tests/api/test_webhook_delivery_recovery.py
+++ b/tests/api/test_webhook_delivery_recovery.py
@@ -8,12 +8,22 @@ rows alone.
 
 from __future__ import annotations
 
+import asyncio
 from datetime import datetime, timedelta, timezone
 from unittest.mock import AsyncMock, patch
 
 import pytest
 
 from primer.model.webhook_delivery import WebhookDelivery
+
+
+async def _cancel(task: asyncio.Task) -> None:
+    """Cancel a re-check task the way the lifespan's teardown does."""
+    task.cancel()
+    try:
+        await task
+    except asyncio.CancelledError:
+        pass
 
 
 @pytest.mark.asyncio
@@ -44,7 +54,7 @@ async def test_recover_webhook_redispatches_stale_pending(fake_storage_provider)
     with patch(
         "primer.api.routers.webhooks._dispatch_webhook", dispatch_spy
     ):
-        await recover_webhook_deliveries(
+        recheck = await recover_webhook_deliveries(
             fake_storage_provider, None, None, None, None
         )
 
@@ -53,6 +63,11 @@ async def test_recover_webhook_redispatches_stale_pending(fake_storage_provider)
     assert args[0] == "trig-1"                 # trigger_id
     assert args[1] == {"webhook_body": "hi"}   # extra_context
     assert kwargs["delivery_id"] == "fire-stale"
+
+    # 'fire-fresh' is inside the grace window, so the sweep hands back a
+    # re-check task for it rather than abandoning it to the next boot.
+    assert recheck is not None
+    await _cancel(recheck)
 
 
 @pytest.mark.asyncio
@@ -95,6 +110,79 @@ async def test_recover_webhook_redispatches_every_row_across_pages(
 
     assert len(dispatched) == total, f"only {len(dispatched)}/{total} dispatched"
     assert sorted(dispatched) == sorted(f"fire-{i:04d}" for i in range(total))
+
+
+@pytest.mark.asyncio
+async def test_grace_skipped_row_is_dispatched_by_the_recheck(
+    fake_storage_provider,
+):
+    """A row inside the grace window at sweep time IS eventually dispatched.
+
+    The boot sweep is one-shot: without the re-check a row younger than the
+    cutoff is skipped and never revisited by this process, so a delivery
+    dropped inside the grace band waits for the NEXT boot - weeks away, or
+    never, on a stable deployment. That is the silent-loss window this batch
+    exists to close, so the grace must be a bound, not a deferral.
+    """
+    from primer.api import _app_lifespan_phases as phases
+
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    await storage.create(WebhookDelivery(
+        id="fire-young", trigger_id="trig-young", extra_context={},
+        status="pending", created_at=datetime.now(timezone.utc),
+    ))
+
+    dispatch_spy = AsyncMock()
+    # A grace short enough to keep the test fast, but long enough that the
+    # row is reliably still inside the window when the sweep reads it.
+    with patch.object(phases, "_WEBHOOK_DELIVERY_GRACE_SECS", 0.3), \
+            patch("primer.api.routers.webhooks._dispatch_webhook", dispatch_spy):
+        recheck = await phases.recover_webhook_deliveries(
+            fake_storage_provider, None, None, None, None
+        )
+        # The one-shot pass skipped it: nothing dispatched yet.
+        assert dispatch_spy.await_count == 0
+        assert recheck is not None
+        # The re-check sleeps until the row clears the window, then fires.
+        await asyncio.wait_for(recheck, timeout=5)
+
+    assert dispatch_spy.await_count == 1
+    assert dispatch_spy.await_args.kwargs["delivery_id"] == "fire-young"
+    # It self-terminates after the single pass - it is not a polling loop.
+    assert recheck.done() and not recheck.cancelled()
+
+
+@pytest.mark.asyncio
+async def test_grace_recheck_task_cancels_cleanly_on_shutdown(
+    fake_storage_provider,
+):
+    """The re-check task is cancellable and dispatches nothing once cancelled.
+
+    It is owned by the lifespan and torn down like chat_tick_task /
+    _claim_depth_task, so shutdown during the grace sleep must not leak the
+    task or fire a delivery on the way out.
+    """
+    from primer.api._app_lifespan_phases import recover_webhook_deliveries
+
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    await storage.create(WebhookDelivery(
+        id="fire-young", trigger_id="trig-young", extra_context={},
+        status="pending", created_at=datetime.now(timezone.utc),
+    ))
+
+    dispatch_spy = AsyncMock()
+    with patch("primer.api.routers.webhooks._dispatch_webhook", dispatch_spy):
+        # Default 300s grace: the task is parked in its sleep when we cancel.
+        recheck = await recover_webhook_deliveries(
+            fake_storage_provider, None, None, None, None
+        )
+        assert recheck is not None
+        await _cancel(recheck)
+
+    assert recheck.cancelled(), "re-check task did not cancel"
+    assert dispatch_spy.await_count == 0
+    # The row stays pending, so the next boot's sweep still owns it.
+    assert (await storage.get("fire-young")).status == "pending"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_webhook_endpoint.py
+++ b/tests/api/test_webhook_endpoint.py
@@ -375,6 +375,107 @@ async def test_webhook_delivery_flips_to_failed_on_dispatch_error(
 
 
 @pytest.mark.asyncio
+async def test_two_same_millisecond_webhooks_both_dispatch(
+    client, fake_storage_provider
+):
+    """Two DISTINCT webhooks landing in the same millisecond BOTH dispatch.
+
+    Regression: the delivery row id used to be the fire_id, which is keyed on
+    (trigger, arrival millisecond) and correlates with neither the sender nor
+    the payload. Two distinct events for one trigger in the same millisecond
+    therefore collided on the primary key, and the second was silently
+    'accepted' without ever dispatching - losing its body outright.
+    """
+    from primer.model.webhook_delivery import WebhookDelivery
+
+    trigger = await _create_webhook_trigger(
+        fake_storage_provider, slug="wh-same-ms"
+    )
+    frozen = datetime(2024, 1, 1, 12, 0, 0, tzinfo=timezone.utc)
+
+    class _FrozenDatetime(datetime):
+        @classmethod
+        def now(cls, tz=None):  # noqa: ARG003 -- signature parity
+            return frozen
+
+    bodies: list[str] = []
+
+    async def _spy(trigger_id, extra_context, *args, **kwargs):
+        bodies.append(extra_context["webhook_body"])
+
+    with patch("primer.api.routers.webhooks.datetime", _FrozenDatetime), \
+         patch("primer.api.routers.webhooks._dispatch_webhook", side_effect=_spy):
+        r1 = await client.post(
+            f"/v1/webhooks/{trigger.config.token}",
+            content=b'{"event": "first"}',
+            headers={"content-type": "application/json"},
+        )
+        r2 = await client.post(
+            f"/v1/webhooks/{trigger.config.token}",
+            content=b'{"event": "second"}',
+            headers={"content-type": "application/json"},
+        )
+
+    assert r1.status_code == 202, r1.text
+    assert r2.status_code == 202, r2.text
+    # Distinct requests never share a row id, even at the same instant.
+    assert r1.json()["delivery_id"] != r2.json()["delivery_id"]
+    # Both payloads reached the dispatcher; neither was dropped.
+    assert bodies == ['{"event": "first"}', '{"event": "second"}']
+    # Both were persisted durably, so a crash can recover either.
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    assert await storage.get(r1.json()["delivery_id"]) is not None
+    assert await storage.get(r2.json()["delivery_id"]) is not None
+
+
+@pytest.mark.asyncio
+async def test_webhook_conflict_on_create_still_dispatches(
+    client, fake_storage_provider
+):
+    """A ConflictError persisting the row must NOT swallow the dispatch.
+
+    The persist is advisory (best effort): if it fails for any reason the
+    request still dispatches, matching the generic-failure branch. Silently
+    returning 202 without dispatching would drop the delivery outright.
+    """
+    from primer.model.except_ import ConflictError
+
+    trigger = await _create_webhook_trigger(
+        fake_storage_provider, slug="wh-conflict"
+    )
+    dispatched: list[str] = []
+
+    async def _spy(trigger_id, extra_context, *args, **kwargs):
+        dispatched.append(extra_context["webhook_body"])
+
+    async def _conflict(*args, **kwargs):
+        raise ConflictError("id already exists")
+
+    # Patch the live storage instance the endpoint resolves (get_storage
+    # memoises one storage per model), so only the WebhookDelivery create is
+    # forced to conflict. A module-path patch is NOT a reliable target here:
+    # tests/ has no __init__.py, so conftest is importable under two names
+    # ("conftest" and "tests.conftest") and a module patch can silently hit a
+    # different class object than the fixture actually uses.
+    from primer.model.webhook_delivery import WebhookDelivery
+
+    delivery_storage = fake_storage_provider.get_storage(WebhookDelivery)
+    with patch.object(
+        delivery_storage, "create", side_effect=_conflict
+    ), patch(
+        "primer.api.routers.webhooks._dispatch_webhook", side_effect=_spy
+    ):
+        r = await client.post(
+            f"/v1/webhooks/{trigger.config.token}",
+            content=b'{"event": "conflicted"}',
+            headers={"content-type": "application/json"},
+        )
+
+    assert r.status_code == 202, r.text
+    assert dispatched == ['{"event": "conflicted"}']
+
+
+@pytest.mark.asyncio
 async def test_webhook_endpoint_does_not_require_auth(raw_client, fake_storage_provider):
     """The webhook endpoint is accessible without authentication."""
     trigger = await _create_webhook_trigger(fake_storage_provider, slug="wh-public")

--- a/tests/api/test_webhook_endpoint.py
+++ b/tests/api/test_webhook_endpoint.py
@@ -268,7 +268,7 @@ async def test_webhook_persists_pending_delivery_before_dispatch(
     client, fake_storage_provider
 ):
     """A durable WebhookDelivery row exists (status=pending) before the
-    fire-and-forget dispatch completes — stubbing the dispatcher out."""
+    fire-and-forget dispatch completes - stubbing the dispatcher out."""
     from primer.model.storage import OffsetPage
     from primer.model.webhook_delivery import WebhookDelivery
 

--- a/tests/api/test_webhook_endpoint.py
+++ b/tests/api/test_webhook_endpoint.py
@@ -264,6 +264,117 @@ async def test_webhook_payload_maps_headers_query(client, fake_storage_provider)
 
 
 @pytest.mark.asyncio
+async def test_webhook_persists_pending_delivery_before_dispatch(
+    client, fake_storage_provider
+):
+    """A durable WebhookDelivery row exists (status=pending) before the
+    fire-and-forget dispatch completes — stubbing the dispatcher out."""
+    from primer.model.storage import OffsetPage
+    from primer.model.webhook_delivery import WebhookDelivery
+
+    trigger = await _create_webhook_trigger(
+        fake_storage_provider, slug="wh-durable-pending"
+    )
+
+    async def _noop_dispatch(*args, **kwargs):
+        return None  # never finalizes the row
+
+    with patch(
+        "primer.api.routers.webhooks._dispatch_webhook",
+        side_effect=_noop_dispatch,
+    ):
+        r = await client.post(
+            f"/v1/webhooks/{trigger.config.token}",
+            content=b'{"event": "test"}',
+            headers={"content-type": "application/json"},
+        )
+    assert r.status_code == 202, r.text
+    delivery_id = r.json()["delivery_id"]
+
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    page = await storage.list(OffsetPage(offset=0, length=10))
+    rows = list(page.items)
+    assert len(rows) == 1
+    row = rows[0]
+    assert row.id == delivery_id
+    assert row.trigger_id == trigger.id
+    assert row.status == "pending"
+    assert row.completed_at is None
+    assert row.extra_context["webhook_body"] == '{"event": "test"}'
+
+
+@pytest.mark.asyncio
+async def test_webhook_delivery_flips_to_done_after_dispatch(
+    client, fake_storage_provider
+):
+    """After a successful background dispatch the row is marked done."""
+    from types import SimpleNamespace
+
+    from primer.model.storage import OffsetPage
+    from primer.model.webhook_delivery import WebhookDelivery
+
+    trigger = await _create_webhook_trigger(
+        fake_storage_provider, slug="wh-durable-done"
+    )
+    seen_pending: list[str] = []
+
+    async def _ok_fire(*args, **kwargs):
+        # Mid-dispatch the row must already be persisted as pending.
+        storage = fake_storage_provider.get_storage(WebhookDelivery)
+        page = await storage.list(OffsetPage(offset=0, length=10))
+        for row in list(page.items):
+            if row.status == "pending":
+                seen_pending.append(row.id)
+        return SimpleNamespace(fire_id="fire-x", results=[])
+
+    with patch("primer.api.routers.webhooks.fire_trigger", side_effect=_ok_fire):
+        r = await client.post(
+            f"/v1/webhooks/{trigger.config.token}",
+            content=b"{}",
+            headers={"content-type": "application/json"},
+        )
+    assert r.status_code == 202, r.text
+    delivery_id = r.json()["delivery_id"]
+    assert delivery_id in seen_pending  # pending mid-dispatch
+
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    row = await storage.get(delivery_id)
+    assert row is not None
+    assert row.status == "done"
+    assert row.completed_at is not None
+    assert row.attempts == 1
+
+
+@pytest.mark.asyncio
+async def test_webhook_delivery_flips_to_failed_on_dispatch_error(
+    client, fake_storage_provider
+):
+    """A raising dispatch marks the row failed but still returns 202."""
+    from primer.model.webhook_delivery import WebhookDelivery
+
+    trigger = await _create_webhook_trigger(
+        fake_storage_provider, slug="wh-durable-failed"
+    )
+
+    async def _boom(*args, **kwargs):
+        raise RuntimeError("dispatch blew up")
+
+    with patch("primer.api.routers.webhooks.fire_trigger", side_effect=_boom):
+        r = await client.post(
+            f"/v1/webhooks/{trigger.config.token}",
+            content=b"{}",
+        )
+    assert r.status_code == 202, r.text
+    delivery_id = r.json()["delivery_id"]
+
+    storage = fake_storage_provider.get_storage(WebhookDelivery)
+    row = await storage.get(delivery_id)
+    assert row is not None
+    assert row.status == "failed"
+    assert row.attempts == 1
+
+
+@pytest.mark.asyncio
 async def test_webhook_endpoint_does_not_require_auth(raw_client, fake_storage_provider):
     """The webhook endpoint is accessible without authentication."""
     trigger = await _create_webhook_trigger(fake_storage_provider, slug="wh-public")

--- a/tests/storage/test_postgres_hot_indexes.py
+++ b/tests/storage/test_postgres_hot_indexes.py
@@ -32,10 +32,29 @@ from primer.storage.postgres import (
 
 def test_registry_declares_the_hot_tables():
     """token_hash / session status / chat recovery / channel routing /
-    useridentity uniqueness are all registered."""
+    useridentity uniqueness / webhook recovery are all registered."""
     assert set(_HOT_FIELD_INDEXES) == {
         "apitoken", "sessions", "chat", "channel", "useridentity",
+        "webhookdelivery",
     }
+
+
+def test_webhookdelivery_index_covers_the_recovery_status_filter():
+    """Startup webhook recovery filters status='pending' on every boot; an
+    expression index on the extracted scalar serves that."""
+    (suffix, unique, expr), = _HOT_FIELD_INDEXES["webhookdelivery"]
+    assert suffix == "status"
+    assert unique is False
+    assert expr == "((data->>'status'))"
+
+
+def test_webhook_delivery_model_maps_to_the_webhookdelivery_table():
+    """The index lives on the same table the WebhookDelivery model stores in
+    (the lowercased class name)."""
+    from primer.model.webhook_delivery import WebhookDelivery
+
+    assert _table_name_for(WebhookDelivery) == "webhookdelivery"
+    assert "webhookdelivery" in _HOT_FIELD_INDEXES
 
 
 def test_chat_index_covers_status_and_turn_status():

--- a/tests/storage/test_postgres_hot_indexes.py
+++ b/tests/storage/test_postgres_hot_indexes.py
@@ -31,11 +31,29 @@ from primer.storage.postgres import (
 
 
 def test_registry_declares_the_hot_tables():
-    """token_hash / session status / channel routing / useridentity uniqueness
-    are all registered."""
+    """token_hash / session status / chat recovery / channel routing /
+    useridentity uniqueness are all registered."""
     assert set(_HOT_FIELD_INDEXES) == {
-        "apitoken", "sessions", "channel", "useridentity",
+        "apitoken", "sessions", "chat", "channel", "useridentity",
     }
+
+
+def test_chat_index_covers_status_and_turn_status():
+    """Startup chat recovery filters status='active' AND turn_status IN
+    (claimable, running); a composite expression index serves that."""
+    (suffix, unique, expr), = _HOT_FIELD_INDEXES["chat"]
+    assert suffix == "status_turn"
+    assert unique is False
+    assert expr == "((data->>'status'), (data->>'turn_status'))"
+
+
+def test_chat_model_maps_to_the_chat_table():
+    """The chat index lives on the same table the Chat model stores in
+    (singular 'chat', the lowercased class name)."""
+    from primer.model.chats import Chat
+
+    assert _table_name_for(Chat) == "chat"
+    assert "chat" in _HOT_FIELD_INDEXES
 
 
 def test_apitoken_token_hash_index_is_unique_on_the_scalar():


### PR DESCRIPTION
Fixes three findings from the platform architecture review (2026-07-17). Each was adversarially verified before any code was written. This branch went through **two review rounds** - the first returned NEEDS-REWORK, and the second caught two further defects that the rework itself had introduced. Both rounds are addressed here.

## 1. Webhook deliveries were lost on crash

`receive_webhook` returned **202 "accepted"** and then dispatched via an in-process background task, with nothing durable written first (`fire_trigger` only persists *after* dispatching). A crash in that window lost the delivery permanently - and because senders treat 202 as accepted, they never retry.

An inbound delivery is now persisted before the 202, and pending rows are re-fired on startup.

### What the reviews caught in the fix itself

- **The recovery loop silently skipped deliveries.** It offset-paged `find(status='pending')` while dispatch flipped each row to `done` - mutating the very predicate it was paging. With 500 stale rows it dispatched 1-200, then jumped to 401-500, silently skipping 201-400. It failed hardest in the mass-crash case the feature exists for. Now it collects the set before dispatching.
- **The dedupe inverted its own intent, both ways.** `delivery_id` was keyed on (trigger, arrival millisecond), which correlates with neither sender nor payload. Two *distinct* webhooks arriving in the same millisecond collided, so the second returned 202 and **never dispatched** - a brand-new silent-loss path inside the fix meant to eliminate silent loss. Meanwhile a *genuine* duplicate retry seconds later got a new id and fired **twice**. Each request now gets its own row, and a conflict logs and dispatches rather than silently accepting.
- **Collect-then-dispatch introduced a boot OOM.** It held every pending row at once, each carrying up to a 1 MB body, where the old code held at most 200 per page. Now only ids are collected; each row is re-read immediately before dispatch - which also skips rows a live sibling already finalized.
- **The grace window deferred recovery indefinitely.** The sweep is one-shot, so a delivery dropped inside the grace band was never revisited by that process and waited for the next boot - possibly never. Widening the window to 300s had made that band 10x larger, *widening the very silent-loss window this batch closes*, and the comment asserted a bound ("bounded by the boot cadence") that a one-shot sweep does not have. A single self-terminating re-check now drains the skipped set, so the window is a genuine bound; the comment states the real trade.

### The attempts cap, and why the obvious version would not have worked

`attempts` was written but never read, so a row that never finalized would re-fire on **every boot forever**, spawning duplicate chats each time. But simply *consulting* the counter would have bounded neither failure mode: it was only incremented *after* the risky work, so a process-killing crash never reaches the increment, and a failing finalize is swallowed. The counter had to move **before** the dispatch. A guard that cannot fire is worse than no guard.

### Accepted trade: at-least-once

Delivery is now at-least-once, not exactly-once - a crash in the delivered-but-not-yet-marked window can double-deliver, and a re-fire has real side effects (it can spawn a duplicate chat and agent run). That is a deliberate trade: a rare, visible duplicate an operator can reconcile beats **permanent silent loss** on a 202 the sender will never retry. The endpoint is explicitly **not** idempotent for duplicate POSTs; real dedupe would need a sender-supplied idempotency key.

## 2. Boot cost scaled with total chat count

Startup chat recovery listed **every** chat row and filtered in Python, while the sibling session recovery pushes the predicate into SQL. Now mirrored, plus a `webhookdelivery` status index (the new table was otherwise a JSONB seq scan, reintroducing the same pathology in the same PR).

## 3. Every authenticated request paid a redundant COUNT

Bearer-token lookup used an offset-paged `find`, which always issues `COUNT(*)` alongside the length-1 SELECT. `token_hash` is a unique index, so the count was pure waste. Now a cursor lookup, which issues none.

## Known residuals (deliberately not fixed here)

- **The re-check is per-process and in-memory.** If the process exits first, those ids revert to next-boot recovery. Better than never revisiting them, but not durable.
- **The multi-process re-fire hazard is unchanged.** The grace narrows latency; it adds no claim or lock. Routing recovery through the platform's own claim machine is the real answer - rejected here as not contained (`ClaimKind` is a closed enum and the engine is a continuous-runner API, so a one-shot sweep would need a new enum member, adapter, factory registration, a consumer loop heartbeating through a longer-than-window dispatch, and a lease write on the webhook hot path). A CAS alternative is unavailable: `Storage.update` is a full-blob replace with no version column.
- **`webhookdelivery` rows are never pruned.** The index bounds scan cost, not table growth. Retention wants its own change.
- Future-dated rows (clock skew) clamp to the grace and defer to the next boot, deliberately.

## Testing

Both HIGH fixes were proven RED against the pre-fix code. The 250-row regression test uses the real page size and its spy actually flips rows to `done`, so it reproduces the mutating predicate rather than mocking past it. Targeted named-file runs only: recovery 9 passed, endpoint 17 passed, hot-indexes 15 passed / 1 skipped (live-Postgres). The broad suite runs in CI.

Held: no merge, no release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
