### PR TITLE
test(e2e): fix pre-existing t0169 failure (frozen_fields moved to extensions)

### DIFF
--- a/tests/e2e/test_internal_collections_lifecycle.py
+++ b/tests/e2e/test_internal_collections_lifecycle.py
@@ -1406,7 +1406,7 @@ async def test_t0169_put_config_reconfigure_embedder_works(
         config_created = True
 
         # After activation, changing embedding_provider_id is frozen --
-        # the API must return 409 with frozen_fields in the detail.
+        # the API must return 409 with frozen_fields in the response.
         put_b = await client.put(
             "/v1/internal_collections/config",
             json=_ic_config_body(embedder_id=embedder_b, ssp_id=ssp_id),
@@ -1415,11 +1415,15 @@ async def test_t0169_put_config_reconfigure_embedder_works(
             f"reconfigure PUT after activation should return 409 "
             f"(frozen fields); got {put_b.status_code}: {put_b.text}"
         )
-        detail = put_b.json().get("detail", {})
-        frozen = detail.get("frozen_fields", []) if isinstance(detail, dict) else []
+        # The problem+json error contract renders an HTTPException dict detail
+        # as a string ``detail`` (the human message) with the machine keys
+        # (frozen_fields, error) carried verbatim in ``extensions``.
+        body_json = put_b.json()
+        extensions = body_json.get("extensions", {})
+        frozen = extensions.get("frozen_fields", [])
         assert "embedding_provider_id" in frozen, (
-            f"expected 'embedding_provider_id' in frozen_fields; "
-            f"got: {detail!r}"
+            f"expected 'embedding_provider_id' in extensions.frozen_fields; "
+            f"got: {body_json!r}"
         )
 
         # Search route still responds cleanly on the ORIGINAL embedder


### PR DESCRIPTION
## What & why

**This is a pre-existing failure on `main`, not caused by any feature branch.**
The `[E2E]` workflow is red on `main` because `test_t0169_put_config_reconfigure_embedder_works`
reads `frozen_fields` from the wrong place after the problem+json error contract
changed (that change is already merged to main).

`PUT /v1/internal_collections/config` raises `HTTPException(409, detail={"error", "message", "frozen_fields"})`.
The error renderer (`primer/api/errors.py` `_http_exception_handler`) reduces a
dict `detail` to the RFC 7807 string `detail` (the human message) and carries the
machine keys **verbatim in `extensions`**. t0169 still read
`response.json()["detail"]["frozen_fields"]`, so `detail` was a string, the dict
lookup yielded `[]`, and the `"embedding_provider_id" in frozen_fields` assertion
failed. Fix: read `frozen_fields` from `extensions`.

This is the **sole** e2e failure (`1 failed, 896 passed`) and it appears on every
open PR because they all branch from a `main` that already carries the contract
change. It is unrelated to the MCP-authz / invoker-role / compaction PRs.

## Test
Cannot be run locally (needs a live server + embedding/search providers); verified
against the shipped response shape by reading `_http_exception_handler`
(dict detail -> `extensions = {k: _jsonable(v) for k, v in detail.items()}`),
so `extensions["frozen_fields"] == ["embedding_provider_id"]`. CI e2e confirms.

HELD -- do not merge without sign-off.
