### PR TITLE
feat: searchable, paginated agent/graph picker (server-side ?q= search + ILIKE)

### DIFF
--- a/primer/api/routers/_crud.py
+++ b/primer/api/routers/_crud.py
@@ -638,7 +638,7 @@ def make_crud_router(
             # q present AND this entity is searchable -> ILIKE substring find,
             # preserving the same page/order_by handling and the identical
             # OffsetPageResponse {items, total} shape as the plain list.
-            if q and search_fields:
+            if q and q.strip() and search_fields:
                 predicate = _build_search_predicate(search_fields, q)
                 return await storage.find(predicate, page, order_by=order_by)
             return await storage.list(page, order_by=order_by)

--- a/primer/api/routers/_crud.py
+++ b/primer/api/routers/_crud.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable, Sequence
 from typing import Any, TypeVar
 
-from fastapi import APIRouter, Body, Depends, HTTPException, Path, Request, status
+from fastapi import APIRouter, Body, Depends, HTTPException, Path, Query, Request, status
 from fastapi.exceptions import RequestValidationError
 from pydantic import ValidationError as PydanticValidationError
 
@@ -50,6 +50,40 @@ _ModelT = TypeVar("_ModelT", bound=Identifiable)
 # Page response is a runtime union of the two concrete page shapes;
 # FastAPI/Pydantic serializes it via the discriminator on ``kind``.
 _PageResp = OffsetPageResponse[Any] | CursorPageResponse[Any]
+
+
+def _escape_like(value: str) -> str:
+    """Escape SQL ``LIKE`` / ``ILIKE`` metacharacters in a user query.
+
+    Escapes the escape char first, then ``%`` and ``_``, so the value matches
+    LITERALLY under the ``ESCAPE '\\'`` clause the ILIKE renderers emit. A user
+    typing ``50%`` then searches for a literal ``50%`` rather than "50 followed
+    by any sequence". Mirrors the backend content-store ``_escape_like``
+    helpers (``primer.storage.sqlite`` / ``primer.storage.postgres``).
+    """
+    return value.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+
+
+def _build_search_predicate(search_fields: Sequence[str], q: str) -> Predicate:
+    """OR a case-insensitive substring (ILIKE) match across ``search_fields``.
+
+    Each field yields ``<field> ILIKE '%<escaped-q>%'``; the terms are folded
+    right-associatively into an OR tree. ``q`` is escaped so its ``%`` / ``_``
+    are treated literally (see :func:`_escape_like`).
+    """
+    pattern = f"%{_escape_like(q)}%"
+    terms = [
+        Predicate(
+            left=FieldRef(name=field),
+            op=Op.ILIKE,
+            right=Value(value=pattern),
+        )
+        for field in search_fields
+    ]
+    combined = terms[-1]
+    for term in reversed(terms[:-1]):
+        combined = Predicate(left=term, op=Op.OR, right=combined)
+    return combined
 
 
 def _compose(
@@ -118,6 +152,7 @@ def make_crud_router(
     managed_by_field: str | None = None,
     references: Sequence[ReferenceCheck] = (),
     cdc_kind: str | None = None,
+    search_fields: list[str] | None = None,
 ) -> APIRouter:
     """Build a CRUD + Find APIRouter for ``model_cls``.
 
@@ -199,6 +234,13 @@ def make_crud_router(
           :func:`~primer.api.routers._cdc_hooks.make_cdc_hooks` into
           ``on_create`` / ``on_update`` / ``on_delete``.  The CDC hooks
           run *before* any user-supplied post-mutate hooks.
+    search_fields
+        When set, the unscoped ``GET /<plural>`` list route accepts an
+        optional ``?q=`` query param and, when it is non-empty, filters
+        rows by a case-insensitive substring (ILIKE) match ORed across
+        these fields via ``storage.find``.  The response keeps the same
+        ``{items, total}`` offset-paged shape as the unfiltered list.
+        ``None`` (the default) leaves the list route unchanged.
     """
 
     # Validate scope params: both must be set together or not at all.
@@ -583,8 +625,22 @@ def make_crud_router(
         async def _list(
             page: PageRequest = Depends(parse_page),
             order_by: list[OrderBy] | None = Depends(parse_order_by),
+            q: str | None = Query(
+                default=None,
+                description=(
+                    "Case-insensitive substring match over the entity's "
+                    "searchable fields. Ignored when the entity declares no "
+                    "searchable fields."
+                ),
+            ),
             storage=Depends(storage_dep),
         ) -> _PageResp:
+            # q present AND this entity is searchable -> ILIKE substring find,
+            # preserving the same page/order_by handling and the identical
+            # OffsetPageResponse {items, total} shape as the plain list.
+            if q and search_fields:
+                predicate = _build_search_predicate(search_fields, q)
+                return await storage.find(predicate, page, order_by=order_by)
             return await storage.list(page, order_by=order_by)
 
         # ---- POST /<plural>/find  (find with predicate) ------------------

--- a/primer/api/routers/compute.py
+++ b/primer/api/routers/compute.py
@@ -49,6 +49,7 @@ agent_router = make_crud_router(
     tag="agents",
     cdc_kind="agent",
     managed_by_field="harness_id",
+    search_fields=["id", "description"],
 )
 
 
@@ -118,6 +119,7 @@ graph_router = make_crud_router(
     tag="graphs",
     cdc_kind="graph",
     managed_by_field="harness_id",
+    search_fields=["id", "description"],
 )
 
 

--- a/primer/model/storage.py
+++ b/primer/model/storage.py
@@ -73,11 +73,20 @@ class Op(str, Enum):
     ``PRAGMA case_sensitive_like = ON`` so the two agree. Backends
     SHOULD translate to their native pattern syntax but MUST preserve
     case sensitivity.
+
+    ``ILIKE`` is ``LIKE`` but case-INSENSITIVE; it inherits the identical
+    ``%`` / ``_`` wildcard and ``\\`` ESCAPE semantics, only the case
+    sensitivity differs. Postgres emits its native ``ILIKE``; SQLite (which
+    has no ``ILIKE`` and pins ``LIKE`` case-sensitive) emulates it as
+    ``LOWER(field) LIKE LOWER(pattern)``, giving ASCII case-insensitive
+    matching. Non-ASCII case folding MAY differ between the two backends,
+    consistent with the SQLite ``LIKE`` note above.
     """
 
     EQ = "="
     NE = "!="
     LIKE = "~="
+    ILIKE = "~=*"
     GT = ">"
     LT = "<"
     GE = ">="

--- a/primer/storage/_predicate.py
+++ b/primer/storage/_predicate.py
@@ -242,8 +242,10 @@ class _PredicateTranslator:
         """
         if isinstance(p.left, FieldRef):
             left_sql = _render_field_expr(self._model, p.left.name)
-        else:
+        elif isinstance(p.left, Value):
             left_sql = self._render(p.left)
+        else:
+            raise BadRequestError("ILIKE left side must be FieldRef or Value")
         right_sql = self._render(p.right)
         return f"({left_sql} ILIKE {right_sql} ESCAPE '\\')"
 

--- a/primer/storage/_predicate.py
+++ b/primer/storage/_predicate.py
@@ -223,10 +223,29 @@ class _PredicateTranslator:
         if p.op in (Op.IS_NULL, Op.IS_NOT_NULL):
             return self._render_null_check(p)
 
+        if p.op == Op.ILIKE:
+            return self._render_ilike(p)
+
         if p.op in _COMPARISON_OPS:
             return self._render_comparison(p)
 
         raise BadRequestError(f"unsupported operator {p.op.value!r}")
+
+    def _render_ilike(self, p: Predicate) -> str:
+        """Render case-insensitive ``ILIKE`` (Postgres-native).
+
+        Parallels the bare ``LIKE`` comparison rendering but emits the native
+        ``ILIKE`` keyword plus an explicit ``ESCAPE '\\'`` so the ``?q=``
+        search layer can escape user ``%`` / ``_`` deterministically. Like
+        ``LIKE``, it compares on the text representation (no numeric cast); a
+        cast would be meaningless and would itself error.
+        """
+        if isinstance(p.left, FieldRef):
+            left_sql = _render_field_expr(self._model, p.left.name)
+        else:
+            left_sql = self._render(p.left)
+        right_sql = self._render(p.right)
+        return f"({left_sql} ILIKE {right_sql} ESCAPE '\\')"
 
     def _render_null_check(self, p: Predicate) -> str:
         # Shared boilerplate (see _predicate_common.render_null_check); the

--- a/primer/storage/_sqlite_predicate.py
+++ b/primer/storage/_sqlite_predicate.py
@@ -126,9 +126,36 @@ class _SqlitePredicateTranslator:
             return self._render_contains(p)
         if p.op in (Op.IS_NULL, Op.IS_NOT_NULL):
             return self._render_null_check(p)
+        if p.op == Op.ILIKE:
+            return self._render_ilike(p)
         if p.op in _COMPARISON_OPS:
             return self._render_comparison(p)
         raise BadRequestError(f"unsupported operator {p.op.value!r}")
+
+    def _render_ilike(self, p: Predicate) -> str:
+        """Render case-insensitive matching for SQLite.
+
+        SQLite has no ``ILIKE`` keyword, and its ``LIKE`` is pinned
+        case-SENSITIVE (``PRAGMA case_sensitive_like = ON``), so emulate ASCII
+        case-insensitivity by lower-casing both operands:
+        ``LOWER(<field>) LIKE LOWER(<pattern>) ESCAPE '\\'``. ``LOWER`` leaves
+        the ``%`` / ``_`` / ``\\`` metacharacters untouched, so the wildcard +
+        escape semantics match the ``LIKE`` path (and Postgres ``ILIKE`` for
+        ASCII).
+        """
+        if isinstance(p.left, FieldRef):
+            left_sql = _render_field_expr(self._model, p.left.name)
+        elif isinstance(p.left, Value):
+            left_sql = self.append_param(p.left.value)
+        else:
+            raise BadRequestError("ILIKE left side must be FieldRef or Value")
+        if isinstance(p.right, FieldRef):
+            right_sql = _render_field_expr(self._model, p.right.name)
+        elif isinstance(p.right, Value):
+            right_sql = self.append_param(p.right.value)
+        else:
+            raise BadRequestError("ILIKE right side must be FieldRef or Value")
+        return f"(LOWER({left_sql}) LIKE LOWER({right_sql}) ESCAPE '\\')"
 
     def _render_null_check(self, p: Predicate) -> str:
         # Shared boilerplate (see _predicate_common.render_null_check). Note:

--- a/primer/tap/selector.py
+++ b/primer/tap/selector.py
@@ -124,12 +124,15 @@ def _resolve_field(name: str, event: TapEvent) -> Any:
     )
 
 
-def _like_to_regex(pattern: str) -> re.Pattern[str]:
-    """Convert a SQL LIKE pattern to a compiled regex (case-sensitive).
+def _like_to_regex(pattern: str, *, flags: int = 0) -> re.Pattern[str]:
+    """Convert a SQL LIKE pattern to a compiled regex.
 
-    * ``%`` → ``.*``
-    * ``_`` → ``.``
+    * ``%`` -> ``.*``
+    * ``_`` -> ``.``
     * All other regex metacharacters are escaped.
+
+    ``flags`` is passed through to :func:`re.compile`; pass
+    ``re.IGNORECASE`` for a case-insensitive (SQL ILIKE) match.
     """
     parts: list[str] = []
     i = 0
@@ -142,7 +145,7 @@ def _like_to_regex(pattern: str) -> re.Pattern[str]:
         else:
             parts.append(re.escape(ch))
         i += 1
-    return re.compile("".join(["^"] + parts + ["$"]))
+    return re.compile("".join(["^"] + parts + ["$"]), flags)
 
 
 def _eval_predicate(pred: Predicate, event: TapEvent) -> bool:
@@ -213,6 +216,13 @@ def _eval_predicate(pred: Predicate, event: TapEvent) -> bool:
             f"Op.LIKE can only match string fields, got {type(field_val)}"
         )
         return bool(_like_to_regex(rhs).match(field_val))
+
+    if op is Op.ILIKE:
+        assert isinstance(rhs, str), f"Op.ILIKE expects a string pattern, got {type(rhs)}"
+        assert isinstance(field_val, str), (
+            f"Op.ILIKE can only match string fields, got {type(field_val)}"
+        )
+        return bool(_like_to_regex(rhs, flags=re.IGNORECASE).match(field_val))
 
     # Should be unreachable if Op enum is exhaustive, but guard anyway.
     raise NotImplementedError(f"Unsupported Op: {op!r}")  # pragma: no cover

--- a/tests/api/test_compute.py
+++ b/tests/api/test_compute.py
@@ -118,6 +118,64 @@ class TestAgentStatus:
         assert resp.json() == {"ok": True, "issues": []}
 
 
+class TestAgentSearch:
+    """`GET /v1/agents?q=` case-insensitive substring search over the
+    entity's search_fields (id + description), same {items,total} shape."""
+
+    async def _seed(self, client) -> None:
+        for aid, desc in (
+            ("agt-alpha", "First HELPER agent"),
+            ("agt-beta", "second helper bot"),
+            ("agt-gamma", "unrelated widget"),
+        ):
+            body = _agent(id=aid, description=desc).model_dump(mode="json")
+            resp = await client.post("/v1/agents", json=body)
+            assert resp.status_code == 201, resp.text
+
+    @pytest.mark.asyncio
+    async def test_q_filters_case_insensitively(self, client) -> None:
+        await self._seed(client)
+        resp = await client.get("/v1/agents", params={"q": "helper"})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        # Identical offset-paged envelope to the unfiltered list.
+        assert {"items", "total", "offset", "length"} <= set(body)
+        assert sorted(a["id"] for a in body["items"]) == ["agt-alpha", "agt-beta"]
+        assert body["total"] == 2
+
+    @pytest.mark.asyncio
+    async def test_q_matches_on_id_field(self, client) -> None:
+        await self._seed(client)
+        # 'gamma' appears only in the id, and the query is upper-cased.
+        resp = await client.get("/v1/agents", params={"q": "GAMMA"})
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert [a["id"] for a in body["items"]] == ["agt-gamma"]
+        assert body["total"] == 1
+
+    @pytest.mark.asyncio
+    async def test_q_absent_is_unfiltered(self, client) -> None:
+        await self._seed(client)
+        resp = await client.get("/v1/agents?limit=20&offset=0")
+        assert resp.status_code == 200, resp.text
+        body = resp.json()
+        assert body["length"] == 3
+        assert body["total"] == 3
+
+    @pytest.mark.asyncio
+    async def test_q_percent_is_literal(self, client) -> None:
+        for aid, desc in (
+            ("agt-pct", "50% discount"),
+            ("agt-plain", "50 percent discount"),
+        ):
+            body = _agent(id=aid, description=desc).model_dump(mode="json")
+            assert (await client.post("/v1/agents", json=body)).status_code == 201
+        # A user typing '50%' searches for a LITERAL '50%', not "50 + wildcard".
+        resp = await client.get("/v1/agents", params={"q": "50%"})
+        assert resp.status_code == 200, resp.text
+        assert [a["id"] for a in resp.json()["items"]] == ["agt-pct"]
+
+
 class TestGraphCRUD:
     """Graph routes are smoke-tested only because constructing a valid
     Graph requires a fully populated topology of nodes/edges. The CRUD

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -145,12 +145,44 @@ def _resolve_field(entity: Any, path: str) -> Any:
     return cur
 
 
+def _like_match(value: str, pattern: str, *, case_insensitive: bool) -> bool:
+    """Emulate SQL ``LIKE`` / ``ILIKE`` (``ESCAPE '\\'``) for the fake store.
+
+    Translates the SQL pattern to a regex: ``%`` -> ``.*``, ``_`` -> ``.``, and
+    a backslash escapes the next metacharacter to a literal. Mirrors the
+    ``ESCAPE '\\'`` clause the SQL backends emit so the ``?q=`` escape test
+    behaves identically over the in-memory provider.
+    """
+    import re
+
+    out: list[str] = ["^"]
+    i = 0
+    while i < len(pattern):
+        ch = pattern[i]
+        if ch == "\\" and i + 1 < len(pattern):
+            out.append(re.escape(pattern[i + 1]))
+            i += 2
+            continue
+        if ch == "%":
+            out.append(".*")
+        elif ch == "_":
+            out.append(".")
+        else:
+            out.append(re.escape(ch))
+        i += 1
+    out.append("$")
+    flags = re.DOTALL | (re.IGNORECASE if case_insensitive else 0)
+    return re.match("".join(out), value, flags) is not None
+
+
 def _eval_predicate(entity: Any, node: Any) -> bool:
     """Tiny predicate evaluator for the in-memory test storage.
 
-    Supports EQ / NE / AND / OR -- the operators the API routers
-    actually emit when translating query params. Other operators fall
-    through to ``True`` (the test storage is intentionally minimal).
+    Supports EQ / NE / GT / LT / GE / LE / LIKE / ILIKE / IS_NULL /
+    IS_NOT_NULL / AND / OR -- the operators the API routers actually emit
+    when translating query params (LIKE/ILIKE back the ``?q=`` search).
+    Other operators fall through to ``True`` (the test storage is
+    intentionally minimal).
     """
     if isinstance(node, Predicate):
         if node.op in (Op.AND, Op.OR):
@@ -181,6 +213,14 @@ def _eval_predicate(entity: Any, node: Any) -> bool:
                 return actual is not None and actual >= expected
             if node.op == Op.LE:
                 return actual is not None and actual <= expected
+            if node.op in (Op.LIKE, Op.ILIKE):
+                if actual is None or not isinstance(expected, str):
+                    return False
+                return _like_match(
+                    str(actual),
+                    expected,
+                    case_insensitive=(node.op == Op.ILIKE),
+                )
         return True
     return True
 

--- a/tests/storage/test_postgres_predicate.py
+++ b/tests/storage/test_postgres_predicate.py
@@ -138,6 +138,33 @@ def test_like_renders_bare_case_sensitive_operator():
     assert params == ["Hello%"]
 
 
+def test_ilike_renders_native_ilike_with_escape():
+    # Postgres has a native ILIKE: the translator must emit it (not a
+    # LOWER()/LIKE emulation) with an explicit ESCAPE '\' clause, parallel
+    # to the bare LIKE rendering. Case-insensitivity is the ONLY difference
+    # from LIKE; like LIKE it compares on the text representation (no cast).
+    sql, params = _sql(
+        Predicate(left=FieldRef(name="name"), op=Op.ILIKE, right=Value(value="%foo%"))
+    )
+    assert sql == "(data->>'name' ILIKE $1 ESCAPE '\\')", sql
+    assert "ILIKE" in sql and "LOWER(" not in sql
+    assert params == ["%foo%"]
+
+
+def test_ilike_differs_from_like_only_by_operator():
+    # Same operands, LIKE vs ILIKE: identical field expression + param,
+    # the operator keyword is the sole difference (ILIKE adds ESCAPE).
+    like_sql, _ = _sql(
+        Predicate(left=FieldRef(name="name"), op=Op.LIKE, right=Value(value="Foo%"))
+    )
+    ilike_sql, _ = _sql(
+        Predicate(left=FieldRef(name="name"), op=Op.ILIKE, right=Value(value="Foo%"))
+    )
+    assert like_sql == "(data->>'name' LIKE $1)", like_sql
+    assert ilike_sql == "(data->>'name' ILIKE $1 ESCAPE '\\')", ilike_sql
+    assert like_sql != ilike_sql
+
+
 def test_order_by_nullable_field_is_nulls_last():
     # NULLs sort LAST so keyset pagination can page across the NULL
     # boundary; parity with SQLite's "(field IS NULL) ASC" sort term.

--- a/tests/storage/test_sqlite_storage.py
+++ b/tests/storage/test_sqlite_storage.py
@@ -295,3 +295,63 @@ async def test_like_is_case_sensitive(sqlite_provider: SqliteStorageProvider):
         OffsetPage(offset=0, length=10),
     )
     assert [d.id for d in hit.items] == ["h"]
+
+
+@pytest.mark.asyncio
+async def test_ilike_is_case_insensitive(sqlite_provider: SqliteStorageProvider):
+    """Op.ILIKE matches case-INSENSITIVELY where Op.LIKE (case-sensitive)
+    does not.
+
+    SQLite has no ILIKE and pins LIKE case-sensitive; the translator emits
+    ``LOWER(field) LIKE LOWER(pattern)`` so "Foo"/"FOO"/"fOo" all match a
+    "%foo%" query.
+    """
+    s = sqlite_provider.get_storage(_Doc)
+    await s.create(_Doc(id="a", title="Foo bar"))
+    await s.create(_Doc(id="b", title="a FOO stop"))
+    await s.create(_Doc(id="c", title="plain foo lower"))
+    await s.create(_Doc(id="d", title="unrelated"))
+    for pattern in ("%foo%", "%FOO%", "%FoO%"):
+        hit = await s.find(
+            Predicate(
+                left=FieldRef(name="title"), op=Op.ILIKE, right=Value(value=pattern)
+            ),
+            OffsetPage(offset=0, length=10),
+        )
+        assert sorted(d.id for d in hit.items) == ["a", "b", "c"], pattern
+    # LIKE (case-sensitive) with a lowercased pattern matches ONLY the row that
+    # literally contains lowercase "foo" -- the capitalised rows are missed.
+    like_hit = await s.find(
+        Predicate(left=FieldRef(name="title"), op=Op.LIKE, right=Value(value="%foo%")),
+        OffsetPage(offset=0, length=10),
+    )
+    assert sorted(d.id for d in like_hit.items) == ["c"]
+
+
+@pytest.mark.asyncio
+async def test_ilike_escapes_wildcards(sqlite_provider: SqliteStorageProvider):
+    """A literal ``%`` in an ILIKE pattern (escaped as ``\\%``) matches only a
+    literal ``%`` -- the ESCAPE '\\' clause must be honoured, not swallowed."""
+    s = sqlite_provider.get_storage(_Doc)
+    await s.create(_Doc(id="pct", title="50% off"))
+    await s.create(_Doc(id="plain", title="50 percent"))
+    # Escaped '%' -> literal '%': only the row containing a literal '%'.
+    hit = await s.find(
+        Predicate(
+            left=FieldRef(name="title"),
+            op=Op.ILIKE,
+            right=Value(value="%50\\%%"),
+        ),
+        OffsetPage(offset=0, length=10),
+    )
+    assert [d.id for d in hit.items] == ["pct"]
+    # Unescaped '%' would over-match: sanity-check the literal path really
+    # discriminates by confirming the plain row is only hit when we let '%'
+    # act as a wildcard.
+    wild = await s.find(
+        Predicate(
+            left=FieldRef(name="title"), op=Op.ILIKE, right=Value(value="%50%")
+        ),
+        OffsetPage(offset=0, length=10),
+    )
+    assert sorted(d.id for d in wild.items) == ["pct", "plain"]

--- a/tests/tap/test_selector.py
+++ b/tests/tap/test_selector.py
@@ -91,6 +91,34 @@ class TestEventMatchesIn:
         assert event_matches(sel, _make_event(class_=TapEventClass.TOOL_CALL)) is True
 
 
+class TestEventMatchesILike:
+    """ILIKE is case-insensitive LIKE. A tap ``?selector=`` predicate can carry
+    it (the op enum is user-reachable and not whitelisted), so the in-memory
+    evaluator must handle it rather than raise NotImplementedError."""
+
+    def _ilike(self, field: str, pattern: str) -> Predicate:
+        return Predicate(
+            left=FieldRef(name=field), op=Op.ILIKE, right=Value(value=pattern)
+        )
+
+    def test_ilike_matches_case_insensitively(self) -> None:
+        sel = TapSelector(events=self._ilike("session_id", "%ABC%"))
+        assert event_matches(sel, _make_event(session_id="sess-abc")) is True
+
+    def test_ilike_no_match(self) -> None:
+        sel = TapSelector(events=self._ilike("session_id", "%zzz%"))
+        assert event_matches(sel, _make_event(session_id="sess-abc")) is False
+
+    def test_like_stays_case_sensitive(self) -> None:
+        # Contrast: plain LIKE with an upper-case pattern must NOT match the
+        # lower-case value, proving ILIKE's IGNORECASE is what matched above.
+        pred = Predicate(
+            left=FieldRef(name="session_id"), op=Op.LIKE, right=Value(value="%ABC%")
+        )
+        sel = TapSelector(events=pred)
+        assert event_matches(sel, _make_event(session_id="sess-abc")) is False
+
+
 # ---------------------------------------------------------------------------
 # event_matches — EQ operator on session_id
 # ---------------------------------------------------------------------------

--- a/tests/ui/test_entity_picker.py
+++ b/tests/ui/test_entity_picker.py
@@ -1,0 +1,191 @@
+"""Searchable + paginated agent/graph picker (EntityPicker).
+
+Replaces the old "GET /agents?limit=200 dumped into a <select>" pattern in
+the New session form (and the New chat creator) with a reusable component
+that searches server-side via the `?q=` ILIKE support added alongside this
+UI change (see primer/api's list-endpoint search), paged through the
+existing shared `usePagedList` + `Pager` primitive (tests/ui/test_pagination.py).
+
+Static-source + bundle-build checks only (matching the rest of the ui/
+suite -- no React render).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+PICKER = UI / "components" / "shared" / "entity-picker.jsx"
+NEW_SESSION = UI / "components" / "new-session-form.jsx"
+CHATS = UI / "components" / "chats.jsx"
+INDEX = UI / "index.html"
+
+
+def _picker_src() -> str:
+    return PICKER.read_text(encoding="utf-8")
+
+
+def _new_session_src() -> str:
+    return NEW_SESSION.read_text(encoding="utf-8")
+
+
+def _chats_src() -> str:
+    return CHATS.read_text(encoding="utf-8")
+
+
+# ---- The component exists + is defined -------------------------------------
+
+
+def test_picker_file_exists() -> None:
+    assert PICKER.exists()
+
+
+def test_component_defined_and_exported() -> None:
+    src = _picker_src()
+    assert "function EntityPicker(" in src
+    # Bare global + primerApi namespace, mirroring shared/pager.jsx's idiom.
+    assert "window.EntityPicker = EntityPicker" in src
+    assert "ns.EntityPicker = EntityPicker" in src
+
+
+# ---- Uses usePagedList with a server-side `q` param ------------------------
+
+
+def test_uses_paged_list_hook() -> None:
+    src = _picker_src()
+    assert "usePagedList(" in src
+
+
+def test_search_text_is_debounced_before_becoming_q() -> None:
+    src = _picker_src()
+    # A raw input value is held separately from the debounced `q` that is
+    # actually sent as a query param, via setTimeout/clearTimeout.
+    assert "setTimeout(" in src
+    assert "clearTimeout(" in src
+    assert "params: q ?" in src or "params:q?" in src.replace(" ", "")
+    assert "resetKey: q" in src or "resetKey:q" in src.replace(" ", "")
+
+
+def test_search_input_present() -> None:
+    src = _picker_src()
+    assert 'name="search"' in src
+    assert "input-icon" in src
+
+
+def test_pager_rendered() -> None:
+    assert "<Pager" in _picker_src()
+
+
+def test_selection_clear_control_present() -> None:
+    src = _picker_src()
+    assert "Selected:" in src
+    assert "onChange(\"\")" in src
+
+
+# ---- Registered in the bundle, in the right order --------------------------
+
+
+def _bundle_order() -> list[str]:
+    out: list[str] = []
+    for line in INDEX.read_text(encoding="utf-8").splitlines():
+        if 'type="text/babel"' in line and "src=" in line:
+            start = line.index('src="') + len('src="')
+            end = line.index('"', start)
+            out.append(line[start:end])
+    return out
+
+
+def test_registered_in_index() -> None:
+    assert "components/shared/entity-picker.jsx" in _bundle_order()
+
+
+def test_loads_after_pager_before_consumers() -> None:
+    order = _bundle_order()
+    picker_at = order.index("components/shared/entity-picker.jsx")
+    assert picker_at > order.index("components/shared.jsx")
+    assert picker_at > order.index("components/shared/pager.jsx")
+    for consumer in ("components/new-session-form.jsx", "components/chats.jsx"):
+        assert order.index(consumer) > picker_at, f"{consumer} loads before entity-picker.jsx"
+
+
+# ---- new-session-form.jsx wires the picker, not a bare <select> -----------
+
+
+def _agent_graph_field_block(src: str) -> str:
+    start = src.index('{kind === "agent" ? "Agent" : "Graph"}')
+    end = src.index("noBinding &&", start)
+    return src[start:end]
+
+
+def test_new_session_form_uses_entity_picker_for_agent_and_graph() -> None:
+    block = _agent_graph_field_block(_new_session_src())
+    assert block.count("<EntityPicker") == 2
+    assert 'path="/agents"' in block
+    assert 'path="/graphs"' in block
+    assert "<select" not in block, "agent/graph binding should use EntityPicker, not a bare <select>"
+
+
+def test_new_session_form_picker_wired_to_existing_state() -> None:
+    block = _agent_graph_field_block(_new_session_src())
+    assert "value={agentId}" in block and "onChange={setAgentId}" in block
+    assert "value={graphId}" in block and "onChange={setGraphId}" in block
+
+
+def test_new_session_form_still_resolves_selected_graph_for_begin_schema() -> None:
+    # The graph binding drives a dependent Begin.input_schema dynamic form
+    # (selectedGraph lookup); dropping the select must not drop this.
+    src = _new_session_src()
+    assert "selectedGraph" in src
+    assert "graphItems.find" in src
+    assert "input_schema" in src and "graph_input" in src
+
+
+# ---- chats.jsx "New chat" creator wires the same picker --------------------
+
+
+def test_new_chat_modal_uses_entity_picker() -> None:
+    src = _chats_src()
+    start = src.index("function CT_NewChatModal(")
+    end = src.index("\nfunction ", start + 1)
+    block = src[start:end]
+    assert "<EntityPicker" in block
+    assert 'path="/agents"' in block
+    assert "<select" not in block, "New chat agent binding should use EntityPicker, not a bare <select>"
+
+
+# ---- Transpile checks -------------------------------------------------------
+
+
+def test_entity_picker_jsx_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    code = b._transform(_picker_src(), "components/shared/entity-picker.jsx")
+    assert code and "EntityPicker" in code
+
+
+def test_new_session_form_jsx_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    code = b._transform(_new_session_src(), "components/new-session-form.jsx")
+    assert code and "EntityPicker" in code
+
+
+def test_chats_jsx_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    code = b._transform(_chats_src(), "components/chats.jsx")
+    assert code and "EntityPicker" in code
+
+
+def test_bundle_transpiles_with_entity_picker() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    etag, body = build_jsx_bundle(UI)
+    assert etag and body
+    text = body.decode("utf-8")
+    assert "/* === components/shared/entity-picker.jsx === */" in text
+    assert "function EntityPicker(" in text

--- a/ui/components/chats.jsx
+++ b/ui/components/chats.jsx
@@ -1,4 +1,4 @@
-/* global React, Icon, Btn, Modal, Banner, BottomSheet, relativeTime, fmtDate */
+/* global React, Icon, Btn, Modal, Banner, BottomSheet, relativeTime, fmtDate, EntityPicker */
 //
 // Chats list + detail. Live updates via WebSocket (`/v1/chats/{id}/ws`)
 // and initial history via REST (`GET /v1/chats/{id}/messages`). Tool
@@ -364,16 +364,13 @@ function CT_NewChatModal({ onClose, pushToast }) {
             <div>No agents registered. Create one before starting a chat.</div>
           </div>
         ) : (
-          <select
-            className="select mono"
-            style={{ width: "100%" }}
+          <EntityPicker
+            path="/agents"
             value={agentId}
-            onChange={(e) => setAgentId(e.target.value)}
-          >
-            {agentItems.map((a) => (
-              <option key={a.id} value={a.id}>{a.id}</option>
-            ))}
-          </select>
+            onChange={setAgentId}
+            placeholder="Search agents…"
+            testid="new-chat-agent-picker"
+          />
         )}
         {fieldErrors["body.agent_id"] && (
           <div className="muted text-sm" style={{ color: "var(--red)", marginTop: 4 }}>{fieldErrors["body.agent_id"]}</div>

--- a/ui/components/new-session-form.jsx
+++ b/ui/components/new-session-form.jsx
@@ -1,4 +1,4 @@
-/* global React, Modal, Btn, Icon */
+/* global React, Modal, Btn, Icon, EntityPicker */
 // ---------------------------------------------------------------------------
 // SharedNewSessionForm (FD2) — the ONE create-session form.
 //
@@ -388,31 +388,21 @@ function SharedNewSessionForm(props) {
       <div className="field">
         <label className="field-label">{kind === "agent" ? "Agent" : "Graph"}</label>
         {kind === "agent" ? (
-          <select
-            className="select"
+          <EntityPicker
+            path="/agents"
             value={agentId}
-            onChange={function (e) { setAgentId(e.target.value); }}
-            style={{ width: "100%" }}
-            disabled={loading || agentItems.length === 0}
-          >
-            {agentItems.length === 0 && (
-              <option value="">{loading ? "Loading…" : "No agents available"}</option>
-            )}
-            {agentItems.map(function (a) { return <option key={a.id} value={a.id}>{a.id}</option>; })}
-          </select>
+            onChange={setAgentId}
+            placeholder="Search agents…"
+            testid="new-session-agent-picker"
+          />
         ) : (
-          <select
-            className="select"
+          <EntityPicker
+            path="/graphs"
             value={graphId}
-            onChange={function (e) { setGraphId(e.target.value); }}
-            style={{ width: "100%" }}
-            disabled={loading || graphItems.length === 0}
-          >
-            {graphItems.length === 0 && (
-              <option value="">{loading ? "Loading…" : "No graphs available"}</option>
-            )}
-            {graphItems.map(function (g) { return <option key={g.id} value={g.id}>{g.id}</option>; })}
-          </select>
+            onChange={setGraphId}
+            placeholder="Search graphs…"
+            testid="new-session-graph-picker"
+          />
         )}
         {noBinding && (
           <div className="field-help warn">

--- a/ui/components/new-session-form.jsx
+++ b/ui/components/new-session-form.jsx
@@ -209,8 +209,24 @@ function SharedNewSessionForm(props) {
   var attachInputRef = React.useRef(null);
   var attachSeqRef = React.useRef(0);
 
+  // Resolve the SELECTED graph's full detail by id so the dependent
+  // Begin.input_schema form renders for ANY selected graph - including one
+  // picked via the server-side search beyond the capped list fetched above.
+  // Always call the hook (Rules of Hooks); the fetcher no-ops unless a graph
+  // is selected. Falls back to the list item until the by-id fetch resolves.
+  var selectedGraphRes = useResource(
+    "shared-new-session:graph-detail:" + (kind === "graph" ? graphId : ""),
+    function (signal) {
+      if (kind !== "graph" || !graphId) return Promise.resolve(null);
+      return apiFetch("GET", "/graphs/" + encodeURIComponent(graphId), null, { signal });
+    },
+    { pollMs: 0 }
+  );
+
   // Look up the selected graph + its Begin node to drive the dynamic form.
-  var selectedGraph = graphItems.find(function (g) { return g.id === graphId; }) || null;
+  var selectedGraph = selectedGraphRes.data
+    || graphItems.find(function (g) { return g.id === graphId; })
+    || null;
   var beginNode = ((selectedGraph && selectedGraph.nodes) || []).find(function (n) {
     return n.kind === "begin";
   }) || null;

--- a/ui/components/shared/entity-picker.jsx
+++ b/ui/components/shared/entity-picker.jsx
@@ -1,0 +1,164 @@
+/* global React, Icon */
+
+// EntityPicker - reusable searchable + paginated agent/graph picker.
+//
+// Replaces the old "GET /<plural>?limit=200 dumped into a <select>" pattern:
+// results are fetched server-side via usePagedList against
+// `GET <path>?q=&limit=&offset=` (the case-insensitive substring search over
+// each entity's id + description shipped alongside this component), with the
+// raw search text DEBOUNCED before it becomes the `q` param so typing does
+// not fire a request per keystroke. This means the picker searches ALL
+// matching rows, not just whatever page happened to be loaded.
+//
+// Registered on window.primerApi the same way shared/pager.jsx registers
+// usePagedList/Pager, so any component can render
+// `window.primerApi.EntityPicker` (or the bare global `EntityPicker`).
+//
+// Props:
+//   path         list endpoint, e.g. "/agents" or "/graphs"
+//   value        currently selected id, or "" for none
+//   onChange(id) called with the picked id, or "" when cleared
+//   placeholder  search input placeholder (optional)
+//   label        label rendered above the search box (optional)
+//   testid       data-testid prefix (optional; derived from `path` otherwise)
+//
+// Deliberately does NOT do a separate GET for the selected item's label -
+// showing the id is sufficient, and callers that need the full selected
+// object (e.g. a graph's Begin.input_schema) already have it from their own
+// list/detail fetch.
+
+(function () {
+  const { useState, useEffect } = window.React;
+
+  const DEBOUNCE_MS = 220;
+
+  function EntityPicker(props) {
+    const path = props.path;
+    const value = props.value || "";
+    const onChange = props.onChange || function () {};
+    const placeholder = props.placeholder || "Search…";
+    const label = props.label || null;
+    const testid = props.testid || "entity-picker" + path.replace(/[^a-zA-Z0-9]+/g, "-");
+
+    const api = window.primerApi || {};
+    const usePagedList = api.usePagedList;
+    const Pager = api.Pager;
+
+    // Raw input text vs. the debounced `q` param sent to the server.
+    const [text, setText] = useState("");
+    const [q, setQ] = useState("");
+
+    useEffect(() => {
+      const t = setTimeout(function () { setQ(text.trim()); }, DEBOUNCE_MS);
+      return function () { clearTimeout(t); };
+    }, [text]);
+
+    const list = usePagedList({
+      key: "picker:" + path,
+      path: path,
+      pageSize: 20,
+      params: q ? { q: q } : null,
+      resetKey: q,
+    });
+
+    const items = list.items || [];
+    const noun = path.replace(/^\//, "") || "items";
+
+    return (
+      <div className="col" data-testid={testid} style={{ gap: 6 }}>
+        {label && <label className="field-label">{label}</label>}
+        {value && (
+          <div
+            style={{
+              display: "flex", alignItems: "center", gap: 6, fontSize: 12,
+              background: "var(--bg-2)", border: "1px solid var(--border)",
+              borderRadius: 6, padding: "5px 8px",
+            }}
+          >
+            <span className="muted">Selected:</span>
+            <span
+              className="mono"
+              style={{ fontWeight: 600, flex: 1, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}
+            >
+              {value}
+            </span>
+            <button
+              type="button"
+              data-testid={testid + "-clear"}
+              title="Clear selection"
+              aria-label="Clear selection"
+              onClick={function () { onChange(""); }}
+              style={{ background: "none", border: "none", cursor: "pointer", color: "var(--text-3)", display: "flex", alignItems: "center", padding: 0 }}
+            >
+              <Icon name="x" size={12} />
+            </button>
+          </div>
+        )}
+        <div className="input-icon">
+          <Icon name="search" size={13} className="icon" />
+          <input
+            className="input"
+            data-testid={testid + "-search"}
+            placeholder={placeholder}
+            value={text}
+            onChange={function (e) { setText(e.target.value); }}
+            style={{ width: "100%" }}
+          />
+        </div>
+        <div
+          data-testid={testid + "-results"}
+          role="listbox"
+          style={{ maxHeight: 220, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6 }}
+        >
+          {list.loading && items.length === 0 ? (
+            <div className="muted text-sm" style={{ padding: 10 }}>Loading…</div>
+          ) : list.error && items.length === 0 ? (
+            <div className="field-help warn" style={{ padding: 10, margin: 0 }}>
+              <Icon name="alert" size={11} />{" "}
+              {(list.error && (list.error.detail || list.error.message)) || ("Couldn't load " + noun)}
+            </div>
+          ) : items.length === 0 ? (
+            <div className="muted text-sm" style={{ padding: 10 }}>
+              No {noun} match {q ? '"' + q + '"' : "your search"}.
+            </div>
+          ) : (
+            items.map(function (item) {
+              const selected = item.id === value;
+              return (
+                <div
+                  key={item.id}
+                  role="option"
+                  aria-selected={selected}
+                  tabIndex={0}
+                  data-testid={testid + "-row"}
+                  onClick={function () { onChange(item.id); }}
+                  onKeyDown={function (e) {
+                    if (e.key === "Enter" || e.key === " ") { e.preventDefault(); onChange(item.id); }
+                  }}
+                  style={{
+                    display: "flex", flexDirection: "column", gap: 2,
+                    padding: "6px 8px", cursor: "pointer",
+                    background: selected ? "var(--accent-dim)" : "transparent",
+                    borderLeft: selected ? "2px solid var(--accent)" : "2px solid transparent",
+                  }}
+                >
+                  <span className="mono" style={{ fontWeight: 600, fontSize: 12.5 }}>{item.id}</span>
+                  {item.description && (
+                    <span className="muted text-sm" style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                      {item.description}
+                    </span>
+                  )}
+                </div>
+              );
+            })
+          )}
+        </div>
+        <Pager pager={list} label={noun} />
+      </div>
+    );
+  }
+
+  window.EntityPicker = EntityPicker;
+  const ns = (window.primerApi = window.primerApi || {});
+  ns.EntityPicker = EntityPicker;
+})();

--- a/ui/index.html
+++ b/ui/index.html
@@ -80,6 +80,7 @@
 <!-- Shared components first (Icon/Btn/Modal etc.) + mock data + unused helper -->
 <script type="text/babel" src="components/shared.jsx"></script>
 <script type="text/babel" src="components/shared/pager.jsx"></script>
+<script type="text/babel" src="components/shared/entity-picker.jsx"></script>
 <script type="text/babel" src="components/session-state.jsx"></script>
 <script type="text/babel" src="components/shared/token-meter.jsx"></script>
 <script type="text/babel" src="components/shared/card-list.jsx"></script>


### PR DESCRIPTION
## What & why

The New session / New chat forms selected an agent or graph from a plain
`<select>` fed by `GET /agents?limit=200` - no search, capped at 200, no
pagination. This replaces that with a **searchable, paginated picker** backed by
real **server-side** search, so it scales to any number of agents/graphs.

## Backend (storage + api)
- New case-insensitive **`Op.ILIKE`** operator in the storage predicate language.
  Postgres uses native `ILIKE`; SQLite has no `ILIKE` and pins `LIKE`
  case-sensitive, so it emits `LOWER(field) LIKE LOWER(value) ESCAPE '\'`.
- Optional **`?q=`** param on the generic list route: when present (and the
  entity declares `search_fields`), it ORs an `ILIKE '%q%'` match across those
  fields via `storage.find`, escaping the user's `%`/`_`/`\`, and preserves the
  identical `{items,total}` offset-paged shape. Agents + graphs search over
  `["id","description"]`.

## UI
- Reusable **`EntityPicker`** (`ui/components/shared/entity-picker.jsx`):
  debounced search box + `usePagedList`(`?q=`) results + `Pager`, a clearable
  "Selected" row, and scroll-capped results. Replaces the `<select>` in the New
  session form (agent + graph) and the New chat modal (agent).
- The selected graph's `Begin.input_schema` form now resolves the graph **by id**
  (`GET /graphs/{id}`) instead of a capped-list lookup, so it renders even for a
  graph found via the new search beyond the old 200 fetch.

## Review (independent, adversarial) - findings fixed
- **HIGH:** adding `Op.ILIKE` to the shared enum broke the tap SSE selector's
  in-memory `_eval_predicate` (exhaustive if-chain ending in
  `NotImplementedError`); a user `?selector=` with an ILIKE predicate would 500
  mid-stream. Added an ILIKE branch (case-insensitive) + regression test.
- **LOW:** Postgres/SQLite `_render_ilike` now reject the same non-FieldRef/Value
  left operand; whitespace-only `?q=` treated as no query.
- Verified: parameter-bound (no SQL injection), consistent escaping across all
  layers, correct case behavior on both backends, filtered `total`, unchanged
  response shape. Residual (accepted): `ILIKE '%q%'` is an unindexed scan - fine
  for picker-scale cardinality; add pg_trgm/FTS later if these tables grow.

## Tests
storage ILIKE (both backends), the `?q=` list route, the tap selector ILIKE
regression, and UI transpile + source assertions - 102 passed across the named
files (single-process, CPU-capped). No U+2014/U+2192 in added lines.

HELD -- do not merge without sign-off. (Inherits the pre-existing `test_t0169`
e2e failure from main until #150 lands.)
