### PR TITLE
feat(toolset): support legacy HTTP+SSE transport for MCP toolsets

### DIFF
--- a/primer/api/routers/providers.py
+++ b/primer/api/routers/providers.py
@@ -688,19 +688,23 @@ async def _probe_mcp_reachable(entity: Toolset, request: Request) -> None:
 
 
 async def _toolset_on_pre_create(entity: Toolset, request: Request) -> None:
-    """Reject creating an MCP-http toolset whose endpoint is unreachable.
+    """Reject creating a network MCP toolset whose endpoint is unreachable.
 
     Runs before ``storage.create`` (raising aborts the create, persisting
-    nothing). Only network MCP transports are probed; the ``allow_unreachable``
-    bypass, non-MCP toolsets, and stdio MCP (no remote endpoint -- probing it
-    would launch a subprocess) all skip the probe.
+    nothing). Only network MCP transports are probed -- both ``http``
+    (streamable) and ``sse`` (legacy); the ``allow_unreachable`` bypass,
+    non-MCP toolsets, and stdio MCP (no remote endpoint -- probing it would
+    launch a subprocess) all skip the probe.
     """
     if _toolset_probe_bypassed(request):
         return
     if entity.provider != ToolsetProviderType.MCP:
         return
     config = entity.config
-    if config is None or config.transport != TransportType.HTTP:
+    if config is None or config.transport not in (
+        TransportType.HTTP,
+        TransportType.SSE,
+    ):
         return
     await _probe_mcp_reachable(entity, request)
 

--- a/primer/model/providers/toolset.py
+++ b/primer/model/providers/toolset.py
@@ -104,6 +104,7 @@ class TransportType(str, Enum):
 
     STDIO = "stdio"
     HTTP = "http"
+    SSE = "sse"
 
 
 class StdioConfig(BaseModel):
@@ -128,8 +129,11 @@ class StdioConfig(BaseModel):
 
 
 class HttpConfig(BaseModel):
-    """HTTP transport for an MCP server — connects to a remote endpoint
-    speaking MCP over HTTP (e.g. SSE / streamable HTTP).
+    """HTTP-based connection details for a remote MCP server endpoint.
+
+    Shared by two wire protocols, selected via ``McpConfig.transport``:
+    ``http`` (modern streamable HTTP) and ``sse`` (legacy HTTP+SSE). Both use
+    the same url / headers / oauth; only the client wire protocol differs.
     """
 
     url: str = Field(
@@ -180,9 +184,12 @@ class McpConfig(BaseModel):
             raise ValueError(
                 "transport='stdio' requires a StdioConfig in 'config'"
             )
-        if self.transport == TransportType.HTTP and not isinstance(self.config, HttpConfig):
+        if self.transport in (
+            TransportType.HTTP,
+            TransportType.SSE,
+        ) and not isinstance(self.config, HttpConfig):
             raise ValueError(
-                "transport='http' requires an HttpConfig in 'config'"
+                "transport='http'/'sse' requires an HttpConfig in 'config'"
             )
         return self
 

--- a/primer/toolset/mcp.py
+++ b/primer/toolset/mcp.py
@@ -382,11 +382,20 @@ class McpToolsetProvider(ToolsetProvider):
                 await stack.aclose()
             return
 
-        if self._config.transport == TransportType.HTTP:
+        if self._config.transport in (TransportType.HTTP, TransportType.SSE):
             assert isinstance(self._config.config, HttpConfig)
             http_cfg: HttpConfig = self._config.config
 
-            from mcp.client.streamable_http import streamablehttp_client
+            # Two HTTP wire protocols share the same connection details: modern
+            # streamable HTTP (transport="http") and legacy HTTP+SSE
+            # (transport="sse", which opens with an SSE `endpoint` event). Both
+            # take url= / headers= and run an anyio task group under the hood.
+            if self._config.transport == TransportType.SSE:
+                from mcp.client.sse import sse_client as transport_client
+            else:
+                from mcp.client.streamable_http import (
+                    streamablehttp_client as transport_client,
+                )
 
             # headers values are SecretStr (masked on every API read path);
             # unwrap here, at the network boundary, where the real token is
@@ -400,8 +409,8 @@ class McpToolsetProvider(ToolsetProvider):
                 base_headers.update(auth_headers)
 
             # Structured, lexically-nested `async with` -- NOT AsyncExitStack.
-            # streamablehttp_client runs an anyio task group whose cancel scope
-            # must be entered AND exited in the same task. AsyncExitStack defers
+            # The HTTP/SSE transport client runs an anyio task group whose
+            # cancel scope must be entered AND exited in the same task. AsyncExitStack defers
             # its __aexit__ callbacks, so on any failure (a refused connection is
             # the common case -- e.g. a containerised Primer reaching a host
             # `localhost:PORT` MCP URL) the task group got torn down in a
@@ -412,15 +421,15 @@ class McpToolsetProvider(ToolsetProvider):
             # in one task; the try/except maps connection/handshake failures
             # onto the documented ProviderError/NetworkError envelope.
             try:
-                async with streamablehttp_client(
+                async with transport_client(
                     url=http_cfg.url,
                     headers=base_headers if base_headers else None,
                 ) as streams:
-                    # mcp >= 1.16 yields (read, write, get_session_id);
-                    # older releases yield (read, write).
+                    # streamable HTTP yields (read, write, get_session_id);
+                    # sse_client yields (read, write). Take the first two.
                     if len(streams) < 2:  # pragma: no cover - older mcp
                         raise ConfigError(
-                            "streamablehttp_client returned an unexpected "
+                            "MCP transport client returned an unexpected "
                             "stream tuple"
                         )
                     read, write = streams[0], streams[1]

--- a/tests/api/test_toolset_create_probe.py
+++ b/tests/api/test_toolset_create_probe.py
@@ -49,6 +49,28 @@ async def test_unreachable_http_mcp_is_rejected_and_not_persisted(client):
 
 
 @pytest.mark.asyncio
+async def test_unreachable_sse_mcp_is_rejected_and_not_persisted(client):
+    # SSE is a network transport too, so an unreachable sse endpoint is probed
+    # and rejected on create, exactly like http (not skipped like stdio).
+    r = await client.post(
+        "/v1/toolsets",
+        json={
+            "id": "ts-dead-sse",
+            "provider": "mcp",
+            "config": {
+                "transport": "sse",
+                "config": {"url": _DEAD_URL, "headers": {}},
+            },
+        },
+    )
+    assert r.status_code == 400, r.text
+    assert r.json()["type"] == "/errors/toolset-unreachable"
+
+    g = await client.get("/v1/toolsets/ts-dead-sse")
+    assert g.status_code == 404, g.text
+
+
+@pytest.mark.asyncio
 async def test_allow_unreachable_false_does_not_bypass(client):
     # Only a truthy flag bypasses; allow_unreachable=false still probes and
     # rejects the dead-port create.

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -150,8 +150,11 @@ class TestTransportType:
     def test_http_value(self):
         assert TransportType.HTTP.value == "http"
 
-    def test_only_two_members(self):
-        assert {t.value for t in TransportType} == {"stdio", "http"}
+    def test_sse_value(self):
+        assert TransportType.SSE.value == "sse"
+
+    def test_members(self):
+        assert {t.value for t in TransportType} == {"stdio", "http", "sse"}
 
     def test_string_inheritance(self):
         # Should be a str subclass for JSON-friendliness.
@@ -206,6 +209,26 @@ class TestMcpConfig:
         with pytest.raises(ValidationError, match="http.*HttpConfig"):
             McpConfig(
                 transport=TransportType.HTTP,
+                config=StdioConfig(command=["x"]),
+            )
+
+    def test_sse_construction(self):
+        # Legacy HTTP+SSE shares HttpConfig with streamable HTTP.
+        cfg = McpConfig(
+            transport=TransportType.SSE,
+            config=HttpConfig(url="https://mcp.example.com/sse"),
+        )
+        assert cfg.transport == TransportType.SSE
+        assert isinstance(cfg.config, HttpConfig)
+
+    def test_sse_with_string_enum_value(self):
+        cfg = McpConfig(transport="sse", config=HttpConfig(url="https://x/sse"))
+        assert cfg.transport == TransportType.SSE
+
+    def test_sse_transport_with_stdio_config_rejected(self):
+        with pytest.raises(ValidationError, match="sse.*HttpConfig"):
+            McpConfig(
+                transport=TransportType.SSE,
                 config=StdioConfig(command=["x"]),
             )
 

--- a/tests/toolset/test_mcp.py
+++ b/tests/toolset/test_mcp.py
@@ -393,6 +393,72 @@ class TestHttpTransportSuccess:
                 pass
 
 
+class TestSseTransport:
+    """Legacy HTTP+SSE routes through mcp.client.sse.sse_client (not
+    streamablehttp_client) and copes with its 2-tuple stream yield."""
+
+    def test_sse_config_is_accepted(self) -> None:
+        provider = McpToolsetProvider(
+            toolset_id="ts1",
+            config=McpConfig(
+                transport=TransportType.SSE,
+                config=HttpConfig(url="http://localhost:9999/mcp/sse"),
+            ),
+        )
+        assert provider is not None
+
+    async def test_sse_session_path_uses_sse_client(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        from contextlib import asynccontextmanager
+        from unittest.mock import AsyncMock, MagicMock
+
+        fake_session = MagicMock()
+        fake_session.__aenter__ = AsyncMock(return_value=fake_session)
+        fake_session.__aexit__ = AsyncMock(return_value=None)
+        fake_session.initialize = AsyncMock()
+        fake_session.list_tools = AsyncMock(
+            return_value=mcp_types.ListToolsResult(tools=[])
+        )
+
+        used = {"sse": False, "streamable": False}
+
+        @asynccontextmanager
+        async def fake_sse(**kwargs):
+            used["sse"] = True
+            # sse_client yields a 2-tuple (read, write), NOT streamable's
+            # 3-tuple; the unified dispatch must handle the shorter arity.
+            yield (object(), object())
+
+        @asynccontextmanager
+        async def fake_streamablehttp(**kwargs):
+            used["streamable"] = True
+            yield (object(), object(), lambda: None)
+
+        monkeypatch.setattr("mcp.client.sse.sse_client", fake_sse)
+        monkeypatch.setattr(
+            "mcp.client.streamable_http.streamablehttp_client",
+            fake_streamablehttp,
+        )
+        monkeypatch.setattr(
+            "primer.toolset.mcp.ClientSession",
+            lambda *args, **kwargs: fake_session,
+        )
+
+        provider = McpToolsetProvider(
+            toolset_id="ts1",
+            config=McpConfig(
+                transport=TransportType.SSE,
+                config=HttpConfig(url="http://example.test/mcp/sse"),
+            ),
+        )
+        tools = [t async for t in provider.list_tools()]
+        assert tools == []
+        fake_session.initialize.assert_awaited_once()
+        assert used["sse"] is True
+        assert used["streamable"] is False
+
+
 class _StdioLifecycle:
     """Test double tracking per-dispatch stdio subprocess lifecycle.
 

--- a/tests/ui/test_toolsets_sse.py
+++ b/tests/ui/test_toolsets_sse.py
@@ -1,0 +1,39 @@
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+SRC = UI / "components" / "toolsets.jsx"
+
+
+def _src() -> str:
+    return SRC.read_text(encoding="utf-8")
+
+
+def test_sse_transport_chip_present() -> None:
+    """The transport selector offers stdio, http, AND sse (legacy)."""
+    src = _src()
+    assert 'setTransport("sse")' in src
+    assert 'transport === "sse"' in src
+
+
+def test_submit_emits_selected_transport() -> None:
+    """The non-stdio config build sends the SELECTED transport value (so
+    'sse' is emitted), not a hardcoded 'http'."""
+    src = _src()
+    assert "transport: transport," in src
+
+
+def test_initial_transport_restores_sse() -> None:
+    """Editing an existing sse toolset restores the sse selection."""
+    src = _src()
+    assert '["http", "sse"].includes(existing?.config?.transport)' in src
+
+
+def test_toolsets_jsx_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(
+        ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text()
+    )
+    code = b._transform(_src(), "components/toolsets.jsx")
+    assert code and "transport" in code

--- a/ui/components/toolsets.jsx
+++ b/ui/components/toolsets.jsx
@@ -308,7 +308,9 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
     return Array.isArray(cmd) ? cmd.join(" ") : "";
   };
   const _initialTransport = () =>
-    existing?.config?.transport === "http" ? "http" : "stdio";
+    ["http", "sse"].includes(existing?.config?.transport)
+      ? existing.config.transport
+      : "stdio";
 
   const [id, setId] = React.useState(existing?.id || "");
   const [provider, setProvider] = React.useState(existing?.provider || "mcp");
@@ -413,7 +415,7 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
             },
           }
         : {
-            transport: "http",
+            transport: transport,
             config: {
               url: url.trim(),
               headers: kvToDict(httpHeaders),
@@ -536,9 +538,14 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
                 className={`chip ${transport === "http" ? "active" : ""}`}
                 onClick={() => setTransport("http")}
               >http</span>
+              <span
+                className={`chip ${transport === "sse" ? "active" : ""}`}
+                onClick={() => setTransport("sse")}
+              >sse</span>
             </div>
             <div className="field-help">
-              Per app spec, MCP TransportType only enumerates stdio + http (no sse).
+              http = streamable HTTP (modern); sse = legacy HTTP+SSE. Both use the
+              same URL / headers / OAuth below.
             </div>
           </div>
 

--- a/ui/components/toolsets.jsx
+++ b/ui/components/toolsets.jsx
@@ -908,7 +908,7 @@ function TS_ToolsTab({ id, ts, onInvalidate }) {
     // the old leaked 500, so treat any server-side failure on an HTTP toolset
     // as the "tools unavailable" anomaly surface.
     const transport = _tsTransport(ts);
-    const t711 = transport === "http" && tools.error.status >= 500;
+    const t711 = (transport === "http" || transport === "sse") && tools.error.status >= 500;
     if (t711) {
       return (
         <div style={{ padding: 14 }}>


### PR DESCRIPTION
## What & why

Registering an MCP toolset only supported the modern **streamable HTTP**
transport. A server speaking the **legacy HTTP+SSE** transport (it opens the
stream with an SSE `endpoint` event) failed with
`mcp.client.streamable_http: Unknown SSE event: endpoint`, because the client
was the streamable one. `TransportType` only enumerated `stdio | http`.

This adds `sse` as a sibling transport, matching the MCP ecosystem's
`stdio | sse | streamable-http` convention.

- **Model** (`primer/model/providers/toolset.py`): `TransportType.SSE`, reusing
  `HttpConfig` (url/headers/oauth - `sse_client` takes the same inputs). The
  `McpConfig` validator now accepts an `HttpConfig` for both `http` and `sse`.
- **Dispatch** (`primer/toolset/mcp.py` `_open_session`): the http and sse paths
  are **unified** into one branch that picks the client factory
  (`mcp.client.sse.sse_client` vs `streamablehttp_client`) by transport. It
  preserves the deliberate **lexical** `async with` (NOT `AsyncExitStack` - the
  anyio task group's cancel scope must enter/exit in the same task, per the
  existing comment) and copes with `sse_client`'s 2-tuple stream yield vs
  streamable's 3-tuple (`streams[0], streams[1]`). Header/OAuth prep is shared.
- **UI** (`ui/components/toolsets.jsx`): an `sse` transport chip in the toolset
  form (reusing the same URL/headers/OAuth fields, which already render for any
  non-stdio transport); submit emits the selected transport; edit restores it.

## Tests
`tests/test_provider.py` (sse model validation + enum), `tests/toolset/test_mcp.py`
(a dispatch test proving `sse` routes through `sse_client`, NOT streamable, and
handles the 2-tuple), `tests/ui/test_toolsets_sse.py` (transpile + source
assertions), plus the existing toolset UI tests for regressions - 150 passed.
No em-dash/arrow in added lines.

HELD -- do not merge without sign-off. (Inherits any pre-existing e2e state from main.)
