### PR TITLE
fix(runtime): raise runtime WS max_msg_size for large read_file/read_doc_content

### DIFF
--- a/primer/workspace/runtime/runtime_client.py
+++ b/primer/workspace/runtime/runtime_client.py
@@ -96,6 +96,13 @@ def _parse_file_stat(raw: dict[str, Any]) -> FileStat:
 
 _STREAM_CLOSED = object()  # signals that the stream has ended normally
 
+# Workspace files (e.g. read_file / read_doc_content on large PDFs) are read
+# over the runtime WebSocket in a single message; aiohttp's 4 MiB default cap
+# drops the socket for larger docs. Allow generously-large runtime messages.
+# NOTE: keep this a bounded cap (never 0/unlimited) so a runaway message
+# cannot exhaust memory.
+_MAX_WS_MSG_SIZE = 256 * 1024 * 1024  # 256 MiB
+
 
 # ---------------------------------------------------------------------------
 # RuntimeClient
@@ -784,7 +791,9 @@ class RuntimeClient:
             self._session = aiohttp.ClientSession()
 
         headers = {"Authorization": f"Bearer {self._token}"}
-        self._ws = await self._session.ws_connect(self._url, headers=headers)
+        self._ws = await self._session.ws_connect(
+            self._url, headers=headers, max_msg_size=_MAX_WS_MSG_SIZE
+        )
 
         # Handshake
         hello = Request(

--- a/tests/workspace/test_runtime_client.py
+++ b/tests/workspace/test_runtime_client.py
@@ -19,7 +19,12 @@ import pytest
 from aiohttp import web
 
 from primer.workspace.runtime.protocol import ErrorCode, OpName, serialize
-from primer.workspace.runtime.runtime_client import ChangeEvent, RuntimeClient, RuntimeError
+from primer.workspace.runtime.runtime_client import (
+    _MAX_WS_MSG_SIZE,
+    ChangeEvent,
+    RuntimeClient,
+    RuntimeError,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -773,3 +778,74 @@ async def test_connect_wrong_token_raises(
     with pytest.raises(Exception):
         await client.connect()
     await client.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Test: large payloads survive the runtime WS (aiohttp 4 MiB default cap)
+# ---------------------------------------------------------------------------
+
+
+async def test_read_file_larger_than_4mib(
+    fake_runtime: tuple[_FakeRuntime, str],
+) -> None:
+    """A read_file over 4 MiB must survive the runtime WS.
+
+    Regression: the client opened the runtime WS without ``max_msg_size``, so
+    aiohttp's 4 MiB default incoming-message cap dropped the socket with
+    "Connection lost" for larger files (e.g. read_doc_content on 5-7 MB PDFs).
+    The base64-encoded envelope for 5 MiB of bytes is ~6.7 MiB, comfortably
+    over the old cap, so this fails without the ``_MAX_WS_MSG_SIZE`` fix.
+    """
+    runtime, url = fake_runtime
+    big = b"\x5a" * (5 * 1024 * 1024)  # 5 MiB — over aiohttp's 4 MiB default
+    runtime.files["/workspace/big.pdf"] = big
+
+    client = await _connected_client(url)
+    data = await client.read_file("/workspace/big.pdf")
+    assert data == big
+    await client.aclose()
+
+
+async def test_ws_connect_max_msg_size_receives_large_message() -> None:
+    """Narrow proof of the fix at the ``ws_connect`` layer.
+
+    A test server sends a single >4 MiB frame. Without ``max_msg_size`` the
+    aiohttp client's 4 MiB default aborts the receive (surfaced as an ERROR
+    message — the socket the RuntimeClient would treat as "Connection lost").
+    With ``max_msg_size=_MAX_WS_MSG_SIZE`` the same payload arrives intact.
+    """
+    payload = b"\x79" * (5 * 1024 * 1024)  # 5 MiB — over the 4 MiB default
+
+    async def handler(request: web.Request) -> web.WebSocketResponse:
+        ws = web.WebSocketResponse(max_msg_size=_MAX_WS_MSG_SIZE)
+        await ws.prepare(request)
+        await ws.send_bytes(payload)
+        # Hold the connection open until the client is done reading/closing.
+        await ws.receive()
+        return ws
+
+    app = web.Application()
+    app.router.add_get("/", handler)
+    runner = web.AppRunner(app)
+    await runner.setup()
+    site = web.TCPSite(runner, "127.0.0.1", 0)
+    await site.start()
+    host, port = runner.addresses[0]
+    url = f"ws://{host}:{port}/"
+
+    try:
+        async with aiohttp.ClientSession() as session:
+            # Default cap (no max_msg_size): the >4 MiB frame is rejected.
+            ws_default = await session.ws_connect(url)
+            msg = await ws_default.receive()
+            assert msg.type is aiohttp.WSMsgType.ERROR
+            await ws_default.close()
+
+            # Runtime client's cap: the same payload is received whole.
+            ws_big = await session.ws_connect(url, max_msg_size=_MAX_WS_MSG_SIZE)
+            msg_big = await ws_big.receive()
+            assert msg_big.type is aiohttp.WSMsgType.BINARY
+            assert msg_big.data == payload
+            await ws_big.close()
+    finally:
+        await runner.cleanup()


### PR DESCRIPTION
## Problem

`system__read_doc_content` (and any `read_file` of a large document) drops the workspace runtime WebSocket with **"Connection lost"** for files larger than ~4 MiB. Confirmed live: PSX financial-report PDFs of 5–7 MB fail, while a <4 MB PDF converts fine.

**Root cause.** In `primer/workspace/runtime/runtime_client.py`, `_do_connect()` opened the runtime WS with:

```python
self._ws = await self._session.ws_connect(self._url, headers=headers)
```

No `max_msg_size` is passed, so aiohttp applies its **default 4 MiB** incoming-message cap. `read_file()` reads the whole file over this WS in a single message (base64-encoded, so a 5 MiB file is a ~6.7 MiB frame). When the frame exceeds the cap, aiohttp aborts the receive and the client's `_on_disconnect()` → `_fail_all_pending(ErrorCode.EPROTOCOL, "Connection lost")` fires.

## Fix

Raise the incoming WS message-size limit on that `ws_connect` call via a new module-level constant:

```python
_MAX_WS_MSG_SIZE = 256 * 1024 * 1024  # 256 MiB
...
self._ws = await self._session.ws_connect(
    self._url, headers=headers, max_msg_size=_MAX_WS_MSG_SIZE
)
```

256 MiB comfortably covers real documents while staying **bounded** — deliberately not `0`/unlimited, so a runaway message can't exhaust memory. The change is minimal and localized to `runtime_client.py`.

## Tests

Added to `tests/workspace/test_runtime_client.py`:

- `test_read_file_larger_than_4mib` — full `RuntimeClient` roundtrip: a 5 MiB file is written to the in-process fake runtime and read back intact over the WS. Verified **failing-first** by temporarily reverting the fix — it reproduces the exact `ConnectionError: Connection lost` symptom.
- `test_ws_connect_max_msg_size_receives_large_message` — narrow proof at the `ws_connect` layer: a test server sends a >4 MiB frame; the default cap surfaces a `WSMsgType.ERROR` (documents the regression), while `max_msg_size=_MAX_WS_MSG_SIZE` receives the payload whole.

Results: `uv run pytest tests/workspace/test_runtime_client.py -q` → **24 passed**. `uv run ruff check` on both touched files → clean.

## Out of scope (follow-up)

The runtime **server** side (`runtime/primer_runtime/…`, a separately-built image) has the mirror limit for `write_file` of large files. That needs its own change plus an image rebuild and is intentionally **not** part of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)