### PR TITLE
chore(toolset): retire the vestigial requires_session flag

### DIFF
--- a/primer/int/toolset.py
+++ b/primer/int/toolset.py
@@ -153,21 +153,6 @@ class ToolsetProvider(ABC):
         del tool_name
         return False
 
-    def requires_session(self, tool_name: str) -> bool:
-        """Return True if this tool requires :class:`AgentSession` context.
-
-        Used by the MCP server endpoint to exclude workspace-style
-        tools that only make sense inside a running agent loop (they
-        depend on ``ctx.session_id`` / ``ctx.workspace_id`` injected
-        by the worker).
-
-        Default: ``False``. Providers whose handlers read
-        ``ctx.session_id`` override this and return ``True`` for the
-        relevant names.
-        """
-        del tool_name
-        return False
-
     def requires_workspace(self, tool_name: str) -> bool:
         """Return True if this tool requires a live workspace.
 

--- a/primer/mcp/safety.py
+++ b/primer/mcp/safety.py
@@ -7,8 +7,8 @@ constraints that v1 MCP can't represent:
 
 * yielding tools — the agent runtime parks them on an event bus,
   MCP v1 tools/list has no equivalent pause/resume primitive.
-* workspace tools requiring an ``AgentSession`` — they read
-  ``ctx.session_id``, which is meaningless outside an agent loop.
+* workspace-bound tools that read ``ctx.workspace_id`` for file
+  I/O, which is meaningless outside a workspace session.
 
 There is intentionally no policy-level denylist. The operator
 chose to enable MCP, chose which tools to expose, and authenticated
@@ -66,9 +66,6 @@ def is_exposable(
 
     * ``"yielding_unsupported"`` — handler yields; MCP v1 has no
       park/resume protocol so the round-trip is impossible.
-    * ``"needs_session"`` — workspace tool that requires a live
-      :class:`AgentSession` (reads ``ctx.session_id``); meaningless
-      outside an agent loop.
     * ``"needs_workspace"`` - tool that requires a live workspace
       (reads ``ctx.workspace_id`` for file I/O); a workspace-bound tool
       cannot run over the stateless MCP surface.
@@ -89,8 +86,6 @@ def is_exposable(
         return False, "not_system_toolset"
     if provider.is_yielding(tool.id):
         return False, "yielding_unsupported"
-    if tool.toolset_id == "workspaces" and provider.requires_session(tool.id):
-        return False, "needs_session"
     # Read the flag straight off the descriptor (mirrors the
     # ``tool.toolset_id`` read above). ``tool`` comes from
     # ``provider.list_tools()`` so its ``requires_workspace`` flag is the

--- a/primer/model/chat.py
+++ b/primer/model/chat.py
@@ -658,17 +658,6 @@ class Tool(Describeable):
             "In-memory metadata only; excluded from serialization."
         ),
     )
-    requires_session: bool = Field(
-        default=False,
-        exclude=True,
-        description=(
-            "True iff the tool's handler needs a live AgentSession (reads "
-            "ctx.session_id). Declared explicitly at the make_tool call site. "
-            "Consumed by InternalToolsetProvider.requires_session and the MCP "
-            "exposure guard. In-memory metadata only; excluded from "
-            "serialization."
-        ),
-    )
     requires_workspace: bool = Field(
         default=False,
         exclude=True,

--- a/primer/toolset/_describe.py
+++ b/primer/toolset/_describe.py
@@ -40,7 +40,6 @@ def make_tool(
     args_schema: dict[str, Any],
     examples: list[ToolExample],
     yields: bool = False,
-    requires_session: bool = False,
     requires_workspace: bool = False,
     required_role: str | None = None,
 ) -> Tool:
@@ -50,19 +49,16 @@ def make_tool(
     Each example's ``args`` is validated against ``args_schema`` (which must be
     a self-contained JSON Schema) and rejected on mismatch.
 
-    ``yields`` and ``requires_session`` are explicit capability flags that
+    ``yields`` and ``requires_workspace`` are explicit capability flags that
     replace the previous source-introspection heuristics in
     :mod:`primer.toolset.internal`. Set ``yields=True`` when the tool's
     handler can park the agent turn (its return annotation includes
     :class:`primer.model.yield_.Yielded` / it raises ``YieldToWorker``).
-    Set ``requires_session=True`` when the handler needs a live
-    ``AgentSession`` (it reads ``ctx.session_id``). Set
-    ``requires_workspace=True`` when the handler needs a live workspace
+    Set ``requires_workspace=True`` when the handler needs a live workspace
     (it reads ``ctx.workspace_id`` for file I/O); such tools are dropped
-    from chat tool context and are not MCP-exposable. All three default
+    from chat tool context and are not MCP-exposable. Both default
     to ``False`` and surface via :meth:`InternalToolsetProvider.is_yielding`
-    / :meth:`InternalToolsetProvider.requires_session` /
-    :meth:`InternalToolsetProvider.requires_workspace`, which the chat
+    / :meth:`InternalToolsetProvider.requires_workspace`, which the chat
     suppression choke point and the MCP exposure guard consult.
     """
     validator = Draft202012Validator(args_schema)
@@ -76,7 +72,6 @@ def make_tool(
         args_schema=args_schema,
         examples=examples,
         yields=yields,
-        requires_session=requires_session,
         requires_workspace=requires_workspace,
         required_role=required_role,
     )

--- a/primer/toolset/internal.py
+++ b/primer/toolset/internal.py
@@ -72,15 +72,14 @@ class InternalToolsetProvider(ToolsetProvider):
         # the introspection cost per call. A True entry tells
         # dispatch to inject the context kwarg.
         self._handler_takes_ctx: dict[str, bool] = {}
-        # Cache: which tools yield (park the turn) and which require an
-        # AgentSession. Both are declared explicitly at the ``make_tool``
-        # call site via the ``yields`` / ``requires_session`` flags (which
+        # Cache: which tools yield (park the turn) and which require a
+        # live workspace. Both are declared explicitly at the ``make_tool``
+        # call site via the ``yields`` / ``requires_workspace`` flags (which
         # replaced the old handler source/annotation introspection - see
         # :func:`primer.toolset._describe.make_tool`). Surfaced via
-        # :meth:`is_yielding` and :meth:`requires_session`; the MCP server
+        # :meth:`is_yielding` and :meth:`requires_workspace`; the MCP server
         # endpoint uses them to filter the exposable tool set.
         self._yielding_names: set[str] = set()
-        self._session_names: set[str] = set()
         self._workspace_names: set[str] = set()
         self._required_roles: dict[str, str] = {}
         for name, (tool, handler) in self._registry.items():
@@ -92,8 +91,6 @@ class InternalToolsetProvider(ToolsetProvider):
             self._handler_takes_ctx[name] = _handler_takes_ctx(handler)
             if tool.yields:
                 self._yielding_names.add(name)
-            if tool.requires_session:
-                self._session_names.add(name)
             if tool.requires_workspace:
                 self._workspace_names.add(name)
             if tool.required_role is not None:
@@ -107,15 +104,6 @@ class InternalToolsetProvider(ToolsetProvider):
         return ``False``.
         """
         return tool_name in self._yielding_names
-
-    def requires_session(self, tool_name: str) -> bool:
-        """Return True iff ``tool_name`` needs a live AgentSession.
-
-        Read at construction time from the tool's explicit
-        ``requires_session`` flag (declared at the ``make_tool`` call
-        site). Unknown names return ``False``.
-        """
-        return tool_name in self._session_names
 
     def requires_workspace(self, tool_name: str) -> bool:
         """Return True iff ``tool_name`` needs a live workspace.

--- a/primer/toolset/system.py
+++ b/primer/toolset/system.py
@@ -799,7 +799,6 @@ def build_system_toolset(
                 ),
             ],
             yields=True,
-            requires_session=True,
         ),
         _switch_to_agent_handler,
     )
@@ -829,7 +828,6 @@ def build_system_toolset(
                 ),
             ],
             yields=True,
-            requires_session=True,
         ),
         _ask_user_handler,
     )

--- a/primer/toolset/trigger.py
+++ b/primer/toolset/trigger.py
@@ -443,7 +443,6 @@ TOOL_SUBSCRIBE = make_tool(
         ),
     ],
     yields=True,
-    requires_session=True,
     required_role="user",
 )
 
@@ -477,7 +476,6 @@ TOOL_SUBSCRIBE_CHANNEL = make_tool(
         ),
     ],
     yields=True,
-    requires_session=True,
     required_role="user",
 )
 

--- a/primer/toolset/workspace_ext.py
+++ b/primer/toolset/workspace_ext.py
@@ -150,7 +150,6 @@ def build_workspace_ext_toolset(
                     ),
                 ],
                 yields=True,
-                requires_session=True,
                 required_role="user",
             ),
             _watch_files_handler,
@@ -181,14 +180,13 @@ def build_workspace_ext_toolset(
                     ),
                 ],
                 yields=True,
-                requires_session=True,
                 required_role="user",
             ),
             _invoke_graph_handler,
         ),
         "subscribe_to_trigger": (
             # Re-home the existing descriptor under the new toolset id; the
-            # bare id, args schema, and yield/session flags are preserved.
+            # bare id, args schema, and yield flag are preserved.
             TOOL_SUBSCRIBE.model_copy(update={"toolset_id": toolset_id}),
             _make_subscribe_handler(storage_provider),
         ),

--- a/primer/toolset/workspaces.py
+++ b/primer/toolset/workspaces.py
@@ -424,7 +424,6 @@ def _tool(
     examples: list[ToolExample],
     *,
     yields: bool = False,
-    requires_session: bool = False,
     requires_workspace: bool = False,
     required_role: str | None = None,
 ) -> tuple[str, tuple[Tool, ToolHandler]]:
@@ -437,7 +436,6 @@ def _tool(
             args_schema=args_cls.model_json_schema(),
             examples=examples,
             yields=yields,
-            requires_session=requires_session,
             requires_workspace=requires_workspace,
             required_role=required_role,
         ),

--- a/tests/agent/test_workspace_ext_chat_suppression.py
+++ b/tests/agent/test_workspace_ext_chat_suppression.py
@@ -62,7 +62,6 @@ def _tool(
         toolset_id=toolset_id,
         args_schema={"type": "object", "properties": {}},
         yields=yields,
-        requires_session=yields,
         requires_workspace=requires_workspace,
     )
 

--- a/tests/api/test_sso_flow.py
+++ b/tests/api/test_sso_flow.py
@@ -777,7 +777,7 @@ def _second_client(app) -> httpx.AsyncClient:
 
 @pytest.mark.asyncio
 @respx.mock
-async def test_link_requires_session(client, app, rsa_keypair):
+async def test_link_requires_authenticated_session(client, app, rsa_keypair):
     _, pub = rsa_keypair
     idp = _IdpFixture(pub)
     idp.register()
@@ -903,7 +903,7 @@ async def test_link_relinking_same_identity_is_idempotent(client, app, rsa_keypa
 
 
 @pytest.mark.asyncio
-async def test_identities_requires_session(client, app):
+async def test_identities_requires_authenticated_session(client, app):
     r = await client.get("/v1/auth/sso/identities")
     assert r.status_code == 401, r.text
 

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -24,9 +24,8 @@ from primer.model.principal import Principal
 class FakeToolsetProvider:
     """ToolsetProvider stand-in that yields a fixed list of tools.
 
-    Both safety probes (``is_yielding`` / ``requires_session``) consult a
-    per-tool override map so individual tests can flip a single tool's
-    flag without subclassing.
+    The safety probe ``is_yielding`` consults a per-tool override map so
+    individual tests can flip a single tool's flag without subclassing.
     """
 
     def __init__(
@@ -35,14 +34,12 @@ class FakeToolsetProvider:
         tools: list[Tool],
         *,
         yielding: set[str] | None = None,
-        sessioned: set[str] | None = None,
         call_handler: Callable[..., ToolCallResult] | None = None,
         roles: dict[str, str] | None = None,
     ) -> None:
         self.toolset_id = toolset_id
         self._tools = tools
         self._yielding = yielding or set()
-        self._sessioned = sessioned or set()
         self._call_handler = call_handler
         self._roles = roles or {}
         self.calls: list[dict[str, Any]] = []
@@ -87,9 +84,6 @@ class FakeToolsetProvider:
 
     def is_yielding(self, tool_name: str) -> bool:
         return tool_name in self._yielding
-
-    def requires_session(self, tool_name: str) -> bool:
-        return tool_name in self._sessioned
 
     def required_role(self, tool_name: str) -> str:
         """Fail-closed default (``"admin"``), mirroring the real

--- a/tests/mcp/test_dispatch_rbac.py
+++ b/tests/mcp/test_dispatch_rbac.py
@@ -46,10 +46,6 @@ class _SysProvider:
         del tool_name
         return False
 
-    def requires_session(self, tool_name: str) -> bool:
-        del tool_name
-        return False
-
     def required_role(self, tool_name: str) -> str:
         return self._roles.get(tool_name, "admin")
 

--- a/tests/mcp/test_safety.py
+++ b/tests/mcp/test_safety.py
@@ -1,8 +1,8 @@
 """is_exposable — Spec §7 (revised).
 
 HARD_DENY is now empty: the operator owns the exposure decision.
-This file pins that the runtime constraints (yielding tools, workspace
-tools that need an AgentSession) still filter, and that previously
+This file pins that the runtime constraints (yielding tools,
+workspace-bound tools) still filter, and that previously
 hard-denied tools (``system__call_tool``, ``web__http_request``) are
 now exposable when the operator opts them in.
 """
@@ -19,18 +19,13 @@ class _StubProvider:
     def __init__(
         self,
         yielding: bool = False,
-        needs_session: bool = False,
         needs_workspace: bool = False,
     ) -> None:
         self.yielding = yielding
-        self.needs_session = needs_session
         self.needs_workspace = needs_workspace
 
     def is_yielding(self, name: str) -> bool:  # noqa: ARG002 — stub
         return self.yielding
-
-    def requires_session(self, name: str) -> bool:  # noqa: ARG002 — stub
-        return self.needs_session
 
     def requires_workspace(self, name: str) -> bool:  # noqa: ARG002 - stub
         return self.needs_workspace
@@ -81,26 +76,6 @@ def test_yielding_tool_blocked() -> None:
     assert reason == "yielding_unsupported"
 
 
-def test_workspace_tool_needing_session_blocked() -> None:
-    tool = _make_tool("workspaces", "write_file")
-    ok, reason = is_exposable(tool, provider=_StubProvider(needs_session=True))
-    assert ok is False
-    assert reason == "needs_session"
-
-
-def test_non_workspace_tool_needing_session_not_filtered_here() -> None:
-    """``needs_session`` only suppresses tools in the ``workspaces`` toolset.
-
-    Other toolsets that happen to declare a session need-flag would
-    surface via a different reason (or not at all) — the workspaces
-    branch is the spec-defined trigger.
-    """
-    tool = _make_tool("search", "search_agents")
-    ok, reason = is_exposable(tool, provider=_StubProvider(needs_session=True))
-    assert ok is True
-    assert reason is None
-
-
 def test_safe_tool_passes() -> None:
     tool = _make_tool("misc", "uuid_v4")
     ok, reason = is_exposable(tool, provider=_StubProvider())
@@ -141,8 +116,8 @@ def test_reserved_system_toolsets_remain_exposable() -> None:
     from primer.mcp.safety import RESERVED_TOOLSET_IDS
 
     for toolset_id in RESERVED_TOOLSET_IDS:
-        # workspaces tools that need a session are denied for a different
-        # reason; use a plain non-session tool to isolate the floor.
+        # workspace-bound tools are denied for a different reason; use a
+        # plain (non-workspace) tool to isolate the floor.
         tool = _make_tool(toolset_id, "some_tool")
         ok, reason = is_exposable(tool, provider=_StubProvider())
         assert ok is True, f"{toolset_id} should be exposable, got {reason}"

--- a/tests/toolset/test_ask_user.py
+++ b/tests/toolset/test_ask_user.py
@@ -105,7 +105,7 @@ class TestAskUserHandler:
             )
         assert exc_info.value.yielded.resume_metadata["response_schema"] == schema
 
-    async def test_handler_requires_session_id_in_ctx(self, misc):
+    async def test_handler_requires_ctx_session_id(self, misc):
         # Without session_id we can't form a unique event_key — the
         # tool fails loudly so future scopes don't accidentally lose
         # uniqueness across sessions.

--- a/tests/toolset/test_describe.py
+++ b/tests/toolset/test_describe.py
@@ -72,7 +72,6 @@ def test_make_tool_flags_default_false():
         examples=[ToolExample(args={"name": "x"})],
     )
     assert tool.yields is False
-    assert tool.requires_session is False
 
 
 def test_make_tool_sets_explicit_flags():
@@ -84,10 +83,8 @@ def test_make_tool_sets_explicit_flags():
         args_schema=_Args.model_json_schema(),
         examples=[ToolExample(args={"name": "x"})],
         yields=True,
-        requires_session=True,
     )
     assert tool.yields is True
-    assert tool.requires_session is True
 
 
 def test_make_tool_flags_excluded_from_serialization():
@@ -101,11 +98,9 @@ def test_make_tool_flags_excluded_from_serialization():
         args_schema=_Args.model_json_schema(),
         examples=[ToolExample(args={"name": "x"})],
         yields=True,
-        requires_session=True,
     )
     dumped = tool.model_dump()
     assert "yields" not in dumped
-    assert "requires_session" not in dumped
 
 
 def test_make_tool_requires_workspace_defaults_false():

--- a/tests/toolset/test_internal_yielding_flags.py
+++ b/tests/toolset/test_internal_yielding_flags.py
@@ -1,10 +1,9 @@
-"""InternalToolsetProvider.is_yielding / requires_session contracts.
+"""InternalToolsetProvider.is_yielding / requires_workspace contracts.
 
-The MCP server endpoint (Spec §7) calls these two predicates to filter
+The MCP server endpoint (Spec §7) calls these predicates to filter
 its exposable tool set. The signals must hold for the canonical
 yielding tools (``sleep``, ``ask_user``, ``watch_files``,
-``subscribe_to_trigger``) and the session-bound workspace tool
-(``watch_files`` reads ``ctx.session_id``).
+``subscribe_to_trigger``).
 """
 
 from __future__ import annotations
@@ -31,14 +30,13 @@ def test_workspace_ext_yielding_tools_flagged() -> None:
 
 
 def test_system_ask_user_flagged() -> None:
-    """``ask_user`` moved to the system toolset; still yields + session-bound."""
+    """``ask_user`` moved to the system toolset; still yields."""
     from primer.toolset.system import build_system_toolset
 
     sp = _SystemSP()
     pr = _system_registry(sp)
     provider = build_system_toolset(storage_provider=sp, provider_registry=pr)
     assert provider.is_yielding("ask_user") is True
-    assert provider.requires_session("ask_user") is True
 
 
 def test_misc_non_yielding_tools_not_flagged() -> None:
@@ -51,13 +49,6 @@ def test_misc_non_yielding_tools_not_flagged() -> None:
     # sleep + ask_user no longer live in misc.
     assert provider.is_yielding("sleep") is False
     assert provider.is_yielding("ask_user") is False
-
-
-def test_misc_session_free_tools_not_flagged() -> None:
-    """Plain misc tools don't read ``ctx.session_id``."""
-    provider = build_misc_toolset()
-    for name in ("uuid_v4", "get_datetime", "hash", "calculate"):
-        assert provider.requires_session(name) is False
 
 
 def _system_registry(sp):
@@ -81,7 +72,6 @@ def _SystemSP():
 def test_unknown_name_defaults_false() -> None:
     provider = build_misc_toolset()
     assert provider.is_yielding("does_not_exist") is False
-    assert provider.requires_session("does_not_exist") is False
 
 
 async def _noop_handler(arguments):  # pragma: no cover - never dispatched here
@@ -89,14 +79,13 @@ async def _noop_handler(arguments):  # pragma: no cover - never dispatched here
 
 
 def test_classification_reads_explicit_flags_not_handler_source() -> None:
-    """The provider reads ``Tool.yields`` / ``Tool.requires_session``.
+    """The provider reads ``Tool.yields``.
 
-    The handler here is a plain no-op whose source contains neither
-    ``Yielded`` nor ``ctx.session_id`` - the OLD getsource/annotation
-    heuristics would classify it as non-yielding and session-free. With
-    the explicit flags set on the Tool, the provider must report it as
-    yielding + session-bound, proving classification comes from the
-    flags, not from introspecting the handler.
+    The handler here is a plain no-op whose source contains no
+    ``Yielded`` - the OLD getsource/annotation heuristic would classify
+    it as non-yielding. With the explicit flag set on the Tool, the
+    provider must report it as yielding, proving classification comes
+    from the flag, not from introspecting the handler.
     """
     flagged = Tool(
         id="flagged_tool",
@@ -104,7 +93,6 @@ def test_classification_reads_explicit_flags_not_handler_source() -> None:
         description="x",
         args_schema={"type": "object"},
         yields=True,
-        requires_session=True,
     )
     plain = Tool(
         id="plain_tool",
@@ -120,9 +108,7 @@ def test_classification_reads_explicit_flags_not_handler_source() -> None:
         },
     )
     assert provider.is_yielding("flagged_tool") is True
-    assert provider.requires_session("flagged_tool") is True
     assert provider.is_yielding("plain_tool") is False
-    assert provider.requires_session("plain_tool") is False
 
 
 def test_base_class_default_is_false() -> None:
@@ -139,7 +125,6 @@ def test_base_class_default_is_false() -> None:
 
     p = _Minimal()
     assert p.is_yielding("anything") is False
-    assert p.requires_session("anything") is False
     # New capability flag: default False on the ABC too.
     assert p.requires_workspace("anything") is False
 

--- a/tests/toolset/test_watch_files.py
+++ b/tests/toolset/test_watch_files.py
@@ -91,7 +91,7 @@ class TestWatchFilesHandler:
             )
         assert exc_info.value.yielded.resume_metadata["batch_window_ms"] == 1000
 
-    async def test_handler_requires_session_id(self, workspaces_toolset):
+    async def test_handler_requires_ctx_session_id(self, workspaces_toolset):
         ctx = ToolContext(
             tool_call_id="tc-x",
             session_id=None,

--- a/tests/toolset/test_workspace_ext.py
+++ b/tests/toolset/test_workspace_ext.py
@@ -71,16 +71,6 @@ def test_all_four_tools_yield():
         assert provider.is_yielding(name) is True, name
 
 
-def test_requires_session_flags_preserved():
-    provider = _provider()
-    # sleep does NOT require a session; the other three do (unchanged).
-    assert provider.requires_session("sleep") is False
-    assert provider.requires_session("watch_files") is True
-    assert provider.requires_session("invoke_graph") is True
-    assert provider.requires_session("subscribe_to_trigger") is True
-    assert provider.requires_session("subscribe_to_channel_event") is True
-
-
 @pytest.mark.asyncio
 async def test_scoped_ids_via_tool_manager():
     """Through the manager the tools surface as workspace_ext__<bare>."""


### PR DESCRIPTION
## What & why

Retires the `requires_session` per-tool capability flag, which is **functionally
dead**:

- Its only consumer was the MCP-exposure branch
  `if tool.toolset_id == "workspaces" and provider.requires_session(tool.id):
  return False, "needs_session"` in `mcp/safety.py` - but **no `workspaces`-toolset
  tool sets `requires_session=True`**, so that branch matched nothing.
- **Every** tool that set `requires_session=True` also set `yields=True`, and
  yielding tools are already denied MCP exposure by the earlier `is_yielding`
  check in the same function - so the flag was redundant everywhere it appeared.
- It never affected chat tool context.

`requires_workspace` (already on `main`) is the meaningful "needs a live
workspace -> suppressed in chat + hidden from MCP" capability; `requires_session`
added nothing on top of `yields` + `requires_workspace`.

## Change
Removes the flag end to end: the `Tool.requires_session` field, the `make_tool`
kwarg + the `workspaces._tool` factory param, the ABC method + the
`InternalToolsetProvider` override/cache, the dead `mcp/safety.py` branch (and its
`"needs_session"` reason), every `requires_session=True` call site
(`workspace_ext`, `system` ask_user/switch_to_agent, `trigger` subscribe_*), and
all test references (including the `needs_session` tests). Net -122 lines.

`is_exposable` ordering is preserved and correct: reserved-toolset ->
`yielding_unsupported` -> `needs_workspace` -> exposable. **Behavior unchanged** -
the removed flag did no functional work.

## Tests
`grep -rn "requires_session\|needs_session" primer/ tests/` returns ZERO. The
affected named tests pass (mcp safety, describe, internal flags, workspace_ext
suppression, ask_user, watch_files, dispatch rbac, web tools, read_doc, sso flow),
CPU-capped. No em-dash/arrow in added lines.

## Note
This supersedes #157, which was accidentally based on the
`feat/workspace-download-docling-tools` branch and therefore merged into that
(already-merged) branch instead of `main`. This PR is based directly on `main`
(which already has `requires_workspace`), so it delivers the retirement to `main`.

HELD -- do not merge without sign-off.
