### PR TITLE
fix(mcp): enforce authorization per-call, not per-connection

### DIFF
--- a/primer/api/_app_mcp.py
+++ b/primer/api/_app_mcp.py
@@ -41,22 +41,28 @@ def _make_mcp_auth_gate(app: FastAPI):
     """Build the ASGI gate that fronts ``StreamableHTTPSessionManager``.
 
     Reads scope state populated by :class:`AuthMiddleware`
-    (``state.user`` / ``state.principal`` / ``state.api_token``),
-    rejects anonymous callers with 401 + ``WWW-Authenticate``, and
-    enforces the ``mcp`` scope on bearer tokens with 403. Cookie
-    sessions carry full user authority (``api_token is None``) and
-    pass through without a scope check.
+    (``state.user`` / ``state.principal`` / ``state.api_token``) and
+    rejects anonymous callers with 401 + ``WWW-Authenticate``. That is
+    the ONLY gate applied at connect time: any authenticated principal
+    -- bearer token regardless of scope, cookie session, or a
+    ``restricted``-role user -- may connect. The ``mcp`` scope and the
+    ``restricted``-role floor are enforced PER CALL instead, inside
+    :func:`primer.mcp.dispatch.invoke_exposed` (scope) and its existing
+    ``required_role`` check (role), so a denial surfaces as an in-band
+    ``isError`` tool result rather than a connection rejection.
 
-    On success the principal + api_token id are stashed in the
-    module-level :class:`ContextVar`s :data:`current_principal` and
-    :data:`current_api_token_id` (from :mod:`primer.mcp.server`) so
-    the MCP request handlers see the authenticated caller. The
-    ContextVars are reset in a ``finally`` so concurrent requests on
-    the same worker do not leak identities.
+    On success the principal, api_token id, actor, and the token's
+    scopes are stashed in the module-level :class:`ContextVar`s
+    :data:`current_principal`, :data:`current_api_token_id`,
+    :data:`current_actor`, and :data:`current_api_token_scopes` (from
+    :mod:`primer.mcp.server`) so the MCP request handlers see the
+    authenticated caller. The ContextVars are reset in a ``finally`` so
+    concurrent requests on the same worker do not leak identities.
     """
     from primer.mcp.server import (
         current_actor as _current_actor,
         current_api_token_id as _current_api_token_id,
+        current_api_token_scopes as _current_api_token_scopes,
         current_principal as _current_principal,
     )
     from starlette.datastructures import State
@@ -96,24 +102,6 @@ def _make_mcp_auth_gate(app: FastAPI):
             )
             return
 
-        if api_token is not None and "mcp" not in api_token.scopes:
-            await _mcp_send_simple_response(
-                send, 403,
-                {"detail": {"code": "scope_required", "scope": "mcp"}},
-            )
-            return
-
-        # RBAC: restricted callers may authenticate but never reach the
-        # MCP dispatch surface. Rejected here before the session manager
-        # is consulted, symmetric with the per-tool admin gate in
-        # :func:`primer.mcp.dispatch.invoke_exposed`.
-        if actor is not None and getattr(actor, "role", None) == "restricted":
-            await _mcp_send_simple_response(
-                send, 403,
-                {"detail": {"code": "forbidden_role"}},
-            )
-            return
-
         session_manager = getattr(app.state, "mcp_session_manager", None)
         if session_manager is None:
             # Should never happen in a well-configured app — surface a
@@ -129,12 +117,20 @@ def _make_mcp_auth_gate(app: FastAPI):
         api_token_id_tok = _current_api_token_id.set(
             api_token.id if api_token is not None else None
         )
+        # None is the sentinel for a cookie session (full user
+        # authority, no scope check); a bearer token stashes its
+        # concrete (possibly empty) scopes list for the per-call
+        # scope floor in primer.mcp.dispatch.invoke_exposed.
+        api_token_scopes_tok = _current_api_token_scopes.set(
+            api_token.scopes if api_token is not None else None
+        )
         try:
             await session_manager.handle_request(scope, receive, send)
         finally:
             _current_principal.reset(principal_tok)
             _current_api_token_id.reset(api_token_id_tok)
             _current_actor.reset(actor_tok)
+            _current_api_token_scopes.reset(api_token_scopes_tok)
 
     return _mcp_auth_gate
 

--- a/primer/mcp/dispatch.py
+++ b/primer/mcp/dispatch.py
@@ -27,6 +27,7 @@ from primer.mcp.exposure import (
     get_exposure,
 )
 from primer.mcp.safety import is_exposable, tool_scoped_id
+from primer.model.api_token import SCOPE_MCP
 from primer.model.chat import Tool, ToolCallResult
 
 if TYPE_CHECKING:
@@ -163,6 +164,7 @@ async def invoke_exposed(
     principal: str | None,
     deps: ExposureDeps,
     actor: "Principal | None" = None,
+    api_token_scopes: list[str] | None = None,
 ) -> ToolCallResult:
     """Dispatch a ``tools/call`` to the owning provider.
 
@@ -207,6 +209,19 @@ async def invoke_exposed(
     failure, not a "does not exist" signal. An ``is_error``
     :class:`ToolCallResult` is returned in-band instead, and the
     provider's handler is never invoked.
+
+    Scope gate
+    ----------
+    Every MCP tool call requires the ``mcp`` scope on bearer-token
+    callers -- this used to be enforced once at connect time (the
+    ``_mcp_auth_gate`` 403 ``scope_required`` response); it now runs
+    here, per call, so any authenticated principal may connect and the
+    scope is re-checked on every ``tools/call``. ``api_token_scopes`` is
+    ``None`` for a cookie session (``request.state.api_token is None``
+    -- full user authority) and bypasses the check, mirroring
+    :func:`primer.api.deps.require_scope`. A bearer token's scopes are a
+    concrete list; ``mcp`` must be a member. Denial is IN-BAND, same
+    shape as the RBAC floor below.
     """
     exposure = await get_exposure(deps)
     if not exposure.enabled or scoped_id not in set(exposure.allowed_tools):
@@ -237,6 +252,18 @@ async def invoke_exposed(
     ok, reason = is_exposable(tool, provider=provider)
     if not ok:
         raise NotExposed(scoped_id, reason=reason)
+    # Scope floor: a bearer-token caller (api_token_scopes is a concrete
+    # list) must carry the ``mcp`` scope to invoke ANY tool. A cookie
+    # session (api_token_scopes is None, full user authority) bypasses,
+    # mirroring ``require_scope`` in primer/api/deps.py. Moved here from
+    # connect-time so any authenticated principal may connect and every
+    # call is re-authorized. Denial is IN-BAND, same shape as the RBAC
+    # floor below; the handler is never reached in that case.
+    if api_token_scopes is not None and SCOPE_MCP not in api_token_scopes:
+        return ToolCallResult(
+            output="access denied: the 'mcp' scope is required for this call",
+            is_error=True,
+        )
     # RBAC floor: every exposed tool -- across every toolset, not just
     # ``system`` -- declares (or fails closed to ``admin`` for) a
     # required_role via the owning provider. The caller's Principal must

--- a/primer/mcp/dispatch.py
+++ b/primer/mcp/dispatch.py
@@ -212,16 +212,21 @@ async def invoke_exposed(
 
     Scope gate
     ----------
-    Every MCP tool call requires the ``mcp`` scope on bearer-token
-    callers -- this used to be enforced once at connect time (the
+    An MCP tool call requires the ``mcp`` scope on bearer-token callers
+    -- this used to reject the connection at connect time (the
     ``_mcp_auth_gate`` 403 ``scope_required`` response); it now runs
-    here, per call, so any authenticated principal may connect and the
-    scope is re-checked on every ``tools/call``. ``api_token_scopes`` is
-    ``None`` for a cookie session (``request.state.api_token is None``
-    -- full user authority) and bypasses the check, mirroring
-    :func:`primer.api.deps.require_scope`. A bearer token's scopes are a
-    concrete list; ``mcp`` must be a member. Denial is IN-BAND, same
-    shape as the RBAC floor below.
+    here in the dispatch path, so any authenticated principal may
+    connect and a disallowed call is denied in-band instead. The scopes
+    are those the auth gate captured for the connecting credential: the
+    MCP session is pinned to one credential for its lifetime (the
+    stateful streamable-HTTP handler runs in the task created at
+    ``initialize``), so this is that caller's scope set. A bearer token
+    whose scopes are edited mid-session keeps its connect-time set until
+    it reconnects. ``api_token_scopes`` is ``None`` for a cookie session
+    (``request.state.api_token is None`` -- full user authority) and
+    bypasses the check, mirroring :func:`primer.api.deps.require_scope`.
+    A bearer token's scopes are a concrete list; ``mcp`` must be a
+    member. Denial is IN-BAND, same shape as the RBAC floor below.
     """
     exposure = await get_exposure(deps)
     if not exposure.enabled or scoped_id not in set(exposure.allowed_tools):
@@ -256,9 +261,10 @@ async def invoke_exposed(
     # list) must carry the ``mcp`` scope to invoke ANY tool. A cookie
     # session (api_token_scopes is None, full user authority) bypasses,
     # mirroring ``require_scope`` in primer/api/deps.py. Moved here from
-    # connect-time so any authenticated principal may connect and every
-    # call is re-authorized. Denial is IN-BAND, same shape as the RBAC
-    # floor below; the handler is never reached in that case.
+    # connect-time so any authenticated principal may connect and a
+    # disallowed call is denied in the dispatch path instead. Denial is
+    # IN-BAND, same shape as the RBAC floor below; the handler is never
+    # reached in that case.
     if api_token_scopes is not None and SCOPE_MCP not in api_token_scopes:
         return ToolCallResult(
             output="access denied: the 'mcp' scope is required for this call",

--- a/primer/mcp/server.py
+++ b/primer/mcp/server.py
@@ -60,6 +60,15 @@ current_api_token_id: ContextVar[str | None] = ContextVar(
 current_actor: ContextVar["Principal | None"] = ContextVar(
     "primer_mcp_actor", default=None,
 )
+# The auth gate also stashes the authenticated bearer token's scopes
+# here so the dispatch layer can enforce the ``mcp`` scope per call (see
+# Task 9 follow-up: the scope floor moved from connect-time to call-time
+# so any authenticated caller may connect). ``None`` is the sentinel for
+# a cookie session (``api_token is None``) -- full user authority, no
+# scope check. A concrete (possibly empty) list means a bearer token.
+current_api_token_scopes: ContextVar["list[str] | None"] = ContextVar(
+    "primer_mcp_api_token_scopes", default=None,
+)
 
 
 def build_mcp_server(deps_factory: Callable[[], ExposureDeps]) -> Server:
@@ -112,6 +121,7 @@ def build_mcp_server(deps_factory: Callable[[], ExposureDeps]) -> Server:
         principal = current_principal.get()
         api_token_id = current_api_token_id.get()
         actor = current_actor.get()
+        api_token_scopes = current_api_token_scopes.get()
         t0 = time.monotonic()
         error_code: str | None = None
         ok = False
@@ -122,6 +132,7 @@ def build_mcp_server(deps_factory: Callable[[], ExposureDeps]) -> Server:
                     arguments=arguments or {},
                     principal=principal,
                     actor=actor,
+                    api_token_scopes=api_token_scopes,
                     deps=deps,
                 )
             except NotExposed as exc:
@@ -176,4 +187,5 @@ __all__ = [
     "current_principal",
     "current_api_token_id",
     "current_actor",
+    "current_api_token_scopes",
 ]

--- a/primer/mcp/server.py
+++ b/primer/mcp/server.py
@@ -61,11 +61,13 @@ current_actor: ContextVar["Principal | None"] = ContextVar(
     "primer_mcp_actor", default=None,
 )
 # The auth gate also stashes the authenticated bearer token's scopes
-# here so the dispatch layer can enforce the ``mcp`` scope per call (see
-# Task 9 follow-up: the scope floor moved from connect-time to call-time
-# so any authenticated caller may connect). ``None`` is the sentinel for
-# a cookie session (``api_token is None``) -- full user authority, no
-# scope check. A concrete (possibly empty) list means a bearer token.
+# here so the dispatch layer can enforce the ``mcp`` scope when a tool
+# call is dispatched (the scope floor moved from connect-time into
+# dispatch so any authenticated caller may connect). The value is
+# captured for the credential that opened the session. ``None`` is the
+# sentinel for a cookie session (``api_token is None``) -- full user
+# authority, no scope check. A concrete (possibly empty) list means a
+# bearer token.
 current_api_token_scopes: ContextVar["list[str] | None"] = ContextVar(
     "primer_mcp_api_token_scopes", default=None,
 )

--- a/tests/api/test_mcp_mount.py
+++ b/tests/api/test_mcp_mount.py
@@ -1,17 +1,25 @@
-"""MCP HTTP mount: auth gate + GZip bypass — Spec §4-5.
+"""MCP HTTP mount: auth gate + GZip bypass -- Spec Sec.4-5.
 
 The ``client`` / ``raw_client`` fixtures in tests/api/conftest.py start
 the MCP session manager + mount the /v1/mcp gate during test setup,
 so we can drive the gate end-to-end.
 
-The tests deliberately do NOT exercise the full MCP protocol — that
-belongs to the Phase 7 e2e tests. Here we only verify the auth gate
-returns the documented status codes for each principal flavour:
+The connect-time gate now authenticates ONLY -- anonymous callers are
+still rejected with 401, but the ``mcp`` scope and the ``restricted``
+role floor moved to per-call enforcement (see primer/mcp/dispatch.py
+`invoke_exposed`). So at connect time:
 
-* anonymous → 401 with WWW-Authenticate
-* cookie session → not 401/403 (passes through to SDK)
-* bearer with mcp scope → not 401/403
-* bearer without mcp scope → 403 + scope_required body
+* anonymous -> 401 with WWW-Authenticate
+* cookie session -> not 401/403 (passes through to SDK, full authority)
+* bearer with mcp scope -> not 401/403
+* bearer without mcp scope -> not 401/403 (CONNECTS; the tool CALL is
+  what gets denied, in-band, per-call)
+* restricted role -> not 401/403 (CONNECTS; a role-gated tool CALL is
+  what gets denied, in-band, per-call)
+
+A handful of tests below drive a real ``tools/call`` through the mount
+(over an in-process ASGI transport, no live socket) to prove the call-
+level outcome, not just the connect-level status code.
 """
 
 from __future__ import annotations
@@ -39,9 +47,42 @@ async def _seeded_user(fake_storage_provider) -> User:
     return items[0]
 
 
+async def _mcp_call(app, *, headers: dict[str, str], tool_name: str, arguments=None):
+    """Drive a real ``tools/call`` through the /v1/mcp mount.
+
+    Uses an in-process ASGI transport (via a custom ``httpx_client_factory``)
+    so the full StreamableHTTP protocol -- initialize handshake, then
+    tools/call -- runs against the test app without a live socket. Returns
+    the SDK's ``CallToolResult``.
+    """
+    import httpx as _httpx
+    from httpx import ASGITransport
+    from mcp import ClientSession
+    from mcp.client.streamable_http import streamablehttp_client
+
+    def _factory(headers=None, timeout=None, auth=None):
+        return _httpx.AsyncClient(
+            transport=ASGITransport(app=app),
+            base_url="http://test",
+            follow_redirects=True,
+            headers=headers,
+            timeout=timeout or _httpx.Timeout(30),
+            auth=auth,
+        )
+
+    async with streamablehttp_client(
+        "http://test/v1/mcp/",
+        headers=headers,
+        httpx_client_factory=_factory,
+    ) as (read, write, _get_session_id):
+        async with ClientSession(read, write) as sess:
+            await sess.initialize()
+            return await sess.call_tool(tool_name, arguments=arguments or {})
+
+
 @pytest.mark.asyncio
 async def test_mcp_endpoint_rejects_anonymous(raw_client):
-    """No auth → 401 with WWW-Authenticate header."""
+    """No auth -> 401 with WWW-Authenticate header."""
     resp = await raw_client.get(
         "/v1/mcp/",
         headers={"Accept": "text/event-stream"},
@@ -54,7 +95,7 @@ async def test_mcp_endpoint_rejects_anonymous(raw_client):
 
 @pytest.mark.asyncio
 async def test_mcp_endpoint_accepts_cookie_session(client):
-    """Cookie session → not 401/403.
+    """Cookie session -> not 401/403.
 
     The SDK rejects a bare GET without proper MCP handshake headers
     (returns 4xx other than 401), but the auth gate must let the
@@ -66,10 +107,29 @@ async def test_mcp_endpoint_accepts_cookie_session(client):
 
 
 @pytest.mark.asyncio
+async def test_mcp_endpoint_cookie_session_call_succeeds(client, app):
+    """Cookie session carries full authority: a real tools/call succeeds
+    with no scope check at all (``api_token`` is None for cookie auth)."""
+    enable = await client.put(
+        "/v1/mcp_exposure",
+        json={"enabled": True, "allowed_tools": ["misc__uuid_v4"]},
+    )
+    assert enable.status_code == 200, enable.text
+
+    cookie_header = "; ".join(
+        f"{c.name}={c.value}" for c in client.cookies.jar
+    )
+    result = await _mcp_call(
+        app, headers={"Cookie": cookie_header}, tool_name="misc__uuid_v4",
+    )
+    assert result.isError is False, getattr(result, "content", result)
+
+
+@pytest.mark.asyncio
 async def test_mcp_endpoint_with_bearer_mcp_scope_passes(
     client, fake_storage_provider,
 ):
-    """Bearer with ``mcp`` scope → not 401/403."""
+    """Bearer with ``mcp`` scope -> not 401/403."""
     user = await _seeded_user(fake_storage_provider)
     plaintext = mint_plaintext()
     token = ApiToken(
@@ -92,10 +152,44 @@ async def test_mcp_endpoint_with_bearer_mcp_scope_passes(
 
 
 @pytest.mark.asyncio
-async def test_mcp_endpoint_with_bearer_no_mcp_scope_403(
-    client, fake_storage_provider,
+async def test_mcp_endpoint_with_bearer_mcp_scope_call_succeeds(
+    client, app, fake_storage_provider,
 ):
-    """Bearer without ``mcp`` scope → 403 + scope_required body."""
+    """Bearer WITH ``mcp`` scope connects and a tools/call succeeds
+    (subject to role -- the seeded testuser is an admin, so the
+    ``user``-role floor on ``misc__uuid_v4`` clears easily)."""
+    user = await _seeded_user(fake_storage_provider)
+    plaintext = mint_plaintext()
+    token = ApiToken(
+        id="at-mcp-call",
+        user_id=user.id,
+        name="test-mcp-call",
+        token_hash=hash_token(plaintext),
+        prefix=extract_prefix(plaintext),
+        scopes=["mcp"],
+        created_at=datetime.now(timezone.utc),
+    )
+    await fake_storage_provider.get_storage(ApiToken).create(token)
+
+    enable = await client.put(
+        "/v1/mcp_exposure",
+        json={"enabled": True, "allowed_tools": ["misc__uuid_v4"]},
+    )
+    assert enable.status_code == 200, enable.text
+
+    client.cookies.clear()
+    headers = {"Authorization": f"Bearer {plaintext}"}
+    result = await _mcp_call(app, headers=headers, tool_name="misc__uuid_v4")
+    assert result.isError is False, getattr(result, "content", result)
+
+
+@pytest.mark.asyncio
+async def test_mcp_endpoint_with_bearer_no_mcp_scope_connects_then_call_denied(
+    client, app, fake_storage_provider,
+):
+    """Bearer without ``mcp`` scope -> CONNECTS (no connect-time 403); a
+    subsequent ``tools/call`` is denied IN-BAND with the scope message --
+    not a connection rejection and not a protocol-level error."""
     user = await _seeded_user(fake_storage_provider)
     plaintext = mint_plaintext()
     token = ApiToken(
@@ -108,12 +202,66 @@ async def test_mcp_endpoint_with_bearer_no_mcp_scope_403(
         created_at=datetime.now(timezone.utc),
     )
     await fake_storage_provider.get_storage(ApiToken).create(token)
-    client.cookies.clear()
-    resp = await client.get(
-        "/v1/mcp/",
-        headers={"Authorization": f"Bearer {plaintext}"},
+
+    enable = await client.put(
+        "/v1/mcp_exposure",
+        json={"enabled": True, "allowed_tools": ["misc__uuid_v4"]},
     )
-    assert resp.status_code == 403
-    body = resp.json()
-    assert body["detail"]["code"] == "scope_required"
-    assert body["detail"]["scope"] == "mcp"
+    assert enable.status_code == 200, enable.text
+
+    client.cookies.clear()
+    headers = {"Authorization": f"Bearer {plaintext}"}
+
+    resp = await client.get("/v1/mcp/", headers=headers)
+    assert resp.status_code != 401, resp.text
+    assert resp.status_code != 403, resp.text
+
+    result = await _mcp_call(app, headers=headers, tool_name="misc__uuid_v4")
+    assert result.isError is True
+    text = result.content[0].text
+    assert "mcp" in text
+    assert "scope" in text
+
+
+@pytest.mark.asyncio
+async def test_mcp_endpoint_restricted_role_connects_but_call_denied(
+    client, raw_client, app,
+):
+    """A ``restricted``-role cookie session now CONNECTS (the connect-time
+    ``forbidden_role`` 403 was removed); the existing per-call
+    ``required_role`` floor is what denies a role-gated tool CALL instead
+    (``misc__uuid_v4`` needs ``user``, which ``restricted`` does not meet)."""
+    from primer.auth.passwords import hash_password
+
+    enable = await client.put(
+        "/v1/mcp_exposure",
+        json={"enabled": True, "allowed_tools": ["misc__uuid_v4"]},
+    )
+    assert enable.status_code == 200, enable.text
+
+    storage = app.state.storage_provider.get_storage(User)
+    await storage.create(User(
+        id="user-restricted-mcp",
+        username="restricted-mcp",
+        password_hash=await hash_password("pw"),
+        created_at=datetime.now(timezone.utc),
+        role="restricted",
+    ))
+    login = await raw_client.post(
+        "/v1/auth/login",
+        json={"username": "restricted-mcp", "password": "pw"},
+    )
+    assert login.status_code == 200, login.text
+
+    resp = await raw_client.get("/v1/mcp/")
+    assert resp.status_code != 401, resp.text
+    assert resp.status_code != 403, resp.text
+
+    cookie_header = "; ".join(
+        f"{c.name}={c.value}" for c in raw_client.cookies.jar
+    )
+    result = await _mcp_call(
+        app, headers={"Cookie": cookie_header}, tool_name="misc__uuid_v4",
+    )
+    assert result.isError is True
+    assert "requires" in result.content[0].text

--- a/tests/api/test_mcp_rbac.py
+++ b/tests/api/test_mcp_rbac.py
@@ -1,13 +1,15 @@
-"""Task 9 — MCP request-entry RBAC gates.
+"""Task 9 -- MCP request-entry RBAC gates.
 
-* ``_make_mcp_auth_gate`` rejects a ``restricted`` caller (via
-  ``state.actor``) with 403 ``forbidden_role`` before any dispatch.
+* ``_make_mcp_auth_gate`` no longer rejects a ``restricted`` caller (via
+  ``state.actor``) at connect time -- only anonymous callers are refused
+  there (401). A restricted caller now reaches the session manager; the
+  ``restricted``-role floor is enforced PER CALL instead, by the existing
+  ``required_role`` check in :func:`primer.mcp.dispatch.invoke_exposed`.
 * ``PUT /v1/mcp_exposure`` is admin-only (``require_admin``).
 """
 
 from __future__ import annotations
 
-import json
 from datetime import datetime, timezone
 
 import pytest
@@ -21,13 +23,27 @@ from primer.model.user import User
 
 
 @pytest.mark.asyncio
-async def test_mcp_gate_rejects_restricted_actor() -> None:
-    """A restricted actor is refused at the gate before the session
-    manager is ever consulted."""
+async def test_mcp_gate_allows_restricted_actor_to_connect() -> None:
+    """A restricted actor now reaches the session manager -- the connect-
+    time ``forbidden_role`` 403 was removed; only the 401 anonymous gate
+    remains at connect. A stub session manager stands in for the real SDK
+    plumbing so this stays a unit test of the gate, not the SDK."""
     from fastapi import FastAPI
     from starlette.datastructures import State
 
-    gate = _make_mcp_auth_gate(FastAPI())
+    stub_app = FastAPI()
+    handled: list[dict] = []
+
+    class _StubSessionManager:
+        async def handle_request(self, scope, receive, send):
+            handled.append(scope)
+            await send({
+                "type": "http.response.start", "status": 200, "headers": [],
+            })
+            await send({"type": "http.response.body", "body": b""})
+
+    stub_app.state.mcp_session_manager = _StubSessionManager()
+    gate = _make_mcp_auth_gate(stub_app)
 
     st = State()
     st.user = User(
@@ -52,15 +68,9 @@ async def test_mcp_gate_rejects_restricted_actor() -> None:
 
     await gate(scope, _receive, _send)
 
+    assert handled, "restricted actor must reach the session manager"
     assert sent[0]["type"] == "http.response.start"
-    assert sent[0]["status"] == 403
-    body = json.loads(sent[1]["body"])
-    # The MCP gate is raw ASGI: it hand-rolls this body (see
-    # _mcp_send_simple_response) before FastAPI's exception machinery runs, so
-    # it does NOT go through the problem+json handler and keeps the bare
-    # {"detail": ...} shape. Contrast test_mcp_exposure_put_forbidden_for_non_admin
-    # below, which is a normal route and gets the RFC 7807 envelope.
-    assert body["detail"]["code"] == "forbidden_role"
+    assert sent[0]["status"] == 200
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_dispatch_rbac.py
+++ b/tests/mcp/test_dispatch_rbac.py
@@ -63,8 +63,14 @@ class _Registry:
 
 
 def _system_deps(storage):
-    """Two reserved tools: a ``user``-role one and an ``admin``-role one."""
+    """Three reserved tools: ``restricted``-, ``user``-, and ``admin``-role."""
     tools = [
+        Tool(
+            id="ping",
+            toolset_id="system",
+            description="Ungated liveness probe.",
+            args_schema={"type": "object", "properties": {}},
+        ),
         Tool(
             id="create_agent",
             toolset_id="system",
@@ -78,7 +84,11 @@ def _system_deps(storage):
             args_schema={"type": "object", "properties": {}},
         ),
     ]
-    roles = {"create_agent": "user", "create_llm_provider": "admin"}
+    roles = {
+        "ping": "restricted",
+        "create_agent": "user",
+        "create_llm_provider": "admin",
+    }
     provider = _SysProvider(tools, roles)
     registry = _Registry({"system": provider})
     deps = ExposureDeps(storage_provider=storage, provider_registry=registry)
@@ -127,6 +137,30 @@ async def test_role_matrix_for_user_type_actor(
         assert result.is_error is True
         assert "requires" in result.output
         assert provider.calls == []  # never dispatched
+
+
+@pytest.mark.asyncio
+async def test_restricted_actor_allowed_on_restricted_role_tool(
+    fake_storage_provider,
+) -> None:
+    """A ``restricted`` actor -- now free to CONNECT at all, per the
+    connect-time gate change (Task 9 follow-up) -- clears a tool whose
+    declared role is itself ``restricted`` (rank 0 meets rank 0), while a
+    ``user``-role tool in the SAME call session is still denied. Proves
+    the per-call ``required_role`` floor is the only gate now, and that
+    it is not a blanket "restricted can never call anything" rule."""
+    deps, provider = _system_deps(fake_storage_provider)
+    actor = Principal(
+        type="user", id="r", display="r", role="restricted", source="local",
+    )
+
+    ok_result = await _invoke(deps, tool_name="ping", actor=actor)
+    denied_result = await _invoke(deps, tool_name="create_agent", actor=actor)
+
+    assert ok_result.is_error is False
+    assert provider.calls == ["ping"]
+    assert denied_result.is_error is True
+    assert "requires" in denied_result.output
 
 
 @pytest.mark.asyncio

--- a/tests/mcp/test_server_handlers.py
+++ b/tests/mcp/test_server_handlers.py
@@ -18,6 +18,7 @@ from primer.mcp.exposure import ExposureDeps, update_exposure
 from primer.mcp.server import (
     build_mcp_server,
     current_api_token_id,
+    current_api_token_scopes,
     current_principal,
 )
 from primer.model.chat import ToolCallResult
@@ -241,6 +242,109 @@ async def test_invoke_allowed_returns_result(
     }]
 
 
+# ---- scope gate (the ``mcp`` scope, enforced per call) ---------------------
+#
+# This used to be a connect-time 403 in the ASGI auth gate
+# (_mcp_auth_gate); it now runs here, per call, so ANY authenticated
+# principal may connect and every tools/call re-checks the token's
+# scopes. ``api_token_scopes=None`` is the cookie-session sentinel (full
+# user authority, no scope check); a bearer token passes its concrete
+# (possibly empty) scopes list.
+
+
+@pytest.mark.asyncio
+async def test_invoke_bearer_without_mcp_scope_denied_in_band(
+    fake_storage_provider, fake_provider_registry_with_tools, system_actor,
+) -> None:
+    """A bearer token whose scopes don't include ``mcp`` is denied
+    IN-BAND -- not raised, not a connection-level rejection. ``system_actor``
+    clears the (unrelated) RBAC floor so this isolates the scope check."""
+    deps = _deps(fake_storage_provider, fake_provider_registry_with_tools)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__uuid_v4"],
+        updated_by="alice", deps=deps,
+    )
+
+    result = await invoke_exposed(
+        scoped_id="misc__uuid_v4", arguments={},
+        principal=None, actor=system_actor,
+        api_token_scopes=["api"], deps=deps,
+    )
+
+    assert isinstance(result, ToolCallResult)
+    assert result.is_error is True
+    assert "mcp" in result.output
+    assert "scope" in result.output
+    provider = await fake_provider_registry_with_tools.get_toolset("misc")
+    assert provider.calls == []  # never dispatched
+
+
+@pytest.mark.asyncio
+async def test_invoke_bearer_empty_scopes_denied_in_band(
+    fake_storage_provider, fake_provider_registry_with_tools, system_actor,
+) -> None:
+    """An empty (but concrete, not ``None``) scopes list is still a bearer
+    token -- it must be treated distinctly from the cookie-session
+    sentinel and denied for lacking ``mcp``."""
+    deps = _deps(fake_storage_provider, fake_provider_registry_with_tools)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__uuid_v4"],
+        updated_by="alice", deps=deps,
+    )
+
+    result = await invoke_exposed(
+        scoped_id="misc__uuid_v4", arguments={},
+        principal=None, actor=system_actor,
+        api_token_scopes=[], deps=deps,
+    )
+
+    assert result.is_error is True
+
+
+@pytest.mark.asyncio
+async def test_invoke_bearer_with_mcp_scope_allowed(
+    fake_storage_provider, fake_provider_registry_with_tools, system_actor,
+) -> None:
+    """A bearer token carrying the ``mcp`` scope runs normally."""
+    deps = _deps(fake_storage_provider, fake_provider_registry_with_tools)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__uuid_v4"],
+        updated_by="alice", deps=deps,
+    )
+
+    result = await invoke_exposed(
+        scoped_id="misc__uuid_v4", arguments={},
+        principal=None, actor=system_actor,
+        api_token_scopes=["mcp"], deps=deps,
+    )
+
+    assert isinstance(result, ToolCallResult)
+    assert result.is_error is False
+
+
+@pytest.mark.asyncio
+async def test_invoke_cookie_session_bypasses_scope_check(
+    fake_storage_provider, fake_provider_registry_with_tools, system_actor,
+) -> None:
+    """``api_token_scopes=None`` is the cookie-session sentinel -- full
+    user authority, no scope check at all -- mirroring
+    :func:`primer.api.deps.require_scope`."""
+    deps = _deps(fake_storage_provider, fake_provider_registry_with_tools)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__uuid_v4"],
+        updated_by="alice", deps=deps,
+    )
+
+    result = await invoke_exposed(
+        scoped_id="misc__uuid_v4", arguments={},
+        principal=None, actor=system_actor,
+        api_token_scopes=None, deps=deps,
+    )
+
+    assert isinstance(result, ToolCallResult)
+    assert result.is_error is False
+
+
 # ---- approval-gate enforcement (security: MCP has no human-park) -----------
 
 
@@ -409,3 +513,4 @@ async def test_context_vars_default_to_none() -> None:
     """Defaults let unit tests + dev REPL call handlers without auth wiring."""
     assert current_principal.get() is None
     assert current_api_token_id.get() is None
+    assert current_api_token_scopes.get() is None


### PR DESCRIPTION
## What & why

Decision 2 from the platform architecture review: bearer-token scopes gated
only the MCP **connection**, not individual tool calls. Per the product
decision, any authenticated client may now connect to `/v1/mcp`, and
authorization is enforced **when a tool call is dispatched** instead.

- `_mcp_auth_gate` keeps only the 401 (anonymous) rejection at connect; the
  connect-time `scope_required` (403) and `forbidden_role` (403) blocks are
  removed. Any authenticated principal connects.
- The bearer token's scopes are stashed in a new `current_api_token_scopes`
  ContextVar and enforced in `invoke_exposed`: a bearer caller must carry the
  `mcp` scope, else the call is denied **in-band** (`ToolCallResult(is_error=True)`,
  same shape as the existing RBAC role floor). Cookie sessions (`api_token is None`)
  bypass with full authority, mirroring `require_scope`.
- Restricted-role users now connect and get the existing per-call `required_role`
  denial automatically (no separate per-call restricted check needed).

No `Tool.required_scope` field was added: only the `mcp` scope exists today, so
per-tool scope mapping would be YAGNI. This establishes the per-call enforcement
point for when more scopes are introduced.

## Tests
`tests/api/test_mcp_mount.py`, `tests/mcp/test_server_handlers.py`,
`tests/mcp/test_dispatch_rbac.py`, `tests/api/test_mcp_rbac.py` -- 39 passed.
Old connect-time-403 assertions were rewritten to prove connect-then-in-band-deny.
Denials are driven through a real `initialize`+`tools/call` over ASGI transport.

## Reviewer-surfaced items (documented, not blocking)
1. **Enforcement is per-session, not literally per-call.** The MCP mount is
   stateful, so a `tools/call` handler runs in the task created at `initialize`;
   the scopes/role are captured once for the connecting credential. A session is
   pinned to one credential, so the outcome matches intent, but a token whose
   scopes are edited mid-session keeps its connect-time set until it reconnects.
   (Token *revocation* is still caught: the auth gate re-authenticates every POST.)
2. **`tools/list` is now enumerable by any authenticated caller** (including a
   no-`mcp`-scope bearer or a restricted user). This is within the letter of the
   decision ("fail the tool *calls*"); the calls themselves are still denied.
   Flagging in case tool-name enumeration should also be gated.
3. **SDK per-session owner-binding is inert** (pre-existing): primer never sets
   `scope["user"]`, so the SDK cannot reject reuse of a leaked `Mcp-Session-Id` by
   a different authenticated credential. Pre-existing for role/identity; worth a
   follow-up (set `scope["user"]`) if session-reuse hardening is wanted.

HELD -- do not merge without sign-off.
