### PR TITLE
feat(ui): combined llm-model-picker widget for harness registration

### DIFF
--- a/tests/ui/test_harness_llm_model_picker.py
+++ b/tests/ui/test_harness_llm_model_picker.py
@@ -1,0 +1,47 @@
+"""Static + transpile checks for the combined LLM provider+model picker widget
+used by the harness registration form (HarnessRegisterDialog)."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+HARNESS_FORM = UI / "components" / "harness_form.jsx"
+
+
+def _src() -> str:
+    return HARNESS_FORM.read_text(encoding="utf-8")
+
+
+def test_llm_model_picker_widget_registered() -> None:
+    src = _src()
+    # The recursive JSON-schema form renders the new combined widget.
+    assert '"llm-model-picker"' in src or "'llm-model-picker'" in src
+    assert "HF_LlmModelPicker" in src
+
+
+def test_llm_model_picker_populates_models_from_provider() -> None:
+    src = _src()
+    # Fetches providers (whose rows carry their model lists) and derives the
+    # model options from the selected provider id.
+    assert "/v1/llm_providers" in src
+    assert ".models" in src
+    # The value is the combined { provider_id, model_name } object.
+    assert "provider_id" in src and "model_name" in src
+
+
+def test_llm_model_picker_defaults_to_first_model_on_provider_select() -> None:
+    src = _src()
+    # Selecting a provider defaults model_name to that provider's first model.
+    assert "ms[0]" in src
+
+
+def test_harness_form_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(
+        ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text()
+    )
+    code = b._transform(_src(), "components/harness_form.jsx")
+    assert code and "HF_LlmModelPicker" in code

--- a/ui/components/harness_form.jsx
+++ b/ui/components/harness_form.jsx
@@ -37,6 +37,82 @@ function HF_ProviderPicker({ endpoint, value, onChange, label }) {
 }
 
 // ============================================================================
+// Custom widget: combined LLM provider + model picker
+// ============================================================================
+//
+// value is an object { provider_id, model_name }. Picking a provider populates
+// the model dropdown from that provider's own model list (already carried on
+// each /v1/llm_providers row) and defaults to its first model, so the operator
+// never types a model name.
+
+function HF_LlmModelPicker({ value, onChange, label }) {
+  const { useResource, apiFetch } = window.primerApi;
+  const res = useResource(
+    "hf-llm-model-picker:/v1/llm_providers",
+    (signal) => apiFetch("GET", "/v1/llm_providers?limit=200", null, { signal }),
+    { pollMs: null }
+  );
+  const providers = res.data?.items ?? [];
+  const v = value && typeof value === "object" && !Array.isArray(value) ? value : {};
+  const providerId = v.provider_id ?? "";
+  const modelName = v.model_name ?? "";
+
+  const modelsFor = (pid) =>
+    (providers.find((p) => p.id === pid)?.models || []).map((m) => m.name);
+  const models = modelsFor(providerId);
+
+  const onProvider = (pid) => {
+    if (!pid) {
+      onChange(null);
+      return;
+    }
+    const ms = modelsFor(pid);
+    // Default to the provider's first model the moment it is selected.
+    onChange({ provider_id: pid, model_name: ms.length ? ms[0] : "" });
+  };
+
+  // Keep a saved model that is no longer in the provider's list visible so it
+  // is not silently dropped when editing an existing binding.
+  const modelOptions =
+    modelName && !models.includes(modelName) ? [modelName, ...models] : models;
+
+  return (
+    <div style={{ display: "flex", gap: 8, flexWrap: "wrap" }}>
+      <select
+        className="select"
+        style={{ flex: "1 1 180px", minWidth: 0 }}
+        value={providerId}
+        onChange={(e) => onProvider(e.target.value)}
+      >
+        <option value="">Select {label}</option>
+        {providers.map((p) => (
+          <option key={p.id} value={p.id}>{p.id}</option>
+        ))}
+      </select>
+      <select
+        className="select"
+        style={{ flex: "1 1 180px", minWidth: 0 }}
+        value={modelName}
+        disabled={!providerId}
+        onChange={(e) =>
+          onChange({ provider_id: providerId, model_name: e.target.value })
+        }
+      >
+        {modelOptions.length === 0 ? (
+          <option value="">
+            {providerId ? "No models on this provider" : "Select a provider first"}
+          </option>
+        ) : (
+          modelOptions.map((m) => (
+            <option key={m} value={m}>{m}</option>
+          ))
+        )}
+      </select>
+    </div>
+  );
+}
+
+// ============================================================================
 // HF_DepCard — collapsible card for one entry in a `dependencies` block
 // ============================================================================
 
@@ -143,6 +219,17 @@ function JsonSchemaForm({ schema, value, onChange, errors, _path }) {
       <div className="field">
         {schema.title && <label className="field-label">{schema.title}</label>}
         <HF_ProviderPicker endpoint="/v1/ssp" value={value} onChange={onChange} label={schema.title || "SSP"} />
+        {err && <div className="field-help" style={{ color: "var(--red)" }}>{err.message}</div>}
+        {schema.description && <div className="field-help">{schema.description}</div>}
+      </div>
+    );
+  }
+  if (widget === "llm-model-picker") {
+    const err = (errors || []).find((e) => e.path === path);
+    return renderInner(
+      <div className="field">
+        {schema.title && <label className="field-label">{schema.title}</label>}
+        <HF_LlmModelPicker value={value} onChange={onChange} label={schema.title || "LLM provider"} />
         {err && <div className="field-help" style={{ color: "var(--red)" }}>{err.message}</div>}
         {schema.description && <div className="field-help">{schema.description}</div>}
       </div>


### PR DESCRIPTION
## What & why

Registering a harness made the operator **type the model name** in a free-text
box next to the provider picker (which was already a dropdown) - tedious and
error-prone.

This adds a combined **`llm-model-picker`** JSON-schema widget to the harness
registration form: it renders the provider and model as **two linked dropdowns**.
Selecting a provider populates the model dropdown from that provider's own model
list (already carried on each `/v1/llm_providers` row - the same source the
aggregated-model editor uses) and **defaults to the provider's first model**, so
no typing. The value is `{ provider_id, model_name }`.

- New `HF_LlmModelPicker` component + a `widget === "llm-model-picker"` branch in
  `JsonSchemaForm` (`ui/components/harness_form.jsx`), sitting alongside the
  existing `llm-provider-picker` / `embedding-provider-picker` / etc.
- Provider change resets the model to the new provider's first; a saved model no
  longer in the list stays visible so it is not silently dropped.

## How a harness uses it
In the harness's overrides schema, declare one object field with the widget:

```json
{
  "type": "object",
  "properties": {
    "llm": {
      "type": "object",
      "title": "LLM",
      "x-primer-widget": "llm-model-picker"
    }
  }
}
```

At register time the operator gets the two linked dropdowns; the resulting
override value is `{ "provider_id": "...", "model_name": "..." }`, which the
harness template references as `overrides.llm.provider_id` /
`overrides.llm.model_name` (replacing the previous separate provider-picker +
free-text model fields).

## Not in this PR (follow-up)
The **outbound harness builder** UI does not yet offer `llm-model-picker` as a
widget choice, because it maps one source leaf to one override, whereas this
widget binds two (provider + model) into one object. Emitting it from the builder
needs a compound-mapping option - a separate change. For now the widget is
consumed by any harness whose overrides schema declares it (hand-added to the
manifest).

## Tests
`tests/ui/test_harness_llm_model_picker.py` (source assertions + JSXBundler
transpile) + the existing harness-form tests - 9 passed. No em-dash/arrow in
added lines.

HELD -- do not merge without sign-off.
