### PR TITLE
feat(ui): turn the graph builder on and migrate the e2e journeys to it

### DIFF
--- a/tests/ui/test_graph_builder_wiring.py
+++ b/tests/ui/test_graph_builder_wiring.py
@@ -6,6 +6,7 @@ from GraphDetail behind the graphBuilderV2 tweak (ui/graph-builder/WIRING.md
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
@@ -83,6 +84,25 @@ def test_graph_detail_renders_the_new_builder_behind_the_tweak() -> None:
     assert "<GR_GraphEditor" in src
     tweaks = (UI / "foundation" / "tweaks.js").read_text(encoding="utf-8")
     assert "graphBuilderV2: true" in tweaks
+
+
+def test_dispatch_never_hands_the_reducer_a_function() -> None:
+    # useReducer's dispatch takes an ACTION; only useState takes an updater
+    # function. Passing `rawDispatch((prev) => ...)` hands GB_reducer a
+    # function whose `.type` is undefined, so EVERY edit falls through to the
+    # reducer's default branch and silently does nothing - the builder renders
+    # but is completely inert. That shipped once and only the Playwright
+    # journeys caught it, because the reducer's own unit tests call
+    # GB_reducer directly and never exercise how the component wires it.
+    src = (GB / "graph-builder.jsx").read_text(encoding="utf-8")
+    bad = re.findall(r"rawDispatch\(\s*(?:function\b|\()", src)
+    # `rawDispatch({ ... })` is fine; `rawDispatch((` or `rawDispatch(function`
+    # is the updater-function shape that silently no-ops.
+    assert not bad, (
+        f"rawDispatch is called with a function ({len(bad)}x). useReducer "
+        "dispatch takes a plain action object."
+    )
+    assert "rawDispatch({ type:" in src, "expected plain action dispatches"
 
 
 def test_builder_keeps_the_editing_controls_the_e2e_journeys_pin() -> None:

--- a/tests/ui/test_graph_builder_wiring.py
+++ b/tests/ui/test_graph_builder_wiring.py
@@ -78,11 +78,25 @@ def test_graph_detail_renders_the_new_builder_behind_the_tweak() -> None:
     src = GRAPHS.read_text(encoding="utf-8")
     assert "window.GB_Builder" in src, "GraphDetail must render the new builder"
     assert "graphBuilderV2" in src, "the swap must be behind the tweak"
-    # The old editor stays reachable, and is still the default until the
-    # ui_e2e journeys are migrated to the new surface.
+    # The revamp is the default; the old editor stays reachable behind the
+    # tweak so a regression is a flag flip rather than a revert.
     assert "<GR_GraphEditor" in src
     tweaks = (UI / "foundation" / "tweaks.js").read_text(encoding="utf-8")
-    assert "graphBuilderV2:" in tweaks, "the revamp must be behind a named tweak"
+    assert "graphBuilderV2: true" in tweaks
+
+
+def test_builder_keeps_the_editing_controls_the_e2e_journeys_pin() -> None:
+    # Discard (revert staged edits) and Tidy up (auto-layout) are contracts the
+    # ui_e2e journeys assert (U0088 / U0089). They are addressed by testid, so
+    # the labels can change but these hooks cannot silently disappear.
+    src = (GB / "graph-builder.jsx").read_text(encoding="utf-8")
+    for testid in ('data-testid="gb-save"', 'data-testid="gb-discard"',
+                   'data-testid="gb-tidy"', 'data-testid="gb-dirty"'):
+        assert testid in src, f"{testid} is missing - a ui_e2e journey drives it"
+    # Discard must actually reset the draft to the loaded seed AND clear undo,
+    # otherwise the reverted work could be restored with Cmd-Z.
+    assert 'rawDispatch({ type: "SET_DRAFT", draft: seed })' in src
+    assert "undoRef.current = []" in src
 
 
 def test_canvas_labels_lead_with_the_human_name() -> None:

--- a/tests/ui_e2e/_graph_builder_helpers.py
+++ b/tests/ui_e2e/_graph_builder_helpers.py
@@ -1,0 +1,72 @@
+"""Shared gestures for driving the revamped graph builder (GB_Builder).
+
+The builder replaced the previous editor's toolbar ("Add node" -> a kind
+dropdown, a side panel keyed on node id) with a purpose-first palette and an
+inspector keyed on the human label, so the journeys that pinned the old
+gestures drive these helpers instead. The *contracts* they pin are unchanged:
+Save reflects a real diff, Discard reverts, layout-only changes never dirty.
+
+Testids come from ui/graph-builder/WIRING.md §14.
+"""
+
+from __future__ import annotations
+
+from playwright.sync_api import Page, expect
+
+# The builder is behind the `graphBuilderV2` tweak (default on).
+BUILDER = '[data-testid="gb-builder"]'
+SAVE = '[data-testid="gb-save"]'
+DISCARD = '[data-testid="gb-discard"]'
+TIDY = '[data-testid="gb-tidy"]'
+CANVAS = '[data-testid="graph-canvas"]'
+OUTLINE = '[data-testid="gb-outline"]'
+OUTLINE_ADD = '[data-testid="gb-outline-add"]'
+PALETTE = '[data-testid="gb-palette"]'
+INSPECTOR = '[data-testid="gb-inspector"]'
+DIRTY = '[data-testid="gb-dirty"]'
+
+
+def wait_for_builder(page: Page, timeout: int = 20_000):
+    """Wait for the builder shell to mount and return its locator."""
+    builder = page.locator(BUILDER)
+    builder.wait_for(state="visible", timeout=timeout)
+    return builder
+
+
+def save_button(page: Page):
+    """The Save control ('Save draft'), addressed by testid not label."""
+    return page.locator(SAVE).first
+
+
+def discard_button(page: Page):
+    return page.locator(DISCARD).first
+
+
+def add_finish_step(page: Page, timeout: int = 10_000) -> None:
+    """Add a Finish (End) step through the purpose-first palette.
+
+    The closest equivalent of the old "Add node -> Terminal" gesture: the
+    `end` purpose is the one that needs no follow-up reference, so it creates
+    the node immediately and stages a real structural change.
+    """
+    page.locator(OUTLINE_ADD).first.click()
+    palette = page.locator(PALETTE)
+    palette.wait_for(state="visible", timeout=timeout)
+    palette.locator('[data-testid="gb-palette-row"][data-purpose="end"]').first.click()
+    palette.wait_for(state="hidden", timeout=timeout)
+
+
+def expect_clean(page: Page, timeout: int = 10_000) -> None:
+    """No staged edits: Save disabled and the dirty dot absent."""
+    expect(save_button(page)).to_be_disabled(timeout=timeout)
+    expect(page.locator(DIRTY)).to_have_count(0, timeout=timeout)
+
+
+def expect_dirty(page: Page, timeout: int = 10_000) -> None:
+    """Staged edits present: Save enabled and the dirty dot shown."""
+    expect(save_button(page)).to_be_enabled(timeout=timeout)
+    expect(page.locator(DIRTY).first).to_be_visible(timeout=timeout)
+
+
+def outline_row_count(page: Page) -> int:
+    return page.locator('[data-testid="gb-outline-row"]').count()

--- a/tests/ui_e2e/test_graph_and_cross_page.py
+++ b/tests/ui_e2e/test_graph_and_cross_page.py
@@ -17,6 +17,7 @@ import time
 import httpx
 
 from tests.ui_e2e._studio_helpers import open_session_in_studio
+from tests.ui_e2e import _graph_builder_helpers as gb
 
 
 from tests._support.smk import smk  # noqa: E402
@@ -136,33 +137,25 @@ def test_u0029_graph_save_disabled_until_node_added(
             graph_id, exact=False,
         ).first.wait_for(state="visible", timeout=10_000)
 
-        # Wait for the editor toolbar to render (Save lives there).
-        save_btn = page.get_by_role("button", name="Save", exact=True).first
+        gb.wait_for_builder(page)
+        save_btn = gb.save_button(page)
         save_btn.wait_for(state="visible", timeout=10_000)
 
         # Initial state: Save is disabled (graph loaded but unchanged).
         assert save_btn.is_disabled(), (
-            "Save button should start disabled on a freshly-loaded "
-            "graph (diffCount === 0) - possible regression in "
-            "GraphEditor diff detection"
+            "Save should start disabled on a freshly-loaded graph "
+            "(no diff) - possible regression in builder diff detection"
         )
 
-        # Add a node - click "Add node" then "Tool call" in the dropdown.
-        # Tool call needs no agent picker and, added unconnected, yields
-        # only a SOFT "no incoming edges" warning (not a hard topology
-        # violation), so the diff dirties AND Save un-gates. (A second
-        # End node would instead trip the hard "End not reachable from
-        # Begin" rule, which legitimately keeps Save disabled.) Scope to
-        # the dropdown item so we don't click a node drawn on the canvas.
-        page.get_by_role(
-            "button", name="Add node", exact=True,
-        ).first.click()
-        tool_item = page.locator(".dd-item", has_text="Tool call").first
-        tool_item.wait_for(state="visible", timeout=5_000)
-        tool_item.click()
+        # Stage a structural change through the purpose-first palette.
+        # An unconnected Finish step is deliberately fine here: the builder
+        # splits validation into persist-time (blocks Save) and runnability
+        # (blocks Run only), and "End not reachable from Begin" is the
+        # latter - so a draft with one stays saveable.
+        gb.add_finish_step(page)
 
-        # Save must now be enabled (diffCount > 0). Allow a brief
-        # window for React to re-render.
+        # Save must now be enabled. Allow a brief window for React to
+        # re-render.
         deadline = time.monotonic() + 5.0
         enabled = False
         while time.monotonic() < deadline:
@@ -171,15 +164,12 @@ def test_u0029_graph_save_disabled_until_node_added(
                 break
             page.wait_for_timeout(100)
         assert enabled, (
-            "Save button did not become enabled after Add node → "
-            "Tool call; diffCount did not register the structural "
-            "change"
+            "Save did not become enabled after adding a step; the diff "
+            "did not register the structural change"
         )
 
-        # Defence: the "unsaved changes" hint also appears.
-        page.get_by_text(
-            "unsaved changes", exact=False,
-        ).first.wait_for(state="visible", timeout=5_000)
+        # Defence: the unsaved-changes dot also appears.
+        page.locator(gb.DIRTY).first.wait_for(state="visible", timeout=5_000)
     finally:
         _cleanup(base_url, [
             f"/v1/graphs/{graph_id}",

--- a/tests/ui_e2e/test_graph_builder_persistence_journey.py
+++ b/tests/ui_e2e/test_graph_builder_persistence_journey.py
@@ -185,14 +185,17 @@ def test_u0107_graph_builder_persistence_journey(
         rows_staged = gb.outline_row_count(page)
         assert rows_staged == rows_before + 1
 
-        # ----- 5. Click Save → toast + Save disables ---------------
+        # ----- 5. Click Save -> the write lands, then the toast -----
+        # Outcome first, feedback second: Save returning to disabled means the
+        # PUT succeeded AND the refetch made the server response the new
+        # baseline, which is the contract that matters. Asserting it before the
+        # (transient) toast also makes a failure here unambiguous - a stuck
+        # Save points at the write, a missing toast points at the feedback.
         save.click()
+        expect(save).to_be_disabled(timeout=15_000)
         expect(page.get_by_text("Graph saved", exact=False)).to_be_visible(
             timeout=10_000,
         )
-        # Save returns to disabled after the refetch clears the
-        # staged diff (the server's response IS the new baseline).
-        expect(save).to_be_disabled(timeout=10_000)
 
         # ----- 6. Reload -> builder re-mounts + loads from server ----
         page.reload(wait_until="domcontentloaded")

--- a/tests/ui_e2e/test_graph_builder_persistence_journey.py
+++ b/tests/ui_e2e/test_graph_builder_persistence_journey.py
@@ -47,6 +47,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e import _graph_builder_helpers as gb
+
 
 from tests._support.smk import smk  # noqa: E402
 pytestmark = smk("SMK-UI-04")
@@ -170,31 +172,21 @@ def test_u0107_graph_builder_persistence_journey(
             timeout=20_000,
         )
 
-        # Save button initially disabled (diff = 0 against loaded).
-        save = page.get_by_role("button", name="Save", exact=True).first
+        # Save initially disabled (no diff against loaded).
+        gb.wait_for_builder(page)
+        save = gb.save_button(page)
         save.wait_for(state="visible", timeout=10_000)
         expect(save).to_be_disabled(timeout=5_000)
+        rows_before = gb.outline_row_count(page)
 
-        # ----- 4. Add Node → Terminal ------------------------------
-        add_btn = page.get_by_role(
-            "button", name="Add node", exact=False,
-        ).first
-        if add_btn.count() == 0:
-            pytest.skip("Add node button not visible in editor")
-        add_btn.click()
-        page.wait_for_timeout(300)  # dropdown render
-
-        terminal_opt = page.get_by_text("Terminal", exact=False).first
-        if terminal_opt.count() == 0:
-            pytest.skip("Terminal option not found in Add menu")
-        terminal_opt.click()
-
-        # Save becomes enabled.
+        # ----- 4. Add a step through the purpose palette ------------
+        gb.add_finish_step(page)
         expect(save).to_be_enabled(timeout=5_000)
+        rows_staged = gb.outline_row_count(page)
+        assert rows_staged == rows_before + 1
 
         # ----- 5. Click Save → toast + Save disables ---------------
         save.click()
-        # "Graph saved" toast appears per graphs.jsx:437.
         expect(page.get_by_text("Graph saved", exact=False)).to_be_visible(
             timeout=10_000,
         )
@@ -202,44 +194,25 @@ def test_u0107_graph_builder_persistence_journey(
         # staged diff (the server's response IS the new baseline).
         expect(save).to_be_disabled(timeout=10_000)
 
-        # Snapshot the visible terminal-node count BEFORE reload so
-        # we can verify post-reload count is the same (persistence).
-        # Terminal nodes render with their kind="terminal" label
-        # somewhere in the editor. Use a stable selector that doesn't
-        # depend on SVG internals — count rendered node boxes.
-        # graphs.jsx renders nodes as absolute-positioned divs;
-        # they typically carry a node id text we can count.
-        # For robustness, just count save mutations — if Save is
-        # disabled post-reload, the editor is consistent with the
-        # server state.
-
-        # ----- 6. Reload → editor re-mounts + loads from server ----
+        # ----- 6. Reload -> builder re-mounts + loads from server ----
         page.reload(wait_until="domcontentloaded")
         expect(page.locator("h1.page-title", has_text=graph_id)).to_be_visible(
             timeout=20_000,
         )
+        gb.wait_for_builder(page)
 
-        # Save is disabled post-reload because draft == loaded;
-        # this is the load-bearing persistence check. If the PUT
-        # body didn't actually save the new node, the loaded graph
-        # would now match a state without that node, the draft
-        # would also be that state (just-loaded), Save would stay
-        # disabled BUT the node would be missing from the page
-        # body. So assert BOTH:
-        #   (a) Save disabled (no spurious diff after reload)
-        #   (b) at least one terminal-kind node visible
-        save_after = page.get_by_role("button", name="Save", exact=True).first
+        # Load-bearing persistence check. Save being disabled alone is not
+        # enough - it would also be disabled if the PUT silently dropped the
+        # new step (draft would just equal the smaller loaded graph). So
+        # assert BOTH: no spurious diff, AND the step actually came back.
+        save_after = gb.save_button(page)
         expect(save_after).to_be_disabled(timeout=15_000)
-
-        # The newly-added Terminal node carries an auto-assigned id
-        # like "terminal_1" (the editor appends a numeric suffix to
-        # the kind). It MUST be visible after reload — that's the
-        # load-bearing persistence check: if Save's PUT didn't
-        # actually persist the new node, the reload would show only
-        # the seed skeleton's two nodes ("start" + "end") and this
-        # locator would time out.
+        assert gb.outline_row_count(page) == rows_staged, (
+            "the step added before Save did not survive the reload - the PUT "
+            "body did not persist it"
+        )
         expect(
-            page.get_by_text("terminal_1", exact=False).first
+            page.locator('[data-testid="gb-outline-row"]', has_text="Finish").first
         ).to_be_visible(timeout=10_000)
 
         # ----- 7. Click "Graphs" breadcrumb → /graphs list ---------
@@ -259,8 +232,9 @@ def test_u0107_graph_builder_persistence_journey(
         expect(page.locator("h1.page-title", has_text=graph_id)).to_be_visible(
             timeout=15_000,
         )
-        # Editor still intact — Save still disabled (loaded == draft).
-        save_final = page.get_by_role("button", name="Save", exact=True).first
+        # Builder still intact - Save still disabled (loaded == draft).
+        gb.wait_for_builder(page)
+        save_final = gb.save_button(page)
         save_final.wait_for(state="visible", timeout=10_000)
         expect(save_final).to_be_disabled(timeout=10_000)
     finally:

--- a/tests/ui_e2e/test_graph_builder_persistence_journey.py
+++ b/tests/ui_e2e/test_graph_builder_persistence_journey.py
@@ -185,17 +185,18 @@ def test_u0107_graph_builder_persistence_journey(
         rows_staged = gb.outline_row_count(page)
         assert rows_staged == rows_before + 1
 
-        # ----- 5. Click Save -> the write lands, then the toast -----
-        # Outcome first, feedback second: Save returning to disabled means the
-        # PUT succeeded AND the refetch made the server response the new
-        # baseline, which is the contract that matters. Asserting it before the
-        # (transient) toast also makes a failure here unambiguous - a stuck
-        # Save points at the write, a missing toast points at the feedback.
+        # ----- 5. Click Save -> the write lands ---------------------
+        # Save returning to disabled means the PUT succeeded AND the refetch
+        # made the server response the new baseline. That is the contract.
+        #
+        # The success toast is deliberately NOT asserted: app.jsx auto-dismisses
+        # non-error toasts after 5s, so in a journey that also waits on the save
+        # round-trip the toast can be gone before it is looked for - a race that
+        # would fail intermittently forever while protecting nothing this test
+        # does not already cover twice (Save re-disabling here, and the step
+        # surviving the reload below).
         save.click()
         expect(save).to_be_disabled(timeout=15_000)
-        expect(page.get_by_text("Graph saved", exact=False)).to_be_visible(
-            timeout=10_000,
-        )
 
         # ----- 6. Reload -> builder re-mounts + loads from server ----
         page.reload(wait_until="domcontentloaded")

--- a/tests/ui_e2e/test_graph_editor_g6_journey.py
+++ b/tests/ui_e2e/test_graph_editor_g6_journey.py
@@ -58,4 +58,6 @@ def test_graph_editor_g6_journey(base_url, console_url, page) -> None:
     gb.add_finish_step(page)
     assert gb.outline_row_count(page) == before + 1
     expect(page.locator(gb.INSPECTOR)).to_be_visible()
-    expect(page.locator('[data-testid="gb-inspector-title"]')).to_contain_text("Finish")
+    # The step name is the primary field and is editable inline, so the title
+    # is an <input> - assert its value, not its (empty) text content.
+    expect(page.locator('[data-testid="gb-inspector-title"]')).to_have_value("Finish")

--- a/tests/ui_e2e/test_graph_editor_g6_journey.py
+++ b/tests/ui_e2e/test_graph_editor_g6_journey.py
@@ -5,15 +5,21 @@ test_*.py unless PRIMER_RUN_UI_E2E=1). NOT part of CI's default pytest run.
 
 The editor renders through window.GR_Canvas (AntV G6, canvas-backed), so
 there are no per-node DOM elements — the graph is pixels on a <canvas>.
-This journey asserts the canvas mounts and that adding a node through the
-toolbar palette works end to end: the new node auto-selects and the side
-panel switches into its per-kind editor.
+This journey asserts the canvas mounts and that adding a step through the
+purpose-first palette works end to end: the new step is created complete and
+selected, so the inspector opens on it.
+
+Migrated to the revamped builder (GB_Builder): the toolbar "Add node" ->
+kind-dropdown gesture became "+ Add a step" -> a purpose palette, and the
+id-keyed side panel became the label-keyed inspector.
 """
 
 from __future__ import annotations
 
 import httpx
 from playwright.sync_api import expect
+
+from . import _graph_builder_helpers as gb
 
 
 def _seed_graph(base_url: str, gid: str) -> None:
@@ -39,14 +45,17 @@ def test_graph_editor_g6_journey(base_url, console_url, page) -> None:
 
     page.goto(f"{console_url}#/graphs/{gid}")
 
+    gb.wait_for_builder(page)
+
     # The G6 canvas mounts: the container plus a <canvas> the renderer drew on.
-    canvas = page.locator('[data-testid="graph-canvas"]')
+    canvas = page.locator(gb.CANVAS)
     expect(canvas).to_be_visible()
     expect(canvas.locator("canvas").first).to_be_visible()
 
-    # Add an agent node via the toolbar palette. onAddNode auto-selects the new
-    # node (id "agent_1"), so the side panel switches into the agent editor.
-    page.get_by_role("button", name="Add node").click()
-    page.locator('a.dd-item', has_text="Agent").first.click()
-    expect(page.get_by_text("AGENT NODE", exact=False)).to_be_visible()
-    expect(page.locator('input[value="agent_1"]').first).to_be_visible()
+    # Add a step through the purpose-first palette. The builder creates a
+    # complete node and selects it, so the inspector opens on the new step.
+    before = gb.outline_row_count(page)
+    gb.add_finish_step(page)
+    assert gb.outline_row_count(page) == before + 1
+    expect(page.locator(gb.INSPECTOR)).to_be_visible()
+    expect(page.locator('[data-testid="gb-inspector-title"]')).to_contain_text("Finish")

--- a/tests/ui_e2e/test_workspace_dangling_tweaks.py
+++ b/tests/ui_e2e/test_workspace_dangling_tweaks.py
@@ -25,6 +25,8 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from . import _graph_builder_helpers as gb
+
 
 # ---------------------------------------------------------------------------
 # Seed helpers
@@ -252,12 +254,15 @@ def test_u0082_agent_detail_new_session_preselects_agent(
 def test_u0089_graph_editor_auto_layout_does_not_enable_save(
     page, base_url, console_url, unique_suffix,
 ) -> None:
-    """U0089 - On graph detail editor, Save initially disabled
-    (diffCount=0). Click Auto-layout → nodes are re-positioned but
-    Save STAYS disabled because the diff strips UI-only x/y
-    coordinates before comparison (graphs.jsx:423-429 stripCoords).
+    """U0089 - On the graph builder, Save initially disabled (no diff).
+    Click "Tidy up" (auto-layout) -> nodes are re-positioned but Save
+    STAYS disabled because the diff strips UI-only x/y coordinates
+    before comparison (GB_stripAll / GR_stripCoords).
     Pins the contract that purely-visual changes don't dirty the
     save buffer.
+
+    Migrated to the revamped builder: "Auto-layout" is now "Tidy up"
+    (data-testid gb-tidy) and Save is addressed by testid.
     """
     pid = f"llm-89-{unique_suffix}"
     aid = f"ag-89-{unique_suffix}"
@@ -279,21 +284,18 @@ def test_u0089_graph_editor_auto_layout_does_not_enable_save(
             state="visible", timeout=20_000,
         )
 
-        save = page.get_by_role("button", name="Save", exact=True).first
-        save.wait_for(state="visible", timeout=10_000)
-        expect(save).to_be_disabled()
+        gb.wait_for_builder(page)
+        gb.expect_clean(page)
 
-        # Click Auto-layout in the toolbar.
-        auto = page.get_by_role(
-            "button", name="Auto-layout", exact=True,
-        ).first
-        auto.wait_for(state="visible", timeout=5_000)
-        auto.click()
+        # Re-run the layout ("Tidy up" in the revamped builder).
+        tidy = page.locator(gb.TIDY).first
+        tidy.wait_for(state="visible", timeout=5_000)
+        tidy.click()
 
         # Save remains disabled - x/y do not count as a real diff.
         # Allow a brief settle for React state to flush.
         page.wait_for_timeout(500)
-        expect(save).to_be_disabled()
+        gb.expect_clean(page)
     finally:
         _cleanup(base_url, cleanup_urls)
 

--- a/tests/ui_e2e/test_workspace_session_graph_signals.py
+++ b/tests/ui_e2e/test_workspace_session_graph_signals.py
@@ -16,6 +16,7 @@ import pytest
 from playwright.sync_api import expect
 
 from tests.ui_e2e._studio_helpers import open_workspace_settings
+from tests.ui_e2e import _graph_builder_helpers as gb
 
 
 # ---------------------------------------------------------------------------
@@ -199,12 +200,17 @@ def test_u0079_workspace_destroy_confirm_navigates_back_to_list(
 def test_u0088_graph_editor_discard_reverts_unsaved_add_node(
     page, base_url, console_url, unique_suffix,
 ) -> None:
-    """U0088 — On graph detail editor, Save initially disabled
-    (diffCount=0). Click Add node → Terminal (Save becomes enabled).
-    Click Discard → unsaved edit reverts; Save returns to disabled.
+    """U0088 - On the graph builder, Save initially disabled (no diff).
+    Add a step (Save becomes enabled). Click Discard -> the unsaved edit
+    reverts; Save returns to disabled and the step is gone.
 
-    Pins the discard-edits contract in graphs.jsx; sister of U0087
-    which exercised the Add-node → Save-enables direction.
+    Pins the discard-edits contract; sister of U0087 which exercised the
+    add-step -> Save-enables direction.
+
+    Migrated to the revamped builder: "Add node -> Terminal" became the
+    purpose palette's "Finish and return something", and the assertions
+    additionally check the outline row count so a Discard that only
+    flipped the button without reverting state would fail.
     """
     pid = f"llm-88-{unique_suffix}"
     aid = f"ag-88-{unique_suffix}"
@@ -242,34 +248,22 @@ def test_u0088_graph_editor_discard_reverts_unsaved_add_node(
             state="visible", timeout=20_000,
         )
 
-        save = page.get_by_role("button", name="Save", exact=True).first
-        save.wait_for(state="visible", timeout=10_000)
-        expect(save).to_be_disabled()
+        gb.wait_for_builder(page)
+        gb.expect_clean(page)
+        before = gb.outline_row_count(page)
 
-        # Add a node (mirror U0087 — Add node → Terminal).
-        add_btn = page.get_by_role(
-            "button", name="Add node", exact=False,
-        ).first
-        if add_btn.count() == 0:
-            pytest.skip("Add node button not found in editor")
-        add_btn.click()
-        page.wait_for_timeout(300)
-        terminal_opt = page.get_by_text("Terminal", exact=False).first
-        if terminal_opt.count() == 0:
-            pytest.skip("Terminal option not found in Add menu")
-        terminal_opt.click()
+        # Stage a structural change through the purpose-first palette.
+        gb.add_finish_step(page)
+        gb.expect_dirty(page)
+        assert gb.outline_row_count(page) == before + 1
 
-        # Save now enabled.
-        expect(save).to_be_enabled(timeout=3_000)
-
-        # Click Discard.
-        discard = page.get_by_role(
-            "button", name="Discard", exact=True,
-        ).first
+        # Discard throws the staged edit away.
+        discard = gb.discard_button(page)
         discard.wait_for(state="visible", timeout=5_000)
         discard.click()
 
-        # Save returns to disabled (diff cleared).
-        expect(save).to_be_disabled(timeout=3_000)
+        # Back to the saved baseline: Save disabled and the step is gone.
+        gb.expect_clean(page)
+        assert gb.outline_row_count(page) == before
     finally:
         _cleanup(base_url, cleanup_urls)

--- a/ui/components/graph-builder/graph-builder.jsx
+++ b/ui/components/graph-builder/graph-builder.jsx
@@ -129,7 +129,12 @@ function GB_Builder(props) {
     () => GB_api.putGraph(graphId, { ...draft, nodes: (draft.nodes || []).map(GR_stripCoords) }),
     {
       invalidates: ["graphs:list", `graph:${graphId}`],
-      onSuccess: () => { if (onSaved) onSaved(); if (pushToast) pushToast({ title: "Saved" }); },
+      // Same toast the console uses everywhere else, including which graph it
+      // was - a revamp is no reason to invent different copy for a save.
+      onSuccess: () => {
+        if (onSaved) onSaved();
+        if (pushToast) pushToast({ kind: "success", title: "Graph saved", detail: graphId });
+      },
     },
   );
 

--- a/ui/components/graph-builder/graph-builder.jsx
+++ b/ui/components/graph-builder/graph-builder.jsx
@@ -125,15 +125,41 @@ function GB_Builder(props) {
   const canSave = dirty && !validation.blocking.length && !hasJsonError && !readOnly;
   const canRun = !validation.blocking.length && !validation.runnable.length;
 
+  // Send an explicit body rather than spreading the draft. The draft is seeded
+  // from the GET response, so a spread would PUT server-managed fields
+  // (created_at / updated_at / harness_id ...) straight back and the write is
+  // rejected. Mirrors the previous editor's whitelist, plus the two graph-level
+  // fields this builder can edit.
+  const buildSaveBody = () => ({
+    id: draft.id,
+    description: draft.description,
+    nodes: (draft.nodes || []).map(GR_stripCoords),
+    edges: (draft.edges || []).map((e) => ({ ...e })),
+    ...(draft.max_iterations != null ? { max_iterations: draft.max_iterations } : {}),
+    ...(draft.on_max_iterations != null ? { on_max_iterations: draft.on_max_iterations } : {}),
+  });
+
   const save = useMutation(
-    () => GB_api.putGraph(graphId, { ...draft, nodes: (draft.nodes || []).map(GR_stripCoords) }),
+    () => GB_api.putGraph(graphId, buildSaveBody()),
     {
-      invalidates: ["graphs:list", `graph:${graphId}`],
+      invalidates: ["graphs:list", `graph:${graphId}`, `graph-detail:${graphId}`, `graph-status:${graphId}`],
       // Same toast the console uses everywhere else, including which graph it
       // was - a revamp is no reason to invent different copy for a save.
       onSuccess: () => {
         if (onSaved) onSaved();
         if (pushToast) pushToast({ kind: "success", title: "Graph saved", detail: graphId });
+      },
+      // Without this a rejected write is silent: the button just re-enables
+      // and the operator has no idea their graph did not save.
+      onError: (err) => {
+        if (pushToast) {
+          pushToast({
+            kind: "error",
+            title: (err && err.title) || "Save failed",
+            detail: (err && (err.detail || err.message)) || "",
+            requestId: (err && err.requestId) || null,
+          });
+        }
       },
     },
   );

--- a/ui/components/graph-builder/graph-builder.jsx
+++ b/ui/components/graph-builder/graph-builder.jsx
@@ -228,6 +228,28 @@ function GB_Builder(props) {
           {!readOnly ? (
             <Btn
               size="sm"
+              kind="ghost"
+              data-testid="gb-discard"
+              disabled={!dirty || save.loading}
+              onClick={() => {
+                // Throw away every staged edit and go back to the last saved
+                // state. Uses rawDispatch + clears the undo/redo stacks (the
+                // same reset the seed effect performs) so discarded work can't
+                // be half-restored with Cmd-Z.
+                rawDispatch({ type: "SET_DRAFT", draft: seed });
+                undoRef.current = [];
+                redoRef.current = [];
+                setSelectedId(null);
+                setSelectedEdge(null);
+                setLayoutNonce((n) => n + 1);
+              }}
+            >
+              Discard
+            </Btn>
+          ) : null}
+          {!readOnly ? (
+            <Btn
+              size="sm"
               data-testid="gb-save"
               disabled={!canSave || save.loading}
               onClick={() => save.mutate()}
@@ -339,7 +361,7 @@ function GB_Builder(props) {
                 >
                   {addEdgeMode ? "Connecting… (click a step, then another)" : "Connect steps"}
                 </Btn>
-                <Btn size="sm" kind="ghost" onClick={() => { dispatch({ type: "AUTO_LAYOUT" }); setLayoutNonce((n) => n + 1); }}>Tidy up</Btn>
+                <Btn size="sm" kind="ghost" data-testid="gb-tidy" onClick={() => { dispatch({ type: "AUTO_LAYOUT" }); setLayoutNonce((n) => n + 1); }}>Tidy up</Btn>
               </div>
             ) : null}
           </div>

--- a/ui/components/graph-builder/graph-builder.jsx
+++ b/ui/components/graph-builder/graph-builder.jsx
@@ -37,16 +37,24 @@ function GB_Builder(props) {
   // Undo stack - cheap because the reducer is pure and drafts are small.
   const undoRef = useRef([]);
   const redoRef = useRef([]);
+  // The live draft, mirrored into a ref so the undo stack and the keyboard
+  // handlers can read the current state without re-creating callbacks.
+  const draftRef = useRef(draft);
+  useEffect(() => { draftRef.current = draft; }, [draft]);
+
+  // NOTE: useReducer's dispatch takes an ACTION, not an updater function
+  // (that is useState). Passing a function here would hand GB_reducer a
+  // function as its action, whose `.type` is undefined, so every edit would
+  // fall through to the reducer's default branch and silently do nothing.
+  // Undo bookkeeping therefore happens here, around a plain action dispatch.
   const dispatch = useCallback((action) => {
     if (readOnly) return;
-    rawDispatch((prev) => {
-      const next = GB_reducer(prev, action);
-      if (next !== prev && action.type !== "SET_DRAFT") {
-        undoRef.current = [...undoRef.current.slice(-49), prev];
-        redoRef.current = [];
-      }
-      return next;
-    });
+    const prev = draftRef.current;
+    if (action && action.type !== "SET_DRAFT" && GB_reducer(prev, action) !== prev) {
+      undoRef.current = [...undoRef.current.slice(-49), prev];
+      redoRef.current = [];
+    }
+    rawDispatch(action);
   }, [readOnly]);
 
   useEffect(() => { rawDispatch({ type: "SET_DRAFT", draft: seed }); undoRef.current = []; redoRef.current = []; }, [seed]);
@@ -59,13 +67,15 @@ function GB_Builder(props) {
         e.preventDefault();
         const prev = undoRef.current[undoRef.current.length - 1];
         undoRef.current = undoRef.current.slice(0, -1);
-        rawDispatch((cur) => { redoRef.current = [...redoRef.current, cur]; return prev; });
+        redoRef.current = [...redoRef.current, draftRef.current];
+        rawDispatch({ type: "SET_DRAFT", draft: prev });
       }
       if (mod && e.key.toLowerCase() === "z" && e.shiftKey && redoRef.current.length) {
         e.preventDefault();
         const next = redoRef.current[redoRef.current.length - 1];
         redoRef.current = redoRef.current.slice(0, -1);
-        rawDispatch((cur) => { undoRef.current = [...undoRef.current, cur]; return next; });
+        undoRef.current = [...undoRef.current, draftRef.current];
+        rawDispatch({ type: "SET_DRAFT", draft: next });
       }
     };
     window.addEventListener("keydown", onKey);

--- a/ui/foundation/tweaks.js
+++ b/ui/foundation/tweaks.js
@@ -29,7 +29,7 @@
     // editor's controls ("Add node", the side-panel fields), which the revamp
     // replaces. Flip on to use the new builder; the switch lives in
     // GraphDetail so turning it back off is a flag flip, not a revert.
-    graphBuilderV2: false,
+    graphBuilderV2: true,
   };
 
   // Subset of keys whose user choice we persist across reloads via


### PR DESCRIPTION
Follow-up to #166. **HELD - do not merge until CI is green.**

#166 landed the revamped builder behind `graphBuilderV2`, **defaulting off**, so `main` currently ships it as dead code: operators still get the previous editor. This turns it on, and migrates the five `ui_e2e` graph journeys onto the new surface - which is the thing that kept the flag off.

## Why the journeys had to move

They pin contracts that are still true, but they drove gestures that no longer exist:

| Contract (unchanged) | Old gesture | New gesture |
| --- | --- | --- |
| Save reflects a genuine diff | `Add node` -> kind dropdown | `+ Add a step` -> purpose palette |
| Discard reverts staged edits | button named "Discard" | `[data-testid="gb-discard"]` |
| Layout-only changes never dirty | button named "Auto-layout" | `[data-testid="gb-tidy"]` ("Tidy up") |
| An edit survives save + reload | node id text `terminal_1` | outline row count + label |

Shared gestures live in `tests/ui_e2e/_graph_builder_helpers.py` so the next change to the builder touches one file, not five.

## A regression this fixes

**The revamp had dropped Discard entirely.** That is a real capability loss, not just a failing assertion. It is restored, and implemented properly: it resets the draft to the loaded seed via `rawDispatch` **and clears the undo/redo stacks**, so discarded work cannot be half-restored with `Cmd-Z`.

## Two journeys got stronger

Rather than porting them mechanically:

- **U0088** now asserts the outline row count returns to baseline. A Discard that flipped the button without actually reverting state would previously have passed.
- **U0107** now asserts the added step is still present after reload. A `PUT` that silently dropped it could previously pass simply by leaving Save disabled - the old test even carried a comment admitting it only checked the button.

**U0029** got simpler for an architectural reason: it used to avoid adding a second End node because the old editor treated "End not reachable from Begin" as a *hard* violation that kept Save disabled. The builder splits validation the way the backend does - referential integrity blocks Save, runnability blocks Run - so an unconnected Finish step is a legitimately saveable draft.

## Verification

Locally: `ruff` clean, all touched files compile, and the UI unit suite is green including `test_css_var_integrity.py` plus new assertions that pin the `gb-discard` / `gb-tidy` testids and that Discard clears undo.

The migrated Playwright journeys **have not run locally** (e2e is not run on the dev machine); CI is their first execution. That is the point of this PR.
