### PR TITLE
fix(ui): hide inert concurrency/timeout controls on the aggregated provider form

### DIFF
--- a/tests/ui/test_providers_aggregated.py
+++ b/tests/ui/test_providers_aggregated.py
@@ -29,6 +29,18 @@ def test_aggregated_member_editor_and_controls_present() -> None:
     assert "provider_id" in src and "model_name" in src
 
 
+def test_limit_controls_gated_for_aggregated() -> None:
+    """Concurrency + timeout controls are inert for an aggregated provider
+    (AggregatedLLM only routes/fails over; each member enforces its own
+    limits), so the form hides them behind a variant guard and shows a
+    per-member note in their place."""
+    src = _src()
+    assert "enforced per member" in src  # the explanatory note
+    # The aggregated branch (the note) renders in place of the limit fields,
+    # so it precedes the "Max concurrency" control it replaces.
+    assert src.index("enforced per member") < src.index("Max concurrency")
+
+
 def test_providers_jsx_transpiles() -> None:
     from primer.api._jsx_bundle import JSXBundler
 

--- a/ui/components/providers.jsx
+++ b/ui/components/providers.jsx
@@ -1102,6 +1102,13 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
         </div>
       </div>
 
+      {def?.variant === "aggregated" ? (
+        <div className="field-help">
+          Concurrency and timeouts are enforced per member (each member
+          provider's own limits). An aggregated provider only routes and
+          fails over between members, so it has no limits of its own.
+        </div>
+      ) : (<>
       <div className="field">
         <label className="field-label">Max concurrency <span className="hint">in-flight requests cap</span></label>
         <input
@@ -1188,6 +1195,7 @@ function NewProviderModal({ kindProp, plural, label, onClose, onCreated, pushToa
           </div>
         )}
       </div>
+      </>)}
     </Modal>
   );
 }


### PR DESCRIPTION
## What & why

The "New llm provider" form rendered **Max concurrency**, **Stream inactivity
timeout**, **Connect timeout**, and **Total generation timeout** for the
`Aggregated` provider type, but those controls have **no effect** on an
aggregated provider:

- `AggregatedLLM` is a pure router -- `stream()` delegates every call to a
  resolved member's `llm.stream(...)` and only reads `members` / `strategy` /
  `failover_point` / `failover_on` from its config. It never reads
  `max_concurrency` or any timeout field.
- The registry builds `AggregatedLLM(provider, resolve_member=...)` **without**
  a `rate_limiter`, unlike every other provider type -- so the aggregate has no
  concurrency gate of its own.
- Concurrency and timeouts are enforced **per member**, from each member
  provider's own config, at the member adapter (and its own rate limiter).

So the four controls were inert and misleading for the aggregated type. This
hides them for the aggregated variant and shows a short note explaining that
limits are per-member. Non-aggregated provider types are unchanged.

Scope is deliberately UI-only (option 1). A real aggregate-level failover-guard
timeout (so a member with unbounded timeouts that stalls still trips failover)
was considered and explicitly deferred.

## Tests
`tests/ui/test_providers_aggregated.py` (incl. the Babel transpile check that
the JSX still compiles) + `tests/ui/test_providers_mobile.py` -- 8 passed. New
`test_limit_controls_gated_for_aggregated` asserts the limit fields are gated
behind the aggregated-variant guard.

HELD -- do not merge without sign-off.
