### PR TITLE
fix(docker): add docling runtime system libs (libgl1, libglib2.0-0, libxcb1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -45,6 +45,7 @@ ENV PYTHONUNBUFFERED=1 \
 # Add `build-essential` here if a future dep requires compilation.
 RUN apt-get update \
     && apt-get install -y --no-install-recommends curl ca-certificates git libatomic1 \
+       libgl1 libglib2.0-0 libxcb1 \
     && rm -rf /var/lib/apt/lists/*
 
 # Install uv (standalone binary, ~25 MB) directly to /usr/local/bin so


### PR DESCRIPTION
The primer image (`python:3.12-slim`) installed only `curl ca-certificates git libatomic1`, missing docling's native runtime system libraries. As a result `system__read_doc_content` failed on **every** document with:

```
DoclingLoader: failed to parse bytes source: libxcb.so.1: cannot open shared object file: No such file or directory
```

## Fix
Add docling / opencv / rapidocr runtime libs to the apt-get layer: `libgl1 libglib2.0-0 libxcb1`.

## Verification
In a running worker pod, after installing exactly these three libs, docling parses a real PDF end to end:
```python
from docling.document_converter import DocumentConverter
DocumentConverter().convert(pdf).document.export_to_markdown()  # -> 687 KB of markdown, no shared-object errors
```
(no test file — this is a container-dependency change; the build + the in-pod docling run are the verification).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
