### PR TITLE
fix(agent): enforce the invoker's role on agent tool calls

### DIFF
--- a/primer/agent/invoke.py
+++ b/primer/agent/invoke.py
@@ -109,6 +109,7 @@ async def build_subagent_toolmanager(
     approved original_call), so the manager wiring lives in exactly one place.
     """
     from primer.agent.tool_manager import ToolExecutionManager
+    from primer.model.principal import PrincipalRef
     from primer.worker.pool import _toolset_ids_from_scoped
 
     tools = list(context.tools or [])
@@ -127,6 +128,12 @@ async def build_subagent_toolmanager(
         if session_id is not None
         else None
     )
+    # A subagent runs as the SAME invoker as its parent turn: the parent's
+    # ``initiated_by`` rides on the ``AgentResumeContext`` (persisted across
+    # park/resume) so the child manager's RBAC tool floor is authorised
+    # identically. System fallback keeps a None invoker from failing closed
+    # and denying every toolset call the subagent makes.
+    initiated_by = getattr(context, "initiated_by", None) or PrincipalRef.system()
     return ToolExecutionManager(
         toolset_providers=toolset_providers,
         workspace_session=subagent_session,
@@ -134,6 +141,7 @@ async def build_subagent_toolmanager(
         provider_registry=provider_registry,
         tools=tools,
         chat_id=context.chat_id if subagent_session is None else None,
+        initiated_by=initiated_by,
     )
 
 
@@ -212,6 +220,9 @@ async def run_subagent(
         chat_id=chat_id,
         principal=principal,
         tools=list(agent.tools),
+        # Carry the parent run's invoker so the subagent's tool floor is
+        # authorised as the same identity (and survives a park/resume).
+        initiated_by=identity,
     )
     tool_manager = await build_subagent_toolmanager(
         context,

--- a/primer/agent/tool_manager.py
+++ b/primer/agent/tool_manager.py
@@ -39,6 +39,7 @@ from primer.agent.approval import (
     ApprovalResolver,
     evaluate_approval_gate,
 )
+from primer.authz import _role_allows
 from primer.int.toolset import ToolsetProvider
 from primer.model.chat import Tool, ToolCallPart, ToolCallResult, ToolResultPart
 from primer.model.except_ import (
@@ -445,6 +446,28 @@ class ToolExecutionManager:
         principal: str | None,
     ) -> ToolResultPart:
         provider = self._toolsets[toolset_id]
+        # RBAC floor: enforce the tool's declared ``required_role`` against
+        # this run's invoker, mirroring the MCP dispatch path
+        # (primer.mcp.dispatch.invoke_exposed) so both surfaces gate on the
+        # single source of truth. Without it a non-admin who authors an
+        # agent whose ``tools`` list includes an admin-only system tool
+        # (e.g. system__create_llm_provider) could run it. Denial is
+        # returned IN-BAND (error=True) -- the same shape this method uses
+        # to surface a PrimerError below -- so the LLM can react and the
+        # provider handler never runs. ``self._initiated_by`` is the run's
+        # persisted PrincipalRef; a None invoker fails closed (deny), which
+        # is why every construction site threads a real ref or the system
+        # fallback.
+        need = provider.required_role(bare_name)
+        if not _role_allows(self._initiated_by, need):
+            return ToolResultPart(
+                id=call.id,
+                output=(
+                    f"access denied: tool {bare_name!r} requires the "
+                    f"{need!r} role"
+                ),
+                error=True,
+            )
         # Yielding tools (ask_user, sleep, watch_files, ...) declare a
         # ``ctx: ToolContext`` parameter so they can form session-scoped
         # event keys and raise YieldToWorker. Build that context from the

--- a/primer/authz.py
+++ b/primer/authz.py
@@ -40,6 +40,12 @@ def _role_allows(actor: "Principal | PrincipalRef | None", need: str) -> bool:
       is trusted internal automation and is allowed through the floor
       exactly like ``system``.
 
+    Note: the ``trigger`` always-allow branch is exercised only by the
+    agent tool path; the MCP consumer (``invoke_exposed``) never sees a
+    trigger-typed Principal -- ``AuthMiddleware`` mints only
+    ``system`` / ``api_token`` / ``user`` for HTTP/MCP -- so this shared
+    predicate does not widen the MCP floor in practice.
+
     We key on ``type`` (NOT ``source == "internal"``): an ``api_token``
     actor is also ``source == "internal"`` but must keep being ranked by
     the owning user's real ``role``, never waved through.

--- a/primer/authz.py
+++ b/primer/authz.py
@@ -1,0 +1,60 @@
+"""Shared RBAC role-floor predicate.
+
+Two independent dispatch paths enforce the SAME per-tool ``required_role``
+floor and must agree bit-for-bit:
+
+* the MCP dispatch path
+  (:func:`primer.mcp.dispatch.invoke_exposed`), authorised against the
+  per-request :class:`primer.model.principal.Principal` (the ``actor``);
+* the agent tool-execution path
+  (:meth:`primer.agent.tool_manager.ToolExecutionManager._dispatch_toolset`),
+  authorised against the run's persisted invoker
+  (:class:`primer.model.principal.PrincipalRef`, the ``initiated_by``).
+
+The predicate lives here so there is exactly one copy of the ranking and
+the always-allow rules. It is deliberately DUCK-TYPED: it reads only
+``.type`` and ``.role``, so it accepts either a live ``Principal`` or its
+persisted projection ``PrincipalRef`` without importing or branching on
+the concrete class.
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from primer.model.principal import Principal, PrincipalRef
+
+
+_ROLE_RANK = {"restricted": 0, "user": 1, "admin": 2}
+
+
+def _role_allows(actor: "Principal | PrincipalRef | None", need: str) -> bool:
+    """True iff ``actor`` may invoke a tool requiring role ``need``.
+
+    Always-allow actors (keyed on ``type``):
+
+    * ``system`` -- the auth-disabled / internal bypass principal.
+    * ``trigger`` -- an internal automation actor: a trigger-fired run
+      identified by its trigger id, carrying no human ``role``. A trigger
+      is trusted internal automation and is allowed through the floor
+      exactly like ``system``.
+
+    We key on ``type`` (NOT ``source == "internal"``): an ``api_token``
+    actor is also ``source == "internal"`` but must keep being ranked by
+    the owning user's real ``role``, never waved through.
+
+    A missing actor never passes. Otherwise the actor's declared ``role``
+    must rank at or above ``need`` in :data:`_ROLE_RANK`; an
+    unranked/unknown role loses the comparison (``-1``) and an
+    unranked/unknown ``need`` can never be satisfied (``99``) -- both fail
+    closed.
+    """
+    if actor is None:
+        return False
+    if actor.type in ("system", "trigger"):
+        return True
+    return _ROLE_RANK.get(actor.role, -1) >= _ROLE_RANK.get(need, 99)
+
+
+__all__ = ["_ROLE_RANK", "_role_allows"]

--- a/primer/chat/dispatch.py
+++ b/primer/chat/dispatch.py
@@ -525,6 +525,10 @@ async def _build_runner(
         tools=agent.tools,
         approval_resolver=approval_resolver,
         chat_id=chat.id,
+        # The chat's persisted initiator authorises the RBAC tool floor
+        # (system fallback for historical chats with no ``initiated_by``);
+        # a None invoker would fail closed and deny every toolset call.
+        initiated_by=chat.initiated_by or PrincipalRef.system(),
     )
     # No inform sink is wired on the chat surface yet: inform_user in a chat
     # returns delivered_to:0 for now. Chat-side inform delivery is deferred to

--- a/primer/graph/_agent_node.py
+++ b/primer/graph/_agent_node.py
@@ -31,6 +31,7 @@ from primer.graph._node_refs import _NodeDone, _PendingAgentYield
 from primer.graph.template import render_input_template
 from primer.model.chat import Message, StreamEvent, TextPart
 from primer.model.graph import GraphContext, NodeOutput, _AgentNodeRef
+from primer.model.principal import PrincipalRef
 from primer.model.yield_ import YieldToWorker
 
 
@@ -76,11 +77,15 @@ class _AgentNodeMixin:
         output constraints with lazy grammar"). Otherwise use the
         resolver, else an empty manager.
         """
+        # These two fallbacks carry NO toolset providers, so the RBAC tool
+        # floor is unreachable through them; still pass the system principal
+        # (never None) to honour the invariant that every manager resolves
+        # to a real invoker and to stay safe if tools are ever added here.
         if node.response_format is not None:
-            return ToolExecutionManager()
+            return ToolExecutionManager(initiated_by=PrincipalRef.system())
         if self._tool_manager_resolver is not None:
             return await self._tool_manager_resolver(agent)
-        return ToolExecutionManager()
+        return ToolExecutionManager(initiated_by=PrincipalRef.system())
 
     def _agent_node_output(
         self,

--- a/primer/graph/workspace_executor.py
+++ b/primer/graph/workspace_executor.py
@@ -52,6 +52,7 @@ from primer.model.graph import (
     _ToolCallNode,
     build_execution_context,
 )
+from primer.model.principal import PrincipalRef
 from primer.model.workspace_session import SessionStatus
 from primer.observability.turn_log_writer import (
     TurnLogWriter,
@@ -62,7 +63,6 @@ from primer.observability.turn_log_writer import (
 if TYPE_CHECKING:
     from primer.int.llm import LLM
     from primer.model.agent import Agent
-    from primer.model.principal import PrincipalRef
     from primer.model.provider import LLMModel
     from primer.workspace.session import AgentSession
     from primer.workspace.local.state import LocalStateRepo
@@ -327,7 +327,10 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             return ToolExecutionManager.for_workspace(
                 toolset_providers=providers,
                 session=workspace_session,
-                initiated_by=identity,
+                # System fallback so the RBAC tool floor never sees a None
+                # invoker (which fails closed and denies every toolset call);
+                # the worker-built graph path always supplies a real identity.
+                initiated_by=identity or PrincipalRef.system(),
             )
 
         return _resolve
@@ -412,6 +415,10 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
                 toolset_providers=toolset_providers,
                 session=self._workspace_session,
                 approval_resolver=self._approval_resolver,
+                # Authorise the RBAC tool floor as this graph run's invoker
+                # (system fallback when unknown); the worker-built path
+                # threads a real identity via ``self._identity``.
+                initiated_by=self._identity or PrincipalRef.system(),
             )
             # Cache only the workspace-only manager; a per-toolset manager
             # must not leak to a later tool_call naming a different toolset.

--- a/primer/mcp/dispatch.py
+++ b/primer/mcp/dispatch.py
@@ -20,6 +20,13 @@ from __future__ import annotations
 from typing import TYPE_CHECKING
 
 from primer.agent.tool_manager import invoke_one
+
+# The RBAC role-floor predicate now lives in :mod:`primer.authz` so the
+# agent tool-execution path can share the very same rules. Re-imported
+# here (``_ROLE_RANK`` for backwards-compatible attribute access,
+# ``_role_allows`` used by :func:`invoke_exposed` below) so anything that
+# references ``primer.mcp.dispatch._role_allows`` keeps working unchanged.
+from primer.authz import _ROLE_RANK, _role_allows  # noqa: F401
 from primer.mcp.exposure import (
     ExposureDeps,
     _iter_catalogue,
@@ -31,26 +38,6 @@ from primer.model.chat import Tool, ToolCallResult
 
 if TYPE_CHECKING:
     from primer.model.principal import Principal
-
-
-_ROLE_RANK = {"restricted": 0, "user": 1, "admin": 2}
-
-
-def _role_allows(actor: "Principal | None", need: str) -> bool:
-    """True iff ``actor`` may invoke a tool requiring role ``need``.
-
-    A ``system``-type actor (the auth-disabled bypass) always passes.
-    A missing actor never does. Otherwise the actor's declared
-    ``role`` must rank at or above ``need`` in :data:`_ROLE_RANK`; an
-    unranked/unknown role loses the comparison (``-1``) and an
-    unranked/unknown ``need`` can never be satisfied (``99``) --
-    both fail closed.
-    """
-    if actor is None:
-        return False
-    if actor.type == "system":
-        return True
-    return _ROLE_RANK.get(actor.role, -1) >= _ROLE_RANK.get(need, 99)
 
 
 class NotExposed(Exception):

--- a/primer/toolset/mcp.py
+++ b/primer/toolset/mcp.py
@@ -113,6 +113,28 @@ class McpToolsetProvider(ToolsetProvider):
 
     # ---------- public API ------------------------------------------------
 
+    def required_role(self, tool_name: str) -> str:
+        """RBAC floor for an external (operator-configured) MCP tool.
+
+        Override the base ABC default of ``"admin"`` (fail-closed) with
+        ``"user"``. External MCP tools are operator-exposed third-party
+        tools: the operator's decision to configure and expose this MCP
+        toolset IS the authorization decision, so the per-tool floor
+        should default them to ``"user"`` -- preserving the pre-floor
+        behaviour where any authenticated, non-restricted user could call
+        them. Fail-closing these to ``"admin"`` (the ABC default) would
+        instead lock every non-admin invoker out of every operator-exposed
+        external tool, which is a regression, not a safeguard.
+
+        This provider has no per-tool ``required_role`` registry of its
+        own, so the floor is uniform across the toolset's tools. An
+        operator who wants to gate a specific external tool higher can do
+        so separately (e.g. via a policy layer above this provider); this
+        method only sets the default floor.
+        """
+        del tool_name  # uniform floor across this toolset's tools
+        return "user"
+
     async def list_tools(
         self,
         *,

--- a/primer/toolset/trigger.py
+++ b/primer/toolset/trigger.py
@@ -444,6 +444,7 @@ TOOL_SUBSCRIBE = make_tool(
     ],
     yields=True,
     requires_session=True,
+    required_role="user",
 )
 
 TOOL_SUBSCRIBE_CHANNEL = make_tool(
@@ -477,6 +478,7 @@ TOOL_SUBSCRIBE_CHANNEL = make_tool(
     ],
     yields=True,
     requires_session=True,
+    required_role="user",
 )
 
 

--- a/primer/toolset/workspace_ext.py
+++ b/primer/toolset/workspace_ext.py
@@ -16,7 +16,7 @@ session. When the same agent is invoked on a CHAT, the
 they never enter the chat's context window. This is the whole point:
 keep these high-token, session-bound tools out of chat context.
 
-Tool catalog (4 tools, all yielding)
+Tool catalog (5 tools, all yielding)
 ------------------------------------
 
 * ``sleep``                - pause the turn for a fixed duration
@@ -27,6 +27,8 @@ Tool catalog (4 tools, all yielding)
   (moved from ``workspaces``).
 * ``subscribe_to_trigger`` - park the session until a trigger fires
   (moved from ``trigger``).
+* ``subscribe_to_channel_event`` - park the session until a matching
+  channel event fires (moved from ``trigger``).
 
 The BARE tool ids are unchanged by the move - only the scoped id
 (``toolset_id__bare``) changes (e.g. ``misc__sleep`` ->
@@ -110,6 +112,7 @@ def build_workspace_ext_toolset(
                     ),
                 ],
                 yields=True,
+                required_role="user",
             ),
             _sleep_handler,
         ),
@@ -148,6 +151,7 @@ def build_workspace_ext_toolset(
                 ],
                 yields=True,
                 requires_session=True,
+                required_role="user",
             ),
             _watch_files_handler,
         ),
@@ -178,6 +182,7 @@ def build_workspace_ext_toolset(
                 ],
                 yields=True,
                 requires_session=True,
+                required_role="user",
             ),
             _invoke_graph_handler,
         ),

--- a/primer/worker/frames.py
+++ b/primer/worker/frames.py
@@ -36,6 +36,7 @@ from typing import Any
 
 from primer.graph.invoke_graph import resume_invoke_graph
 from primer.model.chat import ToolCallPart, ToolResultPart
+from primer.model.principal import PrincipalRef
 from primer.model.yield_ import YieldToWorker
 from primer.worker.yield_resume_registry import get_resume_hook
 from primer.worker.yield_runtime import classify_approval_payload
@@ -67,6 +68,12 @@ class AgentResumeContext:
         The acting principal (used for tool authorisation on resume).
     tools
         The agent's registered tool ids (e.g. ``"system__ask_user"``).
+    initiated_by
+        The run's persisted invoker (:class:`PrincipalRef`), threaded so a
+        resumed subagent turn re-runs under the SAME identity that started
+        it and its RBAC tool floor stays authorised across the park/resume
+        boundary. ``None`` on frames parked before this field existed ->
+        the manager builder falls back to the system principal.
     """
 
     session_id: str
@@ -74,6 +81,7 @@ class AgentResumeContext:
     chat_id: str | None
     principal: str
     tools: list[str]
+    initiated_by: "PrincipalRef | None" = None
 
     def to_jsonable(self) -> dict[str, Any]:
         """Render to a JSON-safe dict."""
@@ -83,16 +91,27 @@ class AgentResumeContext:
             "chat_id": self.chat_id,
             "principal": self.principal,
             "tools": list(self.tools),
+            "initiated_by": (
+                self.initiated_by.model_dump(mode="json")
+                if self.initiated_by is not None
+                else None
+            ),
         }
 
     @classmethod
     def from_jsonable(cls, data: dict[str, Any]) -> "AgentResumeContext":
+        raw_initiated_by = data.get("initiated_by")
         return cls(
             session_id=data["session_id"],
             workspace_id=data["workspace_id"],
             chat_id=data.get("chat_id"),
             principal=data["principal"],
             tools=list(data.get("tools") or []),
+            initiated_by=(
+                PrincipalRef.model_validate(raw_initiated_by)
+                if raw_initiated_by is not None
+                else None
+            ),
         )
 
 

--- a/tests/agent/conftest.py
+++ b/tests/agent/conftest.py
@@ -9,6 +9,7 @@ import pytest
 
 from primer.agent.tool_manager import ToolExecutionManager
 from primer.model.chat import Tool, ToolCallResult
+from primer.model.principal import PrincipalRef
 
 
 class _EchoProvider:
@@ -26,6 +27,10 @@ class _EchoProvider:
             },
         )
 
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
+
     async def call(
         self,
         *,
@@ -41,4 +46,9 @@ class _EchoProvider:
 def tool_manager_with_test_tools() -> ToolExecutionManager:
     """Return a ToolExecutionManager pre-populated with a '_test__echo' tool."""
     provider = _EchoProvider()
-    return ToolExecutionManager(toolset_providers={"_test": provider})  # type: ignore[arg-type]
+    return ToolExecutionManager(
+        toolset_providers={"_test": provider},  # type: ignore[arg-type]
+        # System invoker clears the RBAC tool floor on the toolset dispatch
+        # path (a None invoker fails closed and denies every call).
+        initiated_by=PrincipalRef.system(),
+    )

--- a/tests/agent/test_executor.py
+++ b/tests/agent/test_executor.py
@@ -27,6 +27,7 @@ from primer.model.chat import (
     ToolCallStart,
 )
 from primer.model.common import Identifiable
+from primer.model.principal import PrincipalRef
 from primer.model.except_ import (
     BadRequestError,
     ConflictError,
@@ -179,6 +180,10 @@ class _FakeToolsetProvider:
         for t in self._tools:
             yield t
 
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
+
     async def call(
         self, *, tool_name: str, arguments, principal=None, ctx=None
     ) -> ToolCallResult:
@@ -253,7 +258,10 @@ async def _build_executor(
         title="t",
     )
     provider = _FakeToolsetProvider(toolset_id="t1", tools=tools, handler=handler)
-    mgr = ToolExecutionManager(toolset_providers={"t1": provider})  # type: ignore[arg-type]
+    mgr = ToolExecutionManager(
+        toolset_providers={"t1": provider},  # type: ignore[arg-type]
+        initiated_by=PrincipalRef.system(),
+    )
     executor = AgentExecutor(
         agent=agent,
         llm=llm,  # type: ignore[arg-type]

--- a/tests/agent/test_run_subagent_yield.py
+++ b/tests/agent/test_run_subagent_yield.py
@@ -82,6 +82,10 @@ class _GatedToolsetProvider:
     def is_yielding(self, tool_name: str) -> bool:
         return False
 
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
+
     async def call(
         self, *, tool_name, arguments, principal=None, ctx=None
     ) -> ToolCallResult:  # noqa: ANN001
@@ -107,6 +111,10 @@ class _YieldingToolsetProvider:
 
     def is_yielding(self, tool_name: str) -> bool:
         return tool_name == "wait"
+
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
 
     async def call(
         self, *, tool_name, arguments, principal=None, ctx=None

--- a/tests/agent/test_subagent_resume.py
+++ b/tests/agent/test_subagent_resume.py
@@ -80,6 +80,10 @@ class _PlainToolsetProvider:
     def is_yielding(self, tool_name: str) -> bool:
         return False
 
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
+
     async def call(
         self, *, tool_name, arguments, principal=None, ctx=None
     ) -> ToolCallResult:  # noqa: ANN001
@@ -105,6 +109,10 @@ class _YieldingToolsetProvider:
 
     def is_yielding(self, tool_name: str) -> bool:
         return tool_name == "wait"
+
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
 
     async def call(
         self, *, tool_name, arguments, principal=None, ctx=None

--- a/tests/agent/test_tool_manager.py
+++ b/tests/agent/test_tool_manager.py
@@ -24,6 +24,7 @@ from primer.model.except_ import (
     ProviderError,
     UnsupportedContentError,
 )
+from primer.model.principal import PrincipalRef
 
 
 # ---- Fakes ----------------------------------------------------------------
@@ -32,10 +33,22 @@ from primer.model.except_ import (
 class _FakeToolsetProvider:
     """Fake :class:`ToolsetProvider` implementing the structural protocol."""
 
-    def __init__(self, *, toolset_id: str, tools: list[Tool]) -> None:
+    def __init__(
+        self,
+        *,
+        toolset_id: str,
+        tools: list[Tool],
+        roles: dict[str, str] | None = None,
+    ) -> None:
         self._toolset_id = toolset_id
         self._tools = tools
+        self._roles = roles or {}
         self.calls: list[tuple[str, dict[str, Any], str | None]] = []
+
+    def required_role(self, tool_name: str) -> str:
+        # Mirror the real ToolsetProvider base: fail-closed to ``admin``
+        # for any tool without an explicitly declared role.
+        return self._roles.get(tool_name, "admin")
 
     async def list_tools(
         self, *, principal: str | None = None
@@ -72,7 +85,7 @@ class TestToolsetRouting:
     async def test_list_tools_merges_providers(self) -> None:
         a = _FakeToolsetProvider(toolset_id="a", tools=[_tool("foo", toolset_id="a")])
         b = _FakeToolsetProvider(toolset_id="b", tools=[_tool("bar", toolset_id="b")])
-        mgr = ToolExecutionManager(toolset_providers={"a": a, "b": b})  # type: ignore[arg-type]
+        mgr = ToolExecutionManager(toolset_providers={"a": a, "b": b}, initiated_by=PrincipalRef.system())  # type: ignore[arg-type]
         tools = await mgr.list_tools()
         names = sorted(t.id for t in tools)
         # Tool ids are scoped as ``toolset_id__bare_name`` so collisions
@@ -83,7 +96,7 @@ class TestToolsetRouting:
     async def test_execute_routes_to_owning_toolset(self) -> None:
         a = _FakeToolsetProvider(toolset_id="a", tools=[_tool("foo", toolset_id="a")])
         b = _FakeToolsetProvider(toolset_id="b", tools=[_tool("bar", toolset_id="b")])
-        mgr = ToolExecutionManager(toolset_providers={"a": a, "b": b})  # type: ignore[arg-type]
+        mgr = ToolExecutionManager(toolset_providers={"a": a, "b": b}, initiated_by=PrincipalRef.system())  # type: ignore[arg-type]
         await mgr.list_tools()
         call = ToolCallPart(id="c-1", name="a__foo", arguments={"x": 1})
         result = await mgr.execute(call)
@@ -96,7 +109,7 @@ class TestToolsetRouting:
     @pytest.mark.asyncio
     async def test_execute_passes_principal_through(self) -> None:
         a = _FakeToolsetProvider(toolset_id="a", tools=[_tool("foo", toolset_id="a")])
-        mgr = ToolExecutionManager(toolset_providers={"a": a})  # type: ignore[arg-type]
+        mgr = ToolExecutionManager(toolset_providers={"a": a}, initiated_by=PrincipalRef.system())  # type: ignore[arg-type]
         await mgr.list_tools()
         await mgr.execute(
             ToolCallPart(id="c", name="a__foo", arguments={}),
@@ -107,7 +120,7 @@ class TestToolsetRouting:
     @pytest.mark.asyncio
     async def test_execute_unknown_tool_raises_unsupported(self) -> None:
         a = _FakeToolsetProvider(toolset_id="a", tools=[_tool("foo", toolset_id="a")])
-        mgr = ToolExecutionManager(toolset_providers={"a": a})  # type: ignore[arg-type]
+        mgr = ToolExecutionManager(toolset_providers={"a": a}, initiated_by=PrincipalRef.system())  # type: ignore[arg-type]
         await mgr.list_tools()
         with pytest.raises(UnsupportedContentError):
             await mgr.execute(ToolCallPart(id="c", name="not_a_tool", arguments={}))
@@ -119,7 +132,7 @@ class TestToolsetRouting:
                 raise ProviderError("upstream broke")
 
         a = _Boom(toolset_id="a", tools=[_tool("foo", toolset_id="a")])
-        mgr = ToolExecutionManager(toolset_providers={"a": a})  # type: ignore[arg-type]
+        mgr = ToolExecutionManager(toolset_providers={"a": a}, initiated_by=PrincipalRef.system())  # type: ignore[arg-type]
         await mgr.list_tools()
         result = await mgr.execute(ToolCallPart(id="c", name="a__foo", arguments={}))
         assert result.error is True
@@ -136,7 +149,7 @@ class TestToolsetRouting:
                 )
 
         a = _NeedAuth(toolset_id="a", tools=[_tool("foo", toolset_id="a")])
-        mgr = ToolExecutionManager(toolset_providers={"a": a})  # type: ignore[arg-type]
+        mgr = ToolExecutionManager(toolset_providers={"a": a}, initiated_by=PrincipalRef.system())  # type: ignore[arg-type]
         await mgr.list_tools()
         with pytest.raises(AuthRequiredError):
             await mgr.execute(ToolCallPart(id="c", name="a__foo", arguments={}))
@@ -144,7 +157,7 @@ class TestToolsetRouting:
     @pytest.mark.asyncio
     async def test_execute_lazy_lists_tools_when_not_called_first(self) -> None:
         a = _FakeToolsetProvider(toolset_id="a", tools=[_tool("foo", toolset_id="a")])
-        mgr = ToolExecutionManager(toolset_providers={"a": a})  # type: ignore[arg-type]
+        mgr = ToolExecutionManager(toolset_providers={"a": a}, initiated_by=PrincipalRef.system())  # type: ignore[arg-type]
         result = await mgr.execute(ToolCallPart(id="c", name="a__foo", arguments={}))
         assert result.id == "c"
 
@@ -184,6 +197,7 @@ class TestAgentToolFilter:
         mgr = ToolExecutionManager(
             toolset_providers={"a": a},  # type: ignore[arg-type]
             tools=["a__foo"],
+            initiated_by=PrincipalRef.system(),
         )
         await mgr.list_tools()
         # a__foo is registered and routes correctly.
@@ -359,6 +373,10 @@ class _CapturingProvider:
     def __init__(self) -> None:
         self.captured: dict[str, Any] = {}
 
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
+
     async def list_tools(self, *, principal: str | None = None):
         if False:  # pragma: no cover - makes this an async generator
             yield None
@@ -374,6 +392,7 @@ async def test_set_inform_sink_passed_into_tool_context() -> None:
     mgr = ToolExecutionManager(
         toolset_providers={"misc": provider},  # type: ignore[arg-type]
         chat_id="chat-1",
+        initiated_by=PrincipalRef.system(),
     )
 
     async def _sink(msg: str) -> int:
@@ -388,3 +407,153 @@ async def test_set_inform_sink_passed_into_tool_context() -> None:
         principal=None,
     )
     assert provider.captured["inform"] is _sink
+
+
+# ---- RBAC invoker-role floor ----------------------------------------------
+
+
+class TestInvokerRoleFloor:
+    """The agent tool-execution path enforces each tool's declared
+    ``required_role`` against the run's invoker (``initiated_by``),
+    mirroring the MCP dispatch floor. Denial is IN-BAND (``error=True``)
+    and the provider handler never runs."""
+
+    @staticmethod
+    def _provider() -> _FakeToolsetProvider:
+        # ``create_agent`` needs ``user``; ``create_llm_provider`` needs
+        # ``admin`` -- the same shape as the reserved system tools.
+        return _FakeToolsetProvider(
+            toolset_id="system",
+            tools=[
+                _tool("create_agent", toolset_id="system"),
+                _tool("create_llm_provider", toolset_id="system"),
+            ],
+            roles={
+                "create_agent": "user",
+                "create_llm_provider": "admin",
+            },
+        )
+
+    @staticmethod
+    def _mgr(provider: _FakeToolsetProvider, invoker) -> ToolExecutionManager:
+        return ToolExecutionManager(
+            toolset_providers={"system": provider},  # type: ignore[arg-type]
+            initiated_by=invoker,
+        )
+
+    @pytest.mark.asyncio
+    async def test_user_invoker_denied_admin_tool(self) -> None:
+        provider = self._provider()
+        mgr = self._mgr(
+            provider,
+            PrincipalRef(
+                type="user", id="u", display="u", role="user", source="local",
+            ),
+        )
+        await mgr.list_tools()
+        result = await mgr.execute(
+            ToolCallPart(
+                id="c", name="system__create_llm_provider", arguments={},
+            )
+        )
+        assert result.error is True
+        assert "requires" in result.output
+        assert "admin" in result.output
+        assert provider.calls == []  # handler never ran
+
+    @pytest.mark.asyncio
+    async def test_user_invoker_allowed_user_tool(self) -> None:
+        provider = self._provider()
+        mgr = self._mgr(
+            provider,
+            PrincipalRef(
+                type="user", id="u", display="u", role="user", source="local",
+            ),
+        )
+        await mgr.list_tools()
+        result = await mgr.execute(
+            ToolCallPart(id="c", name="system__create_agent", arguments={})
+        )
+        assert result.error is False
+        assert provider.calls == [("create_agent", {}, None)]
+
+    @pytest.mark.asyncio
+    async def test_admin_invoker_allowed_admin_tool(self) -> None:
+        provider = self._provider()
+        mgr = self._mgr(
+            provider,
+            PrincipalRef(
+                type="user", id="a", display="a", role="admin", source="local",
+            ),
+        )
+        await mgr.list_tools()
+        result = await mgr.execute(
+            ToolCallPart(
+                id="c", name="system__create_llm_provider", arguments={},
+            )
+        )
+        assert result.error is False
+        assert provider.calls == [("create_llm_provider", {}, None)]
+
+    @pytest.mark.asyncio
+    async def test_trigger_invoker_allowed_admin_tool(self) -> None:
+        """A trigger-type invoker is internal automation: allowed through
+        the floor like the system principal even for an admin tool and
+        despite carrying no ``role``."""
+        provider = self._provider()
+        mgr = self._mgr(
+            provider,
+            PrincipalRef(
+                type="trigger", id="trg-1", display="trg-1",
+                role=None, source="internal",
+            ),
+        )
+        await mgr.list_tools()
+        result = await mgr.execute(
+            ToolCallPart(
+                id="c", name="system__create_llm_provider", arguments={},
+            )
+        )
+        assert result.error is False
+        assert provider.calls == [("create_llm_provider", {}, None)]
+
+    @pytest.mark.asyncio
+    async def test_system_invoker_allowed_admin_tool(self) -> None:
+        provider = self._provider()
+        mgr = self._mgr(provider, PrincipalRef.system())
+        await mgr.list_tools()
+        result = await mgr.execute(
+            ToolCallPart(
+                id="c", name="system__create_llm_provider", arguments={},
+            )
+        )
+        assert result.error is False
+        assert provider.calls == [("create_llm_provider", {}, None)]
+
+    @pytest.mark.asyncio
+    async def test_none_invoker_denies_fail_closed(self) -> None:
+        """A manager built with no invoker fails closed: every toolset
+        call is denied. Real construction sites therefore thread a real
+        PrincipalRef or the system fallback."""
+        provider = self._provider()
+        mgr = self._mgr(provider, None)
+        await mgr.list_tools()
+        result = await mgr.execute(
+            ToolCallPart(id="c", name="system__create_agent", arguments={})
+        )
+        assert result.error is True
+        assert provider.calls == []
+
+    @pytest.mark.asyncio
+    async def test_system_fallback_allows_where_none_would_deny(self) -> None:
+        """The system fallback the construction sites use in place of a
+        None invoker ALLOWS the same call a None invoker denies -- proving
+        the threading closes the fail-closed gap without over-denying."""
+        provider = self._provider()
+        mgr = self._mgr(provider, PrincipalRef.system())
+        await mgr.list_tools()
+        result = await mgr.execute(
+            ToolCallPart(id="c", name="system__create_agent", arguments={})
+        )
+        assert result.error is False
+        assert provider.calls == [("create_agent", {}, None)]

--- a/tests/agent/test_tool_manager.py
+++ b/tests/agent/test_tool_manager.py
@@ -25,6 +25,9 @@ from primer.model.except_ import (
     UnsupportedContentError,
 )
 from primer.model.principal import PrincipalRef
+from primer.model.provider import McpConfig, StdioConfig, TransportType
+from primer.toolset.mcp import McpToolsetProvider
+from primer.toolset.workspace_ext import build_workspace_ext_toolset
 
 
 # ---- Fakes ----------------------------------------------------------------
@@ -557,3 +560,140 @@ class TestInvokerRoleFloor:
         )
         assert result.error is False
         assert provider.calls == [("create_agent", {}, None)]
+
+
+# ---- Regression: user-role floor for real threaded surfaces ---------------
+
+
+class _SpyOverRealProvider:
+    """Wrap a REAL provider so the manager consults its REAL
+    ``required_role`` for the floor decision, while observing whether the
+    provider ``call`` layer is reached.
+
+    Every ``workspace_ext`` tool yields and needs a live ``AgentSession``,
+    so dispatching the genuine handler end-to-end is heavy. What the
+    regression turns on is the FLOOR decision, and that reads
+    ``required_role`` -- which we delegate to the real provider verbatim.
+    A pass therefore proves the real declared role cleared the floor and
+    dispatch proceeded to the provider handler layer.
+    """
+
+    def __init__(self, real) -> None:
+        self._real = real
+        self.calls: list[tuple[str, dict[str, Any], str | None]] = []
+
+    def required_role(self, tool_name: str) -> str:
+        return self._real.required_role(tool_name)
+
+    async def list_tools(
+        self, *, principal: str | None = None
+    ) -> AsyncIterator[Tool]:
+        async for t in self._real.list_tools(principal=principal):
+            yield t
+
+    async def call(
+        self,
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        principal: str | None = None,
+        ctx=None,
+    ) -> ToolCallResult:
+        self.calls.append((tool_name, arguments, principal))
+        return ToolCallResult(output=f"reached {tool_name}", is_error=False)
+
+
+class TestUserRoleFloorRealSurfaces:
+    """A ``role="user"`` invoker must be ALLOWED the real ``workspace_ext``
+    tools (they declare ``required_role="user"``) and external MCP proxy
+    tools (``McpToolsetProvider`` defaults the floor to ``"user"``). Both
+    surfaces never declared a role before the RBAC floor existed, so a
+    fail-closed ``"admin"`` default would wrongly deny non-admin invokers
+    -- the regression this test guards against.
+    """
+
+    @staticmethod
+    def _real_workspace_ext():
+        # The subscribe handler factories only capture ``storage_provider``
+        # in a closure; nothing is touched at build time, so a bare stub
+        # suffices to assemble the provider and read its declared roles.
+        return build_workspace_ext_toolset(storage_provider=object())
+
+    def test_real_workspace_ext_tools_declare_user_role(self) -> None:
+        """Every ``workspace_ext`` tool declares ``required_role="user"``;
+        an undeclared name still fails closed to ``admin``."""
+        provider = self._real_workspace_ext()
+        for name in (
+            "sleep",
+            "watch_files",
+            "invoke_graph",
+            "subscribe_to_trigger",
+            "subscribe_to_channel_event",
+        ):
+            assert provider.required_role(name) == "user", name
+        # The floor still bites for anything undeclared.
+        assert provider.required_role("not_a_real_tool") == "admin"
+
+    def test_real_mcp_provider_defaults_floor_to_user(self) -> None:
+        """External MCP proxy tools default the floor to ``"user"`` (the
+        operator's exposure IS the authorization), not the ABC's
+        fail-closed ``"admin"``."""
+        cfg = McpConfig(
+            transport=TransportType.STDIO,
+            config=StdioConfig(command=["echo"]),
+        )
+        provider = McpToolsetProvider(toolset_id="ext", config=cfg)
+        assert provider.required_role("anything") == "user"
+        assert provider.required_role("another_external_tool") == "user"
+
+    @pytest.mark.asyncio
+    async def test_user_invoker_allowed_real_workspace_ext_tools(self) -> None:
+        """Threaded end-to-end: a ``role="user"`` invoker clears the floor
+        for the REAL ``workspace_ext`` tools (handler layer reached) while
+        the SAME invoker is still denied a genuinely admin tool.
+
+        ``workspace_ext`` tools are only visible when a workspace session
+        is bound (they are suppressed from the catalogue on chat), so a
+        minimal fake session is threaded to make them dispatchable -- the
+        spy's ``call`` ignores the built ``ToolContext``.
+        """
+
+        class _FakeSession:
+            session_id = "s-1"
+            workspace_id = "w-1"
+
+        ws = _SpyOverRealProvider(self._real_workspace_ext())
+        # A genuinely admin tool proves the floor still bites.
+        system = _FakeToolsetProvider(
+            toolset_id="system",
+            tools=[_tool("create_llm_provider", toolset_id="system")],
+            roles={"create_llm_provider": "admin"},
+        )
+        mgr = ToolExecutionManager(
+            toolset_providers={"workspace_ext": ws, "system": system},  # type: ignore[arg-type]
+            workspace_session=_FakeSession(),  # type: ignore[arg-type]
+            initiated_by=PrincipalRef(
+                type="user", id="u1", display="u1", role="user", source="local",
+            ),
+        )
+        await mgr.list_tools()
+
+        for bare in ("sleep", "watch_files"):
+            result = await mgr.execute(
+                ToolCallPart(
+                    id=f"c-{bare}", name=f"workspace_ext__{bare}", arguments={},
+                )
+            )
+            assert result.error is False, bare  # floor passed, not denied
+        # The provider handler layer was reached for both allowed tools.
+        assert [c[0] for c in ws.calls] == ["sleep", "watch_files"]
+
+        # Same user invoker, genuinely admin tool -> denied, handler skipped.
+        denied = await mgr.execute(
+            ToolCallPart(
+                id="c-admin", name="system__create_llm_provider", arguments={},
+            )
+        )
+        assert denied.error is True
+        assert "admin" in denied.output
+        assert system.calls == []

--- a/tests/graph/test_workspace_executor.py
+++ b/tests/graph/test_workspace_executor.py
@@ -41,6 +41,7 @@ from primer.model.graph import (
     _JsonPathRouter,
     _StaticEdge,
 )
+from primer.model.principal import PrincipalRef
 from primer.model.provider import LLMModel
 from primer.workspace.local.state import LocalStateRepo as StateRepo
 
@@ -94,6 +95,10 @@ class _FakeToolsetProvider:
             toolset_id="fake",
             args_schema={"type": "object", "properties": {}},
         )
+
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
 
     async def call(
         self,
@@ -543,7 +548,10 @@ class TestToolDispatchInGraphNode:
         provider = _FakeToolsetProvider(tool_id="echo", output="echo-out")
 
         async def tool_mgr_resolver(agent: Agent) -> ToolExecutionManager:
-            return ToolExecutionManager(toolset_providers={"fake": provider})
+            return ToolExecutionManager(
+                toolset_providers={"fake": provider},
+                initiated_by=PrincipalRef.system(),
+            )
 
         repo = await _make_state_repo(tmp_path)
         executor = await _build_executor(
@@ -1129,7 +1137,10 @@ class TestStructuredNodeToolSuppression:
         provider = _FakeToolsetProvider(tool_id="echo", output="echo-out")
 
         async def tool_mgr_resolver(agent: Agent) -> ToolExecutionManager:
-            return ToolExecutionManager(toolset_providers={"fake": provider})
+            return ToolExecutionManager(
+                toolset_providers={"fake": provider},
+                initiated_by=PrincipalRef.system(),
+            )
 
         repo = await _make_state_repo(tmp_path)
         executor = await _build_executor(
@@ -1168,7 +1179,10 @@ class TestStructuredNodeToolSuppression:
         provider = _FakeToolsetProvider(tool_id="echo", output="echo-out")
 
         async def tool_mgr_resolver(agent: Agent) -> ToolExecutionManager:
-            return ToolExecutionManager(toolset_providers={"fake": provider})
+            return ToolExecutionManager(
+                toolset_providers={"fake": provider},
+                initiated_by=PrincipalRef.system(),
+            )
 
         repo = await _make_state_repo(tmp_path)
         executor = await _build_executor(
@@ -1304,7 +1318,8 @@ class TestToolCallApprovalWiring:
                 return ToolResultPart(id=getattr(call, "id", "x"), output="ok")
 
         def _fake_for_workspace(cls, *, toolset_providers, session,
-                                approval_resolver=None, provider_registry=None, tools=None):
+                                approval_resolver=None, provider_registry=None,
+                                tools=None, initiated_by=None, **_kw):
             captured["approval_resolver"] = approval_resolver
             return _FakeMgr()
 

--- a/tests/observability/test_tool_instrumentation.py
+++ b/tests/observability/test_tool_instrumentation.py
@@ -43,6 +43,7 @@ def _make_manager_with_fake_tool(tool_name: str, tool_result: str, *, raises=Non
     from primer.agent.tool_manager import ToolExecutionManager
     from primer.int.toolset import ToolsetProvider
     from primer.model.chat import Tool
+    from primer.model.principal import PrincipalRef
 
     class FakeToolsetProvider(ToolsetProvider):
         async def list_tools(self, *, principal=None):
@@ -63,6 +64,9 @@ def _make_manager_with_fake_tool(tool_name: str, tool_result: str, *, raises=Non
 
     mgr = ToolExecutionManager(
         toolset_providers={"fake": FakeToolsetProvider()},
+        # System invoker clears the RBAC tool floor added on the toolset
+        # dispatch path; without it a None invoker fails closed and denies.
+        initiated_by=PrincipalRef.system(),
     )
     return mgr
 

--- a/tests/test_authz.py
+++ b/tests/test_authz.py
@@ -1,0 +1,97 @@
+"""Unit tests for the shared RBAC role-floor predicate.
+
+``primer.authz._role_allows`` is the single source of truth for both the
+MCP dispatch floor (:func:`primer.mcp.dispatch.invoke_exposed`) and the
+agent tool-execution floor
+(:meth:`primer.agent.tool_manager.ToolExecutionManager._dispatch_toolset`).
+It is duck-typed on ``.type`` / ``.role`` so it accepts either a live
+:class:`Principal` or its persisted :class:`PrincipalRef` projection.
+
+Mirrors the style of ``tests/mcp/test_dispatch_rbac.py`` -- a role matrix
+plus the always-allow / fail-closed edge cases -- and adds the new
+``trigger`` branch the helper grew when it was promoted here.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.authz import _ROLE_RANK, _role_allows
+from primer.model.principal import Principal, PrincipalRef
+
+
+def _user(role: str | None) -> Principal:
+    return Principal(
+        type="user", id="u", display="u", role=role, source="local",
+    )
+
+
+@pytest.mark.parametrize(
+    ("role", "need", "allowed"),
+    [
+        ("admin", "admin", True),
+        ("admin", "user", True),
+        ("admin", "restricted", True),
+        ("user", "admin", False),
+        ("user", "user", True),
+        ("user", "restricted", True),
+        ("restricted", "admin", False),
+        ("restricted", "user", False),
+        ("restricted", "restricted", True),
+        (None, "restricted", False),   # unknown/unset role ranks -1
+        ("user", "bogus", False),      # unknown need ranks 99, never met
+    ],
+)
+def test_user_actor_ranked_against_need(role, need, allowed) -> None:
+    """A ``user``-type actor is gated strictly by ``_ROLE_RANK``."""
+    assert _role_allows(_user(role), need) is allowed
+
+
+def test_missing_actor_denied() -> None:
+    """No actor never passes, even the lowest floor."""
+    assert _role_allows(None, "restricted") is False
+
+
+def test_system_actor_always_allowed() -> None:
+    """The system (auth-disabled) principal clears any floor."""
+    actor = Principal(
+        type="system", id="s", display="s", role=None, source="system",
+    )
+    assert _role_allows(actor, "admin") is True
+
+
+def test_trigger_actor_always_allowed() -> None:
+    """A trigger is internal automation: allowed through the floor exactly
+    like the system principal, even for an ``admin`` tool and despite
+    carrying no ``role``. This is the branch the helper grew on promotion."""
+    actor = PrincipalRef(
+        type="trigger", id="trg-1", display="trg-1",
+        role=None, source="internal",
+    )
+    assert _role_allows(actor, "admin") is True
+
+
+def test_api_token_internal_actor_still_ranked_by_role() -> None:
+    """An ``api_token`` actor is ``source == "internal"`` too, but must be
+    ranked by the owner's real role -- NOT waved through like a trigger.
+    Keying the always-allow branch on ``type`` (not ``source``) is what
+    preserves this distinction."""
+    token = PrincipalRef(
+        type="api_token", id="t", display="t", role="user", source="internal",
+    )
+    assert _role_allows(token, "admin") is False   # ranked, not bypassed
+    assert _role_allows(token, "user") is True
+
+
+def test_principalref_projection_duck_types_like_principal() -> None:
+    """The persisted PrincipalRef projection is accepted identically to a
+    live Principal (the agent path passes ``initiated_by``, a PrincipalRef;
+    the MCP path passes ``actor``, a Principal)."""
+    ref = PrincipalRef(
+        type="user", id="a", display="a", role="admin", source="local",
+    )
+    assert _role_allows(ref, "admin") is True
+
+
+def test_role_rank_ordering() -> None:
+    assert _ROLE_RANK["restricted"] < _ROLE_RANK["user"] < _ROLE_RANK["admin"]

--- a/tests/worker/test_nested_yield_matrix.py
+++ b/tests/worker/test_nested_yield_matrix.py
@@ -121,6 +121,10 @@ class _PlainToolset:
     def is_yielding(self, tool_name: str) -> bool:
         return False
 
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
+
     async def call(self, *, tool_name, arguments, principal=None, ctx=None) -> ToolCallResult:  # noqa: ANN001
         return ToolCallResult(output="did the thing", is_error=False)
 
@@ -143,6 +147,10 @@ class _GatedYieldingToolset:
 
     def is_yielding(self, tool_name: str) -> bool:
         return tool_name == "do_wait"
+
+    def required_role(self, tool_name: str) -> str:
+        del tool_name
+        return "admin"
 
     async def call(self, *, tool_name, arguments, principal=None, ctx=None) -> ToolCallResult:  # noqa: ANN001
         assert ctx is not None


### PR DESCRIPTION
## What & why

Decision 1 from the platform architecture review: the MCP dispatch path enforced
a per-tool `required_role` floor, but the **agent tool-execution path did not**, so
a non-admin who authored an agent whose `tools` list included an admin-only system
tool (e.g. `system__create_llm_provider`) could run it. This enforces the same
floor on the agent path, authorized as the run's **invoker** (`initiated_by`, a
`PrincipalRef` carrying the role stamped server-side at session/chat creation - not
attacker-controlled).

- The shared predicate `_role_allows` (+ `_ROLE_RANK`) is promoted to a new
  `primer/authz.py` so the MCP path and the agent path use one copy. The MCP path
  is a pure refactor (imports it back, behavior unchanged).
- The floor check sits in `ToolExecutionManager._dispatch_toolset` before
  `provider.call`, returning an in-band `error=True` result (the same shape the
  method already uses), only on the toolset path.
- **Triggers** (your decision): a trigger-fired run is an internal automation actor
  identified by its trigger id and is allowed through the floor like `type="system"`.
  Keyed on `.type`, so `api_token` runs keep being ranked by the owner's real role.
- Every `ToolExecutionManager` construction site was audited to thread a real
  invoker or an explicit `PrincipalRef.system()` fallback - **never `None`** (which
  would fail closed and deny every tool). Subagents inherit the parent run's
  invoker (survives park/resume; old parked frames resume as `system()`).

## Fail-closed regression fixed (was CRITICAL in review)
The floor fail-closes to `"admin"` for tools that declare no role. Two agent
surfaces never declared roles (the floor did not exist before), so a `role="user"`
invoker would have been wrongly denied them. Fixed by declaring `required_role="user"`:
- `workspace_ext` toolset: `sleep`, `watch_files`, `invoke_graph`,
  `subscribe_to_trigger`, `subscribe_to_channel_event`.
- **External MCP proxy tools** (`McpToolsetProvider`): overridden to default `"user"`
  instead of the ABC's fail-closed `"admin"`. Rationale: an external MCP tool is
  operator-exposed; the operator's decision to configure/expose it IS the
  authorization decision, so the floor should not newly lock every non-admin out of
  it. **Decision to confirm:** if you'd rather external MCP tools require `admin` by
  default, this one-line override is where to change it.

The fail-closed default still bites for genuinely undeclared tools (unknown tool
-> `admin`), so a new toolset that forgets to declare a role stays locked down.

## Tests
`tests/agent/test_tool_manager.py`, `tests/test_authz.py`, and the affected toolset
suites (`test_workspace_ext`, `test_trigger_toolset`, `test_subscribe_to_trigger`,
`test_mcp`, `test_internal`, `test_workspace_ext_chat_suppression`) -- all pass
(111 in the toolset run; 44 in the floor/authz run). New `TestUserRoleFloorRealSurfaces`
wires the REAL workspace_ext provider under a `role="user"` invoker and asserts
`sleep`/`watch_files` are allowed while `system__create_llm_provider` is still denied,
so the regression cannot recur silently.

HELD -- do not merge without sign-off.
