### PR TITLE
fix(workspace): plumb caller-provided workspace_id through create

### DIFF
--- a/primer/api/registries/workspace_registry.py
+++ b/primer/api/registries/workspace_registry.py
@@ -168,8 +168,15 @@ class WorkspaceRegistry:
         *,
         template: WorkspaceTemplate,
         overrides: WorkspaceTemplateOverrides | None = None,
+        workspace_id: str | None = None,
     ) -> "Workspace":
-        """Create a new live workspace via the right backend."""
+        """Create a new live workspace via the right backend.
+
+        ``workspace_id`` pins the live instance to a caller-supplied id
+        (typically the same id the durable row is keyed by). Forwarding
+        it keeps the row id and the live instance id in sync so re-attach
+        via :meth:`get_workspace` works after the cache is evicted.
+        """
         backend = await self.get_backend(template.provider_id)
         resolvers = FileResolvers(
             document_resolver=make_document_resolver(self._sp),
@@ -180,7 +187,10 @@ class WorkspaceRegistry:
             ),
         )
         return await backend.create(
-            template, overrides=overrides, resolvers=resolvers
+            template,
+            overrides=overrides,
+            workspace_id=workspace_id,
+            resolvers=resolvers,
         )
 
     async def destroy(self, workspace_id: str) -> None:

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -551,7 +551,12 @@ async def create_workspace(
             )
         overrides = overrides.model_copy(update={"files": extra_files})
 
-    live = await registry.materialise(template=template, overrides=overrides)
+    # Pin the live instance to the caller-supplied id (same id the row is
+    # keyed by, below) so re-attach after cache eviction resolves the SAME
+    # backend object instead of 404ing.
+    live = await registry.materialise(
+        template=template, overrides=overrides, workspace_id=body.id
+    )
 
     # materialise() has now created a live container/volume, but the durable
     # WorkspaceRow is written LAST. Any failure in the mount work or the

--- a/primer/int/workspace.py
+++ b/primer/int/workspace.py
@@ -490,6 +490,7 @@ class WorkspaceBackend(ABC):
         template: WorkspaceTemplate,
         *,
         overrides: WorkspaceTemplateOverrides | None = None,
+        workspace_id: str | None = None,
         resolvers: "FileResolvers | None" = None,
     ) -> Workspace:
         """Materialise a new workspace from ``template``.
@@ -498,6 +499,14 @@ class WorkspaceBackend(ABC):
         vars, additional files, additional init commands). Override
         semantics are merge-then-extend (see
         :class:`primer.model.workspace.WorkspaceTemplateOverrides`).
+
+        ``workspace_id`` pins the id of the live instance. When ``None``
+        the backend generates one. When supplied the backend MUST
+        materialise the instance under exactly that id -- callers pass
+        it so the durable row id and the live instance id agree, which
+        is what makes re-attach (see :meth:`get`) work after the
+        in-memory cache is evicted, and gives backends predictable /
+        stable object names (e.g. K8s object names).
 
         ``resolvers`` supplies the document/secret resolver callables
         for ``document``- and ``secret``-sourced file mounts. ``None``

--- a/primer/toolset/workspaces.py
+++ b/primer/toolset/workspaces.py
@@ -979,7 +979,9 @@ def build_workspaces_toolset(
                 )
         try:
             live = await workspace_registry.materialise(
-                template=template, overrides=args.overrides
+                template=template,
+                overrides=args.overrides,
+                workspace_id=args.id,
             )
         except PrimerError as exc:
             return _err_from_primer(exc, error_type="backend-error")

--- a/primer/workspace/container/backend.py
+++ b/primer/workspace/container/backend.py
@@ -126,6 +126,7 @@ class ContainerWorkspaceBackend(BaseWorkspaceBackend):
         template: WorkspaceTemplate,
         *,
         overrides: WorkspaceTemplateOverrides | None = None,
+        workspace_id: str | None = None,
         resolvers: FileResolvers | None = None,
     ) -> Workspace:
         if not isinstance(template.backend, ContainerTemplateConfig):
@@ -142,7 +143,10 @@ class ContainerWorkspaceBackend(BaseWorkspaceBackend):
         if template.strict_write_locking:
             env_str = {**env_str, "PRIMER_STRICT_WRITE_LOCKING": "1"}
 
-        workspace_id = _generate_workspace_id()
+        # Pin the live instance to the caller-supplied id when given so the
+        # durable row id and the container name/id agree -- otherwise
+        # re-attach after cache eviction looks up the wrong id and 404s.
+        workspace_id = workspace_id or _generate_workspace_id()
         # ``workspace-<id>`` is also the docker container's hostname; the
         # bridge_network URL builder reaches the runtime via this exact
         # name. Keep the prefix shared between both reachability modes so

--- a/primer/workspace/local/backend.py
+++ b/primer/workspace/local/backend.py
@@ -91,6 +91,7 @@ class LocalWorkspaceBackend(BaseWorkspaceBackend):
         template: WorkspaceTemplate,
         *,
         overrides: WorkspaceTemplateOverrides | None = None,
+        workspace_id: str | None = None,
         resolvers: FileResolvers | None = None,
     ) -> Workspace:
         if not self._initialised:
@@ -103,7 +104,10 @@ class LocalWorkspaceBackend(BaseWorkspaceBackend):
         merged = self.merge_overrides(template, overrides)
         env_str = merged.env_unwrapped()
 
-        workspace_id = _generate_workspace_id()
+        # Pin the live instance to the caller-supplied id when given so the
+        # durable row id and the on-disk workspace dir agree -- otherwise
+        # re-attach after cache eviction looks up the wrong id and 404s.
+        workspace_id = workspace_id or _generate_workspace_id()
         ws_root = self._root / workspace_id
         await asyncio.to_thread(ws_root.mkdir, parents=True, exist_ok=False)
 

--- a/tests/api/test_workspace_files_studio.py
+++ b/tests/api/test_workspace_files_studio.py
@@ -232,9 +232,11 @@ class _FakeBackend:
             await ws.aclose()
         self._workspaces.clear()
 
-    async def create(self, template, *, overrides=None, resolvers=None):
+    async def create(
+        self, template, *, overrides=None, workspace_id=None, resolvers=None
+    ):
         self._counter += 1
-        wid = f"ws-{self._counter:04d}"
+        wid = workspace_id or f"ws-{self._counter:04d}"
         ws = _FakeWorkspace(wid)
         self._workspaces[wid] = ws
         return ws

--- a/tests/api/test_workspace_mounts.py
+++ b/tests/api/test_workspace_mounts.py
@@ -87,9 +87,11 @@ class _MountFakeWorkspace(_FakeWorkspace):
 
 
 class _MountFakeBackend(_FakeBackend):
-    async def create(self, template, *, overrides=None, resolvers=None):
+    async def create(
+        self, template, *, overrides=None, workspace_id=None, resolvers=None
+    ):
         self._counter += 1
-        wid = f"ws-{self._counter:04d}"
+        wid = workspace_id or f"ws-{self._counter:04d}"
         ws = _MountFakeWorkspace(wid)
         self._workspaces[wid] = ws
         return ws

--- a/tests/api/test_workspace_yields_pending.py
+++ b/tests/api/test_workspace_yields_pending.py
@@ -207,9 +207,11 @@ class _FakeBackend:
             await ws.aclose()
         self._workspaces.clear()
 
-    async def create(self, template, *, overrides=None, resolvers=None):
+    async def create(
+        self, template, *, overrides=None, workspace_id=None, resolvers=None
+    ):
         self._counter += 1
-        wid = f"ws-{self._counter:04d}"
+        wid = workspace_id or f"ws-{self._counter:04d}"
         ws = _FakeWorkspace(wid)
         self._workspaces[wid] = ws
         return ws

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -347,9 +347,11 @@ class _FakeBackend:
             await ws.aclose()
         self._workspaces.clear()
 
-    async def create(self, template, *, overrides=None, resolvers=None):
+    async def create(
+        self, template, *, overrides=None, workspace_id=None, resolvers=None
+    ):
         self._counter += 1
-        wid = f"ws-{self._counter:04d}"
+        wid = workspace_id or f"ws-{self._counter:04d}"
         ws = _FakeWorkspace(wid)
         self._workspaces[wid] = ws
         return ws

--- a/tests/toolset/test_workspaces.py
+++ b/tests/toolset/test_workspaces.py
@@ -243,8 +243,10 @@ class _StubBackend:
     async def aclose(self):
         return
 
-    async def create(self, template, *, overrides=None, resolvers=None):
-        ws = _LiveWorkspace("ws-stub")
+    async def create(
+        self, template, *, overrides=None, workspace_id=None, resolvers=None
+    ):
+        ws = _LiveWorkspace(workspace_id or "ws-stub")
         self._workspaces[ws.id] = ws
         return ws
 

--- a/tests/toolset/test_workspaces_session_attribution.py
+++ b/tests/toolset/test_workspaces_session_attribution.py
@@ -118,8 +118,10 @@ class _StubBackend:
     async def aclose(self):
         return
 
-    async def create(self, template, *, overrides=None, resolvers=None):
-        ws = _LiveWorkspace("ws-stub")
+    async def create(
+        self, template, *, overrides=None, workspace_id=None, resolvers=None
+    ):
+        ws = _LiveWorkspace(workspace_id or "ws-stub")
         self._workspaces[ws.id] = ws
         return ws
 

--- a/tests/workspace/test_registry_resolvers.py
+++ b/tests/workspace/test_registry_resolvers.py
@@ -13,7 +13,9 @@ class _RecordingBackend:
     def __init__(self):
         self.received_resolvers = None
 
-    async def create(self, template, *, overrides=None, resolvers=None):
+    async def create(
+        self, template, *, overrides=None, workspace_id=None, resolvers=None
+    ):
         self.received_resolvers = resolvers
         return "workspace-handle"
 

--- a/tests/workspace/test_workspace_id_passthrough.py
+++ b/tests/workspace/test_workspace_id_passthrough.py
@@ -1,0 +1,113 @@
+"""Regression tests for caller-pinned ``workspace_id`` passthrough.
+
+Creating a workspace with a caller-supplied id must pin the *live*
+instance to that id -- not just the persisted row. Before the fix the
+passthrough was dropped between the API/registry layer and the backend:
+``create`` materialised the instance under an auto-generated id while the
+row was stored under the caller id, so once the in-memory cache was
+evicted ``get(caller_id)`` re-attached to a *different* object (or None)
+and the API 404'd with "row exists but the backend has no live instance".
+
+These tests reproduce that gap end-to-end against the LOCAL backend
+(no container/k8s needed) plus the registry forwarding point.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from primer.api.registries.workspace_registry import WorkspaceRegistry
+from primer.model.workspace import ResourceLimits, WorkspaceTemplate
+from primer.workspace import LocalWorkspaceBackend
+
+
+# LocalWorkspace.materialise stands up a StateRepo, which shells out to git.
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git CLI not available on PATH (StateRepo needs it)",
+)
+
+
+def _template(provider_id: str = "local-1") -> WorkspaceTemplate:
+    return WorkspaceTemplate(
+        id="dev",
+        description="local dev template",
+        provider_id=provider_id,
+        files=[],
+        init_commands=[],
+        env={},
+        resources=ResourceLimits(),
+    )
+
+
+@pytest.fixture
+async def backend(tmp_path: Path) -> LocalWorkspaceBackend:
+    p = LocalWorkspaceBackend(tmp_path / "provider_root")
+    await p.initialize()
+    return p
+
+
+async def test_create_pins_live_instance_to_caller_id(
+    backend: LocalWorkspaceBackend,
+) -> None:
+    """A pinned ``workspace_id`` becomes the live workspace's id."""
+    ws = await backend.create(_template(), workspace_id="psx-financials")
+    assert ws.id == "psx-financials"
+
+
+async def test_pinned_id_reattaches_after_cache_eviction(
+    backend: LocalWorkspaceBackend,
+) -> None:
+    """After eviction, ``get(pinned_id)`` re-attaches to the SAME instance.
+
+    This is the exact production failure: the row is keyed by the caller
+    id, so re-attach looks the backend up by that id. If ``create`` had
+    materialised the instance under an auto-generated id instead, the
+    on-disk workspace directory would live elsewhere and re-attach would
+    return None.
+    """
+    tpl = _template()
+    ws = await backend.create(tpl, workspace_id="psx-financials")
+    assert ws.id == "psx-financials"
+
+    # Simulate the in-memory cache being evicted (process restart / LRU).
+    async with backend._lock:  # noqa: SLF001 -- deliberate white-box eviction
+        backend._workspaces.clear()
+
+    reattached = await backend.get("psx-financials", template=tpl)
+    assert reattached is not None
+    assert reattached.id == "psx-financials"
+
+
+class _RecordingBackend:
+    """Captures the kwargs the registry forwards to ``backend.create``."""
+
+    def __init__(self) -> None:
+        self.received_workspace_id: str | None = "<<unset>>"
+
+    async def create(
+        self, template, *, overrides=None, workspace_id=None, resolvers=None
+    ):
+        self.received_workspace_id = workspace_id
+        return "workspace-handle"
+
+
+async def test_registry_materialise_forwards_workspace_id(monkeypatch) -> None:
+    """``WorkspaceRegistry.materialise`` plumbs the pinned id to the backend."""
+    rec = _RecordingBackend()
+    reg = WorkspaceRegistry(storage_provider=object())
+
+    async def _fake_get_backend(provider_id):
+        return rec
+
+    monkeypatch.setattr(reg, "get_backend", _fake_get_backend)
+
+    class _Tpl:
+        provider_id = "prov1"
+
+    result = await reg.materialise(template=_Tpl(), workspace_id="psx-financials")
+    assert result == "workspace-handle"
+    assert rec.received_workspace_id == "psx-financials"


### PR DESCRIPTION
## Problem

Creating a workspace with a caller-provided `id` breaks re-attach once the in-memory workspace cache is evicted.

`create_workspace` (and the `create_workspace` tool) store the durable `WorkspaceRow` under the caller id (`row_id = body.id`) but materialise the **live** instance under an **auto-generated** id, because the `workspace_id` passthrough was only ever wired into the K8s backend. After cache eviction, `WorkspaceRegistry.get_workspace(id)` calls `backend.get(id)` keyed by the *row* id — which points at a different (or nonexistent) backend object — so it returns `None` and the API 404s:

> Workspace '<id>' row exists but the backend has no live instance and re-attach failed

Reproduced live: a k3s workspace created with `id: "psx-financials"` worked until cache eviction, then every session-create 404'd.

## Root cause

The `workspace_id` passthrough was dropped between the API/registry layer and the backends. `KubernetesWorkspaceBackend.create` already accepted `workspace_id`, but:

- The `WorkspaceBackend.create` ABC did not declare it.
- `LocalWorkspaceBackend.create` and `ContainerWorkspaceBackend.create` always called `_generate_workspace_id()`, ignoring any caller id (same bug, local + container).
- `WorkspaceRegistry.materialise` never forwarded an id, and neither the router nor the tool passed the caller id (`body.id` / `args.id`) they already had.

## Fix

Plumb the caller id end to end so the row id and the live instance id agree:

- `WorkspaceBackend.create` ABC: declare `workspace_id` (keyword-only) and document the pin-to-this-id contract.
- `LocalWorkspaceBackend` / `ContainerWorkspaceBackend.create`: accept the param and use `workspace_id or _generate_workspace_id()`. K8s already honoured it — left unchanged.
- `WorkspaceRegistry.materialise`: accept and forward `workspace_id`.
- `create_workspace` router and `_create_workspace` tool: pass `body.id` / `args.id` into `materialise`.

`k8s_object_name` is deterministic (safe id → `primer-ws-<id>`, else `primer-ws-<sha256[:16]>`), so no id validation/sanitisation is needed — the only requirement is that `create` and `get` use the same id.

## Test

Added `tests/workspace/test_workspace_id_passthrough.py` (local backend, no k8s needed):

1. A pinned `workspace_id` becomes the live workspace's id.
2. After simulated cache eviction, `backend.get(pinned_id)` re-attaches to the same instance (the exact production failure).
3. `WorkspaceRegistry.materialise` forwards the pinned id to `backend.create`.

All three fail before the fix (dropped passthrough) and pass after. In-memory test backends updated for the new ABC signature.

## Verification

- `uv run pytest tests/workspace tests/api/test_workspaces.py tests/api/test_workspace_create_mounts.py tests/api/test_workspace_mounts.py tests/api/test_workspace_files_studio.py tests/api/test_workspace_yields_pending.py tests/toolset/test_workspaces.py tests/toolset/test_workspaces_session_attribution.py -q` → **870 passed, 4 skipped, 1 xfailed**
- `uv run ruff check` on all touched files → **All checks passed**

🤖 Generated with [Claude Code](https://claude.com/claude-code)