### PR TITLE
feat(studio): render HTML files in a sandboxed iframe

### DIFF
--- a/tests/ui/test_studio_center.py
+++ b/tests/ui/test_studio_center.py
@@ -241,6 +241,44 @@ def test_file_panel_preview_branches() -> None:
     assert "<img" in src
 
 
+def test_html_files_render_in_an_iframe() -> None:
+    """.html previews as a live document (srcDoc), not as highlighted source."""
+    src = _center_src()
+    assert "ST_HTML_EXTS" in src
+    assert "<iframe" in src
+    assert "srcDoc={content" in src
+
+
+def test_html_class_takes_precedence_over_code() -> None:
+    """`.html` is in both ST_HTML_EXTS and ST_CODE_LANGS - html must be checked first,
+    otherwise the iframe branch is dead code and .html renders as source."""
+    src = _center_src()
+    body = src[src.index("function ST_fileClassOf("):]
+    body = body[: body.index("\n}")]
+    assert body.index("ST_HTML_EXTS") < body.index("ST_CODE_LANGS"), (
+        "ST_fileClassOf must test ST_HTML_EXTS before ST_CODE_LANGS"
+    )
+
+
+def test_html_iframe_sandbox_withholds_same_origin() -> None:
+    """Workspace HTML must not script against Studio's origin.
+
+    `allow-scripts` + `allow-same-origin` together defeat the sandbox: the framed
+    file could read Studio's cookies/tokens and DOM. Any file in any workspace can
+    be opened this way, so this combination must never appear.
+    """
+    src = _center_src()
+    start = src.index('data-testid="file-preview-html"')
+    frame = src[start : src.index("/>", start)]
+    assert 'sandbox="' in frame, "the html iframe must be sandboxed"
+    sandbox = frame[frame.index('sandbox="') + len('sandbox="') :]
+    sandbox = sandbox[: sandbox.index('"')]
+    assert "allow-scripts" in sandbox, "scripts are the point - a report runs JS on load"
+    assert "allow-same-origin" not in sandbox, (
+        "allow-same-origin + allow-scripts lets workspace HTML script Studio's own origin"
+    )
+
+
 def test_file_panel_dirty_via_patch() -> None:
     src = _center_src()
     # Dirty state mirrors into openTabs via the patch() escape hatch.
@@ -266,6 +304,7 @@ def test_center_testids() -> None:
         'data-testid="file-mode-edit"',
         'data-testid="file-save"',
         'data-testid="file-editor"',
+        'data-testid="file-preview-html"',
         'data-testid="file-conflict-banner"',
     ]
     for tid in required:

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -38,12 +38,16 @@ function ST_basename(path) {
 }
 
 // ---------------------------------------------------------------------------
-// ST_fileClassOf — coarse render-class for a path: "markdown"|"image"|"code"|"text".
-// Drives the preview branch + whether syntax highlighting applies.
+// ST_fileClassOf — coarse render-class for a path:
+//   "markdown"|"image"|"html"|"code"|"text".
+// Drives the preview branch + whether syntax highlighting applies. "html" wins
+// over "code" (both claim the .html extension) so an HTML document renders as a
+// document; its source stays one click away behind the Edit toggle.
 // ---------------------------------------------------------------------------
 
 var ST_IMAGE_EXTS = { png: 1, jpg: 1, jpeg: 1, gif: 1, svg: 1, webp: 1, bmp: 1, ico: 1, avif: 1 };
 var ST_MD_EXTS = { md: 1, markdown: 1, mdx: 1 };
+var ST_HTML_EXTS = { html: 1, htm: 1 };
 var ST_CODE_LANGS = {
   py: "python", pyi: "python",
   js: "javascript", jsx: "javascript", ts: "javascript", tsx: "javascript",
@@ -63,6 +67,7 @@ function ST_fileClassOf(path) {
   var ext = ST_extOf(path);
   if (ST_MD_EXTS[ext]) return "markdown";
   if (ST_IMAGE_EXTS[ext]) return "image";
+  if (ST_HTML_EXTS[ext]) return "html";   // before "code": .html is in both tables
   if (ST_CODE_LANGS[ext]) return "code";
   return "text";
 }
@@ -1180,11 +1185,33 @@ function ST_SessionPanel({ wid, sid, pushToast }) {
 // ---------------------------------------------------------------------------
 // ST_FilePreview — render the held content per file class.
 //   markdown → renderMarkdown; code → highlighted line-numbered <pre>;
-//   image → <img> via files/download; else plain text.
+//   image → <img> via files/download; html → sandboxed <iframe>;
+//   else plain text.
 // ---------------------------------------------------------------------------
 
 function ST_FilePreview({ wid, path, content }) {
   var cls = ST_fileClassOf(path);
+
+  // HTML renders as a live document. `srcdoc` feeds it the content already held
+  // by FilePanel (no second fetch, and no auth to thread through an iframe src).
+  //
+  // The sandbox deliberately omits `allow-same-origin`: with it, a workspace file
+  // would run scripts on Studio's OWN origin and could read its cookies, tokens,
+  // and DOM. Without it the frame gets an opaque origin, so it can still fetch
+  // cross-origin services that allow "*" (this is how a report can query the
+  // trail MCP on load) but cannot reach back into Studio.
+  if (cls === "html") {
+    return (
+      <iframe
+        data-testid="file-preview-html"
+        title={ST_basename(path)}
+        srcDoc={content || ""}
+        sandbox="allow-scripts allow-popups"
+        referrerPolicy="no-referrer"
+        style={{ width: "100%", height: "100%", minHeight: 420, border: 0, background: "#fff" }}
+      />
+    );
+  }
 
   if (cls === "image") {
     var src = "/v1/workspaces/" + encodeURIComponent(wid) + "/files/download?path=" + encodeURIComponent(path);


### PR DESCRIPTION
## What

Clicking an `.html` file in Studio rendered highlighted source. It now previews as a live document in a sandboxed `<iframe>`, so a workspace can hold a real report — one that fetches its own data on load — rather than a page you can only read the markup of.

- `ST_fileClassOf` gains an `"html"` class, checked **before** `ST_CODE_LANGS`. `.html` appears in both tables, and the wrong order makes the iframe branch dead code (there's a test pinning the ordering).
- The preview feeds the iframe via `srcDoc` from the content `FilePanel` has already fetched — no second request, and no auth to thread through an iframe `src`.
- Source stays one click away behind the existing **Edit** toggle.

## Sandbox policy

The sandbox is `allow-scripts allow-popups` and deliberately **withholds `allow-same-origin`**.

Paired with `allow-scripts`, `allow-same-origin` defeats the sandbox: any HTML file in any workspace could run scripts on Studio's own origin and read its cookies, tokens, and DOM. Withholding it also gives the frame an opaque origin, which is what lets a report still call cross-origin services that allow `*`. `test_html_iframe_sandbox_withholds_same_origin` pins that combination shut.

## Testing

- `tests/ui/test_studio_center.py` — 4 new tests: the iframe branch, the html-before-code ordering, the sandbox policy, and the `file-preview-html` testid.
- `uv run pytest tests/ui` → **1155 passed, 1 skipped**, including the bundle-transpile gate.
- Rendered `ST_FilePreview` through real React in headless Chromium: emits `srcdoc`, `sandbox="allow-scripts allow-popups"`, `referrerpolicy="no-referrer"`.
- Verified an opaque-origin sandboxed iframe can still reach a cross-origin service that allows `*`: HTTP 200 with a response header readable through `expose_headers`.

