### PR TITLE
fix(ui): graph builder fills the viewport and clips overflowing labels

### DIFF
--- a/ui/components/graph-builder/gb-model.jsx
+++ b/ui/components/graph-builder/gb-model.jsx
@@ -363,7 +363,11 @@ function GB_reducer(draft, action) {
       const layout = window.primerVendor && window.primerVendor.autoLayout;
       if (!layout) return d;
       try {
-        const laid = layout(d); // autoLayout(draft) -> new draft
+        // Spacing is DERIVED from the real card size rather than left at the
+        // helper's 200px default, which predates the two-line cards: at 196px
+        // wide that default leaves a 4px gutter and the steps visibly collide.
+        const size = (window.GR_NODE_SIZE && window.GR_NODE_SIZE.agent) || { w: 196, h: 64 };
+        const laid = layout(d, { colWidth: size.w + 64, rowHeight: size.h + 40 });
         return laid && Array.isArray(laid.nodes) ? laid : d;
       } catch (_e) {
         return d;
@@ -391,7 +395,14 @@ function GB_stripAll(d) {
   return { ...(d || {}), nodes: ((d && d.nodes) || []).map(strip) };
 }
 
+// The builder body fills the viewport rather than sitting in a fixed slab.
+// The subtraction covers the app chrome + page title + status panel + the
+// builder's own top bar; minHeight keeps it usable on short screens, where the
+// page simply scrolls as normal.
+const GB_BODY_STYLE = { flex: 1, minHeight: 520, height: "calc(100vh - 300px)" };
+
 Object.assign(window, {
+  GB_BODY_STYLE,
   GB_slug, GB_uniqueId, GB_defaultInput, GB_makeNode, GB_makeSplitPair,
   GB_renameStructural, GB_allLinks, GB_supersteps, GB_predecessors,
   GB_reducer, GB_stripAll,

--- a/ui/components/graph-builder/graph-builder.jsx
+++ b/ui/components/graph-builder/graph-builder.jsx
@@ -246,10 +246,15 @@ function GB_Builder(props) {
         className="row"
         style={{ height: 52, flex: "0 0 auto", gap: 12, alignItems: "center", padding: "0 14px", borderBottom: "1px solid var(--border)", background: "var(--bg-elev)", position: "relative" }}
       >
-        <div className="row mono" style={{ gap: 8, alignItems: "center", fontSize: "var(--fs-12)", color: "var(--text-3)", minWidth: 0 }}>
-          <span>graphs</span>
-          <span style={{ color: "var(--border-strong)" }}>/</span>
-          <span style={{ color: "var(--text)", fontFamily: "inherit", fontSize: "var(--fs-13)", fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+        {/* flex + minWidth:0 so a long description actually ellipsises here
+            instead of pushing the controls off the right edge. */}
+        <div className="row mono" style={{ gap: 8, alignItems: "center", fontSize: "var(--fs-12)", color: "var(--text-3)", minWidth: 0, flex: "1 1 auto", overflow: "hidden" }}>
+          <span style={{ flex: "0 0 auto" }}>graphs</span>
+          <span style={{ color: "var(--border-strong)", flex: "0 0 auto" }}>/</span>
+          <span
+            title={draft.description || graphId}
+            style={{ color: "var(--text)", fontFamily: "inherit", fontSize: "var(--fs-13)", fontWeight: 600, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}
+          >
             {draft.description || graphId}
           </span>
           {dirty ? <span data-testid="gb-dirty" title="unsaved changes" style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--amber)", flex: "0 0 auto" }} /> : null}
@@ -329,7 +334,7 @@ function GB_Builder(props) {
           onApply={(spec) => { dispatch({ type: "APPLY_TEMPLATE", spec }); setLayoutNonce((n) => n + 1); }}
         />
       ) : (
-        <div className="row" style={{ flex: 1, minHeight: 520, height: 620 }}>
+        <div className="row" style={GB_BODY_STYLE}>
           {/* Left rail */}
           <div className="col" style={{ width: 252, flex: "0 0 auto", borderRight: "1px solid var(--border)", background: "var(--bg-1)", minHeight: 0 }}>
             <div className="row" style={{ gap: 8, alignItems: "center", padding: "12px 14px 8px" }}>

--- a/ui/components/graph-canvas.jsx
+++ b/ui/components/graph-canvas.jsx
@@ -119,13 +119,24 @@ function _g6Ref(node) {
   return "";
 }
 
+// Node cards are a fixed width, so a label longer than fits is clipped here
+// rather than left to overflow. Descriptions are free text ("write scorer.py
+// into the workspace"), so without this they spill out of the card and collide
+// with neighbouring nodes.
+const _G6_TITLE_CHARS = 24;
+const _G6_SUB_CHARS = 26;
+function _g6Clip(text, max) {
+  const s = String(text == null ? "" : text).replace(/\s+/g, " ").trim();
+  return s.length > max ? `${s.slice(0, max - 1)}…` : s;
+}
+
 // The human name is primary; the id is demoted to the inspector header. During
 // a run the second line shows live metrics instead of the static reference.
 function _g6Label(node, metaByNode) {
   if (_g6Tiny(node.kind)) return "";
-  const title = node.description || node.id;
+  const title = _g6Clip(node.description || node.id, _G6_TITLE_CHARS);
   const m = _g6Metric(metaByNode && metaByNode[node.id]);
-  const second = m || _g6Ref(node);
+  const second = _g6Clip(m || _g6Ref(node), _G6_SUB_CHARS);
   return second ? `${title}\n${second}` : title;
 }
 
@@ -190,6 +201,12 @@ function _g6NodeStyle(P) {
     labelFontSize: 12,
     labelFontFamily: "IBM Plex Mono, monospace",
     labelLineHeight: 15,
+    // Belt and braces with _g6Clip: keep the text inside the card even if a
+    // single unbroken token (a long path, say) survives the character clip.
+    labelWordWrap: true,
+    labelMaxWidth: 168,
+    labelMaxLines: 2,
+    labelTextOverflow: "ellipsis",
     iconSrc: (d) => _g6IconUri(d.data.kind, P.text),
     iconWidth: 15,
     iconHeight: 15,


### PR DESCRIPTION
Follow-up to #167, which made the revamped builder the default. Three layout defects that only show on a real graph. **HELD - do not merge until CI is green.**

| Symptom | Cause | Fix |
| --- | --- | --- |
| Builder renders in the top ~half of the page with dead space below | body was a hard-coded `height: 620` | sizes to the viewport; `minHeight` keeps short screens usable and the page scrolls as before |
| Step labels overflow their cards and collide with the next step | promoting `description` to the primary label was right, but descriptions are free text (*"write trail_mcp_client.py into the workspace"*) where the old label was a short id - and there was no clipping | clipped per line, plus G6 word-wrap/ellipsis as a second guard for one unbroken token such as a long path |
| A long graph description pushes the toolbar off the right edge | the breadcrumb wrapper had no flex constraint, so `text-overflow: ellipsis` never engaged | truncates properly, full text on hover |

Also: **Tidy up** inherited the layout helper's 200px default column, which dates from the 152px cards - at 196px that is a 4px gutter. Spacing is now derived from `GR_NODE_SIZE` so the two cannot drift apart again.

Worth stating what was **not** broken: I first suspected the nodes themselves were overlapping. They were not - the initial layout is dagre, which reads the declared node size and positions correctly. Only the labels overflowed. The column-width change therefore affects the explicit **Tidy up** only, and is not being claimed as the cause of the screenshot.

## Verification

71 UI tests green locally, including every canvas/bundle transpile check. These are visual fixes, so CI can confirm nothing regressed but not that they look right - worth a glance in the browser after merge.
