### PR TITLE
feat(toolset): workspace-only download + read_doc_content tools (requires_workspace)

### DIFF
--- a/primer/agent/tool_manager.py
+++ b/primer/agent/tool_manager.py
@@ -263,6 +263,22 @@ class ToolExecutionManager:
                             f"contains {_SCOPE_SEPARATOR!r} which is "
                             "reserved as the scope separator"
                         )
+                    # Per-tool workspace-only suppression (additive to the
+                    # workspace_ext toolset-id skip above): a tool that
+                    # declares ``requires_workspace`` reads ctx.workspace_id
+                    # for file I/O and only functions inside a workspace
+                    # session. Outside one (chats, bare managers) drop it
+                    # entirely - do NOT populate the routing table - so it
+                    # never enters chat context AND a model that somehow
+                    # references it gets the standard "not registered"
+                    # UnsupportedContentError in ``_execute_inner``, exactly
+                    # like the workspace_ext toolset-id skip. Read straight
+                    # off the descriptor (mirrors the ``toolset_id`` check
+                    # above); ``InternalToolsetProvider.requires_workspace``
+                    # is the same flag surfaced for the MCP guard. Keyed on
+                    # the same session-absent condition.
+                    if suppress_workspace_ext and t.requires_workspace:
+                        continue
                     scoped_id = f"{toolset_id}{_SCOPE_SEPARATOR}{t.id}"
                     # Routing table is built unconditionally so an
                     # allowlist hit still resolves; the visible

--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -212,6 +212,7 @@ def _make_lifespan(config: AppConfig):
             storage_provider=storage_provider,
             provider_registry=provider_registry,
             semantic_search_registry=semantic_search_registry,
+            workspace_registry=workspace_registry,
         )
         provider_registry._system_toolset_provider = system_toolset  # noqa: SLF001
         # NOTE: the always-on _workspaces toolset is built later in this
@@ -273,6 +274,7 @@ def _make_lifespan(config: AppConfig):
         web_toolset = build_web_toolset(
             web_search_service=web_search_service,
             web_fetch_service=web_fetch_service,
+            workspace_registry=workspace_registry,
         )
         logger.info("lifespan: web toolset built")
         provider_registry._web_toolset_provider = web_toolset  # noqa: SLF001

--- a/primer/api/app.py
+++ b/primer/api/app.py
@@ -185,6 +185,7 @@ def create_test_app(
             storage_provider=storage_provider,
             provider_registry=provider_registry,
             semantic_search_registry=_test_ssp_registry,
+            workspace_registry=workspace_registry,
         )
     if workspaces_toolset is None:
         # The test factory builds its scheduler/event_bus/claim_engine
@@ -247,6 +248,7 @@ def create_test_app(
         web_toolset = build_web_toolset(
             web_search_service=_test_ws_service,
             web_fetch_service=_test_wf_service,
+            workspace_registry=workspace_registry,
         )
     # Always-on workspace_ext toolset (workspace-only yielding tools).
     workspace_ext_toolset = build_workspace_ext_toolset(

--- a/primer/int/toolset.py
+++ b/primer/int/toolset.py
@@ -168,6 +168,23 @@ class ToolsetProvider(ABC):
         del tool_name
         return False
 
+    def requires_workspace(self, tool_name: str) -> bool:
+        """Return True if this tool requires a live workspace.
+
+        Such tools read ``ctx.workspace_id`` for file I/O and only make
+        sense inside a workspace session. Consulted by the chat
+        suppression choke point (:meth:`ToolExecutionManager.list_tools`)
+        to drop them from chat tool context, and by the MCP exposure
+        guard (:func:`primer.mcp.safety.is_exposable`) to keep them off
+        the stateless MCP surface.
+
+        Default: ``False``. Providers whose handlers read
+        ``ctx.workspace_id`` override this and return ``True`` for the
+        relevant names.
+        """
+        del tool_name
+        return False
+
     def required_role(self, tool_name: str) -> str:
         """RBAC role required to invoke ``tool_name`` over MCP.
 

--- a/primer/mcp/safety.py
+++ b/primer/mcp/safety.py
@@ -69,6 +69,9 @@ def is_exposable(
     * ``"needs_session"`` — workspace tool that requires a live
       :class:`AgentSession` (reads ``ctx.session_id``); meaningless
       outside an agent loop.
+    * ``"needs_workspace"`` - tool that requires a live workspace
+      (reads ``ctx.workspace_id`` for file I/O); a workspace-bound tool
+      cannot run over the stateless MCP surface.
 
     Approval-gated tools are NOT filtered here — that check lives in
     the dispatcher layer (Phase 4) where the
@@ -88,6 +91,13 @@ def is_exposable(
         return False, "yielding_unsupported"
     if tool.toolset_id == "workspaces" and provider.requires_session(tool.id):
         return False, "needs_session"
+    # Read the flag straight off the descriptor (mirrors the
+    # ``tool.toolset_id`` read above). ``tool`` comes from
+    # ``provider.list_tools()`` so its ``requires_workspace`` flag is the
+    # same value ``InternalToolsetProvider.requires_workspace`` surfaces;
+    # reading it directly keeps the predicate robust for any provider.
+    if tool.requires_workspace:
+        return False, "needs_workspace"
     return True, None
 
 

--- a/primer/model/chat.py
+++ b/primer/model/chat.py
@@ -669,6 +669,20 @@ class Tool(Describeable):
             "serialization."
         ),
     )
+    requires_workspace: bool = Field(
+        default=False,
+        exclude=True,
+        description=(
+            "True for tools that need a live workspace (they read "
+            "ctx.workspace_id for file I/O). Such tools are dropped from "
+            "chat tool context and are not MCP-exposable; they surface only "
+            "inside a workspace session. Declared explicitly at the make_tool "
+            "call site and consumed by InternalToolsetProvider."
+            "requires_workspace, the chat suppression choke point, and the "
+            "MCP exposure guard. In-memory metadata only; excluded from "
+            "serialization."
+        ),
+    )
     required_role: str | None = Field(
         default=None,
         exclude=True,

--- a/primer/toolset/_describe.py
+++ b/primer/toolset/_describe.py
@@ -41,6 +41,7 @@ def make_tool(
     examples: list[ToolExample],
     yields: bool = False,
     requires_session: bool = False,
+    requires_workspace: bool = False,
     required_role: str | None = None,
 ) -> Tool:
     """Build a Tool with validated examples and the standard description anatomy.
@@ -55,10 +56,14 @@ def make_tool(
     handler can park the agent turn (its return annotation includes
     :class:`primer.model.yield_.Yielded` / it raises ``YieldToWorker``).
     Set ``requires_session=True`` when the handler needs a live
-    ``AgentSession`` (it reads ``ctx.session_id``). Both default to
-    ``False`` and surface via :meth:`InternalToolsetProvider.is_yielding`
-    / :meth:`InternalToolsetProvider.requires_session`, which the MCP
-    exposure guard consults.
+    ``AgentSession`` (it reads ``ctx.session_id``). Set
+    ``requires_workspace=True`` when the handler needs a live workspace
+    (it reads ``ctx.workspace_id`` for file I/O); such tools are dropped
+    from chat tool context and are not MCP-exposable. All three default
+    to ``False`` and surface via :meth:`InternalToolsetProvider.is_yielding`
+    / :meth:`InternalToolsetProvider.requires_session` /
+    :meth:`InternalToolsetProvider.requires_workspace`, which the chat
+    suppression choke point and the MCP exposure guard consult.
     """
     validator = Draft202012Validator(args_schema)
     for ex in examples:
@@ -72,5 +77,6 @@ def make_tool(
         examples=examples,
         yields=yields,
         requires_session=requires_session,
+        requires_workspace=requires_workspace,
         required_role=required_role,
     )

--- a/primer/toolset/_system_tools.py
+++ b/primer/toolset/_system_tools.py
@@ -3,22 +3,35 @@
 Split out of :mod:`primer.toolset.system` (a god-module decomposition). This
 module holds the bespoke, hand-written tools whose handlers do not come from
 the generic CRUD factory. Today that is the ``ask_user`` yielding tool (its
-argument model, resume hook, and handler); ``build_system_toolset`` in
-``system.py`` wires the tool entry itself (the other bespoke tools -
-reply-binding, channel-binding, invoke_agent, switch_to_agent - are defined
-inline in the builder because they close over its per-build dependencies).
+argument model, resume hook, and handler) and the workspace-only
+``read_doc_content`` tool (its argument model and handler factory);
+``build_system_toolset`` in ``system.py`` wires the tool entries themselves
+(the other bespoke tools - reply-binding, channel-binding, invoke_agent,
+switch_to_agent - are defined inline in the builder because they close over
+its per-build dependencies).
 """
 
 from __future__ import annotations
 
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, ValidationError
 
 from primer.model.chat import ToolCallResult
+from primer.model.except_ import (
+    BadRequestError,
+    NotFoundError,
+    UnsupportedContentError,
+)
 from primer.toolset._helpers import err as _err, ok as _ok
 from primer.model.yield_ import ToolContext, Yielded
 from primer.toolset._system_common import _err_from_validation
+
+
+if TYPE_CHECKING:
+    from collections.abc import Awaitable, Callable
+
+    from primer.api.registries.workspace_registry import WorkspaceRegistry
 
 
 # ===========================================================================
@@ -158,3 +171,91 @@ async def _ask_user_handler(
             "files": args.files or None,
         },
     )
+
+
+# ===========================================================================
+# read_doc_content - workspace-only tool. Reads a workspace-relative file,
+# runs it through the Docling loader (an OPTIONAL extra), and returns the
+# extracted plain-text/markdown. requires_workspace=True keeps it out of
+# chat context and off the MCP surface. The Docling import is GUARDED so
+# the tool degrades gracefully when the extra is not installed, rather than
+# crashing at dispatch time.
+# ===========================================================================
+
+
+class _ReadDocContentArgs(BaseModel):
+    """Workspace-relative path of the document to convert to text."""
+
+    path: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Workspace-relative path of the document (PDF/DOCX/PPTX/HTML/"
+            "...) to convert. Must not escape the workspace."
+        ),
+    )
+
+
+def make_read_doc_content_handler(
+    *,
+    workspace_registry: "WorkspaceRegistry",
+) -> "Callable[..., Awaitable[ToolCallResult]]":
+    """Build the ``read_doc_content`` handler closing over the registry.
+
+    System handlers are module-level, but this one needs the
+    :class:`WorkspaceRegistry` to resolve the live workspace from
+    ``ctx.workspace_id``, so it is produced by this factory (mirroring how
+    the web toolset factories close over their deps).
+    """
+
+    async def _handle(
+        arguments: dict[str, Any], *, ctx: ToolContext
+    ) -> ToolCallResult:
+        # Defensive guard: chat suppression should keep this tool out of
+        # any non-workspace context, but never attempt file I/O without a
+        # live workspace.
+        if ctx is None or ctx.workspace_id is None:
+            return _err(
+                "read_doc_content requires a workspace session (no "
+                "workspace is bound to this turn)",
+                error_type="bad-request",
+            )
+
+        try:
+            args = _ReadDocContentArgs.model_validate(arguments)
+        except ValidationError as exc:
+            return _err_from_validation(exc)
+
+        try:
+            ws = await workspace_registry.get_workspace(ctx.workspace_id)
+            raw = await ws.read_file(args.path)
+        except (BadRequestError, NotFoundError) as exc:
+            return _err(
+                f"read_doc_content: cannot read {args.path!r}: {exc}",
+                error_type="not-found",
+            )
+
+        # GUARDED optional-extra import: docling is an optional dependency;
+        # importing the loader when it is not installed raises
+        # ModuleNotFoundError. Import lazily (never at module top) so the
+        # tool degrades to a clear install hint instead of crashing.
+        try:
+            from primer.ingest.loaders import DoclingLoader
+        except ModuleNotFoundError:
+            return _err(
+                "read_doc_content requires the 'docling' extra; install "
+                "primer-ai[docling]",
+                error_type="unavailable",
+            )
+
+        try:
+            loaded = await DoclingLoader().load(raw)
+        except (BadRequestError, UnsupportedContentError) as exc:
+            return _err(
+                f"read_doc_content: could not parse document: {exc}",
+                error_type="bad-request",
+            )
+
+        return _ok({"text": loaded.text})
+
+    return _handle

--- a/primer/toolset/internal.py
+++ b/primer/toolset/internal.py
@@ -81,6 +81,7 @@ class InternalToolsetProvider(ToolsetProvider):
         # endpoint uses them to filter the exposable tool set.
         self._yielding_names: set[str] = set()
         self._session_names: set[str] = set()
+        self._workspace_names: set[str] = set()
         self._required_roles: dict[str, str] = {}
         for name, (tool, handler) in self._registry.items():
             if tool.toolset_id != toolset_id:
@@ -93,6 +94,8 @@ class InternalToolsetProvider(ToolsetProvider):
                 self._yielding_names.add(name)
             if tool.requires_session:
                 self._session_names.add(name)
+            if tool.requires_workspace:
+                self._workspace_names.add(name)
             if tool.required_role is not None:
                 self._required_roles[name] = tool.required_role
 
@@ -113,6 +116,15 @@ class InternalToolsetProvider(ToolsetProvider):
         site). Unknown names return ``False``.
         """
         return tool_name in self._session_names
+
+    def requires_workspace(self, tool_name: str) -> bool:
+        """Return True iff ``tool_name`` needs a live workspace.
+
+        Read at construction time from the tool's explicit
+        ``requires_workspace`` flag (declared at the ``make_tool`` call
+        site). Unknown names return ``False``.
+        """
+        return tool_name in self._workspace_names
 
     def required_role(self, tool_name: str) -> str:
         """RBAC role required to invoke ``tool_name`` over MCP.

--- a/primer/toolset/system.py
+++ b/primer/toolset/system.py
@@ -163,13 +163,16 @@ from primer.toolset._system_crud import (
 from primer.toolset._system_tools import (
     _AskUserArgs,
     _ask_user_handler,
+    _ReadDocContentArgs,
     ask_user_resume,
+    make_read_doc_content_handler,
 )
 
 
 if TYPE_CHECKING:
     from primer.api.registries import ProviderRegistry
     from primer.api.registries.semantic_search_registry import SemanticSearchRegistry
+    from primer.api.registries.workspace_registry import WorkspaceRegistry
     from primer.int.storage_provider import StorageProvider
 
 
@@ -183,6 +186,7 @@ def build_system_toolset(
     storage_provider: "StorageProvider",
     provider_registry: "ProviderRegistry",
     semantic_search_registry: "SemanticSearchRegistry | None" = None,
+    workspace_registry: "WorkspaceRegistry | None" = None,
     toolset_id: str = SYSTEM_TOOLSET_ID,
 ) -> InternalToolsetProvider:
     """Construct the immutable ``_system`` toolset.
@@ -829,6 +833,42 @@ def build_system_toolset(
         ),
         _ask_user_handler,
     )
+
+    # ---- read_doc_content (workspace-only document -> text) ----------
+    # Only wired when the workspace layer is available (it resolves the
+    # live workspace from ctx.workspace_id to read the file). When
+    # ``workspace_registry`` is None (bare/test builds) the tool is
+    # omitted. requires_workspace=True keeps it out of chat context and
+    # off the MCP surface.
+    if workspace_registry is not None:
+        registry["read_doc_content"] = (
+            make_tool(
+                id="read_doc_content",
+                toolset_id=toolset_id,
+                purpose=(
+                    "Convert a document in the workspace "
+                    "(PDF/DOCX/PPTX/HTML/...) to plain text."
+                ),
+                when=(
+                    "Use when you need the text content of a binary/rich "
+                    "document at a workspace path; not for plain-text files "
+                    "(read those directly). Workspace only."
+                ),
+                args_schema=_ReadDocContentArgs.model_json_schema(),
+                examples=[
+                    ToolExample(
+                        args={"path": "reports/q3.pdf"},
+                        returns="``{text: <document text as markdown>}``",
+                    ),
+                ],
+                yields=False,
+                requires_workspace=True,
+                required_role="user",
+            ),
+            make_read_doc_content_handler(
+                workspace_registry=workspace_registry,
+            ),
+        )
 
     logger.info(
         "system toolset assembled with %d tools (id=%s)",

--- a/primer/toolset/web/__init__.py
+++ b/primer/toolset/web/__init__.py
@@ -32,10 +32,13 @@ import httpx
 
 from primer.toolset.internal import InternalToolsetProvider
 from primer.toolset.web.tools import (
+    DownloadArgs,
     HttpMethod,
     HttpRequestArgs,
     WebFetchArgs,
     WebSearchArgs,
+    make_download_descriptor,
+    make_download_handler,
     make_http_request_descriptor,
     make_http_request_handler,
     make_web_fetch_descriptor,
@@ -46,11 +49,13 @@ from primer.toolset.web.tools import (
 
 
 if TYPE_CHECKING:
+    from primer.api.registries.workspace_registry import WorkspaceRegistry
     from primer.web_fetch.service import WebFetchService
     from primer.web_search.service import WebSearchService
 
 
 _DEFAULT_RESPONSE_BODY_BYTE_CAP = 1_000_000  # 1 MB
+_DEFAULT_DOWNLOAD_BYTE_CAP = 100_000_000  # 100 MB
 
 
 def build_web_toolset(
@@ -60,6 +65,8 @@ def build_web_toolset(
     toolset_id: str = "web",
     http_client: httpx.AsyncClient | None = None,
     response_body_byte_cap: int = _DEFAULT_RESPONSE_BODY_BYTE_CAP,
+    workspace_registry: "WorkspaceRegistry | None" = None,
+    download_byte_cap: int = _DEFAULT_DOWNLOAD_BYTE_CAP,
 ) -> InternalToolsetProvider:
     """Construct the always-on ``web`` toolset.
 
@@ -90,12 +97,24 @@ def build_web_toolset(
         Maximum bytes returned in ``http_request`` response bodies;
         anything past the cap is truncated and ``"truncated": true``
         is set in the result. Defaults to 1 MB.
+    workspace_registry
+        Optional :class:`WorkspaceRegistry`. When supplied, the
+        workspace-only ``download`` tool is registered (it resolves the
+        live workspace from ``ctx.workspace_id`` and writes the fetched
+        bytes into it). When ``None`` (e.g. bare/test builds with no
+        workspace layer), ``download`` is omitted and the toolset keeps
+        its three stateless tools.
+    download_byte_cap
+        Default hard cap on ``download`` size in bytes; a stream that
+        exceeds it is rejected (nothing is written). A per-call
+        ``max_bytes`` overrides it downward. Defaults to 100 MB.
 
     Returns
     -------
     InternalToolsetProvider
-        A ready-to-register provider with ``web_search`` and
-        ``http_request`` tools wired in.
+        A ready-to-register provider with ``web_search``, ``web_fetch``,
+        and ``http_request`` tools wired in (plus ``download`` when a
+        ``workspace_registry`` is supplied).
     """
     chosen_client: httpx.AsyncClient = (
         http_client if http_client is not None else httpx.AsyncClient(timeout=30.0)
@@ -118,10 +137,23 @@ def build_web_toolset(
             ),
         ),
     }
+    # Workspace-only download tool: only wired when the workspace layer is
+    # available. requires_workspace=True keeps it out of chat context and
+    # off the MCP surface.
+    if workspace_registry is not None:
+        registry["download"] = (
+            make_download_descriptor(toolset_id),
+            make_download_handler(
+                http_client=chosen_client,
+                workspace_registry=workspace_registry,
+                byte_cap=download_byte_cap,
+            ),
+        )
     return InternalToolsetProvider(toolset_id, registry)
 
 
 __all__ = [
+    "DownloadArgs",
     "HttpMethod",
     "HttpRequestArgs",
     "WebFetchArgs",

--- a/primer/toolset/web/tools.py
+++ b/primer/toolset/web/tools.py
@@ -21,13 +21,16 @@ from __future__ import annotations
 
 import json
 import logging
+import os
 from typing import TYPE_CHECKING, Any, Literal
+from urllib.parse import urlsplit
 
 import httpx
 from pydantic import BaseModel, Field, HttpUrl, ValidationError
 
 from primer.model.chat import Tool, ToolCallResult, ToolExample
-from primer.model.except_ import BadRequestError
+from primer.model.except_ import BadRequestError, NotFoundError
+from primer.model.yield_ import ToolContext
 from primer.toolset._describe import make_tool
 from primer.web_fetch.adapter import (
     FetchedPage,
@@ -42,6 +45,8 @@ from primer.web_search.adapter import (
 
 
 if TYPE_CHECKING:
+    from primer.api.registries.workspace_registry import WorkspaceRegistry
+    from primer.toolset.internal import ToolHandler
     from primer.web_fetch.service import WebFetchService
     from primer.web_search.service import WebSearchService
 
@@ -132,6 +137,33 @@ class WebFetchArgs(BaseModel):
     )
 
 
+class DownloadArgs(BaseModel):
+    """Arguments for the ``download`` tool (workspace only)."""
+
+    url: HttpUrl = Field(
+        ...,
+        description="Absolute URL of the file to download (http or https).",
+    )
+    path: str | None = Field(
+        default=None,
+        description=(
+            "Optional workspace-relative destination. When omitted (or "
+            "ending with '/'), the filename is taken from the URL's last "
+            "path segment and the file is written under that directory (or "
+            "the workspace root). Must not escape the workspace."
+        ),
+    )
+    max_bytes: int | None = Field(
+        default=None,
+        gt=0,
+        description=(
+            "Optional per-call maximum download size in bytes. The download "
+            "is rejected (nothing is written) the moment the stream exceeds "
+            "this cap. Defaults to the toolset's configured cap when omitted."
+        ),
+    )
+
+
 # ---- Tool descriptors (the JSON schemas the LLM sees) ----------------------
 
 
@@ -197,6 +229,35 @@ def make_web_fetch_descriptor(toolset_id: str) -> Tool:
             ToolExample(args={"url": "https://docs.python.org/3/whatsnew/3.13.html"}, returns="clean markdown of the page"),
             ToolExample(args={"url": "https://example.com/article", "max_chars": 4000}, returns="first ~4000 chars of clean markdown"),
         ],
+        required_role="user",
+    )
+
+
+def make_download_descriptor(toolset_id: str) -> Tool:
+    return make_tool(
+        id="download",
+        toolset_id=toolset_id,
+        purpose="Download the file at a URL into the agent's workspace at a path.",
+        when=(
+            "Use when you need to save a remote file (dataset, asset, "
+            "release artifact) into the workspace for later processing "
+            "(workspace only). To READ a web page as text use ``web_fetch``; "
+            "to inspect raw bytes/headers use ``http_request``."
+        ),
+        args_schema=DownloadArgs.model_json_schema(),
+        examples=[
+            ToolExample(
+                args={"url": "https://example.com/data.csv"},
+                returns="``{path: 'data.csv', bytes: 1234, url: '...'}``",
+                note="writes data.csv at the workspace root",
+            ),
+            ToolExample(
+                args={"url": "https://example.com/a.pdf", "path": "docs/a.pdf"},
+                returns="``{path: 'docs/a.pdf', bytes: ..., url: '...'}``",
+            ),
+        ],
+        yields=False,
+        requires_workspace=True,
         required_role="user",
     )
 
@@ -372,11 +433,131 @@ def make_web_fetch_handler(service: "WebFetchService") -> ToolHandler:
     return _handle
 
 
+def make_download_handler(
+    *,
+    http_client: httpx.AsyncClient,
+    workspace_registry: "WorkspaceRegistry",
+    byte_cap: int,
+) -> "ToolHandler":
+    """Build the async handler for the ``download`` tool (workspace only).
+
+    Streams the remote file with a HARD size cap: the byte total is
+    checked as chunks arrive and the download is rejected the instant it
+    exceeds the cap, so a truncated (corrupt) file is never written. The
+    fully-buffered bytes are then written into the workspace via the
+    workspace backend, which owns path-confinement (a traversal or
+    reserved-path write raises :class:`BadRequestError`).
+
+    Closes over a shared :class:`httpx.AsyncClient` (connection pooling),
+    the :class:`WorkspaceRegistry` (to resolve the live workspace from
+    ``ctx.workspace_id``), and the default ``byte_cap``.
+    """
+    if byte_cap <= 0:
+        raise ValueError(f"byte_cap must be > 0, got {byte_cap!r}")
+
+    async def _handle(
+        arguments: dict[str, Any], *, ctx: ToolContext
+    ) -> ToolCallResult:
+        # Defensive guard: chat suppression should keep this tool out of
+        # any non-workspace context, but never attempt file I/O without a
+        # live workspace.
+        if ctx is None or ctx.workspace_id is None:
+            return ToolCallResult(
+                output=(
+                    "download requires a workspace session (no workspace "
+                    "is bound to this turn)"
+                ),
+                is_error=True,
+            )
+
+        try:
+            args = DownloadArgs.model_validate(arguments)
+        except ValidationError as exc:
+            raise BadRequestError(
+                f"download: invalid arguments: {exc}"
+            ) from exc
+
+        url_str = str(args.url)
+        # Derive the destination path. A trailing '/' (or an omitted path)
+        # means "a directory" -> append the URL's filename.
+        url_name = os.path.basename(urlsplit(url_str).path)
+        if args.path and not args.path.endswith("/"):
+            dest = args.path
+        else:
+            if not url_name:
+                return ToolCallResult(
+                    output=(
+                        "download: cannot derive a filename from the URL; "
+                        "pass an explicit 'path'"
+                    ),
+                    is_error=True,
+                )
+            dest = f"{args.path}{url_name}" if args.path else url_name
+
+        cap = args.max_bytes if args.max_bytes is not None else byte_cap
+
+        # Stream with a hard cap. A truncated file is corrupt, so reject
+        # (write nothing) the moment the running total exceeds the cap -
+        # do NOT read-all-then-truncate.
+        chunks: list[bytes] = []
+        total = 0
+        try:
+            async with http_client.stream("GET", url_str) as resp:
+                resp.raise_for_status()
+                async for chunk in resp.aiter_bytes():
+                    total += len(chunk)
+                    if total > cap:
+                        return ToolCallResult(
+                            output=(
+                                f"download: file exceeds the maximum of "
+                                f"{cap} bytes; nothing was written"
+                            ),
+                            is_error=True,
+                        )
+                    chunks.append(chunk)
+        except httpx.HTTPStatusError as exc:
+            return ToolCallResult(
+                output=(
+                    f"download failed: server returned "
+                    f"{exc.response.status_code} for {url_str}"
+                ),
+                is_error=True,
+            )
+        except httpx.RequestError as exc:
+            return ToolCallResult(
+                output=f"download failed: {type(exc).__name__}: {exc}",
+                is_error=True,
+            )
+
+        data = b"".join(chunks)
+        try:
+            ws = await workspace_registry.get_workspace(ctx.workspace_id)
+            await ws.write_file(dest, data)
+        except (BadRequestError, NotFoundError) as exc:
+            return ToolCallResult(
+                output=f"download: cannot write {dest!r}: {exc}",
+                is_error=True,
+            )
+
+        return ToolCallResult(
+            output=json.dumps(
+                {"path": dest, "bytes": total, "url": url_str},
+                ensure_ascii=False,
+            ),
+            is_error=False,
+        )
+
+    return _handle
+
+
 __all__ = [
+    "DownloadArgs",
     "HttpMethod",
     "HttpRequestArgs",
     "WebFetchArgs",
     "WebSearchArgs",
+    "make_download_descriptor",
+    "make_download_handler",
     "make_http_request_descriptor",
     "make_http_request_handler",
     "make_web_fetch_descriptor",

--- a/primer/toolset/workspaces.py
+++ b/primer/toolset/workspaces.py
@@ -425,6 +425,7 @@ def _tool(
     *,
     yields: bool = False,
     requires_session: bool = False,
+    requires_workspace: bool = False,
     required_role: str | None = None,
 ) -> tuple[str, tuple[Tool, ToolHandler]]:
     return name, (
@@ -437,6 +438,7 @@ def _tool(
             examples=examples,
             yields=yields,
             requires_session=requires_session,
+            requires_workspace=requires_workspace,
             required_role=required_role,
         ),
         handler,

--- a/tests/agent/test_workspace_ext_chat_suppression.py
+++ b/tests/agent/test_workspace_ext_chat_suppression.py
@@ -49,7 +49,13 @@ class _FakeToolsetProvider:
         return ToolCallResult(output="{}", is_error=False)
 
 
-def _tool(name: str, *, toolset_id: str, yields: bool = False) -> Tool:
+def _tool(
+    name: str,
+    *,
+    toolset_id: str,
+    yields: bool = False,
+    requires_workspace: bool = False,
+) -> Tool:
     return Tool(
         id=name,
         description=f"a test tool named {name}",
@@ -57,6 +63,7 @@ def _tool(name: str, *, toolset_id: str, yields: bool = False) -> Tool:
         args_schema={"type": "object", "properties": {}},
         yields=yields,
         requires_session=yields,
+        requires_workspace=requires_workspace,
     )
 
 
@@ -151,3 +158,79 @@ async def test_for_workspace_keeps_workspace_ext():
     ids = {t.id for t in await mgr.list_tools()}
     assert "workspace_ext__watch_files" in ids
     assert "workspace_ext__sleep" in ids
+
+
+# ---------------------------------------------------------------------------
+# Per-tool ``requires_workspace`` suppression (additive to the workspace_ext
+# toolset-id skip). A requires_workspace tool lives in an ordinary toolset
+# (here ``web``) but is dropped from chat context all the same, because it
+# reads ctx.workspace_id for file I/O and only functions in a session.
+# ---------------------------------------------------------------------------
+
+
+def _providers_with_ws_tool():
+    """A misc toolset (always visible) + a web toolset that owns a
+    requires_workspace tool (``download``)."""
+    misc = _FakeToolsetProvider(
+        toolset_id="misc",
+        tools=[_tool("get_datetime", toolset_id="misc")],
+    )
+    web = _FakeToolsetProvider(
+        toolset_id="web",
+        tools=[
+            _tool("web_search", toolset_id="web"),
+            _tool("download", toolset_id="web", requires_workspace=True),
+        ],
+    )
+    return {"misc": misc, "web": web}
+
+
+_WS_AGENT_TOOLS = ["misc__get_datetime", "web__web_search", "web__download"]
+
+
+@pytest.mark.asyncio
+async def test_requires_workspace_tool_dropped_on_chat_context():
+    """Chat context: a requires_workspace tool is dropped even though its
+    toolset (``web``) is not workspace_ext."""
+    mgr = ToolExecutionManager(
+        toolset_providers=_providers_with_ws_tool(),  # type: ignore[arg-type]
+        tools=_WS_AGENT_TOOLS,
+        chat_id="chat-1",
+    )
+    ids = {t.id for t in await mgr.list_tools()}
+    # Ordinary web tool the agent bound is still there.
+    assert "web__web_search" in ids
+    assert "misc__get_datetime" in ids
+    # The workspace-only tool is suppressed.
+    assert "web__download" not in ids
+
+
+@pytest.mark.asyncio
+async def test_requires_workspace_tool_present_in_workspace_session():
+    """Workspace session context: the requires_workspace tool IS registered."""
+    mgr = ToolExecutionManager(
+        toolset_providers=_providers_with_ws_tool(),  # type: ignore[arg-type]
+        workspace_session=_FakeAgentSession(),  # type: ignore[arg-type]
+        tools=_WS_AGENT_TOOLS,
+    )
+    ids = {t.id for t in await mgr.list_tools()}
+    assert "web__web_search" in ids
+    assert "web__download" in ids
+
+
+@pytest.mark.asyncio
+async def test_suppressed_requires_workspace_call_is_rejected_on_chat():
+    """A model that references a suppressed requires_workspace tool in a chat
+    gets a clean rejection (routing table left unpopulated)."""
+    from primer.model.chat import ToolCallPart
+    from primer.model.except_ import UnsupportedContentError
+
+    mgr = ToolExecutionManager(
+        toolset_providers=_providers_with_ws_tool(),  # type: ignore[arg-type]
+        tools=_WS_AGENT_TOOLS,
+        chat_id="chat-1",
+    )
+    await mgr.list_tools()
+    call = ToolCallPart(id="tc-1", name="web__download", arguments={})
+    with pytest.raises(UnsupportedContentError):
+        await mgr.execute(call)

--- a/tests/mcp/test_safety.py
+++ b/tests/mcp/test_safety.py
@@ -14,11 +14,17 @@ from primer.model.chat import Tool
 
 
 class _StubProvider:
-    """Minimal ToolsetProvider stand-in for the predicate's two probes."""
+    """Minimal ToolsetProvider stand-in for the predicate's probes."""
 
-    def __init__(self, yielding: bool = False, needs_session: bool = False) -> None:
+    def __init__(
+        self,
+        yielding: bool = False,
+        needs_session: bool = False,
+        needs_workspace: bool = False,
+    ) -> None:
         self.yielding = yielding
         self.needs_session = needs_session
+        self.needs_workspace = needs_workspace
 
     def is_yielding(self, name: str) -> bool:  # noqa: ARG002 — stub
         return self.yielding
@@ -26,13 +32,23 @@ class _StubProvider:
     def requires_session(self, name: str) -> bool:  # noqa: ARG002 — stub
         return self.needs_session
 
+    def requires_workspace(self, name: str) -> bool:  # noqa: ARG002 - stub
+        return self.needs_workspace
 
-def _make_tool(toolset_id: str, name: str, descr: str = "") -> Tool:
+
+def _make_tool(
+    toolset_id: str,
+    name: str,
+    descr: str = "",
+    *,
+    requires_workspace: bool = False,
+) -> Tool:
     return Tool(
         id=name,
         toolset_id=toolset_id,
         description=descr,
         args_schema={"type": "object", "properties": {}},
+        requires_workspace=requires_workspace,
     )
 
 
@@ -130,3 +146,30 @@ def test_reserved_system_toolsets_remain_exposable() -> None:
         tool = _make_tool(toolset_id, "some_tool")
         ok, reason = is_exposable(tool, provider=_StubProvider())
         assert ok is True, f"{toolset_id} should be exposable, got {reason}"
+
+
+def test_requires_workspace_tool_is_not_exposable() -> None:
+    """A workspace-bound tool (reads ctx.workspace_id for file I/O) cannot
+    round-trip over the stateless MCP surface, regardless of its reserved
+    toolset id."""
+    tool = _make_tool("web", "download", requires_workspace=True)
+    ok, reason = is_exposable(tool, provider=_StubProvider())
+    assert ok is False
+    assert reason == "needs_workspace"
+
+
+def test_requires_workspace_system_tool_is_not_exposable() -> None:
+    """read_doc_content lives in the reserved ``system`` toolset yet is
+    still denied because it needs a live workspace."""
+    tool = _make_tool("system", "read_doc_content", requires_workspace=True)
+    ok, reason = is_exposable(tool, provider=_StubProvider())
+    assert ok is False
+    assert reason == "needs_workspace"
+
+
+def test_non_workspace_tool_stays_exposable() -> None:
+    """The new gate only fires on ``requires_workspace`` tools."""
+    tool = _make_tool("web", "web_search", requires_workspace=False)
+    ok, reason = is_exposable(tool, provider=_StubProvider())
+    assert ok is True
+    assert reason is None

--- a/tests/toolset/test_describe.py
+++ b/tests/toolset/test_describe.py
@@ -106,3 +106,42 @@ def test_make_tool_flags_excluded_from_serialization():
     dumped = tool.model_dump()
     assert "yields" not in dumped
     assert "requires_session" not in dumped
+
+
+def test_make_tool_requires_workspace_defaults_false():
+    tool = make_tool(
+        id="thing",
+        toolset_id="misc",
+        purpose="Do the thing.",
+        when="Use when you need the thing.",
+        args_schema=_Args.model_json_schema(),
+        examples=[ToolExample(args={"name": "x"})],
+    )
+    assert tool.requires_workspace is False
+
+
+def test_make_tool_sets_requires_workspace_flag():
+    tool = make_tool(
+        id="thing",
+        toolset_id="misc",
+        purpose="Do the thing.",
+        when="Use when you need the thing.",
+        args_schema=_Args.model_json_schema(),
+        examples=[ToolExample(args={"name": "x"})],
+        requires_workspace=True,
+    )
+    assert tool.requires_workspace is True
+
+
+def test_requires_workspace_excluded_from_serialization():
+    # In-memory metadata only; must not appear on the wire.
+    tool = make_tool(
+        id="thing",
+        toolset_id="misc",
+        purpose="Do the thing.",
+        when="Use when you need the thing.",
+        args_schema=_Args.model_json_schema(),
+        examples=[ToolExample(args={"name": "x"})],
+        requires_workspace=True,
+    )
+    assert "requires_workspace" not in tool.model_dump()

--- a/tests/toolset/test_internal_yielding_flags.py
+++ b/tests/toolset/test_internal_yielding_flags.py
@@ -140,3 +140,61 @@ def test_base_class_default_is_false() -> None:
     p = _Minimal()
     assert p.is_yielding("anything") is False
     assert p.requires_session("anything") is False
+    # New capability flag: default False on the ABC too.
+    assert p.requires_workspace("anything") is False
+
+
+def test_internal_provider_requires_workspace_reads_flag() -> None:
+    """InternalToolsetProvider.requires_workspace mirrors the Tool flag."""
+    ws_tool = Tool(
+        id="ws_tool",
+        toolset_id="t",
+        description="x",
+        args_schema={"type": "object"},
+        requires_workspace=True,
+    )
+    plain = Tool(
+        id="plain_tool",
+        toolset_id="t",
+        description="x",
+        args_schema={"type": "object"},
+    )
+    provider = InternalToolsetProvider(
+        toolset_id="t",
+        registry={
+            "ws_tool": (ws_tool, _noop_handler),
+            "plain_tool": (plain, _noop_handler),
+        },
+    )
+    assert provider.requires_workspace("ws_tool") is True
+    assert provider.requires_workspace("plain_tool") is False
+    # Unknown names fail to False.
+    assert provider.requires_workspace("does_not_exist") is False
+
+
+def test_system_read_doc_content_requires_workspace() -> None:
+    """build_system_toolset registers read_doc_content flagged workspace-only."""
+    from primer.toolset.system import build_system_toolset
+
+    sp = _SystemSP()
+    pr = _system_registry(sp)
+
+    class _Reg:  # minimal WorkspaceRegistry stand-in (never dispatched here)
+        async def get_workspace(self, workspace_id):  # pragma: no cover
+            return None
+
+    provider = build_system_toolset(
+        storage_provider=sp, provider_registry=pr, workspace_registry=_Reg()
+    )
+    assert provider.requires_workspace("read_doc_content") is True
+
+
+def test_system_read_doc_content_absent_without_registry() -> None:
+    """Without a workspace_registry the workspace-only tool is not wired."""
+    from primer.toolset.system import build_system_toolset
+
+    sp = _SystemSP()
+    pr = _system_registry(sp)
+    provider = build_system_toolset(storage_provider=sp, provider_registry=pr)
+    # Absent -> unknown name -> False.
+    assert provider.requires_workspace("read_doc_content") is False

--- a/tests/toolset/test_system_read_doc_content.py
+++ b/tests/toolset/test_system_read_doc_content.py
@@ -1,0 +1,224 @@
+"""Unit tests for the workspace-only ``read_doc_content`` system tool.
+
+Covers the handler produced by
+:func:`primer.toolset._system_tools.make_read_doc_content_handler`:
+
+* happy path: bytes read from the workspace -> Docling -> ``{text}``;
+* the GUARDED optional-``docling`` import degrades to an install hint
+  when the extra is not installed (simulated by monkeypatching the
+  loaders package so the import raises ModuleNotFoundError) - so these
+  tests never require ``docling`` to be installed;
+* missing-file / bad-path and no-workspace error branches;
+* a document parse failure surfaced in-band.
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+import primer.ingest.loaders as loaders_mod
+from primer.model.except_ import (
+    BadRequestError,
+    NotFoundError,
+    UnsupportedContentError,
+)
+from primer.model.yield_ import ToolContext
+from primer.toolset._system_tools import make_read_doc_content_handler
+
+
+# ===========================================================================
+# Fakes
+# ===========================================================================
+
+
+class _FakeWorkspace:
+    def __init__(
+        self, *, data: bytes = b"raw-bytes", read_error: Exception | None = None
+    ) -> None:
+        self._data = data
+        self._read_error = read_error
+        self.reads: list[str] = []
+
+    async def read_file(self, path: str) -> bytes:
+        self.reads.append(path)
+        if self._read_error is not None:
+            raise self._read_error
+        return self._data
+
+
+class _FakeWorkspaceRegistry:
+    def __init__(
+        self,
+        *,
+        workspace: _FakeWorkspace | None = None,
+        get_error: Exception | None = None,
+    ) -> None:
+        self.workspace = workspace or _FakeWorkspace()
+        self._get_error = get_error
+        self.get_calls: list[str] = []
+
+    async def get_workspace(self, workspace_id: str):
+        self.get_calls.append(workspace_id)
+        if self._get_error is not None:
+            raise self._get_error
+        return self.workspace
+
+
+class _FakeLoaded:
+    def __init__(self, text: str) -> None:
+        self.text = text
+
+
+class _FakeDoclingLoader:
+    """Stand-in for the real DoclingLoader; no docling install needed."""
+
+    load_error: Exception | None = None
+
+    def __init__(self) -> None:
+        pass
+
+    async def load(self, raw: bytes):
+        if _FakeDoclingLoader.load_error is not None:
+            raise _FakeDoclingLoader.load_error
+        return _FakeLoaded(f"converted:{raw.decode()}")
+
+
+def _install_fake_loader(monkeypatch) -> None:
+    """Route ``from primer.ingest.loaders import DoclingLoader`` to the fake.
+
+    The loaders package resolves ``DoclingLoader`` lazily through a
+    module-level ``__getattr__`` (PEP 562), so patching that hook is
+    enough - the real docling stack is never imported.
+    """
+    _FakeDoclingLoader.load_error = None
+
+    def _getattr(name: str):
+        if name == "DoclingLoader":
+            return _FakeDoclingLoader
+        raise AttributeError(name)
+
+    monkeypatch.setattr(loaders_mod, "__getattr__", _getattr, raising=False)
+
+
+def _install_missing_docling(monkeypatch) -> None:
+    """Simulate the ``docling`` extra not being installed."""
+
+    def _getattr(name: str):
+        if name == "DoclingLoader":
+            raise ModuleNotFoundError("No module named 'docling'")
+        raise AttributeError(name)
+
+    monkeypatch.setattr(loaders_mod, "__getattr__", _getattr, raising=False)
+
+
+def _ctx(workspace_id: str | None = "ws-1") -> ToolContext:
+    return ToolContext(
+        tool_call_id="tc-1", session_id="sess-1", workspace_id=workspace_id
+    )
+
+
+# ===========================================================================
+# Tests
+# ===========================================================================
+
+
+@pytest.mark.asyncio
+async def test_returns_converted_text(monkeypatch) -> None:
+    _install_fake_loader(monkeypatch)
+    reg = _FakeWorkspaceRegistry(workspace=_FakeWorkspace(data=b"hello"))
+    handler = make_read_doc_content_handler(workspace_registry=reg)
+
+    result = await handler({"path": "reports/q3.pdf"}, ctx=_ctx())
+
+    assert not result.is_error
+    assert json.loads(result.output) == {"text": "converted:hello"}
+    assert reg.get_calls == ["ws-1"]
+    assert reg.workspace.reads == ["reports/q3.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_no_workspace_in_ctx_is_error(monkeypatch) -> None:
+    _install_fake_loader(monkeypatch)
+    reg = _FakeWorkspaceRegistry()
+    handler = make_read_doc_content_handler(workspace_registry=reg)
+
+    result = await handler({"path": "a.pdf"}, ctx=_ctx(workspace_id=None))
+
+    assert result.is_error is True
+    payload = json.loads(result.output)
+    assert payload["type"] == "bad-request"
+    assert "workspace" in payload["message"]
+    # The workspace was never resolved.
+    assert reg.get_calls == []
+
+
+@pytest.mark.asyncio
+async def test_missing_file_is_error(monkeypatch) -> None:
+    _install_fake_loader(monkeypatch)
+    ws = _FakeWorkspace(read_error=NotFoundError("'a.pdf' not found"))
+    reg = _FakeWorkspaceRegistry(workspace=ws)
+    handler = make_read_doc_content_handler(workspace_registry=reg)
+
+    result = await handler({"path": "a.pdf"}, ctx=_ctx())
+
+    assert result.is_error is True
+    assert json.loads(result.output)["type"] == "not-found"
+
+
+@pytest.mark.asyncio
+async def test_bad_path_is_error(monkeypatch) -> None:
+    _install_fake_loader(monkeypatch)
+    ws = _FakeWorkspace(read_error=BadRequestError("path escapes workspace"))
+    reg = _FakeWorkspaceRegistry(workspace=ws)
+    handler = make_read_doc_content_handler(workspace_registry=reg)
+
+    result = await handler({"path": "../escape"}, ctx=_ctx())
+
+    assert result.is_error is True
+    assert json.loads(result.output)["type"] == "not-found"
+
+
+@pytest.mark.asyncio
+async def test_missing_docling_extra_returns_install_hint(monkeypatch) -> None:
+    # The optional import must be GUARDED: no crash, just a clear hint.
+    _install_missing_docling(monkeypatch)
+    reg = _FakeWorkspaceRegistry(workspace=_FakeWorkspace(data=b"hello"))
+    handler = make_read_doc_content_handler(workspace_registry=reg)
+
+    result = await handler({"path": "a.pdf"}, ctx=_ctx())
+
+    assert result.is_error is True
+    payload = json.loads(result.output)
+    assert payload["type"] == "unavailable"
+    assert "docling" in payload["message"]
+    # The file was read before the import was attempted.
+    assert reg.workspace.reads == ["a.pdf"]
+
+
+@pytest.mark.asyncio
+async def test_parse_failure_is_in_band_error(monkeypatch) -> None:
+    _install_fake_loader(monkeypatch)
+    _FakeDoclingLoader.load_error = UnsupportedContentError("cannot parse")
+    reg = _FakeWorkspaceRegistry(workspace=_FakeWorkspace(data=b"hello"))
+    handler = make_read_doc_content_handler(workspace_registry=reg)
+
+    result = await handler({"path": "a.pdf"}, ctx=_ctx())
+
+    assert result.is_error is True
+    payload = json.loads(result.output)
+    assert payload["type"] == "bad-request"
+    assert "parse" in payload["message"]
+
+
+@pytest.mark.asyncio
+async def test_invalid_arguments_is_error(monkeypatch) -> None:
+    _install_fake_loader(monkeypatch)
+    reg = _FakeWorkspaceRegistry()
+    handler = make_read_doc_content_handler(workspace_registry=reg)
+
+    # Empty path violates min_length=1.
+    result = await handler({"path": ""}, ctx=_ctx())
+
+    assert result.is_error is True

--- a/tests/toolset/web/test_factory.py
+++ b/tests/toolset/web/test_factory.py
@@ -48,6 +48,14 @@ class _FakeWebFetchService:
         raise AssertionError("fetch should not be called in these tests")
 
 
+class _FakeWorkspaceRegistry:
+    """Minimal WorkspaceRegistry stand-in; list_tools never resolves a
+    workspace (only the download handler's dispatch path would)."""
+
+    async def get_workspace(self, workspace_id: str):  # pragma: no cover
+        raise AssertionError("get_workspace should not be called here")
+
+
 def _ok_client() -> httpx.AsyncClient:
     def _h(req: httpx.Request) -> httpx.Response:
         return httpx.Response(
@@ -161,3 +169,35 @@ class TestFactory:
         # point of this commit.)
         with pytest.raises(TypeError):
             build_web_toolset()  # type: ignore[call-arg]
+
+    @pytest.mark.asyncio
+    async def test_download_registered_with_workspace_registry(self) -> None:
+        client = _ok_client()
+        ts = build_web_toolset(
+            web_search_service=_FakeWebSearchService([]),
+            web_fetch_service=_FakeWebFetchService(),
+            http_client=client,
+            workspace_registry=_FakeWorkspaceRegistry(),
+        )
+        try:
+            ids = sorted([t.id async for t in ts.list_tools()])
+            assert ids == ["download", "http_request", "web_fetch", "web_search"]
+            # The download tool is flagged workspace-only.
+            assert ts.requires_workspace("download") is True
+        finally:
+            await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_download_absent_without_workspace_registry(self) -> None:
+        client = _ok_client()
+        ts = build_web_toolset(
+            web_search_service=_FakeWebSearchService([]),
+            web_fetch_service=_FakeWebFetchService(),
+            http_client=client,
+        )
+        try:
+            ids = sorted([t.id async for t in ts.list_tools()])
+            assert "download" not in ids
+            assert ts.requires_workspace("download") is False
+        finally:
+            await client.aclose()

--- a/tests/toolset/web/test_tools.py
+++ b/tests/toolset/web/test_tools.py
@@ -18,10 +18,14 @@ from typing import Any
 import httpx
 import pytest
 
-from primer.model.except_ import BadRequestError
+from primer.model.except_ import BadRequestError, NotFoundError
+from primer.model.yield_ import ToolContext
 from primer.toolset.web.tools import (
+    DownloadArgs,
     HttpRequestArgs,
     WebSearchArgs,
+    make_download_descriptor,
+    make_download_handler,
     make_http_request_descriptor,
     make_http_request_handler,
     make_web_search_descriptor,
@@ -316,9 +320,259 @@ class TestHttpRequestHandler:
             )
 
 
+# ===========================================================================
+# download handler (workspace only)
+# ===========================================================================
+
+
+def _stream_client(*, status: int, body: bytes) -> httpx.AsyncClient:
+    """An httpx.AsyncClient (MockTransport) whose responses stream via
+    ``client.stream(...)`` / ``aiter_bytes()`` - the real code path."""
+
+    def _h(request: httpx.Request) -> httpx.Response:
+        return httpx.Response(status_code=status, content=body)
+
+    return httpx.AsyncClient(transport=httpx.MockTransport(_h))
+
+
+class _FakeWorkspace:
+    def __init__(self, *, write_error: Exception | None = None) -> None:
+        self.writes: list[tuple[str, bytes]] = []
+        self._write_error = write_error
+
+    async def write_file(self, path: str, content: bytes) -> None:
+        if self._write_error is not None:
+            raise self._write_error
+        self.writes.append((path, content))
+
+
+class _FakeWorkspaceRegistry:
+    def __init__(
+        self,
+        *,
+        workspace: _FakeWorkspace | None = None,
+        get_error: Exception | None = None,
+    ) -> None:
+        self.workspace = workspace or _FakeWorkspace()
+        self._get_error = get_error
+        self.get_calls: list[str] = []
+
+    async def get_workspace(self, workspace_id: str):
+        self.get_calls.append(workspace_id)
+        if self._get_error is not None:
+            raise self._get_error
+        return self.workspace
+
+
+def _ctx(workspace_id: str | None = "ws-1") -> ToolContext:
+    return ToolContext(
+        tool_call_id="tc-1", session_id="sess-1", workspace_id=workspace_id
+    )
+
+
+class TestDownloadDescriptor:
+    def test_descriptor_flags_and_id(self) -> None:
+        t = make_download_descriptor("web")
+        assert t.id == "download"
+        assert t.toolset_id == "web"
+        assert t.requires_workspace is True
+        assert t.required_role == "user"
+        props = t.args_schema.get("properties", {})
+        assert {"url", "path", "max_bytes"}.issubset(props.keys())
+
+
+class TestDownloadHandler:
+    @pytest.mark.asyncio
+    async def test_writes_file_at_url_derived_default_path(self) -> None:
+        client = _stream_client(status=200, body=b"col1,col2\n1,2\n")
+        reg = _FakeWorkspaceRegistry()
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        result = await handler(
+            {"url": "https://example.com/sub/data.csv"}, ctx=_ctx()
+        )
+        assert not result.is_error
+        payload = json.loads(result.output)
+        # Filename derived from the URL's last path segment, at ws root.
+        assert payload["path"] == "data.csv"
+        assert payload["bytes"] == len(b"col1,col2\n1,2\n")
+        assert payload["url"] == "https://example.com/sub/data.csv"
+        assert reg.get_calls == ["ws-1"]
+        assert reg.workspace.writes == [("data.csv", b"col1,col2\n1,2\n")]
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_explicit_path_used_verbatim(self) -> None:
+        client = _stream_client(status=200, body=b"xyz")
+        reg = _FakeWorkspaceRegistry()
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        result = await handler(
+            {"url": "https://example.com/a.bin", "path": "docs/out.bin"},
+            ctx=_ctx(),
+        )
+        assert not result.is_error
+        assert json.loads(result.output)["path"] == "docs/out.bin"
+        assert reg.workspace.writes == [("docs/out.bin", b"xyz")]
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_trailing_slash_path_appends_url_filename(self) -> None:
+        client = _stream_client(status=200, body=b"xyz")
+        reg = _FakeWorkspaceRegistry()
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        result = await handler(
+            {"url": "https://example.com/a.bin", "path": "docs/"},
+            ctx=_ctx(),
+        )
+        assert not result.is_error
+        assert json.loads(result.output)["path"] == "docs/a.bin"
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_byte_cap_rejects_and_writes_nothing(self) -> None:
+        # A truncated file is corrupt: the cap must reject, not truncate.
+        client = _stream_client(status=200, body=b"a" * 5000)
+        reg = _FakeWorkspaceRegistry()
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=100
+        )
+        result = await handler(
+            {"url": "https://example.com/big.bin"}, ctx=_ctx()
+        )
+        assert result.is_error is True
+        assert "exceeds" in result.output
+        # Nothing was written and the workspace was never even resolved.
+        assert reg.workspace.writes == []
+        assert reg.get_calls == []
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_per_call_max_bytes_overrides_cap(self) -> None:
+        client = _stream_client(status=200, body=b"a" * 50)
+        reg = _FakeWorkspaceRegistry()
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        result = await handler(
+            {"url": "https://example.com/x.bin", "max_bytes": 10}, ctx=_ctx()
+        )
+        assert result.is_error is True
+        assert "exceeds" in result.output
+        assert reg.workspace.writes == []
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_no_workspace_in_ctx_is_error(self) -> None:
+        client = _stream_client(status=200, body=b"x")
+        reg = _FakeWorkspaceRegistry()
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        result = await handler(
+            {"url": "https://example.com/x.bin"}, ctx=_ctx(workspace_id=None)
+        )
+        assert result.is_error is True
+        assert "workspace" in result.output
+        assert reg.get_calls == []
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_http_error_status_is_tool_error(self) -> None:
+        client = _stream_client(status=404, body=b"not found")
+        reg = _FakeWorkspaceRegistry()
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        result = await handler(
+            {"url": "https://example.com/missing.bin"}, ctx=_ctx()
+        )
+        assert result.is_error is True
+        assert "404" in result.output
+        assert reg.workspace.writes == []
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_empty_url_filename_needs_explicit_path(self) -> None:
+        client = _stream_client(status=200, body=b"x")
+        reg = _FakeWorkspaceRegistry()
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        result = await handler(
+            {"url": "https://example.com/"}, ctx=_ctx()
+        )
+        assert result.is_error is True
+        assert "path" in result.output
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_workspace_write_rejection_is_tool_error(self) -> None:
+        # A traversal / reserved-path write raises BadRequestError from the
+        # backend; the handler surfaces it in-band, not as a crash.
+        ws = _FakeWorkspace(write_error=BadRequestError("path escapes workspace"))
+        reg = _FakeWorkspaceRegistry(workspace=ws)
+        client = _stream_client(status=200, body=b"x")
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        result = await handler(
+            {"url": "https://example.com/x.bin", "path": "../escape"},
+            ctx=_ctx(),
+        )
+        assert result.is_error is True
+        assert "cannot write" in result.output
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_workspace_not_found_is_tool_error(self) -> None:
+        reg = _FakeWorkspaceRegistry(get_error=NotFoundError("gone"))
+        client = _stream_client(status=200, body=b"x")
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        result = await handler(
+            {"url": "https://example.com/x.bin"}, ctx=_ctx()
+        )
+        assert result.is_error is True
+        await client.aclose()
+
+    @pytest.mark.asyncio
+    async def test_invalid_arguments_raise_bad_request(self) -> None:
+        client = _stream_client(status=200, body=b"x")
+        reg = _FakeWorkspaceRegistry()
+        handler = make_download_handler(
+            http_client=client, workspace_registry=reg, byte_cap=1_000_000
+        )
+        with pytest.raises(BadRequestError, match="invalid arguments"):
+            await handler({"url": "ftp://nope/"}, ctx=_ctx())
+        await client.aclose()
+
+    def test_factory_rejects_zero_byte_cap(self) -> None:
+        client = _stream_client(status=200, body=b"x")
+        with pytest.raises(ValueError, match="byte_cap"):
+            make_download_handler(
+                http_client=client,
+                workspace_registry=_FakeWorkspaceRegistry(),
+                byte_cap=0,
+            )
+
+
 @pytest.mark.asyncio
 async def test_web_tools_conform():
-    from primer.toolset.web.tools import make_web_search_descriptor, make_http_request_descriptor
+    from primer.toolset.web.tools import (
+        make_download_descriptor,
+        make_http_request_descriptor,
+        make_web_search_descriptor,
+    )
     from tests.toolset._desc_conformance import assert_tool_conforms
-    for tool in (make_web_search_descriptor("web"), make_http_request_descriptor("web")):
+    for tool in (
+        make_web_search_descriptor("web"),
+        make_http_request_descriptor("web"),
+        make_download_descriptor("web"),
+    ):
         assert_tool_conforms(tool)


### PR DESCRIPTION
## What & why

Two workspace-only internal tools, plus the mechanism that makes them workspace-only.

- **`download`** (WEB toolset): given a URL and an optional workspace-relative path
  (default = the URL's filename at the workspace root), stream-download the file and
  write it into the agent's workspace.
- **`read_doc_content`** (SYSTEM toolset): given a workspace-relative file path,
  convert the document (PDF / DOCX / PPTX / HTML / ...) to text via docling and
  return it.

Both require a live workspace (they need a file path), so they must NOT appear in
chat tool context and must activate only when an agent runs in a workspace session.

## The `requires_workspace` capability flag (new)

`requires_session=True` does NOT deliver this: the chat-suppression choke point keys
on the `workspace_ext` *toolset id*, and `ask_user` is `requires_session=True` yet
deliberately chat-visible. So this adds a dedicated per-tool `requires_workspace`
flag (mirroring the existing `yields` / `requires_session` capability-flag pattern)
threaded `make_tool` -> `Tool` -> `InternalToolsetProvider`, honored at two
consumers:
- **Chat suppression** (`ToolExecutionManager.list_tools`): a `requires_workspace`
  tool is dropped when there is no workspace session, and its routing entry is left
  unpopulated so a stray chat call gets a clean `UnsupportedContentError`. Additive
  to the existing `workspace_ext` skip; `ask_user` and all other tools are
  unaffected.
- **MCP non-exposure** (`mcp/safety.py is_exposable`): a `requires_workspace` tool
  returns `(False, "needs_workspace")` (it cannot run over the stateless MCP
  surface).

## Safety

- **`download` streams with a hard byte cap** (default 100 MB, or per-call
  `max_bytes`): the running total is checked as chunks arrive and the handler errors
  **before** the workspace is even resolved or anything written, so a truncated file
  is never persisted (a truncated file is a corrupt file).
- **Path confinement is delegated** to the workspace backend's own `write_file` /
  `read_file` (`_resolve_path` + reserved-tree refusal) - no path logic is
  re-implemented in the handlers; traversal / absolute / reserved paths raise
  `BadRequestError`. Filename derivation uses `basename(urlsplit(url).path)`, which
  cannot contain a separator; an underivable filename returns a clean error.
- **docling is an optional extra**: the import is guarded
  (`try/except ModuleNotFoundError`, never at module top), so app startup and the
  system toolset work without it; a miss returns an install hint.
- Both handlers take keyword-only `ctx: ToolContext` and defensively guard
  `ctx.workspace_id is None`. Both declare `required_role="user"`.
- `workspace_registry` is optional on both builders; the tools register only when it
  is provided, and all four production wiring sites pass a valid registry (verified
  the app still starts).

## Tests
Model/flag, chat-suppression (drop-in-chat / present-in-session / clean-rejection),
MCP non-exposure, download (exact bytes+path on success; cap rejects with zero
writes and zero workspace resolution; no-workspace guard; 404 / write-failure
mapping), and read_doc_content (converted text; missing-file; bad-path; guarded
docling-miss install hint; parse-failure) - all via monkeypatched fakes, so tests
never require docling installed. 87 + 74 (regression) + 95 (caller) named tests
pass, CPU-capped. No U+2014/U+2192 in added lines.

The 2 `tests/e2e/test_builtin_toolsets.py` failures in the sandbox are the
live-server fixture (ConnectError); those assertions are superset-tolerant, so the
additions do not break them in CI.

## Review
Independent adversarial review: **APPROVE**, 0 Critical / 0 Important, 4 Minor. The
Minors are documented follow-ups, intentionally not addressed here to keep the PR to
the reviewed scope:
1. **SSRF**: `download` fetches an arbitrary URL server-side. There is no existing
   SSRF guard in the web layer (`http_request` / `web_fetch` allow the same), so
   nothing to mirror and no regression; a guard should be added centrally to all web
   tools if desired.
2. Full-body buffering up to the cap (bounded by spec; lower the cap or stream to
   disk if concurrent-download memory matters).
3. `Content-Length` is not used to fail fast before streaming (optimization).
4. `test_required_role_completeness` does not enumerate these tools (they are
   non-exposable, so it would skip them anyway).

HELD -- do not merge without sign-off.
