### PR TITLE
fix(graph): don't reuse cached workspace-only tool manager for a non-workspace toolset

### DIFF
--- a/primer/graph/workspace_executor.py
+++ b/primer/graph/workspace_executor.py
@@ -394,7 +394,31 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
         from primer.agent.tool_manager import WORKSPACE_TOOLSET_ID, _SCOPE_SEPARATOR
         from primer.model.chat import ToolCallPart
 
+        # Determine the toolset this node needs from its scoped tool_id. A
+        # workspace-scoped id (``workspace__*``) or one with no resolvable
+        # toolset needs no extra provider; a non-workspace toolset id
+        # (``web__``, ``system__``, ...) needs THAT toolset's provider
+        # registered on the manager to dispatch.
+        needs_toolset: str | None = None
+        if self._toolset_resolver is not None and _SCOPE_SEPARATOR in node.tool_id:
+            candidate = node.tool_id.split(_SCOPE_SEPARATOR, 1)[0]
+            if candidate and candidate != WORKSPACE_TOOLSET_ID:
+                needs_toolset = candidate
+
         manager = self._tool_manager
+        # A cached / injected manager may be reused only if it already covers
+        # the toolset this node needs. The manager cached below is
+        # workspace-ONLY (no non-workspace providers); reusing it for a later
+        # node that names a different toolset would make that tool resolve to
+        # "unknown tool ...; not registered with any toolset or workspace".
+        # Rebuild whenever the needed toolset isn't already registered.
+        if (
+            manager is not None
+            and needs_toolset is not None
+            and needs_toolset not in manager.toolset_providers
+        ):
+            manager = None
+
         if manager is None:
             if self._workspace_session is None:
                 raise RuntimeError(
@@ -405,12 +429,10 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             # Resolve the toolset for a scoped, non-workspace tool_id so
             # internal-toolset tools are dispatchable from a tool_call node.
             toolset_providers: dict[str, Any] = {}
-            if self._toolset_resolver is not None and _SCOPE_SEPARATOR in node.tool_id:
-                toolset_id = node.tool_id.split(_SCOPE_SEPARATOR, 1)[0]
-                if toolset_id and toolset_id != WORKSPACE_TOOLSET_ID:
-                    toolset_providers[toolset_id] = await self._toolset_resolver(
-                        toolset_id
-                    )
+            if needs_toolset is not None:
+                toolset_providers[needs_toolset] = await self._toolset_resolver(
+                    needs_toolset
+                )
             manager = ToolExecutionManager.for_workspace(
                 toolset_providers=toolset_providers,
                 session=self._workspace_session,

--- a/tests/graph/test_workspace_executor.py
+++ b/tests/graph/test_workspace_executor.py
@@ -1255,7 +1255,106 @@ class TestTeeFanInAggregation:
         assert state["ended_reason"] == "completed"
 
 
+class _FakeWorkspaceTool:
+    """Structural :class:`WorkspaceTool` double exposing one workspace tool."""
+
+    id = "echo_ws"
+    description = "a fake workspace tool"
+    examples: list = []
+    requires_workspace_context = True
+
+    def __init__(self) -> None:
+        self.executed: list[Any] = []
+
+    def parameters(self):
+        from pydantic import BaseModel
+
+        class _Args(BaseModel):
+            x: int = 0
+
+        return _Args
+
+    async def execute(self, args, ctx):
+        self.executed.append((args, ctx))
+        from primer.workspace.tool import ToolResult
+
+        return ToolResult(output=f"ws({args.x})", metadata={}, truncated=False)
+
+
+class _WorkspaceSessionWithTools(_FakeWorkspaceSession):
+    """Fake session carrying a real workspace tool so a ``workspace__*``
+    tool_call dispatches cleanly through the lazily-built manager."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.workspace_tools = [_FakeWorkspaceTool()]
+
+
 class TestToolCallInternalToolset:
+    @pytest.mark.asyncio
+    async def test_workspace_toolcall_then_internal_toolset_resolves(
+        self, tmp_path: Path
+    ) -> None:
+        """Ordering regression: a non-workspace tool_call must resolve its
+        toolset even after an EARLIER workspace tool_call in the same run.
+
+        The executor lazily builds a workspace-ONLY ToolExecutionManager on
+        the first workspace-scoped tool_call and cached it in
+        ``self._tool_manager``. A later tool_call naming a non-workspace
+        toolset (``fake__echo``, ``system__...``) then reused that cached
+        workspace-only manager -- which carries no provider for that toolset
+        -- so dispatch failed with ``unknown tool ...; not registered with
+        any toolset or workspace`` (surfaced as ``tool_execution_failed``).
+        A non-workspace tool_call that runs FIRST worked, so the bug was
+        strictly ordering-dependent.
+        """
+        from primer.model.graph import _ToolCallNode
+
+        provider = _FakeToolsetProvider(tool_id="echo", output="echo-out")
+
+        async def toolset_resolver(toolset_id: str):
+            assert toolset_id == "fake"
+            return provider
+
+        async def agent_resolver(agent_id: str) -> Agent:
+            raise KeyError(agent_id)
+
+        async def llm_resolver(agent: Agent):
+            raise NotImplementedError
+
+        repo = await _make_state_repo(tmp_path)
+        # No ``tool_manager=`` -> lazy-build + cache path, mirroring
+        # production ``build_graph_executor`` (executor_builders.py).
+        executor = WorkspaceGraphExecutor(
+            graph=Graph(
+                id="g-order",
+                description="begin -> end (dispatch tested directly)",
+                nodes=[_BeginNode(id="b"), _EndNode(id="e")],
+                edges=[_StaticEdge(from_node="b", to_node="e")],
+            ),
+            agent_resolver=agent_resolver,
+            llm_resolver=llm_resolver,  # type: ignore[arg-type]
+            state_repo=repo,
+            graph_session_id="gsid-order",
+            workspace_session=_WorkspaceSessionWithTools(),  # type: ignore[arg-type]
+            toolset_resolver=toolset_resolver,
+        )
+
+        # 1) WORKSPACE tool_call FIRST -> builds + caches a workspace-only
+        #    manager in ``self._tool_manager``.
+        ws_node = _ToolCallNode(id="w", tool_id="workspace__echo_ws", arguments={})
+        ws_result = await executor._dispatch_toolcall(ws_node, {"x": 3})
+        assert ws_result.output == "ws(3)"
+
+        # 2) NON-workspace tool_call SECOND -> must NOT reuse the cached
+        #    workspace-only manager; it must resolve the ``fake`` toolset and
+        #    dispatch, not raise "unknown tool ...".
+        sys_node = _ToolCallNode(id="t", tool_id="fake__echo", arguments={})
+        sys_result = await executor._dispatch_toolcall(sys_node, {"x": 1})
+
+        assert sys_result.output == "echo-out"
+        assert provider.calls and provider.calls[0]["tool_name"] == "echo"
+
     @pytest.mark.asyncio
     async def test_toolcall_resolves_internal_toolset(self, tmp_path: Path) -> None:
         """A tool_call node naming an internal-toolset tool (e.g.


### PR DESCRIPTION
## Summary

In a graph run inside a workspace session, a `tool_call` node whose `tool_id` names a **non-workspace** toolset (`system__read_doc_content`, `system__call_tool`, `web__web_search`, …) failed with:

```
tool_execution_failed: "unknown tool '<tool_id>'; not registered with any toolset or workspace"
```

…but **only when an earlier node in the same run was a workspace tool_call** (`workspace__exec`, `workspace__write`, …). If the non-workspace tool_call was the first tool_call in the run, it worked. Reproduced live: `... -> workspace__exec(download) -> ... -> system__read_doc_content(convert)` 404s, while an isolated `begin -> system__read_doc_content -> end` succeeds.

## Root cause

`WorkspaceGraphExecutor._dispatch_toolcall` (in `primer/graph/workspace_executor.py`) lazily builds a `ToolExecutionManager` on the first tool_call when none was injected (the production `build_graph_executor` path passes no `tool_manager`). For a workspace-scoped `tool_id` it builds a **workspace-only** manager (`toolset_providers={}`) and **caches** it in `self._tool_manager`.

A later node then did `manager = self._tool_manager` (now non-`None`) and **reused** the cached workspace-only manager. That manager carries no provider for the needed non-workspace toolset, so `ToolExecutionManager` couldn't resolve the tool and raised `unknown tool …; not registered with any toolset or workspace`. The `if manager is None` build path — which would have resolved the needed toolset via `toolset_resolver` — was skipped.

## Fix

Compute the node's needed toolset from its scoped `tool_id` **up front**, then reuse a cached/injected manager only when it already covers that toolset:

- A workspace-scoped `tool_id` (or one with no resolvable toolset) needs no extra provider → reuse/cache the shared workspace-only manager as before.
- A non-workspace toolset id whose provider is **not** already registered on the current manager → rebuild a manager that includes that toolset's provider (resolved via `toolset_resolver`), and do **not** cache the per-toolset manager (matching the existing "must not leak" invariant).

The membership check (`needs_toolset not in manager.toolset_providers`) also preserves an injected manager that already covers the toolset, so the worker-injected `self._tool_manager` path is not regressed.

## Test

Added `TestToolCallInternalToolset::test_workspace_toolcall_then_internal_toolset_resolves` in `tests/graph/test_workspace_executor.py`. It drives the executor through a **workspace** tool_call (`workspace__echo_ws`) first, then a **non-workspace** tool_call (`fake__echo`), and asserts the second resolves/dispatches instead of raising "unknown tool". Confirmed it **fails before** the fix (`UnsupportedContentError: unknown tool 'fake__echo'`) and **passes after**. Reuses the existing `_FakeWorkspaceSession` / `_FakeToolsetProvider` fixtures plus a minimal fake workspace tool.

## Verification

- `uv run pytest tests/graph -q` → **351 passed**
- `uv run ruff check primer/graph/workspace_executor.py tests/graph/test_workspace_executor.py` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)