### PR TITLE
fix(agent): compaction preserves the event log and defers steers

### DIFF
--- a/primer/agent/base.py
+++ b/primer/agent/base.py
@@ -144,8 +144,43 @@ class _BaseAgentExecutor(ABC):
     async def _replace_compacted_head(
         self,
         compacted: list[Message],
+        *,
+        summary_message: Message | None = None,
+        tokens_before: int = 0,
+        tokens_after: int = 0,
     ) -> None:
-        """Replace the persisted history with the compacted form."""
+        """Replace the persisted history with the compacted form.
+
+        ``summary_message`` is the assistant-role summary the strategy
+        produced (``None`` for pruning-only compaction, where nothing was
+        summarised); ``tokens_before`` / ``tokens_after`` are the strategy's
+        telemetry. Surfaces that record compaction as an append-only marker
+        (the workspace executor) use these to build the marker payload;
+        surfaces that rewrite in place (the chat/thread executor) ignore them.
+        """
+
+    # ---- Compaction-window hooks (steer-deferral; workspace override) -----
+
+    async def _open_compaction_window(self) -> list[Message] | None:
+        """Hook run just before the compaction region. Default: no-op.
+
+        Returns a history snapshot to use for compaction, or ``None`` to let
+        the caller fall back to :meth:`_load_history`. The workspace executor
+        overrides this to set a per-session ``compacting`` flag AND snapshot
+        history under the SAME messages lock, so a steer can never slip
+        between the snapshot and the flag (see PR-C). The lock is released
+        before the compaction LLM await -- it is NEVER held across it.
+        """
+        return None
+
+    async def _close_compaction_window(self) -> None:
+        """Hook run after the compaction region (in a ``finally``). No-op here.
+
+        The workspace executor overrides this to clear the ``compacting`` flag
+        and drain any steers deferred during the window, applying them AFTER
+        the compaction marker. Must not raise on the default no-op path.
+        """
+        return None
 
     # ---- Public surface --------------------------------------------------
 
@@ -168,30 +203,48 @@ class _BaseAgentExecutor(ABC):
         non-tool-use stop. Streaming chunks are NOT persisted -- only
         the materialised :class:`Message` is.
         """
-        history = await self._load_history()
-
-        compacted = await self._compaction.maybe_compact(
-            agent=self._agent,
-            llm=self._llm,
-            model=self._model,
-            history=history,
-            new_messages=messages,
-            last_known_input_tokens=self._last_input_tokens,
-            **self._compaction_tool_kwargs(),
-        )
-        if compacted is not None:
-            await self._replace_compacted_head(compacted.new_messages)
-            history = compacted.new_messages
-            logger.info(
-                "AgentExecutor: compaction fired",
-                extra={
-                    "agent_id": self._agent.id,
-                    "before_tokens": compacted.estimated_tokens_before,
-                    "after_tokens": compacted.estimated_tokens_after,
-                    "pruned": compacted.pruned_tool_outputs,
-                    "head_replaced": compacted.head_messages_replaced,
-                },
+        # Bracket the pre-turn compaction region with the window hooks so a
+        # steer arriving mid-compaction is deferred (workspace surface). The
+        # snapshot is taken inside _open_compaction_window under the messages
+        # lock (atomic with setting the compacting flag); the base no-op
+        # returns None and we fall back to _load_history unchanged. The flag is
+        # only live across an ACTUAL LLM await: maybe_compact returns None with
+        # no await when compaction does not fire, and pruning-only is
+        # synchronous, so steers on non-compaction turns are never deferred.
+        snapshot = await self._open_compaction_window()
+        try:
+            history = (
+                snapshot if snapshot is not None else await self._load_history()
             )
+            compacted = await self._compaction.maybe_compact(
+                agent=self._agent,
+                llm=self._llm,
+                model=self._model,
+                history=history,
+                new_messages=messages,
+                last_known_input_tokens=self._last_input_tokens,
+                **self._compaction_tool_kwargs(),
+            )
+            if compacted is not None:
+                await self._replace_compacted_head(
+                    compacted.new_messages,
+                    summary_message=compacted.summary_message,
+                    tokens_before=compacted.estimated_tokens_before,
+                    tokens_after=compacted.estimated_tokens_after,
+                )
+                history = compacted.new_messages
+                logger.info(
+                    "AgentExecutor: compaction fired",
+                    extra={
+                        "agent_id": self._agent.id,
+                        "before_tokens": compacted.estimated_tokens_before,
+                        "after_tokens": compacted.estimated_tokens_after,
+                        "pruned": compacted.pruned_tool_outputs,
+                        "head_replaced": compacted.head_messages_replaced,
+                    },
+                )
+        finally:
+            await self._close_compaction_window()
 
         try:
             async for ev in self._run_loop(
@@ -207,15 +260,27 @@ class _BaseAgentExecutor(ABC):
                 "AgentExecutor: hard-overflow detected; force-compacting and retrying",
                 extra={"agent_id": self._agent.id, "error": str(exc)},
             )
-            forced = await self._compaction.force_compact(
-                agent=self._agent,
-                llm=self._llm,
-                model=self._model,
-                history=history,
-                **self._compaction_tool_kwargs(),
-            )
-            await self._replace_compacted_head(forced.new_messages)
-            history = forced.new_messages
+            # Hard-overflow recovery also runs an LLM await (force_compact), so
+            # bracket it too; ``history`` is already in hand, so the snapshot
+            # from the hook is not needed here (the flag/drain is what matters).
+            await self._open_compaction_window()
+            try:
+                forced = await self._compaction.force_compact(
+                    agent=self._agent,
+                    llm=self._llm,
+                    model=self._model,
+                    history=history,
+                    **self._compaction_tool_kwargs(),
+                )
+                await self._replace_compacted_head(
+                    forced.new_messages,
+                    summary_message=forced.summary_message,
+                    tokens_before=forced.estimated_tokens_before,
+                    tokens_after=forced.estimated_tokens_after,
+                )
+                history = forced.new_messages
+            finally:
+                await self._close_compaction_window()
             async for ev in self._run_loop(
                 history=history,
                 new_messages=messages,

--- a/primer/agent/executor.py
+++ b/primer/agent/executor.py
@@ -222,8 +222,17 @@ class AgentExecutor(_BaseAgentExecutor):
     async def _replace_compacted_head(
         self,
         compacted: list[Message],
+        *,
+        summary_message: Message | None = None,
+        tokens_before: int = 0,
+        tokens_after: int = 0,
     ) -> None:
         """Rewrite the thread's persisted history to the compacted form.
+
+        The ``summary_message`` / ``tokens_*`` kwargs are part of the shared
+        hook signature (the workspace surface records them in an append-only
+        marker); this in-place-rewrite surface derives its summary row from
+        ``compacted`` directly and ignores them.
 
         Strategy: load every existing :class:`ThreadMessage`, identify
         the rows that match the tail of ``compacted`` (by structural

--- a/primer/agent/workspace_executor.py
+++ b/primer/agent/workspace_executor.py
@@ -27,6 +27,8 @@ from primer.model.chat import Message
 from primer.model.except_ import ConflictError
 from primer.model.graph import build_execution_context
 from primer.model.workspace_session import (
+    SessionMessageKind,
+    SessionMessageRecord,
     SessionStatus,
     _UserInputWaiting,
 )
@@ -171,39 +173,124 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
     async def _replace_compacted_head(
         self,
         compacted: list[Message],
+        *,
+        summary_message: "Message | None" = None,
+        tokens_before: int = 0,
+        tokens_after: int = 0,
     ) -> None:
-        """Rewrite ``messages.jsonl`` with the compacted history.
+        """Record a compaction by APPENDING one ``compaction_marker`` record.
 
-        Git history naturally preserves the pre-compaction snapshot --
-        anyone inspecting ``.state/sessions/<id>/`` can ``git show``
-        the previous commit to recover the original messages.
+        ``messages.jsonl`` is APPEND-ONLY: this NEVER whole-file-replaces the
+        file (the old behaviour, which wiped the event log and every
+        pre-compaction message from the live file). Instead it appends ONE
+        ``SessionMessageRecord`` of kind ``COMPACTION_MARKER`` whose payload
+        mirrors the chat surface (primer/chat/executor.py). On the NEXT load,
+        the two history readers (:meth:`_read_messages_jsonl` and
+        :meth:`AgentSession.take_pending_messages`, both via
+        :func:`reconstruct_compacted_history`) fold every Message line
+        physically before the LAST marker into one synthetic assistant
+        summary. The in-memory compacted history for THIS turn is already
+        applied by the base loop; this hook only records the marker for future
+        loads. Nothing is deleted.
 
-        The messages lock is held across the rewrite so it cannot interleave
-        with a concurrent O_APPEND event row or another full-file rewriter.
+        ``summary_message is None`` => pruning-only compaction (tier 1): there
+        is nothing to summarise, so NO marker is written -- the (unpruned)
+        Message lines stay live on disk and pruning is re-derived in-memory
+        each turn. Writing an empty-summary marker would instead drop the
+        pruned head entirely on the next load.
 
-        NOTE (arch-review batch 1, MEDIUM-1): unlike ``_persist_turn`` this
-        hook does NOT contain its own read -- ``compacted`` is derived from
-        the snapshot ``AgentExecutor.invoke`` took at ``_load_history``,
-        which is separated from this rewrite by the compaction LLM call.
-        Locking only the rewrite therefore does not make compaction atomic
-        against a steer that arrives mid-compaction: that steer is appended
-        after the snapshot and is dropped by this rewrite. Closing that
-        window would mean holding the lock across the summarisation call
-        (stalling every append for its duration) or reconciling the file's
-        tail against the snapshot, neither of which belongs in this fix --
-        it is called out in the review notes instead.
+        The messages lock is held across the read+append so it cannot
+        interleave with a concurrent O_APPEND event row or another full-file
+        rewriter. The lock is NOT held across the compaction LLM call (that
+        already completed before this hook runs).
         """
-        new_jsonl = (
-            "\n".join(m.model_dump_json() for m in compacted) + "\n"
-            if compacted
-            else ""
-        )
+        del compacted  # the marker carries the summary text, not the message list
+        if summary_message is None:
+            return
+        summary_text = "".join(
+            part.text
+            for part in summary_message.parts
+            if getattr(part, "type", None) == "text"
+        ).strip()
+        if not summary_text:
+            return
         async with self._session.messages_lock:
+            existing = await self._read_messages_jsonl_text()
+            boundary_seq = _max_event_log_seq(existing)
+            now = datetime.now(timezone.utc)
+            marker = SessionMessageRecord(
+                seq=boundary_seq + 1,
+                kind=SessionMessageKind.COMPACTION_MARKER,
+                payload={
+                    "summary": summary_text,
+                    "replaced_from_seq": 1,
+                    # Message lines are seqless, so physical position in the
+                    # append-only file IS the boundary; ``replaced_to_seq`` is
+                    # the last event-log seq at/before the marker, recorded so
+                    # tap/UI consumers know the seq-space boundary too.
+                    "replaced_to_seq": boundary_seq,
+                    "model": self._model.name,
+                    "tokens_before": tokens_before,
+                    "tokens_after": tokens_after,
+                    "created_at": now.isoformat(),
+                },
+                created_at=now,
+            )
+            if existing and not existing.endswith("\n"):
+                existing += "\n"
+            new_jsonl = existing + marker.model_dump_json() + "\n"
             await self._session.commit_state(
-                summary=f"{self._session.session_id}: compaction",
+                summary=f"{self._session.session_id}: compaction marker",
                 op="message",
                 files={"messages.jsonl": new_jsonl},
             )
+
+    async def _open_compaction_window(self) -> list["Message"]:
+        """Set the ``compacting`` flag AND snapshot history atomically.
+
+        Both happen under the SAME per-session messages lock so a steer can
+        never land between the snapshot and the flag: any steer either lands
+        BEFORE (included in the snapshot, correctly summarised) or AFTER (sees
+        the flag, is deferred and drained past the marker). The lock is
+        released here -- it is NEVER held across the compaction LLM await.
+        Returns the marker-aware history snapshot the base loop compacts.
+        """
+        async with self._session.messages_lock:
+            self._session._state.begin_compaction(self._session.session_id)
+            return await self._read_messages_jsonl()
+
+    async def _close_compaction_window(self) -> None:
+        """Clear the ``compacting`` flag AND drain deferred steers.
+
+        Held under the messages lock so the flag-clear + drain + append are
+        atomic vs a concurrent :meth:`AgentSession.append_instruction`. Drained
+        steers are appended (FIFO submission order) AFTER the compaction marker
+        that :meth:`_replace_compacted_head` wrote earlier this turn, so the
+        next load reads ``[summary(from marker), tail, steer...]``. The flag is
+        cleared BEFORE the append so a failure there cannot strand the session
+        in a permanently-compacting state.
+        """
+        async with self._session.messages_lock:
+            self._session._state.end_compaction(self._session.session_id)
+            pending = self._session._state.drain_pending_steers(
+                self._session.session_id
+            )
+            if not pending:
+                return
+            new_jsonl = await self._appended_jsonl(pending)
+            await self._session.commit_state(
+                summary=(
+                    f"{self._session.session_id}: apply "
+                    f"{len(pending)} deferred steer(s)"
+                ),
+                op="user_instruction",
+                files={"messages.jsonl": new_jsonl},
+            )
+            for _ in pending:
+                logger.info(
+                    "session %s: applied a steer deferred during compaction",
+                    self._session.session_id,
+                )
 
     async def _ensure_artifact_dir(self) -> None:
         """Best-effort create ``<workspace_root>/artifacts/<session_id>/``.
@@ -333,33 +420,31 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
         return f"sessions/{self._session.session_id}/messages.jsonl"
 
     async def _read_messages_jsonl(self) -> list[Message]:
+        """Rebuild the LLM history, honoring the last compaction marker.
+
+        messages.jsonl is shared between the LLM conversation history
+        (role/parts Messages, written by AgentSession + ``_persist_turn``) and
+        the session event log (seq/kind/ts SessionMessageRecords, written by
+        the dispatch WorkspaceMessageWriter for WS replay). Only the
+        Message-shaped lines are LLM history; the event records are skipped
+        (see FINDINGS F10b). When a ``compaction_marker`` record is present,
+        every Message line physically at/before the LAST marker is folded into
+        one synthetic assistant summary (see
+        :func:`reconstruct_compacted_history`).
+        """
         raw = await self._session._state.read_state_file(self._messages_jsonl_rel())
         if not raw:
             return []
         text = raw.decode("utf-8")
 
         def _parse() -> list[Message]:
-            out: list[Message] = []
-            for line in text.splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                # messages.jsonl is shared between the LLM conversation
-                # history (role/parts Messages, written by AgentSession +
-                # _persist_turn) and the session event log
-                # (seq/kind/ts SessionMessageRecords, written by the
-                # dispatch WorkspaceMessageWriter for WS replay). Only the
-                # Message-shaped lines are LLM history; skip the event
-                # records so a resumed/multi-turn session can reload its
-                # history without choking on them (see FINDINGS F10b).
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if not (isinstance(obj, dict) and "role" in obj and "parts" in obj):
-                    continue
-                out.append(Message.model_validate(obj))
-            return out
+            # Deferred import: reconstruct_compacted_history lives in
+            # primer.workspace.session; a module-top import would pull the
+            # primer.workspace package initialisation into primer.agent's
+            # import graph. Imported here (off the event loop, in the thread).
+            from primer.workspace.session import reconstruct_compacted_history
+
+            return reconstruct_compacted_history(text.splitlines())
 
         return await asyncio.to_thread(_parse)
 
@@ -386,6 +471,32 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
                         texts.append(part.text)  # type: ignore[union-attr]
                 return "".join(texts) if texts else None
         return None
+
+
+def _max_event_log_seq(text: str) -> int:
+    """Return the highest ``seq`` among event-log records in ``text``, else 0.
+
+    Only :class:`SessionMessageRecord` lines carry a ``seq`` (the interleaved
+    role/parts Message lines are seqless). Used to give an appended compaction
+    marker a strictly-greater monotonic seq than every prior event-log record.
+    """
+    max_seq = 0
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if (
+            isinstance(obj, dict)
+            and "kind" in obj
+            and isinstance(obj.get("seq"), int)
+            and obj["seq"] > max_seq
+        ):
+            max_seq = obj["seq"]
+    return max_seq
 
 
 def _ends_with_question(text: str) -> bool:

--- a/primer/agent/workspace_executor.py
+++ b/primer/agent/workspace_executor.py
@@ -269,23 +269,43 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
         next load reads ``[summary(from marker), tail, steer...]``. The flag is
         cleared BEFORE the append so a failure there cannot strand the session
         in a permanently-compacting state.
+
+        The steers are only *removed* from the queue after the write is
+        durable: we peek, persist, and drain-on-success. If the append or
+        commit raises (e.g. a git/IO failure, or ``commit_state`` raising
+        ``ConflictError`` because a concurrent cancel just moved the session
+        to ENDED) the steers stay queued and a later close re-attempts them --
+        the whole point of Decision 5 is that a deferred steer is NEVER lost.
+        The failure is logged, not re-raised, so it cannot mask the in-flight
+        turn's own exception (this runs in ``invoke``'s ``finally``).
         """
         async with self._session.messages_lock:
             self._session._state.end_compaction(self._session.session_id)
-            pending = self._session._state.drain_pending_steers(
+            pending = self._session._state.peek_pending_steers(
                 self._session.session_id
             )
             if not pending:
                 return
-            new_jsonl = await self._appended_jsonl(pending)
-            await self._session.commit_state(
-                summary=(
-                    f"{self._session.session_id}: apply "
-                    f"{len(pending)} deferred steer(s)"
-                ),
-                op="user_instruction",
-                files={"messages.jsonl": new_jsonl},
-            )
+            try:
+                new_jsonl = await self._appended_jsonl(pending)
+                await self._session.commit_state(
+                    summary=(
+                        f"{self._session.session_id}: apply "
+                        f"{len(pending)} deferred steer(s)"
+                    ),
+                    op="user_instruction",
+                    files={"messages.jsonl": new_jsonl},
+                )
+            except Exception:
+                logger.exception(
+                    "session %s: failed to persist %d deferred steer(s); "
+                    "keeping them queued for the next compaction close",
+                    self._session.session_id,
+                    len(pending),
+                )
+                return
+            # Durable now -- safe to remove from the queue.
+            self._session._state.drain_pending_steers(self._session.session_id)
             for _ in pending:
                 logger.info(
                     "session %s: applied a steer deferred during compaction",

--- a/primer/model/workspace_session.py
+++ b/primer/model/workspace_session.py
@@ -557,8 +557,19 @@ class SessionMessageKind(StrEnum):
     GRAPH_TRANSITION = "graph_transition"
     # Written by reset_session on ENDED->CREATED re-open. Payload:
     # ``{"invocation": int}``. Rendered by the UI session adapter as a
-    # "— invocation N —" divider row (studio-agents-interact §5.2 / §3).
+    # "- invocation N -" divider row (studio-agents-interact §5.2 / §3).
     INVOCATION_DIVIDER = "invocation_divider"
+    # Appended (append-only, never a whole-file replace) by the workspace
+    # executor's ``_replace_compacted_head`` when history compaction fires.
+    # Payload mirrors the chat surface's compaction marker
+    # (primer/chat/executor.py): ``{"summary": str, "replaced_from_seq": int,
+    # "replaced_to_seq": int, "model": str, "tokens_before": int,
+    # "tokens_after": int, "created_at": str}``. The two history readers
+    # (``WorkspaceAgentExecutor._read_messages_jsonl`` and
+    # ``AgentSession.take_pending_messages``) fold every Message line
+    # physically at/before the LAST marker into one synthetic assistant
+    # summary; the event log and pre-compaction messages are NEVER deleted.
+    COMPACTION_MARKER = "compaction_marker"
 
 
 class SessionMessageRecord(BaseModel):

--- a/primer/tap/event.py
+++ b/primer/tap/event.py
@@ -35,6 +35,12 @@ class TapEventClass(StrEnum):
     CANCELLED = "cancelled"
     ERROR = "error"
     INVOCATION_DIVIDER = "invocation_divider"
+    # Mirrors SessionMessageKind.COMPACTION_MARKER so record_to_tap_event maps
+    # it 1:1 rather than crashing on the new kind (keeps the enum invariant the
+    # tap tests assert). The marker is an INTERNAL history-management record,
+    # not activity: the tap reader skips it (see primer/tap/reader.py) so it is
+    # never surfaced on the activity rail.
+    COMPACTION_MARKER = "compaction_marker"
 
     # -- tap-layer extension -------------------------------------------------
     GRAPH_TRANSITION = "graph_transition"

--- a/primer/tap/reader.py
+++ b/primer/tap/reader.py
@@ -35,6 +35,7 @@ import logging
 from typing import TYPE_CHECKING, Any, Protocol
 
 from primer.model.workspace_session import (
+    SessionMessageKind,
     SessionMessageRecord,
     WorkspaceSession,
 )
@@ -141,14 +142,25 @@ def _complete_lines(raw: bytes) -> tuple[list[bytes], int]:
 
 
 def _parse_record(line: bytes) -> SessionMessageRecord | None:
-    """Parse one jsonl line into a record; return ``None`` if unparseable."""
+    """Parse one jsonl line into a record; return ``None`` if unparseable.
+
+    COMPACTION_MARKER records are treated as unparseable (``None``) here so
+    they are skipped by both read paths: the marker is an internal
+    history-management record, not activity, and it shares a seq with the
+    turn's first streamed record (the executor assigns it max_event_seq+1 out
+    of band from the dispatch writer). Skipping it WITHOUT advancing the cursor
+    means that shared seq can never cause the real record to be dropped.
+    """
     text = line.strip()
     if not text:
         return None
     try:
-        return SessionMessageRecord.model_validate(json.loads(text))
+        record = SessionMessageRecord.model_validate(json.loads(text))
     except (json.JSONDecodeError, ValueError):
         return None
+    if record.kind == SessionMessageKind.COMPACTION_MARKER:
+        return None
+    return record
 
 
 # ---------------------------------------------------------------------------

--- a/primer/tap/reader.py
+++ b/primer/tap/reader.py
@@ -291,7 +291,8 @@ async def read_batch(
     than byte 0, so repeated drains skip already-consumed bytes.
 
     Correctness guarantee: the byte offset is a *performance hint only* — it is
-    valid because ``messages.jsonl`` is append-only (no rewrite or compaction).
+    valid because ``messages.jsonl`` only ever grows: turn writes and the
+    compaction marker are byte-appends, so already-consumed bytes never shift.
     The ``seq > cursor.resume_seq(session.id)`` filter remains the authoritative
     backstop: a stale or wrong offset causes at most a harmless re-read of some
     records from an earlier position, never a skip or duplicate.

--- a/primer/workspace/local/state.py
+++ b/primer/workspace/local/state.py
@@ -155,6 +155,16 @@ class LocalStateRepo:
         """Record a steer deferred during compaction. Caller holds messages_lock."""
         self._pending_steers.setdefault(session_id, []).append(message)
 
+    def peek_pending_steers(self, session_id: str) -> list["Message"]:
+        """Return the pending steers WITHOUT clearing them (FIFO).
+
+        Caller holds messages_lock. Used to drain-after-commit: read the
+        queued steers, persist them durably, and only then call
+        :meth:`drain_pending_steers`, so a failed write leaves them queued
+        instead of dropping them.
+        """
+        return list(self._pending_steers.get(session_id, []))
+
     def drain_pending_steers(self, session_id: str) -> list["Message"]:
         """Return + clear the pending steers (FIFO). Caller holds messages_lock."""
         return self._pending_steers.pop(session_id, [])

--- a/primer/workspace/local/state.py
+++ b/primer/workspace/local/state.py
@@ -29,6 +29,7 @@ import logging
 from contextlib import AbstractAsyncContextManager
 from datetime import datetime
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 from pydantic import TypeAdapter
 
@@ -52,6 +53,10 @@ from primer.workspace.state_helpers import (
     validate_relative_path as _validate_relative_path,
     validate_session_id as _validate_session_id,
 )
+
+
+if TYPE_CHECKING:
+    from primer.model.chat import Message
 
 
 logger = logging.getLogger(__name__)
@@ -119,6 +124,40 @@ class LocalStateRepo:
         # init scan. The commit-trailer assembler uses this so callers
         # don't have to thread agent_id through every commit call.
         self._agent_by_session: dict[str, str] = {}
+        # Steer-deferral state, keyed by session id (same sharing model as
+        # ``_messages_locks``): while a session is compacting, a steer arriving
+        # via ``AgentSession.append_instruction`` is recorded PENDING here
+        # instead of committed to messages.jsonl, then drained (FIFO) AFTER the
+        # compaction marker once the window closes. These plain dicts are
+        # ALWAYS mutated under the session's ``messages_lock`` by the caller
+        # (append_instruction already holds it; the executor's window hooks
+        # acquire it), so the flag-check + window open/close stay atomic; the
+        # accessors below take no lock of their own (the non-reentrant
+        # messages_lock must not be re-taken).
+        self._compaction_flags: dict[str, bool] = {}
+        self._pending_steers: dict[str, list["Message"]] = {}
+
+    # ---- steer-deferral state (guarded by the caller's messages_lock) -----
+
+    def begin_compaction(self, session_id: str) -> None:
+        """Mark ``session_id`` as compacting. Caller MUST hold messages_lock."""
+        self._compaction_flags[session_id] = True
+
+    def end_compaction(self, session_id: str) -> None:
+        """Clear the compacting flag. Caller MUST hold messages_lock."""
+        self._compaction_flags[session_id] = False
+
+    def is_compacting(self, session_id: str) -> bool:
+        """Whether ``session_id`` is mid-compaction. Caller holds messages_lock."""
+        return self._compaction_flags.get(session_id, False)
+
+    def add_pending_steer(self, session_id: str, message: "Message") -> None:
+        """Record a steer deferred during compaction. Caller holds messages_lock."""
+        self._pending_steers.setdefault(session_id, []).append(message)
+
+    def drain_pending_steers(self, session_id: str) -> list["Message"]:
+        """Return + clear the pending steers (FIFO). Caller holds messages_lock."""
+        return self._pending_steers.pop(session_id, [])
 
     # ---- public surface --------------------------------------------------
 

--- a/primer/workspace/sandbox/state.py
+++ b/primer/workspace/sandbox/state.py
@@ -47,7 +47,7 @@ from primer.workspace.state_helpers import (
 )
 
 if TYPE_CHECKING:
-    pass
+    from primer.model.chat import Message
 
 
 logger = logging.getLogger(__name__)
@@ -240,6 +240,36 @@ class SandboxStateRepo:
         # session_id -> agent_id cache (populated by create_session /
         # initialize scan; used by commit() to resolve the agent trailer).
         self._agent_by_session: dict[str, str] = {}
+        # Steer-deferral state, keyed by session id. Mirrors
+        # LocalStateRepo: while a session compacts, an arriving steer is
+        # recorded PENDING here and drained (FIFO) after the compaction marker.
+        # Always mutated under the caller's messages_lock (the accessors below
+        # take no lock of their own -- the non-reentrant messages_lock must not
+        # be re-taken).
+        self._compaction_flags: dict[str, bool] = {}
+        self._pending_steers: dict[str, list["Message"]] = {}
+
+    # ---- steer-deferral state (guarded by the caller's messages_lock) -----
+
+    def begin_compaction(self, session_id: str) -> None:
+        """Mark ``session_id`` as compacting. Caller MUST hold messages_lock."""
+        self._compaction_flags[session_id] = True
+
+    def end_compaction(self, session_id: str) -> None:
+        """Clear the compacting flag. Caller MUST hold messages_lock."""
+        self._compaction_flags[session_id] = False
+
+    def is_compacting(self, session_id: str) -> bool:
+        """Whether ``session_id`` is mid-compaction. Caller holds messages_lock."""
+        return self._compaction_flags.get(session_id, False)
+
+    def add_pending_steer(self, session_id: str, message: "Message") -> None:
+        """Record a steer deferred during compaction. Caller holds messages_lock."""
+        self._pending_steers.setdefault(session_id, []).append(message)
+
+    def drain_pending_steers(self, session_id: str) -> list["Message"]:
+        """Return + clear the pending steers (FIFO). Caller holds messages_lock."""
+        return self._pending_steers.pop(session_id, [])
 
     @property
     def workspace_id(self) -> str:

--- a/primer/workspace/sandbox/state.py
+++ b/primer/workspace/sandbox/state.py
@@ -267,6 +267,16 @@ class SandboxStateRepo:
         """Record a steer deferred during compaction. Caller holds messages_lock."""
         self._pending_steers.setdefault(session_id, []).append(message)
 
+    def peek_pending_steers(self, session_id: str) -> list["Message"]:
+        """Return the pending steers WITHOUT clearing them (FIFO).
+
+        Caller holds messages_lock. Used to drain-after-commit: read the
+        queued steers, persist them durably, and only then call
+        :meth:`drain_pending_steers`, so a failed write leaves them queued
+        instead of dropping them.
+        """
+        return list(self._pending_steers.get(session_id, []))
+
     def drain_pending_steers(self, session_id: str) -> list["Message"]:
         """Return + clear the pending steers (FIFO). Caller holds messages_lock."""
         return self._pending_steers.pop(session_id, [])

--- a/primer/workspace/session.py
+++ b/primer/workspace/session.py
@@ -39,6 +39,7 @@ from primer.model.workspace_session import (
     AgentBinding,
     Instruction,
     SessionInfo,
+    SessionMessageKind,
     SessionStatus,
     WaitingState,
 )
@@ -107,6 +108,57 @@ def _normalise_path(path: str) -> str:
     are kept literal so ``a`` and ``./a`` collapse to the same key.
     """
     return PurePosixPath(path.replace("\\", "/")).as_posix()
+
+
+def reconstruct_compacted_history(raw_lines: "list[str]") -> list[Message]:
+    """Rebuild the LLM history from ``messages.jsonl`` lines, honoring markers.
+
+    ``messages.jsonl`` is APPEND-ONLY and interleaves two record types:
+    role/parts :class:`Message` lines (LLM history) and seq/kind
+    :class:`~primer.model.workspace_session.SessionMessageRecord` event-log
+    lines (written by the dispatch writer). Only the Message lines are LLM
+    history; other event-log records are skipped.
+
+    When the session has been compacted, a ``compaction_marker`` event-log
+    record is appended. Every Message line PHYSICALLY BEFORE the LAST marker is
+    replaced by a single synthetic assistant summary carrying the marker's
+    ``summary`` payload (mirrors the chat surface's positional
+    ``rows[last_marker_idx + 1:]`` reassembly in primer/chat/executor.py).
+    Message lines are seqless, so physical position in the append-only file IS
+    the ``replaced_to_seq`` boundary. A later marker supersedes an earlier one
+    (its summary already subsumes the earlier head + tail).
+
+    Shared by both history readers -- ``WorkspaceAgentExecutor.
+    _read_messages_jsonl`` and :meth:`AgentSession.take_pending_messages` -- so
+    neither replays uncompacted history after a compaction.
+    """
+    summary_text: str | None = None
+    msgs: list[Message] = []
+    marker_kind = SessionMessageKind.COMPACTION_MARKER.value
+    for line in raw_lines:
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            obj = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(obj, dict):
+            continue
+        if obj.get("kind") == marker_kind:
+            # A marker replaces everything read so far (head AND tail).
+            summary_text = (obj.get("payload") or {}).get("summary") or None
+            msgs = []
+            continue
+        if "role" in obj and "parts" in obj:
+            msgs.append(Message.model_validate(obj))
+        # else: a non-marker event-log record -> not LLM history, skip.
+    if summary_text:
+        return [
+            Message(role="assistant", parts=[TextPart(text=summary_text)]),
+            *msgs,
+        ]
+    return msgs
 
 
 # ---------------------------------------------------------------------------
@@ -453,6 +505,25 @@ class AgentSession:
             # the acquisition order (messages_lock -> _commit_lock) is never
             # inverted by any other acquirer.
             async with self.messages_lock:
+                # Steer-during-compaction deferral (PR-C, Decision 5). The
+                # compacting flag + pending list live on the repo keyed by
+                # session id (same sharing model as messages_lock) and are only
+                # ever touched under THIS lock -- so the flag-check here is
+                # atomic vs the executor's window open/close. A steer that
+                # arrives while compacting must NOT be committed now: the
+                # compaction marker will be appended after the pre-compaction
+                # snapshot, and folding this steer into that drop-zone (without
+                # it being in the summary) would silently lose it. Record it
+                # PENDING; the executor drains it to messages.jsonl AFTER the
+                # marker once compaction completes, preserving submission order.
+                if self._state.is_compacting(self.session_id):
+                    self._state.add_pending_steer(self.session_id, message)
+                    logger.info(
+                        "session %s: steer recorded PENDING during compaction",
+                        self.session_id,
+                    )
+                    self._info = updated_info
+                    return instruction
                 new_messages_jsonl = await self._appended_messages_jsonl(message)
                 await self._state.commit(
                     self.session_id,
@@ -644,35 +715,24 @@ class AgentSession:
     async def take_pending_messages(self) -> list[Message]:
         """Return the messages added since the last assistant turn.
 
-        Reads ``messages.jsonl`` and returns every message after the
-        most recent ``role == "assistant"`` entry. If no assistant
-        message exists yet (fresh session), returns every message in
-        the log -- typically just the initial user instruction.
+        Reads ``messages.jsonl``, rebuilds the LLM history via
+        :func:`reconstruct_compacted_history` (so a compaction marker folds the
+        pre-compaction head into one synthetic assistant summary -- WITHOUT
+        this, a resumed turn would replay uncompacted history), then returns
+        every message after the most recent ``role == "assistant"`` entry
+        (the synthetic summary counts as an assistant message). If no assistant
+        message exists yet (fresh session), returns every message in the
+        rebuilt log -- typically just the initial user instruction.
 
-        Uses the :class:`StateRepo` protocol's ``read_state_file`` so
-        this works for both local and sandbox (container/k8s) backends.
+        Uses the :class:`StateRepo` protocol's ``read_state_file`` so this
+        works for both local and sandbox (container/k8s) backends, and shares
+        the marker reassembly with ``WorkspaceAgentExecutor._read_messages_jsonl``.
         """
         rel = f"sessions/{self.session_id}/messages.jsonl"
         raw: bytes | None = await self._state.read_state_file(rel)
 
         def _parse(data: bytes) -> list[Message]:
-            messages: list[Message] = []
-            for line in data.decode("utf-8").splitlines():
-                line = line.strip()
-                if not line:
-                    continue
-                # messages.jsonl interleaves LLM-history Messages
-                # (role/parts) with session event-log records
-                # (seq/kind/ts) written by the dispatch writer. Keep only
-                # the Message-shaped lines (see FINDINGS F10b).
-                try:
-                    obj = json.loads(line)
-                except json.JSONDecodeError:
-                    continue
-                if not (isinstance(obj, dict) and "role" in obj and "parts" in obj):
-                    continue
-                messages.append(Message.model_validate(obj))
-            return messages
+            return reconstruct_compacted_history(data.decode("utf-8").splitlines())
 
         all_messages = _parse(raw) if raw else []
         last_assistant_idx = -1
@@ -721,4 +781,5 @@ class AgentSession:
 
 __all__ = [
     "AgentSession",
+    "reconstruct_compacted_history",
 ]

--- a/tests/agent/test_workspace_executor.py
+++ b/tests/agent/test_workspace_executor.py
@@ -811,3 +811,65 @@ class TestSteerDeferredDuringCompaction:
         finally:
             await session.aclose()
             await backend.aclose()
+
+    @pytest.mark.asyncio
+    async def test_deferred_steer_survives_a_drain_commit_failure(
+        self, tmp_path: Path
+    ) -> None:
+        """If persisting a drained steer fails, it stays queued (never lost)
+        and the compacting flag is still cleared (not stranded)."""
+        backend, workspace, session = await _build_session(tmp_path)
+        try:
+            await _seed_compactable_history(session)
+            entered = asyncio.Event()
+            release = asyncio.Event()
+            llm = _BlockingCompactionLLM(
+                summary_text="COMPACTION-SUMMARY",
+                turn_text="post-compaction-turn",
+                entered=entered,
+                release=release,
+            )
+            mgr = ToolExecutionManager.for_workspace(
+                toolset_providers={}, session=session
+            )
+            executor = WorkspaceAgentExecutor(
+                agent=_agent(),
+                llm=llm,  # type: ignore[arg-type]
+                llm_model=_small_model(),
+                tool_manager=mgr,
+                session=session,
+                compaction=CompactionStrategy(tail_turns=1),
+            )
+
+            # Fail ONLY the deferred-steer drain commit (op="user_instruction");
+            # the compaction-marker commit (op="message") still succeeds.
+            real_commit = session.commit_state
+
+            async def _flaky_commit(*args: object, **kwargs: object) -> str:
+                if kwargs.get("op") == "user_instruction":
+                    raise RuntimeError("simulated drain commit failure")
+                return await real_commit(*args, **kwargs)  # type: ignore[arg-type]
+
+            session.commit_state = _flaky_commit  # type: ignore[assignment]
+
+            invoke_task = asyncio.create_task(_drain(executor.invoke([])))
+            await asyncio.wait_for(entered.wait(), timeout=5.0)
+            await session.append_instruction("STEER-DROPPED-IF-BUGGY")
+            release.set()
+            # The turn still completes -- the drain failure is swallowed (logged),
+            # never re-raised, so it cannot mask the turn's own outcome.
+            await asyncio.wait_for(invoke_task, timeout=5.0)
+
+            # Flag cleared (not stranded) AND the steer is still queued (peeked,
+            # commit failed, never popped) -- the "never lost" guarantee holds.
+            assert session._state.is_compacting(session.session_id) is False
+            pending = session._state.peek_pending_steers(session.session_id)
+            assert any(
+                "STEER-DROPPED-IF-BUGGY" in p.parts[0].text for p in pending
+            )
+            # And it is NOT on disk, because the write failed.
+            text = _messages_path(workspace, session).read_text(encoding="utf-8")
+            assert "STEER-DROPPED-IF-BUGGY" not in text
+        finally:
+            await session.aclose()
+            await backend.aclose()

--- a/tests/agent/test_workspace_executor.py
+++ b/tests/agent/test_workspace_executor.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 
+from primer.agent.compaction import CompactionStrategy
 from primer.agent.tool_manager import ToolExecutionManager
 from primer.agent.workspace_executor import WorkspaceAgentExecutor
 from primer.model.agent import Agent, AgentModel
@@ -24,8 +25,11 @@ from primer.model.except_ import ConflictError
 from primer.model.provider import LLMModel
 from primer.model.workspace_session import (
     AgentBinding,
+    SessionMessageKind,
+    SessionMessageRecord,
     SessionStatus,
 )
+from primer.session.persistence import WorkspaceMessageWriter
 from primer.model.workspace import (
     FileMount,
     LocalWorkspaceConfig,
@@ -507,6 +511,303 @@ class TestPersistTurnInstructionRace:
             assert b"hello" in content, content
             # The interleave actually occurred (no vacuous pass).
             assert fired is True
+        finally:
+            await session.aclose()
+            await backend.aclose()
+
+
+# ===========================================================================
+# Compaction preserves the event log + defers steers (PR-C)
+# ===========================================================================
+
+
+def _small_model() -> LLMModel:
+    """Tiny context so a modest seeded history trips the compaction trigger."""
+    return LLMModel(name="m", context_length=500)
+
+
+def _messages_path(workspace, session):
+    return (
+        workspace.root
+        / workspace.template.state_path
+        / "sessions"
+        / session.session_id
+        / "messages.jsonl"
+    )
+
+
+def _event_log_records(text: str) -> list[dict]:
+    """Parse the seq/kind SessionMessageRecord lines from messages.jsonl text."""
+    out: list[dict] = []
+    for line in text.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        import json as _json
+
+        try:
+            obj = _json.loads(line)
+        except _json.JSONDecodeError:
+            continue
+        if isinstance(obj, dict) and "kind" in obj and isinstance(obj.get("seq"), int):
+            out.append(obj)
+    return out
+
+
+class TestCompactionPreservesEventLog:
+    """Decision 4: compaction appends a marker; it never wipes the log."""
+
+    @pytest.mark.asyncio
+    async def test_event_log_survives_compaction(self, tmp_path: Path) -> None:
+        backend, workspace, session = await _build_session(tmp_path)
+        try:
+            # Seed the append-only log with a MIX of event-log records
+            # (seq 1..3, via the same writer the dispatch path uses) and the
+            # initial "hello" Message line already written by start_session.
+            writer = WorkspaceMessageWriter(
+                workspace_io=workspace,
+                session_id=session.session_id,
+                start_seq=0,
+            )
+            from datetime import datetime, timezone
+
+            now = datetime.now(timezone.utc)
+            for kind, payload in (
+                (SessionMessageKind.USER_INPUT, {"text": "seed-user"}),
+                (SessionMessageKind.ASSISTANT_TOKEN, {"text": "seed-assistant"}),
+                (SessionMessageKind.DONE, {"stop_reason": "stop"}),
+            ):
+                await writer.append(
+                    SessionMessageRecord(
+                        seq=1, kind=kind, payload=payload, created_at=now,
+                    )
+                )
+            await writer.flush()
+
+            # Seed enough Message-line history (big user turns) to trip the
+            # compaction trigger for the tiny-context model below.
+            for i in range(3):
+                await session.append_instruction("PRE-COMPACTION-" + ("x" * 900))
+                del i
+
+            llm = _FakeLLM(
+                scripts=[
+                    # 1st stream call = the compaction summary.
+                    [
+                        TextDelta(text="COMPACTION-SUMMARY-TEXT", index=0),
+                        Done(stop_reason="stop", raw_reason="stop"),
+                    ],
+                    # 2nd stream call = the post-compaction turn.
+                    [
+                        TextDelta(text="post-compaction-turn", index=0),
+                        Done(stop_reason="stop", raw_reason="stop"),
+                    ],
+                ]
+            )
+            mgr = ToolExecutionManager.for_workspace(
+                toolset_providers={}, session=session
+            )
+            executor = WorkspaceAgentExecutor(
+                agent=_agent(),
+                llm=llm,  # type: ignore[arg-type]
+                llm_model=_small_model(),
+                tool_manager=mgr,
+                session=session,
+                compaction=CompactionStrategy(tail_turns=1),
+            )
+
+            await _drain(executor.invoke([]))
+
+            text = _messages_path(workspace, session).read_text(encoding="utf-8")
+            records = _event_log_records(text)
+            by_kind = {r["kind"]: r for r in records}
+
+            # (i) the pre-existing event-log records survive with original seqs.
+            assert by_kind["user_input"]["seq"] == 1
+            assert by_kind["assistant_token"]["seq"] == 2
+            assert by_kind["done"]["seq"] == 3
+
+            # (ii) exactly one compaction_marker, with a STRICTLY greater seq.
+            markers = [r for r in records if r["kind"] == "compaction_marker"]
+            assert len(markers) == 1, markers
+            assert markers[0]["seq"] > 3
+            # The stored summary is the strategy's full summary message text
+            # (it carries an "[earlier conversation compacted ...]" preamble).
+            assert "COMPACTION-SUMMARY-TEXT" in markers[0]["payload"]["summary"]
+            assert markers[0]["payload"]["replaced_to_seq"] == 3
+
+            # (iii) the reader returns the COMPACTED view (summary + tail), not
+            # the raw pre-compaction messages.
+            history = await executor._read_messages_jsonl()
+            assert history[0].role == "assistant"
+            assert "COMPACTION-SUMMARY-TEXT" in history[0].parts[0].text
+            joined = "\n".join(
+                p.text
+                for m in history
+                for p in m.parts
+                if getattr(p, "type", None) == "text"
+            )
+            assert "PRE-COMPACTION-" not in joined  # folded into the summary
+        finally:
+            await session.aclose()
+            await backend.aclose()
+
+
+class _BlockingCompactionLLM:
+    """First stream call (compaction) parks on ``release`` after signalling
+    ``entered``; the second call (the turn) streams immediately."""
+
+    def __init__(self, *, summary_text, turn_text, entered, release) -> None:
+        self._summary_text = summary_text
+        self._turn_text = turn_text
+        self._entered = entered
+        self._release = release
+        self._calls = 0
+
+    async def list_models(self):
+        return ["m"]
+
+    def stream(self, *, model, messages, **kwargs) -> AsyncIterator[StreamEvent]:
+        self._calls += 1
+        if self._calls == 1:
+            return self._compaction_stream()
+        return self._turn_stream()
+
+    async def _compaction_stream(self) -> AsyncIterator[StreamEvent]:
+        self._entered.set()
+        await self._release.wait()
+        yield TextDelta(text=self._summary_text, index=0)
+        yield Done(stop_reason="stop", raw_reason="stop")
+
+    async def _turn_stream(self) -> AsyncIterator[StreamEvent]:
+        yield TextDelta(text=self._turn_text, index=0)
+        yield Done(stop_reason="stop", raw_reason="stop")
+
+
+async def _seed_compactable_history(session) -> None:
+    for _ in range(3):
+        await session.append_instruction("PRE-COMPACTION-" + ("x" * 900))
+
+
+class TestSteerDeferredDuringCompaction:
+    """Decision 5: a steer during compaction is deferred, never lost, and
+    applied AFTER compaction in submission order."""
+
+    @pytest.mark.asyncio
+    async def test_steer_during_compaction_is_deferred_not_lost_and_applied_after(
+        self, tmp_path: Path
+    ) -> None:
+        backend, workspace, session = await _build_session(tmp_path)
+        try:
+            await _seed_compactable_history(session)
+            entered = asyncio.Event()
+            release = asyncio.Event()
+            llm = _BlockingCompactionLLM(
+                summary_text="COMPACTION-SUMMARY",
+                turn_text="post-compaction-turn",
+                entered=entered,
+                release=release,
+            )
+            mgr = ToolExecutionManager.for_workspace(
+                toolset_providers={}, session=session
+            )
+            executor = WorkspaceAgentExecutor(
+                agent=_agent(),
+                llm=llm,  # type: ignore[arg-type]
+                llm_model=_small_model(),
+                tool_manager=mgr,
+                session=session,
+                compaction=CompactionStrategy(tail_turns=1),
+            )
+
+            invoke_task = asyncio.create_task(_drain(executor.invoke([])))
+            # Wait until the compaction LLM is parked mid-summarise.
+            await asyncio.wait_for(entered.wait(), timeout=5.0)
+
+            # The window is open: the flag is set...
+            assert session._state.is_compacting(session.session_id) is True
+
+            # ...so a steer arriving now is DEFERRED, not committed.
+            await session.append_instruction("STEER-DURING-COMPACTION")
+
+            during = _messages_path(workspace, session).read_text(encoding="utf-8")
+            assert "STEER-DURING-COMPACTION" not in during  # not yet on disk
+            pending = session._state._pending_steers.get(session.session_id, [])
+            assert any(
+                "STEER-DURING-COMPACTION" in p.parts[0].text for p in pending
+            )  # recorded PENDING
+
+            # Release the compaction LLM; let the turn finish.
+            release.set()
+            await asyncio.wait_for(invoke_task, timeout=5.0)
+
+            text = _messages_path(workspace, session).read_text(encoding="utf-8")
+            lines = text.splitlines()
+            marker_idx = next(
+                i for i, ln in enumerate(lines) if '"compaction_marker"' in ln
+            )
+            steer_idx = next(
+                i for i, ln in enumerate(lines) if "STEER-DURING-COMPACTION" in ln
+            )
+            # The summary is present AND the steer is present AND the steer was
+            # applied AFTER the marker (applied-after ordering).
+            assert "COMPACTION-SUMMARY" in text
+            assert steer_idx > marker_idx
+
+            # Non-vacuous: the interleave actually fired.
+            assert entered.is_set() is True
+            # And the flag has been cleared again.
+            assert session._state.is_compacting(session.session_id) is False
+        finally:
+            await session.aclose()
+            await backend.aclose()
+
+    @pytest.mark.asyncio
+    async def test_multiple_steers_during_compaction_survive_in_order(
+        self, tmp_path: Path
+    ) -> None:
+        backend, workspace, session = await _build_session(tmp_path)
+        try:
+            await _seed_compactable_history(session)
+            entered = asyncio.Event()
+            release = asyncio.Event()
+            llm = _BlockingCompactionLLM(
+                summary_text="COMPACTION-SUMMARY",
+                turn_text="post-compaction-turn",
+                entered=entered,
+                release=release,
+            )
+            mgr = ToolExecutionManager.for_workspace(
+                toolset_providers={}, session=session
+            )
+            executor = WorkspaceAgentExecutor(
+                agent=_agent(),
+                llm=llm,  # type: ignore[arg-type]
+                llm_model=_small_model(),
+                tool_manager=mgr,
+                session=session,
+                compaction=CompactionStrategy(tail_turns=1),
+            )
+
+            invoke_task = asyncio.create_task(_drain(executor.invoke([])))
+            await asyncio.wait_for(entered.wait(), timeout=5.0)
+
+            # Two steers during ONE compaction window, submitted in order.
+            await session.append_instruction("STEER-ONE")
+            await session.append_instruction("STEER-TWO")
+
+            release.set()
+            await asyncio.wait_for(invoke_task, timeout=5.0)
+
+            text = _messages_path(workspace, session).read_text(encoding="utf-8")
+            lines = text.splitlines()
+            marker_idx = next(
+                i for i, ln in enumerate(lines) if '"compaction_marker"' in ln
+            )
+            one_idx = next(i for i, ln in enumerate(lines) if "STEER-ONE" in ln)
+            two_idx = next(i for i, ln in enumerate(lines) if "STEER-TWO" in ln)
+            # Both survived, both after the marker, in submission order.
+            assert marker_idx < one_idx < two_idx
         finally:
             await session.aclose()
             await backend.aclose()

--- a/tests/tap/test_event.py
+++ b/tests/tap/test_event.py
@@ -94,6 +94,55 @@ def test_record_to_tap_event_maps_each_kind(kind: SessionMessageKind) -> None:
     assert event.cursor == "cursor-abc"
 
 
+def test_record_to_tap_event_tolerates_compaction_marker() -> None:
+    """record_to_tap_event must MAP the new COMPACTION_MARKER kind rather than
+    crash on it (the enum stays 1:1 with SessionMessageKind). The tap reader
+    then skips it from the activity stream (see primer/tap/reader.py)."""
+    record = _make_record(SessionMessageKind.COMPACTION_MARKER, seq=7)
+    event = record_to_tap_event(
+        record,
+        workspace_id="ws-1",
+        session_id="sess-1",
+        agent_id="agent-1",
+        graph_id=None,
+        cursor="cur-cm",
+    )
+    assert event.class_ == TapEventClass.COMPACTION_MARKER
+    assert event.class_.value == "compaction_marker"
+    assert event.seq == 7
+
+
+def test_compaction_marker_is_skipped_by_tap_reader_parse() -> None:
+    """The reader's line parser drops a compaction_marker line (returns None)
+    so it is never surfaced as activity and cannot advance the drain cursor
+    onto a colliding real-record seq."""
+    import json
+
+    from primer.tap.reader import _parse_record
+
+    marker_line = json.dumps(
+        {
+            "seq": 4,
+            "kind": "compaction_marker",
+            "payload": {"summary": "s", "replaced_to_seq": 3},
+            "created_at": FIXED_TS.isoformat(),
+        }
+    ).encode()
+    assert _parse_record(marker_line) is None
+
+    # A normal record still parses.
+    real_line = json.dumps(
+        {
+            "seq": 5,
+            "kind": "assistant_token",
+            "payload": {"text": "hi"},
+            "created_at": FIXED_TS.isoformat(),
+        }
+    ).encode()
+    parsed = _parse_record(real_line)
+    assert parsed is not None and parsed.seq == 5
+
+
 def test_record_to_tap_event_none_optional_ids() -> None:
     record = _make_record(SessionMessageKind.DONE)
     event = record_to_tap_event(

--- a/tests/test_session_models.py
+++ b/tests/test_session_models.py
@@ -360,6 +360,11 @@ class TestSessionMessageKind:
             # Reset-same-session ENDED->CREATED marker (studio-agents-interact
             # §5.2 / plan Task 6).
             "invocation_divider",
+            # Compaction summary marker: keeps messages.jsonl append-only so the
+            # event log survives, while the compacted view is reconstructed at
+            # read time. Skipped by the tap reader. Shared 1:1 with
+            # TapEventClass.COMPACTION_MARKER.
+            "compaction_marker",
         }
         actual = {k.value for k in SessionMessageKind}
         assert actual == expected


### PR DESCRIPTION
## What & why

Decisions 4 + 5 from the platform architecture review, fixed together because
both were symptoms of one root cause: compaction did a **whole-file overwrite**
of `messages.jsonl` built from a stale pre-compaction snapshot.

**Decision 4 - the event log survives compaction.** `messages.jsonl` interleaves
LLM `Message` history with append-only `SessionMessageRecord` event-log rows. The
old `_replace_compacted_head` overwrote the whole file with just the compacted
messages, destroying the event log (only git history retained it). Now compaction
is **append-only**: it appends one `COMPACTION_MARKER` record (additive enum, no
DB migration) and readers reconstruct the compacted LLM view from the marker,
exactly like the chat surface already does. The event log is byte-preserved.

**Decision 5 - a steer during compaction is deferred, never lost.** A steer that
arrived during the compaction LLM call was dropped by the overwrite. Now a
per-session `compacting` flag + a pending-steer FIFO (repo-level, keyed by session
id like `messages_lock`) defer such a steer: it is logged pending and drained
**after** compaction completes, appended past the marker in submission order. The
snapshot and the flag are set atomically under one `messages_lock`, closing the
race the earlier review only documented. No lock is held across the LLM await.

## Review fix included (Important)
The initial implementation popped the pending queue *before* the durable commit,
so a commit failure (git/IO error, or `ConflictError` on a concurrently-ENDED
session) would drop the drained steers. Fixed to **peek -> persist -> drain-on-
success**; on failure the steers stay queued for the next close and the error is
logged, not re-raised (so it cannot mask the turn's own exception). Regression
test added.

## Tests
`tests/agent/test_workspace_executor.py`, `tests/agent/test_compaction.py`,
`tests/tap/test_event.py` -- 60 passed (single-process, CPU-capped). Covers:
event log survives, steer deferred-then-applied-after, multi-steer ordering,
drain-commit-failure keeps the steer queued, tap tolerates the new marker kind.

## Reviewer-surfaced observations (documented, not blocking)
1. **Deferred steer lands before this turn's assistant response** (drain runs
   before the turn loop), so it gets its own response on the *next* turn -
   consistent with existing mid-turn steer semantics, not a regression. Flag if
   you want a deferred steer to drive a fresh turn immediately.
2. **On reload, the preserved tail folds into the summary** (positional marker
   reconstruction) - a shared, pre-existing property inherited from the chat
   surface's pattern, not introduced here.
3. **`messages.jsonl` never shrinks** (append-only now), so per-turn parse is
   O(total history) with no size cap. Consistent with the "store both" intent;
   worth a future cap for very long sessions.
4. **Cancellation during the compaction await** can briefly strand the
   `compacting` flag; it self-heals on the next completed turn (only stuck if the
   session never runs another turn, in which case it is moot).

HELD -- do not merge without sign-off.
