### PR TITLE
feat(ui): rebuild the Studio around attention, panes and a four-state status language [HELD]

### DIFF
--- a/tests/ui/test_studio_attention.py
+++ b/tests/ui/test_studio_attention.py
@@ -69,6 +69,28 @@ def test_pending_yield_promotes_a_running_session_to_needs() -> None:
     assert ctx.eval("b.bucket") == "needs"
 
 
+def test_pending_yield_promotion_works_on_the_list_endpoint_shape() -> None:
+    # GET /workspaces/{wid}/sessions returns SessionInfo, which carries
+    # `session_id` and NOT `id`. Resolving only `id` silently never promoted a
+    # single row in the rail, because every row comes from that endpoint - and
+    # the bug is invisible (a needs-you row just renders as "working").
+    ctx = _ctx()
+    ctx.eval(
+        'var b = ST2_bucketOf({session_id:"s1", status:"running"},'
+        " {pendingBySession:{s1:true}});"
+    )
+    assert ctx.eval("b.bucket") == "needs"
+
+
+def test_pending_snapshot_for_another_session_does_not_leak() -> None:
+    ctx = _ctx()
+    ctx.eval(
+        'var b = ST2_bucketOf({session_id:"s1", status:"running"},'
+        " {pendingBySession:{s2:true}});"
+    )
+    assert ctx.eval("b.bucket") == "working"
+
+
 def test_watch_and_sleep_parks_read_as_working() -> None:
     # Technically parked, but nothing waits on a human - so the queue count and
     # the rail's "needs you" group agree.

--- a/tests/ui/test_studio_attention.py
+++ b/tests/ui/test_studio_attention.py
@@ -1,0 +1,273 @@
+"""Studio revamp: the four-state status language and the attention bar.
+
+ui/studio/STUDIO-WIRING.md §3 (attention bar), §4 (status buckets).
+
+The bucket mapping decides what every rail row, group header and queue count
+says, so it is executed for real in MiniRacer rather than substring-matched.
+The React surfaces are checked by source + transpile, the ui/ suite convention.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+STUDIO = UI / "components" / "studio"
+STATUS = STUDIO / "st-status.jsx"
+API = STUDIO / "st-api.jsx"
+ATTENTION = STUDIO / "st-attention.jsx"
+
+
+def _ctx():
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = globalThis;")
+    ctx.eval(STATUS.read_text(encoding="utf-8"))
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# §4 - the four-state status language
+# ---------------------------------------------------------------------------
+
+
+def test_status_module_exists_and_exports() -> None:
+    assert STATUS.exists()
+    src = STATUS.read_text(encoding="utf-8")
+    assert "function ST2_bucketOf(" in src
+    assert "ST2_BUCKET_ORDER" in src
+    assert "window.ST2_bucketOf" in src
+
+
+def test_bucket_order_is_needs_first() -> None:
+    ctx = _ctx()
+    assert ctx.eval('ST2_BUCKET_ORDER.join(",")') == "needs,working,broken,done"
+
+
+def test_parked_asking_a_question_needs_you() -> None:
+    ctx = _ctx()
+    ctx.eval('var b = ST2_bucketOf({status:"parked", park_reason:"ask_user"}, {});')
+    assert ctx.eval("b.bucket") == "needs"
+    assert ctx.eval("b.tone") == "--amber"
+    assert ctx.eval("b.label") == "needs you"
+    assert "question" in ctx.eval("b.detail")
+
+
+def test_approval_park_names_the_command_when_known() -> None:
+    ctx = _ctx()
+    ctx.eval('var b = ST2_bucketOf({status:"parked", park_reason:"approval", tool:"shell__run"}, {});')
+    assert ctx.eval("b.bucket") == "needs"
+    assert "shell__run" in ctx.eval("b.detail")
+
+
+def test_pending_yield_promotes_a_running_session_to_needs() -> None:
+    # A session can be RUNNING and still have an unanswered yield.
+    ctx = _ctx()
+    ctx.eval('var b = ST2_bucketOf({id:"s1", status:"running"}, {pendingBySession:{s1:true}});')
+    assert ctx.eval("b.bucket") == "needs"
+
+
+def test_watch_and_sleep_parks_read_as_working() -> None:
+    # Technically parked, but nothing waits on a human - so the queue count and
+    # the rail's "needs you" group agree.
+    ctx = _ctx()
+    for reason in ("watch", "watch_files", "sleep"):
+        ctx.eval(f'var b = ST2_bucketOf({{status:"parked", park_reason:"{reason}"}}, {{}});')
+        assert ctx.eval("b.bucket") == "working", reason
+        assert ctx.eval("b.tone") == "--blue", reason
+
+
+def test_failed_is_broken_and_carries_the_error_code() -> None:
+    ctx = _ctx()
+    ctx.eval('var b = ST2_bucketOf({status:"failed", ended_detail:"tool_execution_failed", tool:"shell__run"}, {});')
+    assert ctx.eval("b.bucket") == "broken"
+    assert ctx.eval("b.tone") == "--red"
+    assert "tool_execution_failed" in ctx.eval("b.detail")
+
+
+def test_ended_with_an_error_code_is_broken_not_done() -> None:
+    ctx = _ctx()
+    ctx.eval('var b = ST2_bucketOf({status:"ended", ended_detail:"routing_failed"}, {});')
+    assert ctx.eval("b.bucket") == "broken"
+
+
+def test_clean_terminal_states_are_done() -> None:
+    ctx = _ctx()
+    for st in ("completed", "ended", "cancelled"):
+        ctx.eval(f'var b = ST2_bucketOf({{status:"{st}"}}, {{}});')
+        assert ctx.eval("b.bucket") == "done", st
+        assert ctx.eval("b.tone") == "--text-3", st
+
+
+def test_unmapped_status_is_visible_never_silently_green() -> None:
+    ctx = _ctx()
+    ctx.eval('var b = ST2_bucketOf({status:"quantum"}, {});')
+    assert ctx.eval("b.bucket") == "working"
+    assert "quantum" in ctx.eval("b.detail")
+
+
+def test_grouping_uses_the_fixed_bucket_order() -> None:
+    ctx = _ctx()
+    ctx.eval(
+        """
+        var g = ST2_groupSessions([
+          {id:"a", status:"running"},
+          {id:"b", status:"parked", park_reason:"ask_user"},
+          {id:"c", status:"failed"},
+          {id:"d", status:"completed"}
+        ], {});
+        """
+    )
+    assert ctx.eval('g.needs.map(function(s){return s.id}).join(",")') == "b"
+    assert ctx.eval('g.working.map(function(s){return s.id}).join(",")') == "a"
+    assert ctx.eval('g.broken.map(function(s){return s.id}).join(",")') == "c"
+    assert ctx.eval('g.done.map(function(s){return s.id}).join(",")') == "d"
+
+
+# ---------------------------------------------------------------------------
+# §2.3 - the endpoint surface
+# ---------------------------------------------------------------------------
+
+
+def test_api_names_every_endpoint_this_feature_touches() -> None:
+    api = API.read_text(encoding="utf-8")
+    assert "/tool_approval/respond" in api
+    assert '"approved"' in api and '"rejected"' in api
+    assert "/ask_user/respond" in api
+    assert "/yields/" in api and "/cancel" in api
+    assert "/yields/pending" in api
+    assert "/log?limit=" in api
+    assert "/node_states" in api
+
+
+def test_node_states_uses_the_top_level_graph_route() -> None:
+    # It lives on compute.py:249 as /graphs/{gid}/runs/{rid}/node_states - NOT
+    # a workspace-scoped path. Wiring it under /workspaces would 404.
+    api = API.read_text(encoding="utf-8")
+    assert '"/graphs/"' in api
+    assert "nodeStates: function (graphId, runId" in api
+
+
+def test_cache_keys_live_in_one_place() -> None:
+    # So a mutation's `invalidates` cannot drift from the reader's resource key.
+    api = API.read_text(encoding="utf-8")
+    assert "keys:" in api
+    assert "studio-yields-pending:" in api
+
+
+def test_no_studio_component_names_a_url_directly() -> None:
+    for f in sorted(STUDIO.glob("st-*.jsx")):
+        if f.name == "st-api.jsx":
+            continue
+        body = f.read_text(encoding="utf-8")
+        for marker in ('apiFetch("GET"', 'apiFetch("POST"', 'apiFetch("PUT"', 'apiFetch("DELETE"'):
+            assert marker not in body, f"{f.name} calls apiFetch directly; route it through ST2_api"
+
+
+# ---------------------------------------------------------------------------
+# §3 - the attention bar
+# ---------------------------------------------------------------------------
+
+
+def test_attention_bar_is_always_mounted_and_never_collapses() -> None:
+    # The stated negative ("Nothing needs you") is the feature.
+    src = ATTENTION.read_text(encoding="utf-8")
+    assert 'data-testid="attention-bar"' in src
+    assert 'data-testid="attention-bar-calm"' in src
+    assert "Nothing needs you" in src
+
+
+def test_attention_bar_guards_a_null_tool_call_id() -> None:
+    # tool_call_id is nullable; such a park renders but must not POST.
+    src = ATTENTION.read_text(encoding="utf-8")
+    assert "actionable" in src
+    assert "tool_call_id" in src
+
+
+def test_attention_bar_keeps_the_shipped_testids() -> None:
+    # Journeys locate these; they change parent but keep their ids (§13).
+    src = ATTENTION.read_text(encoding="utf-8")
+    for tid in (
+        "action-required", "action-item", "approve", "reject", "respond",
+        "cancel-yield", "action-required-count", "attention-count",
+        "attention-queue", "attention-queue-item", "unblock-focus",
+        "inform-item", "inform-dismiss",
+    ):
+        assert f'"{tid}"' in src, tid
+
+
+def test_attention_bar_reuses_the_one_tap_listener() -> None:
+    # Never a second EventSource (§0).
+    src = ATTENTION.read_text(encoding="utf-8")
+    assert "useWorkspaceTapListener" in src
+    assert "EventSource" not in src
+
+
+def _code_only(path: Path) -> str:
+    """Source with `//` comment bodies stripped.
+
+    The checks below are about what the code *does*; a comment that explains
+    which old pattern was replaced must not trip them.
+    """
+    out = []
+    for line in path.read_text(encoding="utf-8").splitlines():
+        idx = line.find("//")
+        out.append(line if idx == -1 else line[:idx])
+    return "\n".join(out)
+
+
+def test_attention_writes_go_through_use_mutation_with_invalidates() -> None:
+    # Replaces the hand-rolled SA_invalidateSessionPending + delayed-refetch pair.
+    src = ATTENTION.read_text(encoding="utf-8")
+    assert "useMutation" in src
+    assert "invalidates" in src
+    code = _code_only(ATTENTION)
+    assert "setTimeout(refetch" not in code
+    assert "SA_invalidateSessionPending" not in code
+
+
+def test_keyboard_shortcuts_are_scoped_not_global() -> None:
+    # j/k/d/c must not eat typing when no overlay is open.
+    src = ATTENTION.read_text(encoding="utf-8")
+    assert "queueOpen" in src or "focusOpen" in src
+
+
+def test_studio_mounts_the_bar_behind_the_v2_tweak() -> None:
+    studio = (UI / "components" / "studio.jsx").read_text(encoding="utf-8")
+    assert "AttentionBar" in studio
+    assert "studioV2" in studio
+    tweaks = (UI / "foundation" / "tweaks.js").read_text(encoding="utf-8")
+    assert "studioV2:" in tweaks
+
+
+def test_v2_is_strictly_opt_in_while_incomplete() -> None:
+    # === true, not !== false: the graph builder shipped inert behind a
+    # permissive guard, so this one must refuse to appear until finished.
+    studio = (UI / "components" / "studio.jsx").read_text(encoding="utf-8")
+    assert "studioV2 === true" in studio
+
+
+def test_new_files_are_registered_in_index_html_before_studio() -> None:
+    lines = (UI / "index.html").read_text(encoding="utf-8").splitlines()
+    order = [i for i, ln in enumerate(lines) if 'type="text/babel"' in ln and "src=" in ln]
+    def idx(frag: str) -> int:
+        for i in order:
+            if frag in lines[i]:
+                return i
+        raise AssertionError(f"{frag} is not registered in index.html")
+
+    assert idx("studio/st-status.jsx") < idx("components/studio.jsx")
+    assert idx("studio/st-api.jsx") < idx("components/studio.jsx")
+    assert idx("studio/st-attention.jsx") < idx("components/studio.jsx")
+
+
+def test_every_studio_file_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    for f in sorted(STUDIO.glob("st-*.jsx")):
+        rel = f"components/studio/{f.name}"
+        code = b._transform(f.read_text(encoding="utf-8"), rel)
+        assert code, rel

--- a/tests/ui/test_studio_center.py
+++ b/tests/ui/test_studio_center.py
@@ -372,4 +372,6 @@ def test_center_close_all_wired_to_state() -> None:
     # CenterTabs takes an onCloseAll prop and StudioCenter feeds it the hook's
     # closeAllTabs action.
     assert "onCloseAll" in src
-    assert "onCloseAll={studio.closeAllTabs}" in src
+    # The prop is overridable so PaneHost can point the companion pane's tab bar
+    # at closeAllAsideTabs (§6); omitted, it still resolves to the hook action.
+    assert "onCloseAll={onCloseAll || studio.closeAllTabs}" in src

--- a/tests/ui/test_studio_changes.py
+++ b/tests/ui/test_studio_changes.py
@@ -1,0 +1,442 @@
+"""Studio revamp: the Changes view (ui/studio/STUDIO-WIRING.md §7).
+
+Two things carry the risk here and both run for real in MiniRacer:
+
+1. The unified-diff parser. It renumbers every line from the hunk headers, so an
+   off-by-one silently mislabels which line changed - and a diff that points at
+   the wrong line is worse than no diff.
+2. The trail grouping, where `files: null` (a backend that cannot report file
+   data) must never be counted as zero.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+DIFF = UI / "components" / "studio" / "st-diff.jsx"
+CHANGES = UI / "components" / "studio" / "st-changes.jsx"
+API = UI / "components" / "studio" / "st-api.jsx"
+CENTER = UI / "components" / "studio-center.jsx"
+STUDIO = UI / "components" / "studio.jsx"
+
+
+def _code_only(src: str) -> str:
+    out = []
+    for line in src.splitlines():
+        idx = line.find("//")
+        out.append(line if idx == -1 else line[:idx])
+    return "\n".join(out)
+
+
+def _ctx():
+    """MiniRacer with the pure diff + grouping logic (no React)."""
+    py_mini_racer = pytest.importorskip("py_mini_racer")
+    ctx = py_mini_racer.MiniRacer()
+    d = DIFF.read_text(encoding="utf-8")
+    ctx.eval(d[: d.index("// ---------------------------------------------------------------------------\n// Rendering")])
+    # ST2_pairRows lives in the rendering half but is pure, so lift just it.
+    ctx.eval(d[d.index("function ST2_pairRows(rows)"): d.index("function ST2_SideCell(")])
+    c = CHANGES.read_text(encoding="utf-8")
+    ctx.eval(c[c.index("function ST2_opTone(op)"): c.index("// ------", c.index("function ST2_groupTrail("))])
+    # ST2_bucketOf, used by the grouping.
+    s = (UI / "components" / "studio" / "st-status.jsx").read_text(encoding="utf-8")
+    ctx.eval(s[: s.index("window.")])
+    return ctx
+
+
+def _parse(ctx, patch: str):
+    ctx.eval(f"var out = ST2_parseUnifiedDiff({json.dumps(patch)});")
+    return json.loads(ctx.eval("JSON.stringify(out)"))
+
+
+# A real `git show` patch body for one file.
+PATCH = """diff --git a/f1.txt b/f1.txt
+index 0123456..789abcd 100644
+--- a/f1.txt
++++ b/f1.txt
+@@ -1,3 +1,4 @@
+ a
+-b
++B
+ c
++d
+"""
+
+
+# ---------------------------------------------------------------------------
+# The unified-diff parser
+# ---------------------------------------------------------------------------
+
+
+def test_the_preamble_is_not_rendered_as_content() -> None:
+    # diff --git / index / --- / +++ lines start with characters the row parser
+    # also uses ('-', '+'), so a parser that starts before the first @@ emits
+    # the file header as though it were removed and added lines.
+    out = _parse(_ctx(), PATCH)
+    texts = [r["text"] for r in out["rows"]]
+    assert not any("diff --git" in t for t in texts)
+    assert not any(t.startswith("a/f1.txt") or t.startswith("b/f1.txt") for t in texts)
+    assert out["stats"] == {"added": 2, "removed": 1}
+
+
+def test_rows_come_out_in_order_with_the_right_kinds() -> None:
+    out = _parse(_ctx(), PATCH)
+    assert [r["kind"] for r in out["rows"]] == ["same", "del", "add", "same", "add"]
+    assert [r["text"] for r in out["rows"]] == ["a", "b", "B", "c", "d"]
+
+
+def test_line_numbers_are_taken_from_the_hunk_header() -> None:
+    # A diff that points at the wrong line is worse than no diff.
+    out = _parse(_ctx(), PATCH)
+    rows = out["rows"]
+    assert (rows[0]["a"], rows[0]["b"]) == (1, 1)   # context 'a'
+    assert (rows[1]["a"], rows[1]["b"]) == (2, None)  # removed 'b'
+    assert (rows[2]["a"], rows[2]["b"]) == (None, 2)  # added 'B'
+    assert (rows[3]["a"], rows[3]["b"]) == (3, 3)   # context 'c'
+    assert (rows[4]["a"], rows[4]["b"]) == (None, 4)  # added 'd'
+
+
+def test_a_hunk_starting_late_in_the_file_numbers_from_its_offset() -> None:
+    out = _parse(_ctx(), (
+        "--- a/f\n+++ b/f\n"
+        "@@ -120,3 +120,3 @@\n x\n-y\n+Y\n z\n"
+    ))
+    rows = out["rows"]
+    assert rows[0]["a"] == 120
+    assert rows[1]["a"] == 121
+    assert rows[2]["b"] == 121
+    assert rows[3]["a"] == 122
+
+
+def test_multiple_hunks_get_a_gap_between_them() -> None:
+    out = _parse(_ctx(), (
+        "--- a/f\n+++ b/f\n"
+        "@@ -1,2 +1,2 @@\n a\n-b\n+B\n"
+        "@@ -50,2 +50,2 @@\n y\n-z\n+Z\n"
+    ))
+    kinds = [r["kind"] for r in out["rows"]]
+    assert "gap" in kinds
+    assert kinds.index("gap") > 0, "no leading gap before the first hunk"
+    # The skipped run's length is genuinely unknown - git never sent it.
+    gap = next(r for r in out["rows"] if r["kind"] == "gap")
+    assert gap["count"] is None
+    assert out["stats"] == {"added": 2, "removed": 2}
+
+
+def test_the_second_hunk_numbers_from_its_own_header() -> None:
+    out = _parse(_ctx(), (
+        "--- a/f\n+++ b/f\n"
+        "@@ -1,2 +1,2 @@\n a\n-b\n+B\n"
+        "@@ -50,2 +50,2 @@\n y\n-z\n+Z\n"
+    ))
+    tail = [r for r in out["rows"] if r["kind"] != "gap"][-3:]
+    assert tail[0]["a"] == 50   # context 'y'
+    assert tail[1]["a"] == 51   # removed 'z'
+    assert tail[2]["b"] == 51   # added 'Z'
+
+
+def test_a_single_line_hunk_header_without_a_count_parses() -> None:
+    # git writes "@@ -1 +1 @@" when the range is one line.
+    out = _parse(_ctx(), "--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n+A\n")
+    assert out["stats"] == {"added": 1, "removed": 1}
+    assert out["rows"][0]["a"] == 1
+    assert out["rows"][1]["b"] == 1
+
+
+def test_no_newline_marker_is_not_content() -> None:
+    out = _parse(_ctx(), "--- a/f\n+++ b/f\n@@ -1 +1 @@\n-a\n\\ No newline at end of file\n+A\n")
+    assert [r["text"] for r in out["rows"]] == ["a", "A"]
+    assert out["stats"] == {"added": 1, "removed": 1}
+
+
+def test_an_empty_context_line_is_kept_as_a_line() -> None:
+    # git emits a bare "" for a blank context line, not " ".
+    out = _parse(_ctx(), "--- a/f\n+++ b/f\n@@ -1,3 +1,3 @@\n a\n\n-c\n+C\n")
+    kinds = [r["kind"] for r in out["rows"]]
+    assert kinds == ["same", "same", "del", "add"]
+
+
+def test_a_binary_patch_is_reported_not_parsed_as_lines() -> None:
+    out = _parse(_ctx(), "diff --git a/b.png b/b.png\nBinary files a/b.png and b/b.png differ\n")
+    assert out["binary"] is True
+    assert out["rows"] == []
+
+
+def test_an_empty_patch_yields_nothing() -> None:
+    ctx = _ctx()
+    for value in ('""', "null", "undefined"):
+        ctx.eval(f"var o = ST2_parseUnifiedDiff({value});")
+        assert ctx.eval("o.rows.length") == 0
+        assert ctx.eval("o.stats.added") == 0
+
+
+def test_a_pure_addition_patch_counts_every_line() -> None:
+    out = _parse(_ctx(), "--- /dev/null\n+++ b/new.txt\n@@ -0,0 +1,3 @@\n+a\n+b\n+c\n")
+    assert out["stats"] == {"added": 3, "removed": 0}
+    assert [r["b"] for r in out["rows"]] == [1, 2, 3]
+
+
+# ---------------------------------------------------------------------------
+# Side-by-side pairing
+# ---------------------------------------------------------------------------
+
+
+def test_a_changed_line_pairs_its_removal_with_its_replacement() -> None:
+    ctx = _ctx()
+    ctx.eval("""
+        var rows = [
+          {kind: "same", a: 1, b: 1, text: "a"},
+          {kind: "del", a: 2, b: null, text: "b"},
+          {kind: "add", a: null, b: 2, text: "B"}
+        ];
+        var pairs = ST2_pairRows(rows);
+    """)
+    assert ctx.eval("pairs.length") == 2
+    assert ctx.eval("pairs[1].left.text") == "b"
+    assert ctx.eval("pairs[1].right.text") == "B"
+
+
+def test_an_uneven_del_add_run_leaves_the_short_side_blank() -> None:
+    ctx = _ctx()
+    ctx.eval("""
+        var rows = [
+          {kind: "del", a: 1, b: null, text: "x"},
+          {kind: "del", a: 2, b: null, text: "y"},
+          {kind: "add", a: null, b: 1, text: "X"}
+        ];
+        var pairs = ST2_pairRows(rows);
+        var secondRight = pairs[1].right;
+    """)
+    assert ctx.eval("pairs.length") == 2
+    assert ctx.eval("secondRight") is None
+
+
+def test_pairing_never_drops_a_row() -> None:
+    ctx = _ctx()
+    ctx.eval("""
+        var rows = [
+          {kind: "add", a: null, b: 1, text: "1"},
+          {kind: "same", a: 1, b: 2, text: "2"},
+          {kind: "del", a: 2, b: null, text: "3"}
+        ];
+        var pairs = ST2_pairRows(rows);
+        var seen = 0;
+        pairs.forEach(function (p) {
+          if (p.both) { seen += 1; return; }
+          if (p.left) seen += 1;
+          if (p.right) seen += 1;
+        });
+    """)
+    assert ctx.eval("seen") == 3
+
+
+def test_layout_is_chosen_by_width_not_by_a_user_toggle() -> None:
+    src = DIFF.read_text(encoding="utf-8")
+    assert "ST2_SIDE_BY_SIDE_MIN_W = 900" in src
+    assert "ResizeObserver" in src
+    assert 'data-layout={wide ? "side-by-side" : "unified"}' in src
+    code = _code_only(src)
+    # No toggle: the right answer is a property of the container.
+    assert "sideBySide" not in code or "setSideBySide" not in code
+
+
+def test_a_long_diff_is_capped_and_says_so() -> None:
+    src = DIFF.read_text(encoding="utf-8")
+    assert "ST2_DIFF_ROW_CAP = 500" in src
+    assert '"diff-truncated"' in src
+    assert "rows.slice(0, ST2_DIFF_ROW_CAP)" in src
+
+
+def test_a_parsed_patch_is_not_re_collapsed() -> None:
+    # git already omitted its unchanged runs; collapsing again would eat the
+    # context lines it deliberately sent.
+    src = DIFF.read_text(encoding="utf-8")
+    assert "patch != null ? diff.rows : ST2_collapseContext(diff.rows, context)" in src
+
+
+# ---------------------------------------------------------------------------
+# Trail grouping
+# ---------------------------------------------------------------------------
+
+
+def _group(ctx, commits, sessions=None):
+    ctx.eval(
+        f"var g = ST2_groupTrail({json.dumps(commits)}, "
+        f"{{sessionsById: {json.dumps(sessions or {})}}});"
+    )
+    return json.loads(ctx.eval("JSON.stringify(g)"))
+
+
+def test_commits_group_by_session_in_first_seen_order() -> None:
+    groups = _group(_ctx(), [
+        {"sha": "a", "session_id": "s1", "files": [{"path": "x", "additions": 1, "deletions": 0}]},
+        {"sha": "b", "session_id": "s2", "files": [{"path": "y", "additions": 1, "deletions": 0}]},
+        {"sha": "c", "session_id": "s1", "files": [{"path": "z", "additions": 1, "deletions": 0}]},
+    ])
+    assert [g["session_id"] for g in groups] == ["s1", "s2"]
+    assert len(groups[0]["commits"]) == 2
+
+
+def test_a_commit_with_no_session_is_kept_not_dropped() -> None:
+    # Platform writes have no session trailer; dropping them would hide real
+    # changes to the workspace.
+    groups = _group(_ctx(), [
+        {"sha": "a", "session_id": None, "files": [{"path": "x", "additions": 1, "deletions": 0}]},
+    ])
+    assert len(groups) == 1
+    assert groups[0]["session_id"] is None
+    assert groups[0]["label"] == "workspace"
+
+
+def test_null_files_is_never_counted_as_zero() -> None:
+    # The sandbox backend cannot report file data. Counting null as 0 would
+    # draw "0 files" over a commit that certainly touched some.
+    groups = _group(_ctx(), [{"sha": "a", "session_id": "s1", "files": None}])
+    assert groups[0]["fileCount"] == 0
+    assert groups[0]["unknownFiles"] is True
+
+
+def test_a_known_empty_commit_is_not_flagged_unknown() -> None:
+    groups = _group(_ctx(), [{"sha": "a", "session_id": "s1", "files": []}])
+    assert groups[0]["fileCount"] == 0
+    assert groups[0]["unknownFiles"] is False
+
+
+def test_file_counts_sum_across_a_sessions_commits() -> None:
+    groups = _group(_ctx(), [
+        {"sha": "a", "session_id": "s1", "files": [
+            {"path": "x", "additions": 1, "deletions": 0},
+            {"path": "y", "additions": 2, "deletions": 1},
+        ]},
+        {"sha": "b", "session_id": "s1", "files": [{"path": "z", "additions": 1, "deletions": 0}]},
+    ])
+    assert groups[0]["fileCount"] == 3
+
+
+def test_the_group_label_prefers_the_session_name() -> None:
+    groups = _group(
+        _ctx(),
+        [{"sha": "a", "session_id": "s1", "files": []}],
+        {"s1": {"session_id": "s1", "name": "refactor the parser", "status": "running"}},
+    )
+    assert groups[0]["label"] == "refactor the parser"
+    assert groups[0]["bucket"] == "working"
+
+
+def test_file_tone_distinguishes_create_delete_and_edit() -> None:
+    ctx = _ctx()
+    ctx.eval("var created = ST2_fileTone({additions: 5, deletions: 0});")
+    ctx.eval("var deleted = ST2_fileTone({additions: 0, deletions: 5});")
+    ctx.eval("var edited = ST2_fileTone({additions: 5, deletions: 5});")
+    ctx.eval("var bin = ST2_fileTone({binary: true, additions: 0, deletions: 0});")
+    assert ctx.eval("created") == "--green"
+    assert ctx.eval("deleted") == "--red"
+    assert ctx.eval("edited") == "--blue"
+    assert ctx.eval("bin") == "--text-3"
+
+
+# ---------------------------------------------------------------------------
+# Wiring + the honest gaps
+# ---------------------------------------------------------------------------
+
+
+def test_the_trail_uses_with_files_and_the_commit_endpoint_for_patches() -> None:
+    api = API.read_text(encoding="utf-8")
+    assert "with_files=1" in api
+    assert '"/commit/"' in api
+    changes = CHANGES.read_text(encoding="utf-8")
+    assert "ST2_api.trail(wid, ST2_CHANGES_LIMIT, true, signal)" in changes
+    assert "ST2_api.commit(wid, sel.commit.sha, signal)" in changes
+
+
+def test_the_trail_is_not_polled() -> None:
+    # History does not change under the reader; WS_LogTab's manual refresh is
+    # kept deliberately (§7.1).
+    src = CHANGES.read_text(encoding="utf-8")
+    trail_block = src[src.index("var trail = api.useResource("):src.index("var commits =")]
+    assert "pollMs" not in trail_block
+    assert '"changes-refresh"' in src
+
+
+def test_patches_are_fetched_per_opened_commit_only() -> None:
+    # The whole reason the trail carries counts instead of content.
+    src = CHANGES.read_text(encoding="utf-8")
+    assert "function ST2_ChangesDetail(" in src
+    detail = src[src.index("function ST2_ChangesDetail("):src.index("function ChangesView(")]
+    assert "ST2_api.keys.commit(" in detail
+
+
+def test_revert_stays_hidden_until_a_backend_op_exists() -> None:
+    src = CHANGES.read_text(encoding="utf-8")
+    assert '"studio.revert"' in src
+    assert "revertEnabled ? (" in src
+    # Never faked with a file write.
+    code = _code_only(src)
+    assert "files/write" not in code
+    assert 'apiFetch("PUT"' not in code
+
+
+def test_mark_reviewed_is_local_and_labelled_honestly() -> None:
+    src = CHANGES.read_text(encoding="utf-8")
+    assert "localStorage" in src
+    assert '"changes-unreviewed-chip"' in src
+    assert ">Unreviewed<" in src
+
+
+def test_show_the_turn_opens_in_the_other_pane() -> None:
+    # So the diff stays on screen next to its explanation (§7.2).
+    src = CHANGES.read_text(encoding="utf-8")
+    assert "studio.openAside" in src
+    assert '"changes-show-turn"' in src
+
+
+def test_no_rationale_field_is_invented() -> None:
+    # The footer is the commit subject the runtime already writes.
+    src = CHANGES.read_text(encoding="utf-8")
+    assert '"changes-rationale"' in src
+    assert "sel.commit.subject" in src
+    assert "rationale:" not in _code_only(src)
+
+
+def test_changes_is_a_center_tab_with_a_header_entry_point() -> None:
+    center = CENTER.read_text(encoding="utf-8")
+    assert 'activeTab.kind === "changes"' in center
+    studio = STUDIO.read_text(encoding="utf-8")
+    assert '"studio-changes-toggle"' in studio
+    assert 'kind: "changes"' in studio
+    # v2 only, like every other revamp surface.
+    assert "onOpenChanges={isV2 ?" in studio
+
+
+def test_changes_does_not_name_urls_directly() -> None:
+    src = CHANGES.read_text(encoding="utf-8")
+    assert "/workspaces/" not in _code_only(src)
+    assert "ST2_api." in src
+
+
+def test_changes_registered_after_the_diff_module() -> None:
+    lines = (UI / "index.html").read_text(encoding="utf-8").splitlines()
+    reg = [i for i, ln in enumerate(lines) if 'type="text/babel"' in ln and "src=" in ln]
+
+    def idx(frag: str) -> int:
+        for i in reg:
+            if frag in lines[i]:
+                return i
+        raise AssertionError(f"{frag} is not registered")
+
+    assert idx("studio/st-diff.jsx") < idx("studio/st-changes.jsx")
+    assert idx("studio/st-changes.jsx") < idx("components/studio.jsx")
+
+
+def test_changes_modules_transpile() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    for rel in ("components/studio/st-changes.jsx", "components/studio/st-diff.jsx",
+                "components/studio-center.jsx", "components/studio.jsx"):
+        assert b._transform((UI / rel).read_text(encoding="utf-8"), rel), rel

--- a/tests/ui/test_studio_diff.py
+++ b/tests/ui/test_studio_diff.py
@@ -32,9 +32,7 @@ def _ctx():
 
 
 def _diff(ctx, before: str, after: str):
-    ctx.eval(
-        "var out = ST2_diffLines(%s, %s);" % (json.dumps(before), json.dumps(after))
-    )
+    ctx.eval(f"var out = ST2_diffLines({json.dumps(before)}, {json.dumps(after)});")
     return json.loads(ctx.eval("JSON.stringify(out)"))
 
 

--- a/tests/ui/test_studio_diff.py
+++ b/tests/ui/test_studio_diff.py
@@ -1,0 +1,279 @@
+"""Studio revamp: line diffing (ui/studio/STUDIO-WIRING.md §7).
+
+The diff is hand-rolled (the console ships no bundler, so the alternative is
+vendoring another UMD blob), which means the LCS walk and both size guards have
+to be exercised for real rather than eyeballed. Every test here runs the actual
+JavaScript in MiniRacer.
+
+The Changes VIEW that consumes this is still blocked on a backend addition (the
+plan's §0.2: CommitInfo carries no file list and there is no diff route), but
+the diffing itself needs none of that.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+DIFF = UI / "components" / "studio" / "st-diff.jsx"
+
+
+def _ctx():
+    """MiniRacer with st-diff's pure logic loaded (no React)."""
+    py_mini_racer = pytest.importorskip("py_mini_racer")
+    ctx = py_mini_racer.MiniRacer()
+    src = DIFF.read_text(encoding="utf-8")
+    ctx.eval(src[: src.index("// ---------------------------------------------------------------------------\n// Rendering")])
+    return ctx
+
+
+def _diff(ctx, before: str, after: str):
+    ctx.eval(
+        "var out = ST2_diffLines(%s, %s);" % (json.dumps(before), json.dumps(after))
+    )
+    return json.loads(ctx.eval("JSON.stringify(out)"))
+
+
+# ---------------------------------------------------------------------------
+# Line splitting
+# ---------------------------------------------------------------------------
+
+
+def test_a_trailing_newline_is_not_a_phantom_last_line() -> None:
+    # Otherwise every whole-file diff reports a spurious final empty line.
+    ctx = _ctx()
+    ctx.eval('var n = ST2_splitLines("a\\nb\\n").length;')
+    assert ctx.eval("n") == 2
+
+
+def test_empty_text_has_no_lines() -> None:
+    ctx = _ctx()
+    ctx.eval('var a = ST2_splitLines("").length, b = ST2_splitLines(null).length;')
+    assert ctx.eval("a") == 0
+    assert ctx.eval("b") == 0
+
+
+def test_interior_blank_lines_are_preserved() -> None:
+    ctx = _ctx()
+    ctx.eval('var n = ST2_splitLines("a\\n\\nb").length;')
+    assert ctx.eval("n") == 3
+
+
+# ---------------------------------------------------------------------------
+# The diff itself
+# ---------------------------------------------------------------------------
+
+
+def test_identical_files_have_no_changes() -> None:
+    out = _diff(_ctx(), "a\nb\nc\n", "a\nb\nc\n")
+    assert out["stats"] == {"added": 0, "removed": 0}
+    assert [r["kind"] for r in out["rows"]] == ["same", "same", "same"]
+
+
+def test_a_single_inserted_line() -> None:
+    out = _diff(_ctx(), "a\nc\n", "a\nb\nc\n")
+    assert out["stats"] == {"added": 1, "removed": 0}
+    kinds = [r["kind"] for r in out["rows"]]
+    assert kinds == ["same", "add", "same"]
+    added = [r for r in out["rows"] if r["kind"] == "add"][0]
+    assert added["text"] == "b"
+    # Line numbers: absent on the side where the line does not exist.
+    assert added["a"] is None
+    assert added["b"] == 2
+
+
+def test_a_single_deleted_line() -> None:
+    out = _diff(_ctx(), "a\nb\nc\n", "a\nc\n")
+    assert out["stats"] == {"added": 0, "removed": 1}
+    assert [r["kind"] for r in out["rows"]] == ["same", "del", "same"]
+    removed = [r for r in out["rows"] if r["kind"] == "del"][0]
+    assert removed["a"] == 2
+    assert removed["b"] is None
+
+
+def test_a_changed_line_reads_as_delete_then_add() -> None:
+    out = _diff(_ctx(), "a\nb\nc\n", "a\nB\nc\n")
+    assert [r["kind"] for r in out["rows"]] == ["same", "del", "add", "same"]
+    assert out["stats"] == {"added": 1, "removed": 1}
+
+
+def test_line_numbers_stay_correct_after_an_insertion() -> None:
+    # The two gutters diverge after any add/del; an off-by-one here sends
+    # "open at line N" to the wrong line.
+    out = _diff(_ctx(), "a\nb\n", "a\nx\ny\nb\n")
+    last = out["rows"][-1]
+    assert last["kind"] == "same"
+    assert last["a"] == 2
+    assert last["b"] == 4
+
+
+def test_creating_a_file_is_all_additions() -> None:
+    out = _diff(_ctx(), "", "a\nb\n")
+    assert out["stats"] == {"added": 2, "removed": 0}
+    assert all(r["kind"] == "add" for r in out["rows"])
+
+
+def test_emptying_a_file_is_all_deletions() -> None:
+    out = _diff(_ctx(), "a\nb\n", "")
+    assert out["stats"] == {"added": 0, "removed": 2}
+    assert all(r["kind"] == "del" for r in out["rows"])
+
+
+def test_a_move_is_reported_as_one_delete_and_one_add() -> None:
+    out = _diff(_ctx(), "a\nb\nc\n", "b\nc\na\n")
+    assert out["stats"] == {"added": 1, "removed": 1}
+
+
+def test_lcs_finds_the_minimal_edit_not_a_wholesale_replace() -> None:
+    # A naive line-by-line compare would call all five lines changed.
+    out = _diff(_ctx(), "1\n2\n3\n4\n5\n", "1\n2\nX\n4\n5\n")
+    assert out["stats"] == {"added": 1, "removed": 1}
+    assert sum(1 for r in out["rows"] if r["kind"] == "same") == 4
+
+
+def test_repeated_lines_do_not_confuse_the_walk() -> None:
+    out = _diff(_ctx(), "a\na\na\n", "a\na\n")
+    assert out["stats"] == {"added": 0, "removed": 1}
+
+
+# ---------------------------------------------------------------------------
+# The guards - both of these hang the tab rather than degrading
+# ---------------------------------------------------------------------------
+
+
+def test_an_oversized_side_is_refused_not_diffed() -> None:
+    ctx = _ctx()
+    ctx.eval("var big = 'x\\n'.repeat(200000);")
+    ctx.eval("var out = ST2_diffLines(big, 'y');")
+    assert ctx.eval("out.tooLarge") is True
+    assert "too large" in ctx.eval("out.reason")
+
+
+def test_the_cap_is_stated_in_kb_the_user_can_understand() -> None:
+    ctx = _ctx()
+    ctx.eval("var out = ST2_diffLines('x'.repeat(300000), 'y');")
+    assert "200 KB" in ctx.eval("out.reason")
+
+
+def test_a_file_just_under_the_cap_still_diffs() -> None:
+    ctx = _ctx()
+    ctx.eval("var s = 'a\\n'.repeat(1000);")
+    ctx.eval("var out = ST2_diffLines(s, s + 'b\\n');")
+    assert ctx.eval("!!out.tooLarge") is False
+    assert ctx.eval("out.stats.added") == 1
+
+
+def test_a_wholesale_rewrite_degrades_instead_of_freezing() -> None:
+    # Nothing trims, so the DP would be huge. It must fall back, stay exact on
+    # the counts, and say that it did.
+    ctx = _ctx()
+    ctx.eval("var a = [], b = [];")
+    ctx.eval("for (var i = 0; i < 3000; i++) { a.push('a' + i); b.push('b' + i); }")
+    ctx.eval("var out = ST2_diffLines(a.join('\\n'), b.join('\\n'));")
+    assert ctx.eval("out.coarse") is True
+    assert ctx.eval("out.stats.removed") == 3000
+    assert ctx.eval("out.stats.added") == 3000
+
+
+def test_the_coarse_fallback_keeps_the_untouched_tail() -> None:
+    # The trimmed suffix must survive the fallback path too.
+    ctx = _ctx()
+    ctx.eval("var a = [], b = [];")
+    ctx.eval("for (var i = 0; i < 2500; i++) { a.push('a' + i); b.push('b' + i); }")
+    ctx.eval("a.push('shared-tail'); b.push('shared-tail');")
+    ctx.eval("var out = ST2_diffLines(a.join('\\n'), b.join('\\n'));")
+    ctx.eval("var tail = out.rows[out.rows.length - 1];")
+    assert ctx.eval("out.coarse") is True
+    assert ctx.eval("tail.kind") == "same"
+    assert ctx.eval("tail.text") == "shared-tail"
+
+
+def test_a_large_but_localised_edit_is_not_coarse() -> None:
+    # Prefix/suffix trimming is what keeps the common case exact.
+    ctx = _ctx()
+    ctx.eval("var lines = [];")
+    ctx.eval("for (var i = 0; i < 5000; i++) lines.push('line ' + i);")
+    ctx.eval("var a = lines.join('\\n');")
+    ctx.eval("lines[2500] = 'CHANGED'; var b = lines.join('\\n');")
+    ctx.eval("var out = ST2_diffLines(a, b);")
+    assert ctx.eval("!!out.coarse") is False
+    assert ctx.eval("out.stats.added") == 1
+    assert ctx.eval("out.stats.removed") == 1
+
+
+# ---------------------------------------------------------------------------
+# Context collapsing
+# ---------------------------------------------------------------------------
+
+
+def test_long_unchanged_runs_collapse_to_a_gap_marker() -> None:
+    ctx = _ctx()
+    ctx.eval("var lines = [];")
+    ctx.eval("for (var i = 0; i < 200; i++) lines.push('l' + i);")
+    ctx.eval("var a = lines.join('\\n');")
+    ctx.eval("lines[100] = 'X'; var b = lines.join('\\n');")
+    ctx.eval("var rows = ST2_collapseContext(ST2_diffLines(a, b).rows, 3);")
+    ctx.eval("var gaps = rows.filter(function (r) { return r.kind === 'gap'; });")
+    # Two gaps: before and after the change.
+    assert ctx.eval("gaps.length") == 2
+    # And the whole thing is now short enough to read.
+    assert ctx.eval("rows.length") < 15
+
+
+def test_the_gap_marker_counts_the_lines_it_hides() -> None:
+    ctx = _ctx()
+    ctx.eval("var lines = [];")
+    ctx.eval("for (var i = 0; i < 50; i++) lines.push('l' + i);")
+    ctx.eval("var a = lines.join('\\n');")
+    ctx.eval("lines[49] = 'X'; var b = lines.join('\\n');")
+    ctx.eval("var rows = ST2_collapseContext(ST2_diffLines(a, b).rows, 3);")
+    ctx.eval("var gap = rows.filter(function (r) { return r.kind === 'gap'; })[0];")
+    # 50 lines, last one changed, 3 lines of context kept -> 46 hidden.
+    assert ctx.eval("gap.count") == 46
+
+
+def test_changed_lines_are_never_collapsed() -> None:
+    ctx = _ctx()
+    ctx.eval("var rows = ST2_collapseContext(ST2_diffLines('a\\nb\\n', 'a\\nB\\n').rows, 3);")
+    ctx.eval("var kinds = rows.map(function (r) { return r.kind; }).join(',');")
+    assert "del" in ctx.eval("kinds")
+    assert "add" in ctx.eval("kinds")
+    assert "gap" not in ctx.eval("kinds")
+
+
+def test_an_unchanged_file_collapses_entirely() -> None:
+    ctx = _ctx()
+    ctx.eval("var rows = ST2_collapseContext(ST2_diffLines('a\\nb\\nc\\n', 'a\\nb\\nc\\n').rows, 3);")
+    ctx.eval("var kinds = rows.map(function (r) { return r.kind; }).join(',');")
+    assert ctx.eval("kinds") == "gap"
+
+
+# ---------------------------------------------------------------------------
+# No vendored library, and it renders
+# ---------------------------------------------------------------------------
+
+
+def test_no_diff_library_was_vendored() -> None:
+    names = [p.name.lower() for p in (UI / "vendor").iterdir()]
+    for lib in ("diff", "jsdiff", "diff2html", "diff-match-patch"):
+        assert not any(lib in n for n in names), lib
+
+
+def test_diff_view_reports_both_counts_and_the_refusal() -> None:
+    src = DIFF.read_text(encoding="utf-8")
+    for tid in ("diff-view", "diff-added", "diff-removed", "diff-too-large",
+                "diff-gap", "diff-coarse"):
+        assert f'"{tid}"' in src, tid
+    assert '"diff-row-" + row.kind' in src
+
+
+def test_diff_module_transpiles_and_is_registered() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    assert b._transform(DIFF.read_text(encoding="utf-8"), "components/studio/st-diff.jsx")
+    assert "components/studio/st-diff.jsx" in (UI / "index.html").read_text(encoding="utf-8")

--- a/tests/ui/test_studio_dock.py
+++ b/tests/ui/test_studio_dock.py
@@ -1,0 +1,149 @@
+"""Studio revamp: the investigate dock (ui/studio/STUDIO-WIRING.md §8, §2.1).
+
+The dock re-houses the tap and the terminal and adds a derived Problems list.
+It replaces the right rail, but ONLY under the studioV2 tweak - that tweak is a
+runtime flag, so one build has to serve both shells and both sets of persisted
+state. These tests pin that coexistence, which is the part most likely to rot.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+STUDIO_JSX = UI / "components" / "studio.jsx"
+DOCK = UI / "components" / "studio" / "st-dock.jsx"
+
+
+def _studio() -> str:
+    return STUDIO_JSX.read_text(encoding="utf-8")
+
+
+def _dock() -> str:
+    return DOCK.read_text(encoding="utf-8")
+
+
+def test_dock_module_exists_and_exports() -> None:
+    assert DOCK.exists()
+    src = _dock()
+    assert "function InvestigateDock(" in src
+    assert "window.InvestigateDock" in src
+
+
+def test_dock_rehouses_the_tap_and_terminal_verbatim() -> None:
+    # Re-housed, not rebuilt: same components, same props.
+    src = _dock()
+    assert "<WorkspaceTap" in src
+    assert "fillHeight" in src
+    assert "<TerminalPanel" in src
+
+
+def test_dock_exposes_its_tab_testids() -> None:
+    src = _dock()
+    for tid in ("investigate-dock", "problems-list"):
+        assert f'"{tid}"' in src, tid
+    # Tab ids are composed (`"dock-tab-" + id`) so one component renders them
+    # all; assert the prefix plus each id that is passed in.
+    assert '"dock-tab-" + id' in src
+    for tab in ('id="events"', 'id="problems"'):
+        assert tab in src, tab
+    # The terminal tab id must resolve even with several terminals open, so
+    # test_studio_terminal.py has one stable locator.
+    assert '"terminal"' in src and '"terminal-"' in src
+
+
+def test_problems_is_derived_and_needs_no_endpoint() -> None:
+    # Failed runs come from the bucket language; errors from the shared tap.
+    src = _dock()
+    assert "ST2_bucketOf" in src
+    assert '"broken"' in src
+    assert "useWorkspaceTapListener" in src
+    assert "EventSource" not in src
+
+
+def test_dock_does_not_name_urls_directly() -> None:
+    src = _dock()
+    for marker in ('apiFetch("GET"', 'apiFetch("POST"'):
+        assert marker not in src
+
+
+# ---------------------------------------------------------------------------
+# §2.1 - state model, and the coexistence the runtime tweak demands
+# ---------------------------------------------------------------------------
+
+
+def test_dock_state_keys_are_added_and_persisted() -> None:
+    src = _studio()
+    for key in ('"dockOpen"', '"dockTab"', '"dockHeight"'):
+        assert key in src, key
+    assert "dockOpen: false" in src
+    assert "dockTab: \"events\"" in src
+
+
+def test_v1_state_keys_survive_because_the_tweak_is_a_runtime_flag() -> None:
+    # The plan originally said to delete these. That would break the v1 shell,
+    # which is still reachable at runtime whenever studioV2 is off.
+    src = _studio()
+    assert '"terminalOpen"' in src
+    assert '"debugOpen"' in src
+    assert '"terminalHeight"' in src
+
+
+def test_terminal_state_migrates_into_the_dock_once() -> None:
+    # Switching the tweak on must not silently close a terminal the operator
+    # had open.
+    src = _studio()
+    assert "keep.dockOpen === undefined" in src
+    assert "parsed.terminalOpen" in src
+    assert "keep.dockHeight === undefined" in src
+    assert "parsed.terminalHeight" in src
+
+
+def test_dock_actions_exist_and_clamp_height() -> None:
+    src = _studio()
+    for fn in ("toggleDock", "setDockTab", "setDockHeight"):
+        assert fn + ":" in src, fn
+    assert "Math.max(120" in src
+
+
+def test_the_right_column_is_gone_under_v2_only() -> None:
+    src = _studio()
+    # Rendered behind !isV2, never removed outright.
+    assert "{!isV2 && (" in src
+    assert "<StudioActivity" in src
+    assert "InvestigateDock" in src
+
+
+def test_ctrl_backtick_and_the_resize_follow_the_active_shell() -> None:
+    src = _studio()
+    assert "if (isV2) studio.toggleDock(); else studio.toggleTerminal();" in src
+    assert "if (isV2) studio.setDockHeight(h); else studio.setTerminalHeight(h);" in src
+    assert '"dock-resize"' in src
+
+
+def test_right_width_css_var_collapses_under_v2() -> None:
+    src = _studio()
+    assert "!isV2 && s.debugOpen" in src
+
+
+def test_dock_is_registered_before_studio_in_index_html() -> None:
+    lines = (UI / "index.html").read_text(encoding="utf-8").splitlines()
+    order = [i for i, ln in enumerate(lines) if 'type="text/babel"' in ln and "src=" in ln]
+
+    def idx(frag: str) -> int:
+        for i in order:
+            if frag in lines[i]:
+                return i
+        raise AssertionError(f"{frag} is not registered")
+
+    assert idx("studio/st-dock.jsx") < idx("components/studio.jsx")
+
+
+def test_studio_bundle_still_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    for rel in ("components/studio.jsx", "components/studio/st-dock.jsx"):
+        code = b._transform((UI / rel).read_text(encoding="utf-8"), rel)
+        assert code, rel

--- a/tests/ui/test_studio_focus_links.py
+++ b/tests/ui/test_studio_focus_links.py
@@ -1,0 +1,295 @@
+"""Studio revamp: ?focus=<tool_call_id> deep links (WIRING §9, §2.3).
+
+The feature is a URL you paste into Slack, which means the link outlives the
+yield it points at. Almost every interesting case is therefore the STALE one, so
+that is what these tests concentrate on: a shared link whose request was already
+answered has to land somewhere useful and say so, never on an empty panel and
+never on the wrong item.
+
+The parse/serialise core is pure string work precisely so it can run here for
+real. URL / URLSearchParams are Web APIs, not ECMAScript - code built on them
+evaluates to nothing in V8, so a query-string edge case written against them
+would look tested while asserting on a swallowed exception.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+ATT = UI / "components" / "studio" / "st-attention.jsx"
+
+
+def _code_only(src: str) -> str:
+    out = []
+    for line in src.splitlines():
+        idx = line.find("//")
+        out.append(line if idx == -1 else line[:idx])
+    return "\n".join(out)
+
+
+def _ctx():
+    """MiniRacer with the pure focus helpers loaded - no window, no Web APIs."""
+    py_mini_racer = pytest.importorskip("py_mini_racer")
+    ctx = py_mini_racer.MiniRacer()
+    src = ATT.read_text(encoding="utf-8")
+    start = src.index("function ST2_splitHash(hash)")
+    end = src.index("function ST2_focusFromUrl()")
+    ctx.eval(src[start:end])
+    start2 = src.index("function ST2_resolveFocusTarget(")
+    end2 = src.index("\n}\n", start2) + 3
+    ctx.eval(src[start2:end2])
+    return ctx
+
+
+def test_v8_really_lacks_the_web_apis_this_avoids() -> None:
+    # Guards the reason the helpers are pure: if a future runtime gains these,
+    # the constraint is gone, but until then anything built on them is untested.
+    py_mini_racer = pytest.importorskip("py_mini_racer")
+    ctx = py_mini_racer.MiniRacer()
+    assert ctx.eval("typeof URL") == "undefined"
+    assert ctx.eval("typeof URLSearchParams") == "undefined"
+
+
+# ---------------------------------------------------------------------------
+# Parsing
+# ---------------------------------------------------------------------------
+
+
+def test_focus_is_read_from_the_hash_query() -> None:
+    # The Studio is a hash router, so ?focus= lives after the '#'.
+    ctx = _ctx()
+    assert ctx.eval('ST2_focusFromHash("#/workspaces/ws-1?focus=tc-42")') == "tc-42"
+
+
+def test_no_focus_param_reads_as_null() -> None:
+    ctx = _ctx()
+    assert ctx.eval('ST2_focusFromHash("#/workspaces/ws-1?open=session:s1")') is None
+
+
+def test_a_hash_with_no_query_reads_as_null() -> None:
+    ctx = _ctx()
+    assert ctx.eval('ST2_focusFromHash("#/workspaces/ws-1")') is None
+
+
+def test_an_empty_hash_reads_as_null() -> None:
+    ctx = _ctx()
+    assert ctx.eval('ST2_focusFromHash("")') is None
+    assert ctx.eval("ST2_focusFromHash(null)") is None
+
+
+def test_focus_coexists_with_the_pane_params() -> None:
+    ctx = _ctx()
+    h = "#/workspaces/ws-1?open=session:s1&aside=file:a.py&focus=tc-9"
+    assert ctx.eval(f'ST2_focusFromHash("{h}")') == "tc-9"
+
+
+def test_focus_is_found_regardless_of_position() -> None:
+    ctx = _ctx()
+    assert ctx.eval('ST2_focusFromHash("#/w?focus=tc-1&open=session:s")') == "tc-1"
+    assert ctx.eval('ST2_focusFromHash("#/w?open=session:s&focus=tc-1")') == "tc-1"
+
+
+def test_an_empty_focus_value_reads_as_null() -> None:
+    ctx = _ctx()
+    assert ctx.eval('ST2_focusFromHash("#/w?focus=")') is None
+
+
+# ---------------------------------------------------------------------------
+# Serialising
+# ---------------------------------------------------------------------------
+
+
+def test_setting_focus_adds_the_param() -> None:
+    ctx = _ctx()
+    out = ctx.eval('ST2_hashWithFocus("#/workspaces/ws-1", "tc-7")')
+    assert out == "#/workspaces/ws-1?focus=tc-7"
+
+
+def test_clearing_focus_removes_the_param_and_the_lone_question_mark() -> None:
+    ctx = _ctx()
+    assert ctx.eval('ST2_hashWithFocus("#/workspaces/ws-1?focus=tc-7", null)') == "#/workspaces/ws-1"
+
+
+def test_setting_focus_preserves_the_open_tab_param() -> None:
+    # Losing ?open= here would close the reader's tab as a side effect.
+    ctx = _ctx()
+    out = ctx.eval('ST2_hashWithFocus("#/workspaces/ws-1?open=session:s1", "tc-3")')
+    assert "focus=tc-3" in out
+    assert "open=session" in out
+    assert ctx.eval(f'ST2_focusFromHash("{out}")') == "tc-3"
+
+
+def test_clearing_focus_preserves_the_route_and_other_params() -> None:
+    ctx = _ctx()
+    out = ctx.eval('ST2_hashWithFocus("#/workspaces/ws-1?open=session:s1&focus=tc-3", null)')
+    assert out.startswith("#/workspaces/ws-1?")
+    assert "open=session" in out
+    assert "focus" not in out
+
+
+def test_resetting_focus_replaces_rather_than_duplicates() -> None:
+    ctx = _ctx()
+    out = ctx.eval('ST2_hashWithFocus("#/w?focus=old", "new")')
+    assert out.count("focus=") == 1
+    assert ctx.eval(f'ST2_focusFromHash("{out}")') == "new"
+
+
+def test_a_round_trip_preserves_every_param() -> None:
+    ctx = _ctx()
+    ctx.eval("""
+        var h = "#/workspaces/ws-1?open=session:s1&aside=file:a.py";
+        var withFocus = ST2_hashWithFocus(h, "tc-1");
+        var back = ST2_hashWithFocus(withFocus, null);
+        var openStill = ST2_focusFromHash(withFocus);
+    """)
+    assert ctx.eval("openStill") == "tc-1"
+    # Values are re-encoded, so compare by parsing rather than by string.
+    back = ctx.eval("back")
+    assert "open=session%3As1" in back
+    assert "aside=file%3Aa.py" in back
+    assert "focus" not in back
+
+
+def test_a_tool_call_id_needing_escaping_survives_the_round_trip() -> None:
+    ctx = _ctx()
+    ctx.eval("""
+        var out = ST2_hashWithFocus("#/w", "tc/1 2&3");
+        var got = ST2_focusFromHash(out);
+    """)
+    assert ctx.eval("got") == "tc/1 2&3"
+
+
+# ---------------------------------------------------------------------------
+# Resolution - the stale case is the common one
+# ---------------------------------------------------------------------------
+
+
+def test_a_live_id_opens_that_item() -> None:
+    ctx = _ctx()
+    ctx.eval(
+        'var r = ST2_resolveFocusTarget("tc-2",'
+        ' [{tool_call_id: "tc-1"}, {tool_call_id: "tc-2"}], false);'
+    )
+    assert ctx.eval("r.kind") == "focus"
+    assert ctx.eval("r.item.tool_call_id") == "tc-2"
+
+
+def test_an_already_answered_id_is_stale_not_a_silent_empty_panel() -> None:
+    ctx = _ctx()
+    ctx.eval('var r = ST2_resolveFocusTarget("tc-gone", [{tool_call_id: "tc-1"}], false);')
+    assert ctx.eval("r.kind") == "stale"
+
+
+def test_an_unknown_id_never_falls_through_to_a_different_item() -> None:
+    # Opening the wrong request and letting someone approve it would be the
+    # worst possible outcome here.
+    ctx = _ctx()
+    ctx.eval('var r = ST2_resolveFocusTarget("nonsense", [{tool_call_id: "tc-1"}], false);')
+    assert ctx.eval("r.kind") == "stale"
+    assert ctx.eval("!!r.item") is False
+
+
+def test_nothing_is_decided_while_the_snapshot_is_still_loading() -> None:
+    # Deciding "stale" against an empty in-flight list would flash the resolved
+    # note on every cold load of a perfectly good link.
+    ctx = _ctx()
+    ctx.eval('var r = ST2_resolveFocusTarget("tc-1", [], true);')
+    assert ctx.eval("r.kind") == "wait"
+
+
+def test_an_empty_queue_after_loading_is_stale() -> None:
+    ctx = _ctx()
+    ctx.eval('var r = ST2_resolveFocusTarget("tc-1", [], false);')
+    assert ctx.eval("r.kind") == "stale"
+
+
+def test_no_focus_param_is_a_distinct_outcome_from_stale() -> None:
+    ctx = _ctx()
+    ctx.eval("var r = ST2_resolveFocusTarget(null, [{tool_call_id: 'tc-1'}], false);")
+    assert ctx.eval("r.kind") == "none"
+
+
+# ---------------------------------------------------------------------------
+# Wiring
+# ---------------------------------------------------------------------------
+
+
+def test_the_deep_link_is_applied_once_per_url_value() -> None:
+    # Focusing writes the URL and the URL is read back as a deep link, so
+    # without a guard the two effects feed each other.
+    src = _code_only(ATT.read_text(encoding="utf-8"))
+    assert "appliedFocusRef" in src
+    assert "appliedFocusRef.current === tcid" in src
+
+
+def test_the_resolver_waits_for_the_snapshot_before_deciding() -> None:
+    src = _code_only(ATT.read_text(encoding="utf-8"))
+    assert 'target.kind === "wait"' in src
+    assert "att.loading" in src
+
+
+def test_a_stale_link_opens_the_queue_and_clears_the_param() -> None:
+    src = _code_only(ATT.read_text(encoding="utf-8"))
+    assert "queue: true, focus: null, staleFocus: tcid" in src
+    # Leaving the dead id in the address bar would re-trigger on reload.
+    assert "ST2_syncFocusUrl(null)" in src
+
+
+def test_the_resolved_note_is_rendered_in_the_queue() -> None:
+    src = ATT.read_text(encoding="utf-8")
+    assert '"focus-resolved-note"' in src
+    assert "already handled" in src
+    # Both queue call sites (calm bar and loud bar) must pass it.
+    assert src.count("staleFocus={ui.staleFocus}") == 2
+
+
+def test_closing_the_queue_clears_the_stale_note() -> None:
+    src = ATT.read_text(encoding="utf-8")
+    assert src.count("focus: null, staleFocus: null") >= 2
+
+
+def test_the_url_helpers_keep_the_web_api_at_the_boundary() -> None:
+    # Only these two touch history/clipboard; the logic they call is pure.
+    src = _code_only(ATT.read_text(encoding="utf-8"))
+    assert "ST2_hashWithFocus(window.location.hash, tcid)" in src
+    assert "window.history.replaceState" in src
+    assert "URLSearchParams" not in src
+    assert "new URL(" not in src
+
+
+def test_copy_link_does_not_navigate() -> None:
+    # Building the link must not move the reader off the panel they are
+    # answering, so ST2_focusLinkFor never touches history.
+    src = ATT.read_text(encoding="utf-8")
+    start = src.index("function ST2_focusLinkFor(")
+    body = src[start:src.index("\n}\n", start)]
+    assert "replaceState" not in body
+    assert "ST2_hashWithFocus" in body
+
+
+def test_copy_link_reports_a_failed_copy_instead_of_claiming_success() -> None:
+    # navigator.clipboard is unavailable outside a secure context; a silent
+    # no-op there would have the user paste stale clipboard content.
+    src = ATT.read_text(encoding="utf-8")
+    assert '"focus-copy-link"' in src
+    assert "navigator.clipboard" in src
+    assert 'title: "Could not copy"' in src
+    assert "detail: link" in src
+
+
+def test_focus_helpers_are_exported() -> None:
+    src = ATT.read_text(encoding="utf-8")
+    for fn in ("ST2_focusFromUrl", "ST2_syncFocusUrl", "ST2_resolveFocusTarget",
+               "ST2_focusLinkFor", "ST2_focusFromHash", "ST2_hashWithFocus"):
+        assert f"window.{fn} = {fn};" in src, fn
+
+
+def test_attention_module_still_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    assert b._transform(ATT.read_text(encoding="utf-8"), "components/studio/st-attention.jsx")

--- a/tests/ui/test_studio_graph_run_panel.py
+++ b/tests/ui/test_studio_graph_run_panel.py
@@ -1,0 +1,349 @@
+"""Studio revamp: the graph run strip and the phone layout (WIRING §10, §11).
+
+The superstep grouping is derived, not served, so it is the part that can be
+silently wrong - a strip that drops the un-run nodes claims the graph is smaller
+than it is, and one that paints a pending segment as live is worse than no strip.
+Both are exercised for real in MiniRacer.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+GRAPH = UI / "components" / "studio" / "st-graph-run.jsx"
+MOBILE = UI / "components" / "studio" / "st-mobile.jsx"
+STUDIO = UI / "components" / "studio.jsx"
+
+
+def _code_only(src: str) -> str:
+    out = []
+    for line in src.splitlines():
+        idx = line.find("//")
+        out.append(line if idx == -1 else line[:idx])
+    return "\n".join(out)
+
+
+def _ctx():
+    """MiniRacer with the pure superstep derivation loaded (no React)."""
+    py_mini_racer = pytest.importorskip("py_mini_racer")
+    ctx = py_mini_racer.MiniRacer()
+    src = GRAPH.read_text(encoding="utf-8")
+    start = src.index("function ST2_nodeBucket(status)")
+    end = src.index("// ---------------------------------------------------------------------------\n// Rendering")
+    ctx.eval(src[start:end])
+    return ctx
+
+
+def _steps(ctx, items):
+    ctx.eval("var out = ST2_supersteps(%s);" % json.dumps(items))
+    return json.loads(ctx.eval("JSON.stringify(out)"))
+
+
+# ---------------------------------------------------------------------------
+# The endpoint carries no superstep field - pin that the derivation is honest
+# ---------------------------------------------------------------------------
+
+
+def test_node_states_really_has_no_superstep_field() -> None:
+    # WIRING §10 says "one segment per superstep". The endpoint's model has no
+    # such field, so the strip derives from `iteration`. If a superstep field is
+    # ever added, this test fails and the derivation should be replaced by it.
+    from primer.api.routers.compute import _NodeStateOut
+
+    fields = set(_NodeStateOut.model_fields)
+    assert "superstep" not in fields
+    assert "iteration" in fields
+    assert fields == {
+        "node_id", "kind", "status", "iteration", "last_run_at",
+        "tokens_in", "tokens_out", "duration_ms", "error",
+    }
+
+
+def test_node_status_vocabulary_matches_the_backend() -> None:
+    # The five statuses the route can emit (compute.py docstring), each of which
+    # ST2_nodeBucket must map deliberately.
+    ctx = _ctx()
+    got = {
+        status: ctx.eval(f'ST2_nodeBucket("{status}")')
+        for status in ("pending", "running", "completed", "failed", "skipped")
+    }
+    assert got == {
+        "pending": "pending",
+        "running": "working",
+        "completed": "done",
+        "failed": "broken",
+        "skipped": "done",
+    }
+
+
+def test_pending_stays_distinct_from_working() -> None:
+    # Folding "not started" into "working" would paint an idle segment as live,
+    # which is the one thing the strip exists to tell you.
+    ctx = _ctx()
+    assert ctx.eval('ST2_nodeBucket("pending")') != ctx.eval('ST2_nodeBucket("running")')
+
+
+def test_an_unknown_status_reads_as_pending_not_done() -> None:
+    ctx = _ctx()
+    assert ctx.eval('ST2_nodeBucket("something-new")') == "pending"
+    assert ctx.eval("ST2_nodeBucket(null)") == "pending"
+
+
+# ---------------------------------------------------------------------------
+# Grouping
+# ---------------------------------------------------------------------------
+
+
+def test_supersteps_group_by_iteration_in_order() -> None:
+    steps = _steps(_ctx(), [
+        {"node_id": "c", "status": "pending", "iteration": 2},
+        {"node_id": "a", "status": "completed", "iteration": 0},
+        {"node_id": "b", "status": "running", "iteration": 1},
+    ])
+    assert [s["index"] for s in steps] == [0, 1, 2]
+
+
+def test_iterations_sort_numerically_not_lexically() -> None:
+    # Keyed through an object, so "10" would sort before "2" as a string.
+    steps = _steps(_ctx(), [
+        {"node_id": "a", "status": "completed", "iteration": 10},
+        {"node_id": "b", "status": "completed", "iteration": 2},
+    ])
+    assert [s["index"] for s in steps] == [2, 10]
+
+
+def test_a_fan_out_becomes_one_segment_carrying_its_width() -> None:
+    steps = _steps(_ctx(), [
+        {"node_id": "fan", "status": "completed", "iteration": 1},
+        {"node_id": "fan", "status": "completed", "iteration": 1},
+        {"node_id": "fan", "status": "running", "iteration": 1},
+    ])
+    assert len(steps) == 1
+    assert steps[0]["width"] == 3
+    assert steps[0]["label"] == "fan"
+
+
+def test_the_caption_shows_the_multiplier_only_when_it_fanned_out() -> None:
+    ctx = _ctx()
+    ctx.eval('var one = ST2_stepCaption({index: 0, label: "n", width: 1});')
+    ctx.eval('var many = ST2_stepCaption({index: 1, label: "fan", width: 4});')
+    assert ctx.eval("one") == "0 n"
+    assert ctx.eval("many") == "1 fan x4"
+
+
+def test_not_yet_run_nodes_become_a_trailing_upcoming_segment() -> None:
+    # They carry no iteration, so they cannot be placed in a numbered step -
+    # but dropping them would make the strip claim a shorter graph.
+    steps = _steps(_ctx(), [
+        {"node_id": "a", "status": "completed", "iteration": 0},
+        {"node_id": "b", "status": "pending"},
+        {"node_id": "c", "status": "pending", "iteration": None},
+    ])
+    assert len(steps) == 2
+    assert steps[-1]["upcoming"] is True
+    assert steps[-1]["index"] is None
+    assert steps[-1]["width"] == 2
+    assert steps[-1]["bucket"] == "pending"
+
+
+def test_no_upcoming_segment_when_every_node_has_run() -> None:
+    steps = _steps(_ctx(), [{"node_id": "a", "status": "completed", "iteration": 0}])
+    assert len(steps) == 1
+    assert steps[0]["upcoming"] is False
+
+
+def test_an_empty_run_yields_no_segments() -> None:
+    assert _steps(_ctx(), []) == []
+    ctx = _ctx()
+    ctx.eval("var out = ST2_supersteps(null);")
+    assert ctx.eval("out.length") == 0
+
+
+def test_iteration_zero_is_a_real_superstep_not_a_falsy_miss() -> None:
+    # `if (!it)` here would send every first superstep into "upcoming".
+    steps = _steps(_ctx(), [{"node_id": "a", "status": "completed", "iteration": 0}])
+    assert steps[0]["index"] == 0
+    assert steps[0]["upcoming"] is False
+
+
+# ---------------------------------------------------------------------------
+# A step is as bad as its worst node
+# ---------------------------------------------------------------------------
+
+
+def test_one_failure_defines_the_segment() -> None:
+    # Nine siblings completing does not make the step fine; the failure is what
+    # the operator has to act on.
+    ctx = _ctx()
+    items = [{"node_id": "f", "status": "completed", "iteration": 0} for _ in range(9)]
+    items.append({"node_id": "f", "status": "failed", "iteration": 0})
+    steps = _steps(ctx, items)
+    assert steps[0]["bucket"] == "broken"
+
+
+def test_running_beats_pending_and_done() -> None:
+    ctx = _ctx()
+    steps = _steps(ctx, [
+        {"node_id": "a", "status": "completed", "iteration": 0},
+        {"node_id": "a", "status": "running", "iteration": 0},
+        {"node_id": "a", "status": "pending", "iteration": 0},
+    ])
+    assert steps[0]["bucket"] == "working"
+
+
+def test_a_failure_beats_a_running_sibling() -> None:
+    ctx = _ctx()
+    steps = _steps(ctx, [
+        {"node_id": "a", "status": "running", "iteration": 0},
+        {"node_id": "a", "status": "failed", "iteration": 0},
+    ])
+    assert steps[0]["bucket"] == "broken"
+
+
+def test_all_completed_is_done() -> None:
+    steps = _steps(_ctx(), [
+        {"node_id": "a", "status": "completed", "iteration": 0},
+        {"node_id": "b", "status": "skipped", "iteration": 0},
+    ])
+    assert steps[0]["bucket"] == "done"
+
+
+def test_a_skipped_node_names_its_exclusion_without_inventing_one() -> None:
+    ctx = _ctx()
+    ctx.eval('var withReason = ST2_skipReason({status: "skipped", error: "findings == 0"});')
+    ctx.eval('var bare = ST2_skipReason({status: "skipped"});')
+    ctx.eval('var notSkipped = ST2_skipReason({status: "completed"});')
+    assert "findings == 0" in ctx.eval("withReason")
+    assert ctx.eval("bare") == "condition false"
+    assert ctx.eval("notSkipped") is None
+
+
+# ---------------------------------------------------------------------------
+# Rendering + wiring
+# ---------------------------------------------------------------------------
+
+
+def test_the_strip_is_dom_chrome_never_a_second_canvas() -> None:
+    src = GRAPH.read_text(encoding="utf-8")
+    assert '"superstep-strip"' in src
+    code = _code_only(src)
+    for banned in ("GR_Canvas", "new G6", "window.G6"):
+        assert banned not in code, banned
+
+
+def test_segments_are_weighted_by_node_count() -> None:
+    src = GRAPH.read_text(encoding="utf-8")
+    assert 'flex: step.width + " 1 0"' in src
+
+
+def test_only_the_live_segment_sweeps() -> None:
+    src = GRAPH.read_text(encoding="utf-8")
+    assert 'var live = step.bucket === "working";' in src
+    assert '"superstep-sweep"' in src
+
+
+def test_the_sweep_class_exists_and_reuses_the_shipped_keyframes() -> None:
+    css = (UI / "styles.css").read_text(encoding="utf-8")
+    assert ".st-sweep {" in css
+    assert "animation: shimmer" in css
+    # One sweep animation, not two.
+    assert css.count("@keyframes shimmer") == 1
+
+
+def test_the_node_states_fetch_never_runs_with_a_null_key() -> None:
+    # useResource has no null-key guard: a null key composes to "null", creates
+    # a cache entry, and fires GET /graphs/null/runs/null/node_states.
+    src = GRAPH.read_text(encoding="utf-8")
+    assert "function ST2_RunSteps({ gid, rid, onPickNode })" in src
+    assert "{gid && rid ? <ST2_RunSteps" in src
+    assert "ST2_api.keys.nodeStates(gid, rid)" in src
+
+
+def test_the_node_states_cache_key_exists() -> None:
+    api = (UI / "components" / "studio" / "st-api.jsx").read_text(encoding="utf-8")
+    assert "nodeStates: function (gid, rid)" in api
+
+
+def test_the_lane_inspector_is_the_companion_pane_not_a_drawer() -> None:
+    src = GRAPH.read_text(encoding="utf-8")
+    assert "studio.openAside" in src
+    # And it degrades to the shipped in-place node filter when there is no pane.
+    assert "onFallback" in src
+
+
+def test_graph_run_module_does_not_name_urls() -> None:
+    src = GRAPH.read_text(encoding="utf-8")
+    assert "/graphs/" not in _code_only(src)
+    assert "ST2_api.nodeStates" in src
+
+
+# ---------------------------------------------------------------------------
+# Mobile (§11)
+# ---------------------------------------------------------------------------
+
+
+def test_the_bottom_bar_keeps_the_shipped_mobile_testids() -> None:
+    # The drawers are gone, but the shipped journeys locate the bar by these.
+    src = MOBILE.read_text(encoding="utf-8")
+    assert '"studio-left-toggle"' in src
+    assert '"studio-right-toggle"' in src
+
+
+def test_bottom_bar_items_meet_the_touch_target_minimum() -> None:
+    src = MOBILE.read_text(encoding="utf-8")
+    assert "minHeight: 44" in src
+
+
+def test_the_phone_layout_is_triage_not_a_shrunk_desktop() -> None:
+    src = _code_only(MOBILE.read_text(encoding="utf-8"))
+    # No editor, no terminal, no event feed on a phone.
+    for banned in ("TerminalPanel", "FilePanel", "WorkspaceTap", "FilesTree", "InvestigateDock"):
+        assert banned not in src, banned
+    assert "mobile-desktop-only" in src
+
+
+def test_suggestion_chips_are_offered_for_questions_only() -> None:
+    # A one-tap "Yes" on an approval would authorise an arbitrary command.
+    src = MOBILE.read_text(encoding="utf-8")
+    assert 'item.kind === "ask_user" ? (' in src
+    assert "ST2_ASK_SUGGESTIONS" in src
+    assert '"mobile-suggestions"' in src
+
+
+def test_mobile_reuses_the_shared_yield_controls_and_actions() -> None:
+    src = MOBILE.read_text(encoding="utf-8")
+    assert "<ST2_YieldControls item={item} actions={actions} />" in src
+    assert "ST2_useYieldActions(wid)" in src
+    # Not a second implementation of the write path.
+    assert "useMutation" not in src
+    assert "apiFetch" not in src
+
+
+def test_mobile_runs_reuse_the_bucket_language_and_sort() -> None:
+    src = MOBILE.read_text(encoding="utf-8")
+    assert "ST2_bucketOf(s, { pendingBySession: pendingBySession })" in src
+    assert "ST_sessionSort(sessions || [])" in src
+
+
+def test_the_desktop_body_is_not_rendered_on_a_phone() -> None:
+    # A hidden terminal / file editor would still open its websockets.
+    src = STUDIO.read_text(encoding="utf-8")
+    assert "isV2 && isMobileView && typeof window.StudioMobile" in src
+    assert "window.primerApi.useViewport().isMobile" in src
+
+
+def test_both_new_modules_transpile_and_are_registered() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    index = (UI / "index.html").read_text(encoding="utf-8")
+    for rel in ("components/studio/st-graph-run.jsx", "components/studio/st-mobile.jsx",
+                "components/studio.jsx"):
+        assert b._transform((UI / rel).read_text(encoding="utf-8"), rel), rel
+    assert "studio/st-graph-run.jsx" in index
+    assert "studio/st-mobile.jsx" in index

--- a/tests/ui/test_studio_graph_run_panel.py
+++ b/tests/ui/test_studio_graph_run_panel.py
@@ -40,7 +40,7 @@ def _ctx():
 
 
 def _steps(ctx, items):
-    ctx.eval("var out = ST2_supersteps(%s);" % json.dumps(items))
+    ctx.eval(f"var out = ST2_supersteps({json.dumps(items)});")
     return json.loads(ctx.eval("JSON.stringify(out)"))
 
 

--- a/tests/ui/test_studio_panes.py
+++ b/tests/ui/test_studio_panes.py
@@ -1,0 +1,332 @@
+"""Studio revamp: the two-pane center (ui/studio/STUDIO-WIRING.md §6).
+
+The pane state machine is where this feature can lose user data - a file edited
+in the companion pane whose dirty flag never gets set closes without a
+confirmation. So the move/close/dirty logic is exercised for real in MiniRacer
+rather than grepped for.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+STUDIO = UI / "components" / "studio.jsx"
+CENTER = UI / "components" / "studio-center.jsx"
+PANES = UI / "components" / "studio" / "st-panes.jsx"
+
+
+def _code_only(src: str) -> str:
+    out = []
+    for line in src.splitlines():
+        idx = line.find("//")
+        out.append(line if idx == -1 else line[:idx])
+    return "\n".join(out)
+
+
+def _ctx():
+    """MiniRacer with st-panes' pure helpers loaded (no React)."""
+    py_mini_racer = pytest.importorskip("py_mini_racer")
+    ctx = py_mini_racer.MiniRacer()
+    src = PANES.read_text(encoding="utf-8")
+    # Just the pure helpers: stop before the window exports, which reference the
+    # React components that are deliberately not loaded here.
+    start = src.index("var ST2_WRITE_TOOLS")
+    ctx.eval(src[start:src.index("window.PaneHost")])
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# WROTE-row derivation
+# ---------------------------------------------------------------------------
+
+
+def test_write_tools_are_the_ids_the_runtime_actually_emits() -> None:
+    # WIRING names fs__write_file / fs__apply_patch. Those do not exist here;
+    # the runtime emits `workspace__<bare>` (tool_manager.WORKSPACE_TOOLSET_ID
+    # + the tool's ClassVar id). Matching the spec verbatim would have matched
+    # nothing, silently and forever - so pin against the real source.
+    from primer.agent.tool_manager import WORKSPACE_TOOLSET_ID
+    from primer.workspace.sandbox.tools import SandboxEdit, SandboxWrite
+
+    expected = {
+        f"{WORKSPACE_TOOLSET_ID}__{SandboxWrite.id}",
+        f"{WORKSPACE_TOOLSET_ID}__{SandboxEdit.id}",
+    }
+    src = _code_only(PANES.read_text(encoding="utf-8"))
+    for name in expected:
+        assert name in src, name
+    assert "fs__write_file" not in src
+    assert "fs__apply_patch" not in src
+
+
+def test_a_write_call_yields_its_path() -> None:
+    ctx = _ctx()
+    ctx.eval(
+        'var r = ST2_wroteFromToolCall({name: "workspace__write",'
+        ' args: {path: "src/a.py", content: "x"}});'
+    )
+    assert ctx.eval("r.path") == "src/a.py"
+
+
+def test_an_edit_call_yields_its_path() -> None:
+    ctx = _ctx()
+    ctx.eval('var r = ST2_wroteFromToolCall({tool_name: "workspace__edit", args: {path: "b.txt"}});')
+    assert ctx.eval("r.path") == "b.txt"
+
+
+def test_exec_is_never_treated_as_a_write() -> None:
+    # `exec` can write via a redirect, but its argv cannot say WHICH file, and a
+    # WROTE row pointing at the wrong path is worse than no row.
+    ctx = _ctx()
+    ctx.eval(
+        'var r = ST2_wroteFromToolCall({name: "workspace__exec",'
+        ' args: {command: "echo hi > out.txt"}});'
+    )
+    assert ctx.eval("r") is None
+
+
+def test_a_read_call_is_not_a_write() -> None:
+    ctx = _ctx()
+    ctx.eval('var r = ST2_wroteFromToolCall({name: "workspace__read", args: {path: "a"}});')
+    assert ctx.eval("r") is None
+
+
+def test_a_write_with_no_resolvable_path_is_skipped_not_guessed() -> None:
+    ctx = _ctx()
+    ctx.eval('var a = ST2_wroteFromToolCall({name: "workspace__write", args: {}});')
+    ctx.eval('var b = ST2_wroteFromToolCall({name: "workspace__write"});')
+    ctx.eval('var c = ST2_wroteFromToolCall({name: "workspace__write", args: {path: 42}});')
+    assert ctx.eval("a") is None
+    assert ctx.eval("b") is None
+    assert ctx.eval("c") is None
+
+
+def test_derivation_handles_a_null_row() -> None:
+    ctx = _ctx()
+    ctx.eval("var r = ST2_wroteFromToolCall(null);")
+    assert ctx.eval("r") is None
+
+
+# ---------------------------------------------------------------------------
+# Pane composition
+# ---------------------------------------------------------------------------
+
+
+def test_panehost_mounts_the_same_center_body_twice() -> None:
+    src = PANES.read_text(encoding="utf-8")
+    assert src.count("<StudioCenter") == 2
+    # Reused, not forked - so FilePanel / the transcript / the panels are all
+    # untouched and both panes get the same CenterTabs testids.
+    for forked in ("function StudioCenter(", "function CenterTabs(", "function FilePanel("):
+        assert forked not in src, forked
+
+
+def test_center_body_is_parameterised_not_state_bound() -> None:
+    src = CENTER.read_text(encoding="utf-8")
+    assert "function StudioCenter({ wid, studio, tabs, activeId, onFocus, onClose, onCloseAll, testId })" in src
+    # Omitted props must resolve to the primary pane, so v1 is unaffected.
+    assert "var openTabs = tabs || s.openTabs || [];" in src
+    assert "activeId !== undefined ? activeId : s.activeTabId" in src
+    assert "onFocus || studio.focusTab" in src
+    assert "onClose || studio.closeTab" in src
+    assert "onCloseAll || studio.closeAllTabs" in src
+
+
+def test_aside_is_open_exactly_when_it_holds_tabs() -> None:
+    # No asideOpen flag: a second source of truth for "is the pane open" is a
+    # desync waiting to happen, and §6 requires closing the last tab to close
+    # the pane - which is free if openness is derived.
+    src = PANES.read_text(encoding="utf-8")
+    assert "var asideOpen = asideTabs.length > 0;" in src
+    assert '"asideOpen"' not in _code_only(STUDIO.read_text(encoding="utf-8"))
+
+
+def test_narrow_viewports_get_an_overlay_not_a_squeezed_column() -> None:
+    src = PANES.read_text(encoding="utf-8")
+    assert "ST2_PANE_STACK_W = 1280" in src
+    assert "position: \"absolute\"" in src
+    # useViewport's width is enough; no isMobile fork (§6).
+    assert "window.primerApi.useViewport()" in src
+    assert "isMobile" not in _code_only(src)
+
+
+def test_viewport_hook_is_called_unconditionally() -> None:
+    # A hook behind a `typeof ... === "function"` guard is a conditional hook.
+    src = _code_only(PANES.read_text(encoding="utf-8"))
+    assert 'typeof window.useViewport === "function" ? window.useViewport()' not in src
+
+
+def test_panes_expose_their_testids() -> None:
+    src = PANES.read_text(encoding="utf-8")
+    for tid in ("studio-panes", "studio-aside", "studio-aside-inner",
+                "aside-resize", "aside-close", "aside-move-back"):
+        assert f'"{tid}"' in src, tid
+
+
+def test_aside_width_is_clamped() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    assert "Math.max(380, Math.min(900, w))" in src
+
+
+# ---------------------------------------------------------------------------
+# State machine
+# ---------------------------------------------------------------------------
+
+
+def _studio_actions():
+    """Extract the pane reducers into MiniRacer as plain state->state functions."""
+    py_mini_racer = pytest.importorskip("py_mini_racer")
+    ctx = py_mini_racer.MiniRacer()
+    src = STUDIO.read_text(encoding="utf-8")
+    # moveTabAcross's body is the interesting one; lift it verbatim.
+    start = src.index("var moveTabAcross = React.useCallback(function () {")
+    end = src.index("}, []);", start) + len("}, []);")
+    body = src[start:end]
+    body = body.replace("var moveTabAcross = React.useCallback(function () {", "function moveTabAcross(s) {")
+    body = body.replace("setState(function (s) {", "return (function () {")
+    body = body.replace("});\n  }, []);", "})();\n}")
+    ctx.eval(body)
+    return ctx
+
+
+def test_move_across_sends_the_active_main_tab_to_the_companion() -> None:
+    ctx = _studio_actions()
+    ctx.eval("""
+        var s = {
+          openTabs: [{id: "a"}, {id: "b"}], activeTabId: "b",
+          asideTabs: [], activeAsideTabId: null
+        };
+        var out = moveTabAcross(s);
+        var mainIds = out.openTabs.map(function (t) { return t.id; }).join(',');
+        var asideIds = out.asideTabs.map(function (t) { return t.id; }).join(',');
+    """)
+    assert ctx.eval("mainIds") == "a"
+    assert ctx.eval("asideIds") == "b"
+    assert ctx.eval("out.activeAsideTabId") == "b"
+    assert ctx.eval("out.activeTabId") == "a"
+
+
+def test_move_across_is_reversible_with_the_same_gesture() -> None:
+    # Alt-\ both directions: the tab in the companion pane comes back.
+    ctx = _studio_actions()
+    ctx.eval("""
+        var s = {
+          openTabs: [{id: "a"}], activeTabId: "a",
+          asideTabs: [{id: "b"}], activeAsideTabId: "b"
+        };
+        var out = moveTabAcross(s);
+        var mainIds = out.openTabs.map(function (t) { return t.id; }).join(',');
+        var asideLen = out.asideTabs.length;
+    """)
+    assert ctx.eval("mainIds") == "a,b"
+    assert ctx.eval("asideLen") == 0
+    assert ctx.eval("out.activeAsideTabId") is None
+    assert ctx.eval("out.activeTabId") == "b"
+
+
+def test_move_across_is_a_noop_with_nothing_active() -> None:
+    ctx = _studio_actions()
+    ctx.eval("""
+        var s = {openTabs: [], activeTabId: null, asideTabs: [], activeAsideTabId: null};
+        var same = moveTabAcross(s) === s;
+    """)
+    assert ctx.eval("same") is True
+
+
+def test_close_aside_tab_activates_the_left_neighbour() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    # Same post-filter index rule as closeTab, so there is no off-by-one.
+    assert "asideTabs[Math.min(Math.max(0, idx - 1), asideTabs.length - 1)].id" in src
+
+
+def test_closing_the_last_aside_tab_clears_the_active_id() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    assert "activeAsideTabId = asideTabs.length" in src
+
+
+def test_dirty_tracking_covers_the_companion_pane() -> None:
+    # A file edited in the companion pane whose dirty flag never lands gets
+    # closed with no confirmation - silent data loss.
+    src = CENTER.read_text(encoding="utf-8")
+    assert '["openTabs", "asideTabs"].forEach' in src
+    assert "studio.patch(patch)" in src
+
+
+def test_pane_state_is_persisted() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    for key in ('"asideTabs"', '"activeAsideTabId"', '"asideWidth"'):
+        assert key in src, key
+    assert "asideTabs: []" in src
+    assert "asideWidth: 520" in src
+
+
+def test_pane_actions_are_exposed_on_the_store() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    for fn in ("openAside", "focusAsideTab", "closeAsideTab",
+               "closeAllAsideTabs", "setAsideWidth", "moveTabAcross"):
+        assert f"{fn}: {fn}," in src, fn
+
+
+# ---------------------------------------------------------------------------
+# ?aside= deep link
+# ---------------------------------------------------------------------------
+
+
+def test_both_panes_mirror_to_the_url() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    assert "function ST_syncUrl(activeTabId, activeAsideTabId)" in src
+    assert 'params.set("aside", activeAsideTabId)' in src
+    assert 'params.delete("aside")' in src
+    assert "ST_syncUrl(state.activeTabId, state.activeAsideTabId)" in src
+
+
+def test_a_pasted_two_pane_url_restores_both_sides() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    assert 'ST_tabFromUrl("open")' in src
+    assert 'ST_tabFromUrl("aside")' in src
+    assert "function ST_applyUrlTabTo(base, tabsKey, activeKey, urlTab)" in src
+
+
+def test_url_parser_is_parameterised_by_pane() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    assert "function ST_tabFromUrl(param)" in src
+    assert '.get(param || "open")' in src
+
+
+def test_alt_backslash_moves_the_tab_across() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    assert 'isV2 && e.altKey && e.key === "\\\\"' in src
+    assert "studio.moveTabAcross();" in src
+
+
+def test_v1_center_is_untouched_when_the_tweak_is_off() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    assert "window.PaneHost" in src
+    assert "<StudioCenter wid={wid} studio={studio} />" in src
+
+
+def test_panes_module_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    for rel in ("components/studio/st-panes.jsx", "components/studio-center.jsx",
+                "components/studio.jsx"):
+        assert b._transform((UI / rel).read_text(encoding="utf-8"), rel), rel
+
+
+def test_panes_registered_after_the_center() -> None:
+    lines = (UI / "index.html").read_text(encoding="utf-8").splitlines()
+    reg = [i for i, ln in enumerate(lines) if 'type="text/babel"' in ln and "src=" in ln]
+
+    def idx(frag: str) -> int:
+        for i in reg:
+            if frag in lines[i]:
+                return i
+        raise AssertionError(f"{frag} is not registered")
+
+    assert idx("studio-center.jsx") < idx("studio/st-panes.jsx")
+    assert idx("studio/st-panes.jsx") < idx("components/studio.jsx")

--- a/tests/ui/test_studio_rail.py
+++ b/tests/ui/test_studio_rail.py
@@ -1,0 +1,281 @@
+"""Studio revamp: one rail, two modes (ui/studio/STUDIO-WIRING.md §5).
+
+The rail's whole value is ordering - "what needs me" becomes a position on
+screen instead of a badge. So the tests that matter are about the grouping and
+the reuse: that the four groups render in the fixed order, that sorting stays
+inside a group, and that the 1000-line FilesTree plus the create form and
+dialogs are re-hosted rather than forked.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+STUDIO = UI / "components" / "studio.jsx"
+RAIL = UI / "components" / "studio" / "st-rail.jsx"
+RUNS = UI / "components" / "studio" / "st-runs-rail.jsx"
+FILES = UI / "components" / "studio" / "st-files-rail.jsx"
+SIDEBAR = UI / "components" / "studio-sidebar.jsx"
+
+
+def _code_only(src: str) -> str:
+    """Strip `//` comment bodies so a prose mention cannot satisfy a test."""
+    out = []
+    for line in src.splitlines():
+        idx = line.find("//")
+        out.append(line if idx == -1 else line[:idx])
+    return "\n".join(out)
+
+
+def _ctx():
+    """MiniRacer with the pure grouping logic loaded (no React)."""
+    py_mini_racer = pytest.importorskip("py_mini_racer")
+    ctx = py_mini_racer.MiniRacer()
+    ctx.eval((UI / "components" / "studio" / "st-status.jsx").read_text(encoding="utf-8")
+             .replace("window.", "var _unused_"))
+    # ST_sessionSort is the ordering rule the rail reuses; pull just that
+    # function out of the sidebar so its behaviour is exercised for real.
+    src = SIDEBAR.read_text(encoding="utf-8")
+    start = src.index("function ST_sessionSort(")
+    end = src.index("\n}\n", start) + 3
+    ctx.eval(src[start:end])
+    return ctx
+
+
+# ---------------------------------------------------------------------------
+# Grouping and ordering - the actual behaviour change
+# ---------------------------------------------------------------------------
+
+
+def test_groups_render_in_the_fixed_bucket_order() -> None:
+    ctx = _ctx()
+    ctx.eval("var order = ST2_BUCKET_ORDER.join(',');")
+    assert ctx.eval("order") == "needs,working,broken,done"
+
+
+def test_sorting_happens_inside_a_group_never_across_it() -> None:
+    # A done session that sorts first by ST_sessionSort must still land below
+    # every needs-you row, because the group order IS the priority.
+    ctx = _ctx()
+    ctx.eval("""
+        var sessions = [
+          {session_id: "a-done",  status: "ended"},
+          {session_id: "z-needs", status: "parked", park_reason: "ask_user"},
+          {session_id: "m-run",   status: "running"}
+        ];
+        var groups = {needs: [], working: [], broken: [], done: []};
+        sessions.forEach(function (s) {
+          groups[ST2_bucketOf(s, {}).bucket].push(s);
+        });
+        ST2_BUCKET_ORDER.forEach(function (k) { groups[k] = ST_sessionSort(groups[k]); });
+        var flat = [];
+        ST2_BUCKET_ORDER.forEach(function (k) {
+          groups[k].forEach(function (s) { flat.push(s.session_id); });
+        });
+        var out = flat.join(',');
+    """)
+    assert ctx.eval("out") == "z-needs,m-run,a-done"
+
+
+def test_a_running_session_with_a_pending_yield_groups_under_needs() -> None:
+    # This is the case the rail exists for, and it only works if the pending
+    # snapshot is keyed the same way the list endpoint keys its rows.
+    ctx = _ctx()
+    ctx.eval("""
+        var sessions = [{session_id: "s1", status: "running"}];
+        var g = ST2_groupSessions(sessions, {pendingBySession: {s1: true}});
+        var needs = g.needs.length, working = g.working.length;
+    """)
+    assert ctx.eval("needs") == 1
+    assert ctx.eval("working") == 0
+
+
+def test_within_group_sort_is_the_shipped_rule_not_a_reimplementation() -> None:
+    src = _code_only(RUNS.read_text(encoding="utf-8"))
+    assert "ST_sessionSort(" in src
+    assert "function ST_sessionSort" not in src, "must reuse, not fork, the sort"
+    assert ".sort(" not in src, "no second ordering rule in the rail"
+
+
+# ---------------------------------------------------------------------------
+# Reuse, not duplication
+# ---------------------------------------------------------------------------
+
+
+def test_files_rail_rehosts_filestree_and_does_not_copy_it() -> None:
+    src = FILES.read_text(encoding="utf-8")
+    assert "<FilesTree" in src
+    assert "function FilesTree(" not in src
+    # A copy would drag the context menu / upload / mount modals along with it.
+    for forked in ("ST_FileContextMenu", "ST_MountCollectionModal", "ST_ApplyPreviewModal"):
+        assert f"function {forked}(" not in src, forked
+    assert len(src.splitlines()) < 60, "the files rail is a wrapper, not a rewrite"
+
+
+def test_runs_rail_reuses_the_create_form_and_both_dialogs() -> None:
+    src = RUNS.read_text(encoding="utf-8")
+    for comp in ("NewSessionForm", "ST_SessionDeleteDialog", "ST_SessionRenameDialog"):
+        assert f"<{comp}" in src, comp
+        assert f"function {comp}(" not in src, f"{comp} must be reused, not forked"
+
+
+def test_runs_rail_does_not_name_urls_directly() -> None:
+    src = RUNS.read_text(encoding="utf-8")
+    assert 'apiFetch("GET"' not in src
+    assert "/workspaces/" not in src
+    assert "ST2_api." in src
+
+
+def test_rail_shares_the_sessions_cache_key_with_the_attention_bar() -> None:
+    # Three components poll sessions; one key means one request.
+    assert "ST2_api.keys.sessions(wid)" in RUNS.read_text(encoding="utf-8")
+
+
+# ---------------------------------------------------------------------------
+# Row affordances
+# ---------------------------------------------------------------------------
+
+
+def test_needs_rows_carry_the_amber_left_edge() -> None:
+    src = RUNS.read_text(encoding="utf-8")
+    assert "isNeeds" in src
+    assert "var(--amber)" in src
+
+
+def test_dot_tone_uses_the_vocabulary_st_dotstyle_implements() -> None:
+    # ST_dotStyle knows green-pulse/amber/red/gray; anything else silently
+    # renders the inert dim dot, so a live run would look idle.
+    src = RUNS.read_text(encoding="utf-8")
+    assert "ST2_BUCKET_DOT" in src
+    assert "green-pulse" in src
+    assert 'ST_dotStyle("blue")' not in src
+    dotstyle = SIDEBAR.read_text(encoding="utf-8")
+    for tone in ("green-pulse", "amber", "red", "gray"):
+        assert f'tone === "{tone}"' in dotstyle, tone
+
+
+def test_delete_closes_the_matching_tab_in_both_panes() -> None:
+    src = RUNS.read_text(encoding="utf-8")
+    assert "studio.closeTab" in src
+    # §5: extend the shipped close-on-delete to the companion pane, so a
+    # deleted session cannot sit there 404ing.
+    assert "studio.closeAsideTab" in src
+
+
+def test_open_beside_is_guarded_until_the_companion_pane_exists() -> None:
+    # Task 6 builds openAside. Until then the affordance must not render as a
+    # button that does nothing.
+    src = RUNS.read_text(encoding="utf-8")
+    assert 'typeof studio.openAside === "function"' in src
+    assert "onOpenAside ? (" in src
+
+
+def test_cmd_click_opens_beside_when_available() -> None:
+    src = RUNS.read_text(encoding="utf-8")
+    assert "e.metaKey || e.ctrlKey" in src
+
+
+def test_row_keeps_the_shipped_testids() -> None:
+    # The existing e2e journeys locate rows by these.
+    src = RUNS.read_text(encoding="utf-8")
+    for tid in ("session-row", "session-status-dot", "session-rename",
+                "session-delete", "new-session-btn"):
+        assert f'"{tid}"' in src, tid
+    assert "data-session-id={sid}" in src
+
+
+# ---------------------------------------------------------------------------
+# The rail shell + state
+# ---------------------------------------------------------------------------
+
+
+def test_rail_exposes_its_mode_and_filter_testids() -> None:
+    rail = RAIL.read_text(encoding="utf-8")
+    assert '"studio-rail"' in rail
+    assert '"rail-mode-" + m.id' in rail
+    for m in ('id: "runs"', 'id: "files"'):
+        assert m in rail, m
+    runs = RUNS.read_text(encoding="utf-8")
+    assert '"rail-filter-" + f.id' in runs
+    assert '"rail-group-" + key' in runs
+
+
+def test_the_mine_filter_is_absent_because_no_field_backs_it() -> None:
+    # SessionInfo has no owner/user field (session_id, agent_id, workspace_id,
+    # name, status, ended_reason, parent_session_id, started_at,
+    # last_activity_at, ended_at, initial_instructions), so a "mine" chip could
+    # only ever lie. "Open" is the same intent over data that exists.
+    from primer.model.workspace_session import SessionInfo
+
+    fields = set(SessionInfo.model_fields)
+    assert not fields & {"owner", "user_id", "created_by", "owner_id"}
+    runs = _code_only(RUNS.read_text(encoding="utf-8"))
+    assert '"mine"' not in runs
+    assert 'id: "open"' in runs
+
+
+def test_rail_state_is_persisted_and_defaulted() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    assert '"railMode"' in src
+    assert '"railFilter"' in src
+    assert 'railMode: "runs"' in src
+    assert 'railFilter: "all"' in src
+    assert "setRailMode:" in src
+    assert "setRailFilter:" in src
+
+
+def test_v1_sidebar_still_renders_when_the_tweak_is_off() -> None:
+    src = STUDIO.read_text(encoding="utf-8")
+    assert "<StudioSidebar wid={wid} studio={studio} />" in src
+    assert "window.StudioRail" in src
+    # The column testid must not move - the drag handle and every shipped
+    # journey locate the left column by it.
+    assert 'data-testid="studio-sidebar"' in src
+
+
+def test_files_rail_opens_the_collapsed_v1_section_once() -> None:
+    # filesOpen is persisted from the two-section sidebar; in the rail Files IS
+    # the mode, so a collapsed carry-over would render an empty panel.
+    src = FILES.read_text(encoding="utf-8")
+    assert "studio.state.filesOpen" in src
+    assert "studio.toggleFiles" in src
+    assert "opened.current" in src
+
+
+def test_changed_by_agents_lens_is_not_faked() -> None:
+    # WIRING §5 specifies it, but the turn trail it filters on needs a backend
+    # endpoint that does not exist yet (plan §0.2). It must be absent, not stubbed.
+    src = _code_only(FILES.read_text(encoding="utf-8"))
+    assert "Changed by agents" not in src
+
+
+def test_registration_order_puts_the_rail_after_the_sidebar() -> None:
+    lines = (UI / "index.html").read_text(encoding="utf-8").splitlines()
+    reg = [i for i, ln in enumerate(lines) if 'type="text/babel"' in ln and "src=" in ln]
+
+    def idx(frag: str) -> int:
+        for i in reg:
+            if frag in lines[i]:
+                return i
+        raise AssertionError(f"{frag} is not registered")
+
+    # The rail reuses FilesTree / NewSessionForm / the dialogs from the sidebar.
+    assert idx("studio-sidebar.jsx") < idx("studio/st-runs-rail.jsx")
+    assert idx("studio/st-runs-rail.jsx") < idx("studio/st-rail.jsx")
+    assert idx("studio/st-files-rail.jsx") < idx("studio/st-rail.jsx")
+    assert idx("studio/st-rail.jsx") < idx("components/studio.jsx")
+
+
+def test_every_rail_module_transpiles() -> None:
+    from primer.api._jsx_bundle import JSXBundler
+
+    b = JSXBundler(ui_dir=UI, babel_source=(UI / "vendor" / "babel.min.js").read_text())
+    for rel in ("components/studio/st-rail.jsx",
+                "components/studio/st-runs-rail.jsx",
+                "components/studio/st-files-rail.jsx",
+                "components/studio.jsx"):
+        assert b._transform((UI / rel).read_text(encoding="utf-8"), rel), rel

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -135,9 +135,12 @@ def test_deep_link_synthesizes_url_tab() -> None:
     # appended (concat) and activated rather than ignored.
     assert "ST_applyUrlTab" in src
     assert "ST_tabFromUrlId(urlTab)" in src
-    # When the url tab isn't already open we append + activate it.
-    assert "base.openTabs = openTabs.concat([tab]);" in src
-    assert "base.activeTabId = urlTab;" in src
+    # When the url tab isn't already open we append + activate it. The append is
+    # keyed by pane (openTabs / asideTabs) so ?open= and ?aside= share one
+    # implementation instead of two that can drift.
+    assert "base[tabsKey] = tabs.concat([tab]);" in src
+    assert "base[activeKey] = urlTab;" in src
+    assert 'ST_applyUrlTabTo(base, "openTabs", "activeTabId",' in src
 
 
 def test_workspace_selector_uses_workspaces_resource() -> None:

--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -58,7 +58,9 @@ def test_debug_rail_open_state_lives_in_the_studio_store() -> None:
     assert "toggleDebug: toggleDebug," in src        # exposed on the store
     # Column width is a clean binary driven from state: 0 (fully hidden) when
     # closed, rightWidth when open — opened from the header events toggle.
-    assert '"--st-right-w": (s.debugOpen ? s.rightWidth : 0) + "px"' in src
+    # studioV2 has no right column at all (the investigate dock replaces it),
+    # so the same expression also collapses it to 0 whenever that tweak is on.
+    assert '"--st-right-w": (!isV2 && s.debugOpen ? s.rightWidth : 0) + "px"' in src
 
 
 def test_events_panel_opened_from_a_prominent_header_toggle() -> None:

--- a/tests/ui/test_studio_terminal.py
+++ b/tests/ui/test_studio_terminal.py
@@ -165,13 +165,23 @@ def test_terminal_panel_component_and_exports() -> None:
 def test_terminal_panel_mounted_in_center_column() -> None:
     src = _studio_src()
     center_idx = src.index('data-testid="studio-center"')
-    center_block = src[center_idx : center_idx + 800]
+    # The block ends where the center column does - the studioV2 dock mounts
+    # inside it too, so a fixed character window would clip.
+    center_block = src[center_idx : src.index('{!isV2 && (', center_idx)]
     assert "<StudioCenter wid={wid} studio={studio} />" in center_block
     assert "<TerminalPanel wid={wid} studio={studio} />" in center_block
     # Gated on terminalOpen, so unmounting on collapse tears the WS(s) down.
     assert "s.terminalOpen &&" in center_block
     # StudioCenter renders first, terminal panel below it.
     assert center_block.index("<StudioCenter") < center_block.index("<TerminalPanel")
+
+
+def test_terminal_panel_is_the_same_component_under_studio_v2() -> None:
+    # studioV2 re-houses the terminal in the investigate dock rather than
+    # reimplementing it, so every protocol test above still covers the v2 path.
+    dock = (UI / "components" / "studio" / "st-dock.jsx").read_text(encoding="utf-8")
+    assert "<TerminalPanel wid={wid} studio={studio} />" in dock
+    assert "function ST_TerminalInstance(" not in dock, "must not fork the xterm mount"
 
 
 def test_ws_url_and_control_frame_protocol() -> None:

--- a/tests/ui/test_studio_terminal_resize.py
+++ b/tests/ui/test_studio_terminal_resize.py
@@ -73,12 +73,14 @@ def test_start_term_resize_handler_present() -> None:
 
 def test_terminal_resize_handle_rendered_between_center_and_panel() -> None:
     src = _studio_src()
-    # The divider is gated on terminalOpen and wired to the drag handler.
-    assert 'data-testid="terminal-resize"' in src
+    # The divider is gated on the open state and wired to the drag handler.
+    # One handle serves both shells: studioV2 drags the investigate dock, so the
+    # testid switches with it rather than a second handle being added.
+    assert 'data-testid={isV2 ? "dock-resize" : "terminal-resize"}' in src
     assert 'className="st-term-resize"' in src
     assert "onMouseDown={startTermResize}" in src
     # It must sit BEFORE the TerminalPanel mount inside the center column.
-    handle = src.index('data-testid="terminal-resize"')
+    handle = src.index('data-testid={isV2 ? "dock-resize" : "terminal-resize"}')
     panel = src.index("<TerminalPanel wid={wid}")
     assert handle < panel, "resize handle must precede the terminal panel"
 
@@ -90,7 +92,12 @@ def test_terminal_resize_handle_rendered_between_center_and_panel() -> None:
 def test_term_height_css_var_wired_on_root() -> None:
     src = _studio_src()
     # The var is written inline on .st-root next to --st-left-w / --st-right-w.
-    assert '"--st-term-h": s.terminalHeight + "px"' in src
+    # studioV2 sizes the same bottom row from the dock's own height, and
+    # collapses it to 0 when the dock is closed (the v1 panel unmounts instead).
+    assert (
+        '"--st-term-h": (isV2 ? (s.dockOpen ? s.dockHeight : 0) : s.terminalHeight) + "px"'
+        in src
+    )
 
 
 def test_term_panel_flex_reads_css_var() -> None:

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -1323,20 +1323,30 @@ function FilePanel({ wid, tab, studio, pushToast }) {
   }, [data]);
 
   // A dirty tab is one whose draft diverges from the held content. We mirror
-  // that into studio.state.openTabs[*].dirty via the patch() escape hatch so
-  // the tab bar + sidebar dirty dots reflect it.
+  // that into the tab record via the patch() escape hatch so the tab bar +
+  // rail dirty dots reflect it.
+  //
+  // The tab can live in EITHER pane (§6). Marking only openTabs would leave a
+  // companion-pane edit with no dirty dot AND no close confirmation, which is
+  // exactly how unsaved work gets thrown away - so update whichever array
+  // holds it, and only patch the arrays that actually changed.
   function setTabDirty(dirty) {
-    var openTabs = (studio.state.openTabs || []).map(function (t) {
-      if (t.id !== tabId) return t;
-      if (!!t.dirty === !!dirty) return t;
-      return Object.assign({}, t, { dirty: !!dirty });
+    var patch = null;
+    ["openTabs", "asideTabs"].forEach(function (key) {
+      var list = studio.state[key] || [];
+      var changed = false;
+      var next = list.map(function (t) {
+        if (t.id !== tabId) return t;
+        if (!!t.dirty === !!dirty) return t;
+        changed = true;
+        return Object.assign({}, t, { dirty: !!dirty });
+      });
+      if (changed) {
+        patch = patch || {};
+        patch[key] = next;
+      }
     });
-    // Only patch when something actually changed (avoid render churn).
-    var changed = false;
-    for (var i = 0; i < openTabs.length; i++) {
-      if (openTabs[i] !== (studio.state.openTabs || [])[i]) { changed = true; break; }
-    }
-    if (changed) studio.patch({ openTabs: openTabs });
+    if (patch) studio.patch(patch);
   }
 
   function onEditInput(e) {
@@ -1551,10 +1561,14 @@ function FilePanel({ wid, tab, studio, pushToast }) {
 // Props: { wid, studio }  (studio = useStudioState(wid) bag)
 // ---------------------------------------------------------------------------
 
-function StudioCenter({ wid, studio }) {
+// The optional tabs/activeId/on* props parameterise WHICH tab array this body
+// renders, so studioV2's PaneHost (st-panes.jsx §6) can mount a second instance
+// over asideTabs without forking the component. Omitted, everything resolves to
+// the primary pane exactly as before.
+function StudioCenter({ wid, studio, tabs, activeId, onFocus, onClose, onCloseAll, testId }) {
   var s = studio.state;
-  var openTabs = s.openTabs || [];
-  var activeTabId = s.activeTabId;
+  var openTabs = tabs || s.openTabs || [];
+  var activeTabId = activeId !== undefined ? activeId : s.activeTabId;
   // pushToast threads down from app.jsx → Studio when wired; B1 renders Studio
   // without it today, so every toast call below is guarded and simply no-ops
   // until a later task passes it. The 412-conflict UX uses an inline banner
@@ -1595,15 +1609,15 @@ function StudioCenter({ wid, studio }) {
 
   return (
     <div
-      data-testid="studio-center-inner"
+      data-testid={testId || "studio-center-inner"}
       style={{ display: "flex", flexDirection: "column", height: "100%", minHeight: 0, overflow: "hidden" }}
     >
       <CenterTabs
         openTabs={openTabs}
         activeTabId={activeTabId}
-        onFocus={studio.focusTab}
-        onClose={studio.closeTab}
-        onCloseAll={studio.closeAllTabs}
+        onFocus={onFocus || studio.focusTab}
+        onClose={onClose || studio.closeTab}
+        onCloseAll={onCloseAll || studio.closeAllTabs}
       />
       <div style={{ flex: 1, minHeight: 0, display: "flex", flexDirection: "column", overflow: "hidden" }}>
         {panel}

--- a/ui/components/studio-center.jsx
+++ b/ui/components/studio-center.jsx
@@ -1599,6 +1599,10 @@ function StudioCenter({ wid, studio, tabs, activeId, onFocus, onClose, onCloseAl
     panel = <ST_SessionPanel key={"sess:" + activeTab.ref} wid={wid} sid={activeTab.ref} pushToast={pushToast} />;
   } else if (activeTab.kind === "file") {
     panel = <FilePanel key={"file:" + activeTab.ref} wid={wid} tab={activeTab} studio={studio} pushToast={pushToast} />;
+  } else if (activeTab.kind === "changes" && typeof window.ChangesView === "function") {
+    // The turn trail is a full-width two-column surface (WIRING §7.2), so it
+    // lives as a center tab rather than in the 248px rail.
+    panel = <window.ChangesView wid={wid} studio={studio} />;
   } else {
     panel = (
       <div className="st-placeholder" data-testid="center-unknown" style={{ flex: 1 }}>

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -42,6 +42,8 @@ var ST_PERSIST_KEYS = [
   "dockOpen",
   "dockTab",
   "dockHeight",
+  "railMode",
+  "railFilter",
 ];
 
 function ST_storageKey(wid) {
@@ -204,6 +206,10 @@ function ST_defaultState() {
     dockOpen: false,
     dockTab: "events",
     dockHeight: 268,
+    // studioV2 rail (§5): one column, two modes, replacing the stacked
+    // Sessions-above-Files sidebar. railFilter narrows the runs list.
+    railMode: "runs",
+    railFilter: "all",
     termTabs: [{ id: "bash", title: "bash" }],
     activeTermId: "bash",
     // Right sidebar activity-feed chip filter
@@ -432,6 +438,14 @@ function useStudioState(wid, initialOpen) {
     });
   }, []);
 
+  // ---- rail (studioV2; §5) ----
+  var setRailMode = React.useCallback(function (m) {
+    setState(function (s) { return Object.assign({}, s, { railMode: m }); });
+  }, []);
+  var setRailFilter = React.useCallback(function (f) {
+    setState(function (s) { return Object.assign({}, s, { railFilter: f }); });
+  }, []);
+
   // ---- right debug/activity rail (StudioActivity) open/collapsed ----
   var toggleDebug = React.useCallback(function () {
     setState(function (s) { return Object.assign({}, s, { debugOpen: !s.debugOpen }); });
@@ -500,6 +514,8 @@ function useStudioState(wid, initialOpen) {
     toggleDock: toggleDock,
     setDockTab: setDockTab,
     setDockHeight: setDockHeight,
+    setRailMode: setRailMode,
+    setRailFilter: setRailFilter,
     toggleChip: toggleChip,
     setLeftWidth: setLeftWidth,
     setRightWidth: setRightWidth,
@@ -899,13 +915,19 @@ function Studio({ wid, pushToast, initialOpen }) {
           <div className="st-panel-overlay mobile-only" data-testid="studio-panel-overlay" onClick={closePanels} />
         )}
 
-        {/* ---- LEFT: B2 StudioSidebar (sessions + files tree) ---- On phones
-            this column is an off-canvas sheet toggled from the sub-header. ---- */}
+        {/* ---- LEFT: the rail ---- On phones this column is an off-canvas
+            sheet toggled from the sub-header. studioV2 swaps the stacked
+            Sessions-above-Files sidebar for one column with two modes (§5);
+            the studio-sidebar testid stays on the column either way, so the
+            drag handle, the drawer behaviour and the shipped journeys that
+            locate the left column are untouched. ---- */}
         <div
           className={"st-col st-col-left" + (leftPanelOpen ? " is-drawer-open" : "")}
           data-testid="studio-sidebar"
         >
-          <StudioSidebar wid={wid} studio={studio} />
+          {isV2 && typeof window.StudioRail === "function"
+            ? <window.StudioRail wid={wid} studio={studio} />
+            : <StudioSidebar wid={wid} studio={studio} />}
         </div>
 
         <div className="st-resize desktop-only" onMouseDown={function (e) { startResize("left", e); }} data-testid="studio-resize-left" />

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -44,6 +44,9 @@ var ST_PERSIST_KEYS = [
   "dockHeight",
   "railMode",
   "railFilter",
+  "asideTabs",
+  "activeAsideTabId",
+  "asideWidth",
 ];
 
 function ST_storageKey(wid) {
@@ -95,12 +98,13 @@ function ST_savePersisted(wid, state) {
 // Parse ?open=session:<id> / ?open=file:<path> into a tab id string, or
 // null. The Studio uses a hash router (see foundation/router.js), so the
 // query lives in the hash fragment, not window.location.search.
-function ST_tabFromUrl() {
+// `param` selects the pane: "open" is the primary, "aside" the companion (§6).
+function ST_tabFromUrl(param) {
   try {
     var hash = window.location.hash || "";
     var qIdx = hash.indexOf("?");
     if (qIdx < 0) return null;
-    var open = new URLSearchParams(hash.slice(qIdx + 1)).get("open");
+    var open = new URLSearchParams(hash.slice(qIdx + 1)).get(param || "open");
     if (!open) return null;
     if (open.indexOf("session:") === 0) return open;
     if (open.indexOf("file:") === 0) return open;
@@ -136,25 +140,34 @@ function ST_tabFromUrlId(urlTab) {
 // on mount, the first persist effect's ST_syncUrl re-writes the same ?open=
 // value instead of deleting it (so deep-links survive the mount).
 function ST_applyUrlTab(base, fallbackOpen) {
-  var urlTab = ST_tabFromUrl() || (fallbackOpen || null);
+  base = ST_applyUrlTabTo(base, "openTabs", "activeTabId",
+    ST_tabFromUrl("open") || (fallbackOpen || null));
+  // The companion pane is deep-linkable too, so a pasted two-pane URL (a
+  // transcript beside its diff) restores both sides (§6).
+  return ST_applyUrlTabTo(base, "asideTabs", "activeAsideTabId",
+    ST_tabFromUrl("aside"));
+}
+
+// Shared by both panes: activate the url tab if it is already open, else
+// synthesize a minimal one and append it.
+function ST_applyUrlTabTo(base, tabsKey, activeKey, urlTab) {
   if (!urlTab) return base;
-  var openTabs = base.openTabs || [];
-  var present = openTabs.some(function (t) { return t.id === urlTab; });
-  if (present) {
-    base.activeTabId = urlTab;
+  var tabs = base[tabsKey] || [];
+  if (tabs.some(function (t) { return t.id === urlTab; })) {
+    base[activeKey] = urlTab;
     return base;
   }
   var tab = ST_tabFromUrlId(urlTab);
   if (!tab) return base;
-  base.openTabs = openTabs.concat([tab]);
-  base.activeTabId = urlTab;
+  base[tabsKey] = tabs.concat([tab]);
+  base[activeKey] = urlTab;
   return base;
 }
 
-// Mirror the active tab to the URL query via replaceState — no history
-// entry per tab switch. activeTabId is already in `session:<id>` /
-// `file:<path>` form so it maps straight onto ?open=.
-function ST_syncUrl(activeTabId) {
+// Mirror the active tab(s) to the URL query via replaceState - no history
+// entry per tab switch. The ids are already in `session:<id>` / `file:<path>`
+// form so they map straight onto ?open= and ?aside=.
+function ST_syncUrl(activeTabId, activeAsideTabId) {
   try {
     var url = new URL(window.location.href);
     var hash = url.hash || "#/";
@@ -163,6 +176,8 @@ function ST_syncUrl(activeTabId) {
     var params = new URLSearchParams(qIdx >= 0 ? hash.slice(qIdx + 1) : "");
     if (activeTabId) params.set("open", activeTabId);
     else params.delete("open");
+    if (activeAsideTabId) params.set("aside", activeAsideTabId);
+    else params.delete("aside");
     var qs = params.toString();
     url.hash = qs ? path + "?" + qs : path;
     window.history.replaceState(null, "", url.toString());
@@ -210,6 +225,13 @@ function ST_defaultState() {
     // Sessions-above-Files sidebar. railFilter narrows the runs list.
     railMode: "runs",
     railFilter: "all",
+    // studioV2 companion pane (§6). There is deliberately no `asideOpen`
+    // flag: the pane is open exactly when it holds tabs, so "closing the last
+    // companion tab clears asideOpen" is true by construction instead of
+    // being a second source of truth that can desync from the tab list.
+    asideTabs: [],
+    activeAsideTabId: null,
+    asideWidth: 520,
     termTabs: [{ id: "bash", title: "bash" }],
     activeTermId: "bash",
     // Right sidebar activity-feed chip filter
@@ -266,7 +288,7 @@ function useStudioState(wid, initialOpen) {
   // Persist + URL-mirror after every committed state change.
   React.useEffect(function () {
     ST_savePersisted(wid, state);
-    ST_syncUrl(state.activeTabId);
+    ST_syncUrl(state.activeTabId, state.activeAsideTabId);
   }, [wid, state]);
 
   // React to ?open= changes that happen AFTER mount (deep-links followed
@@ -383,6 +405,90 @@ function useStudioState(wid, initialOpen) {
         activeTabId: activeTabId,
         fileModes: fileModes,
       });
+    });
+  }, []);
+
+  // ---- companion pane (studioV2; ui/studio/STUDIO-WIRING.md §6) ----
+  // A second tab strip + panel to the right of the primary one, so a diff can
+  // open BESIDE the transcript that produced it instead of replacing it.
+  var openAside = React.useCallback(function (tab) {
+    setState(function (s) {
+      var prev = s.asideTabs || [];
+      var exists = prev.some(function (t) { return t.id === tab.id; });
+      var fileModes = s.fileModes;
+      if (tab.kind === "file" && fileModes[tab.id] === undefined) {
+        fileModes = Object.assign({}, fileModes);
+        fileModes[tab.id] = tab.mode || "preview";
+      }
+      return Object.assign({}, s, {
+        asideTabs: exists ? prev : prev.concat([tab]),
+        activeAsideTabId: tab.id,
+        fileModes: fileModes,
+      });
+    });
+  }, []);
+
+  var focusAsideTab = React.useCallback(function (id) {
+    setState(function (s) { return Object.assign({}, s, { activeAsideTabId: id }); });
+  }, []);
+
+  var closeAsideTab = React.useCallback(function (id) {
+    setState(function (s) {
+      var prev = s.asideTabs || [];
+      var idx = prev.findIndex(function (t) { return t.id === id; });
+      if (idx < 0) return s;
+      var asideTabs = prev.filter(function (t) { return t.id !== id; });
+      var activeAsideTabId = s.activeAsideTabId;
+      if (activeAsideTabId === id) {
+        // Same left-neighbour rule as closeTab, computed against the
+        // post-filter array so there is no off-by-one.
+        activeAsideTabId = asideTabs.length
+          ? asideTabs[Math.min(Math.max(0, idx - 1), asideTabs.length - 1)].id
+          : null;
+      }
+      return Object.assign({}, s, { asideTabs: asideTabs, activeAsideTabId: activeAsideTabId });
+    });
+  }, []);
+
+  var closeAllAsideTabs = React.useCallback(function () {
+    setState(function (s) {
+      if (!(s.asideTabs && s.asideTabs.length) && s.activeAsideTabId == null) return s;
+      return Object.assign({}, s, { asideTabs: [], activeAsideTabId: null });
+    });
+  }, []);
+
+  var setAsideWidth = React.useCallback(function (w) {
+    setState(function (s) { return Object.assign({}, s, { asideWidth: Math.max(380, Math.min(900, w)) }); });
+  }, []);
+
+  // Alt-\ : move the ACTIVE tab to the other pane (§6). One action rather than
+  // two, so the gesture is reversible with the same keystroke.
+  var moveTabAcross = React.useCallback(function () {
+    setState(function (s) {
+      var from = (s.asideTabs || []).some(function (t) { return t.id === s.activeAsideTabId; })
+        && s.activeAsideTabId
+        ? "aside" : "main";
+      var srcKey = from === "aside" ? "asideTabs" : "openTabs";
+      var dstKey = from === "aside" ? "openTabs" : "asideTabs";
+      var srcActive = from === "aside" ? "activeAsideTabId" : "activeTabId";
+      var dstActive = from === "aside" ? "activeTabId" : "activeAsideTabId";
+      var id = s[srcActive];
+      if (!id) return s;
+      var src = s[srcKey] || [];
+      var idx = src.findIndex(function (t) { return t.id === id; });
+      if (idx < 0) return s;
+      var tab = src[idx];
+      var nextSrc = src.filter(function (t) { return t.id !== id; });
+      var dst = s[dstKey] || [];
+      var nextDst = dst.some(function (t) { return t.id === id; }) ? dst : dst.concat([tab]);
+      var patch = {};
+      patch[srcKey] = nextSrc;
+      patch[dstKey] = nextDst;
+      patch[srcActive] = nextSrc.length
+        ? nextSrc[Math.min(Math.max(0, idx - 1), nextSrc.length - 1)].id
+        : null;
+      patch[dstActive] = id;
+      return Object.assign({}, s, patch);
     });
   }, []);
 
@@ -516,6 +622,12 @@ function useStudioState(wid, initialOpen) {
     setDockHeight: setDockHeight,
     setRailMode: setRailMode,
     setRailFilter: setRailFilter,
+    openAside: openAside,
+    focusAsideTab: focusAsideTab,
+    closeAsideTab: closeAsideTab,
+    closeAllAsideTabs: closeAllAsideTabs,
+    setAsideWidth: setAsideWidth,
+    moveTabAcross: moveTabAcross,
     toggleChip: toggleChip,
     setLeftWidth: setLeftWidth,
     setRightWidth: setRightWidth,
@@ -862,13 +974,18 @@ function Studio({ wid, pushToast, initialOpen }) {
       } else if (e.ctrlKey && e.key === "`") {
         e.preventDefault();
         if (isV2) studio.toggleDock(); else studio.toggleTerminal();
+      } else if (isV2 && e.altKey && e.key === "\\") {
+        // Alt-\ moves the active tab to the other pane (§6). Same keystroke
+        // both directions, so the gesture undoes itself.
+        e.preventDefault();
+        studio.moveTabAcross();
       } else if (e.key === "Escape") {
         if (s.paletteOpen) studio.closePalette();
       }
     }
     window.addEventListener("keydown", onKeyDown);
     return function () { window.removeEventListener("keydown", onKeyDown); };
-  }, [s.paletteOpen, studio.togglePalette, studio.openPalette, studio.closePalette, studio.toggleTerminal]);
+  }, [s.paletteOpen, studio.togglePalette, studio.openPalette, studio.closePalette, studio.toggleTerminal, studio.moveTabAcross]);
 
   return (
     <div
@@ -934,7 +1051,12 @@ function Studio({ wid, pushToast, initialOpen }) {
 
         {/* ---- CENTER: B3 StudioCenter (tabs + active panel) + P7 terminal ---- */}
         <div className="st-col st-col-center" data-testid="studio-center">
-          <StudioCenter wid={wid} studio={studio} />
+          {/* studioV2 hosts the center in PaneHost, which mounts the SAME
+              StudioCenter body twice (primary + companion) so a diff can open
+              beside its transcript instead of replacing it (§6). */}
+          {isV2 && typeof window.PaneHost === "function"
+            ? <window.PaneHost wid={wid} studio={studio} />
+            : <StudioCenter wid={wid} studio={studio} />}
           {/* Horizontal splitter: drag to resize the terminal (writes
               terminalHeight → --st-term-h). Mirrors the column handles. */}
           {(isV2 ? s.dockOpen : s.terminalOpen) && (

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -681,6 +681,11 @@ function Studio({ wid, pushToast, initialOpen }) {
   // work even when app.jsx hasn't passed the prop yet.
   studio.pushToast = pushToast || (window.primerApi && window.primerApi.toastPush) || null;
 
+  // Studio revamp gate (ui/studio/STUDIO-WIRING.md §15). Read with `=== true`
+  // below so the incomplete shell is strictly opt-in. The bar fetches its own
+  // data, so nothing extra is polled while the revamp is off.
+  var studioV2 = (window.primerApi.useTweaks()[0] || {}).studioV2;
+
   // Remember the last workspace whose Studio was opened so the global "Studio"
   // nav item (chrome.jsx) can re-open it without a workspace picker. Written on
   // every mount / wid change; read in app.jsx's openStudio().
@@ -818,6 +823,14 @@ function Studio({ wid, pushToast, initialOpen }) {
         onToggleLeftPanel={function () { setRightPanelOpen(false); setLeftPanelOpen(function (o) { return !o; }); }}
         onToggleRightPanel={function () { setLeftPanelOpen(false); setRightPanelOpen(function (o) { return !o; }); }}
       />
+
+      {/* Attention bar (ui/studio/STUDIO-WIRING.md §3): always mounted, never
+          collapses. Strictly opt-in while the revamp is incomplete - the graph
+          builder shipped inert behind a permissive `!== false` guard, so this
+          one must refuse to appear until it is finished. */}
+      {studioV2 === true && typeof window.AttentionBar === "function" ? (
+        <window.AttentionBar wid={wid} studio={studio} />
+      ) : null}
 
       <div className="st-body">
         {/* Mobile backdrop: dims the center doc while a panel drawer is open.

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -36,6 +36,12 @@ var ST_PERSIST_KEYS = [
   "leftWidth",
   "rightWidth",
   "terminalHeight",
+  // studioV2 (ui/studio/STUDIO-WIRING.md §2.1). Added alongside the v1 keys
+  // rather than replacing them: studioV2 is a runtime tweak, so one build has
+  // to serve both shells and both sets of state.
+  "dockOpen",
+  "dockTab",
+  "dockHeight",
 ];
 
 function ST_storageKey(wid) {
@@ -54,6 +60,17 @@ function ST_loadPersisted(wid) {
     ST_PERSIST_KEYS.forEach(function (k) {
       if (parsed[k] !== undefined) keep[k] = parsed[k];
     });
+    // studioV2 migration: carry the v1 terminal panel's state into the dock the
+    // first time the revamp is used, so switching the tweak on does not silently
+    // close a terminal the operator had open. The key set is a whitelist, not a
+    // schema, so no storage version bump is needed.
+    if (keep.dockOpen === undefined && parsed.terminalOpen !== undefined) {
+      keep.dockOpen = parsed.terminalOpen;
+      if (parsed.terminalOpen) keep.dockTab = keep.dockTab || "term:bash";
+    }
+    if (keep.dockHeight === undefined && parsed.terminalHeight !== undefined) {
+      keep.dockHeight = parsed.terminalHeight;
+    }
     return keep;
   } catch (_e) {
     return {};
@@ -181,6 +198,12 @@ function ST_defaultState() {
     // Debug toggle + the rail's own handle both flip this.
     debugOpen: false,
     terminalHeight: 240,
+    // studioV2 investigate dock. Seeded from terminalOpen/terminalHeight on
+    // first load (see ST_loadPersisted) so an operator who had the terminal
+    // open does not lose it when the revamp is switched on.
+    dockOpen: false,
+    dockTab: "events",
+    dockHeight: 268,
     termTabs: [{ id: "bash", title: "bash" }],
     activeTermId: "bash",
     // Right sidebar activity-feed chip filter
@@ -392,6 +415,23 @@ function useStudioState(wid, initialOpen) {
     setState(function (s) { return Object.assign({}, s, { terminalOpen: !s.terminalOpen }); });
   }, []);
 
+  // ---- investigate dock (studioV2; ui/studio/STUDIO-WIRING.md §8) ----
+  // The dock supersedes the bottom terminal panel AND the right rail, but the
+  // v1 shell is still reachable at runtime via the studioV2 tweak, so its
+  // terminalOpen / debugOpen state stays untouched alongside these keys.
+  var toggleDock = React.useCallback(function () {
+    setState(function (s) { return Object.assign({}, s, { dockOpen: !s.dockOpen }); });
+  }, []);
+  var setDockTab = React.useCallback(function (t) {
+    setState(function (s) { return Object.assign({}, s, { dockOpen: true, dockTab: t }); });
+  }, []);
+  var setDockHeight = React.useCallback(function (h) {
+    setState(function (s) {
+      var max = Math.round(window.innerHeight * 0.7);
+      return Object.assign({}, s, { dockHeight: Math.max(120, Math.min(max, h)) });
+    });
+  }, []);
+
   // ---- right debug/activity rail (StudioActivity) open/collapsed ----
   var toggleDebug = React.useCallback(function () {
     setState(function (s) { return Object.assign({}, s, { debugOpen: !s.debugOpen }); });
@@ -457,6 +497,9 @@ function useStudioState(wid, initialOpen) {
     toggleDensity: toggleDensity,
     toggleTerminal: toggleTerminal,
     toggleDebug: toggleDebug,
+    toggleDock: toggleDock,
+    setDockTab: setDockTab,
+    setDockHeight: setDockHeight,
     toggleChip: toggleChip,
     setLeftWidth: setLeftWidth,
     setRightWidth: setRightWidth,
@@ -484,7 +527,7 @@ function useStudioState(wid, initialOpen) {
 // collapse to a single document there.
 // ---------------------------------------------------------------------------
 
-function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, debugOpen, onToggleDebug, onToggleLeftPanel, onToggleRightPanel }) {
+function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, debugOpen, onToggleDebug, onToggleLeftPanel, onToggleRightPanel, hideDebugToggle }) {
   var { useResource, apiFetch } = window.primerApi;
   var [menuOpen, setMenuOpen] = React.useState(false);
   // Workspace Settings overlay — restores the orphaned WorkspaceDetail tabs
@@ -627,16 +670,20 @@ function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, term
           rail itself (a thin strip at the screen edge); operators repeatedly
           could not open it, so the primary control lives in the header. Uses a
           panel icon (not a bell — per earlier feedback). */}
-      <button
-        className={"st-hbtn touch-target desktop-only" + (debugOpen ? " is-active" : "")}
-        data-testid="studio-debug-toggle"
-        title="Workspace events (Action Required + Activity)"
-        aria-label="Toggle workspace events panel"
-        aria-pressed={debugOpen ? "true" : "false"}
-        onClick={onToggleDebug}
-      >
-        <Icon name="panel-right" size={15} />
-      </button>
+      {/* Retired under studioV2: Action Required lives in the attention bar and
+          the tap lives in the dock, so there is no right rail to toggle. */}
+      {!hideDebugToggle && (
+        <button
+          className={"st-hbtn touch-target desktop-only" + (debugOpen ? " is-active" : "")}
+          data-testid="studio-debug-toggle"
+          title="Workspace events (Action Required + Activity)"
+          aria-label="Toggle workspace events panel"
+          aria-pressed={debugOpen ? "true" : "false"}
+          onClick={onToggleDebug}
+        >
+          <Icon name="panel-right" size={15} />
+        </button>
+      )}
 
       {/* Mobile-only panel-drawer toggle (right: Action Required + Activity). */}
       <button
@@ -684,7 +731,14 @@ function Studio({ wid, pushToast, initialOpen }) {
   // Studio revamp gate (ui/studio/STUDIO-WIRING.md §15). Read with `=== true`
   // below so the incomplete shell is strictly opt-in. The bar fetches its own
   // data, so nothing extra is polled while the revamp is off.
-  var studioV2 = (window.primerApi.useTweaks()[0] || {}).studioV2;
+  var isV2 = (window.primerApi.useTweaks()[0] || {}).studioV2 === true;
+
+  // The session the primary pane is showing, so the dock's Events tab can offer
+  // a "this session only" filter without a second source of truth.
+  var activeSessionId = React.useMemo(function () {
+    var t = (s.openTabs || []).find(function (x) { return x.id === s.activeTabId; });
+    return t && t.kind === "session" ? t.ref : null;
+  }, [s.openTabs, s.activeTabId]);
 
   // Remember the last workspace whose Studio was opened so the global "Studio"
   // nav item (chrome.jsx) can re-open it without a workspace picker. Written on
@@ -752,14 +806,14 @@ function Studio({ wid, pushToast, initialOpen }) {
   var termDragRef = React.useRef(null);
   function startTermResize(e) {
     e.preventDefault();
-    termDragRef.current = { startY: e.clientY, startH: s.terminalHeight };
+    termDragRef.current = { startY: e.clientY, startH: isV2 ? s.dockHeight : s.terminalHeight };
     function onMove(ev) {
       var d = termDragRef.current;
       if (!d) return;
       var delta = d.startY - ev.clientY;
       var maxH = Math.min(800, Math.round(window.innerHeight * 0.7));
       var h = Math.max(120, Math.min(maxH, d.startH + delta));
-      studio.setTerminalHeight(h);
+      if (isV2) studio.setDockHeight(h); else studio.setTerminalHeight(h);
     }
     function onUp() {
       termDragRef.current = null;
@@ -791,7 +845,7 @@ function Studio({ wid, pushToast, initialOpen }) {
         studio.openPalette("quickopen");
       } else if (e.ctrlKey && e.key === "`") {
         e.preventDefault();
-        studio.toggleTerminal();
+        if (isV2) studio.toggleDock(); else studio.toggleTerminal();
       } else if (e.key === "Escape") {
         if (s.paletteOpen) studio.closePalette();
       }
@@ -809,17 +863,23 @@ function Studio({ wid, pushToast, initialOpen }) {
       // regardless of :has() support, and the header Debug toggle controls it.
       // Right rail is a clean binary: full width when open, 0 (fully hidden)
       // when closed — opened from the header toggle, not a thin edge rail.
-      style={{ "--st-left-w": s.leftWidth + "px", "--st-right-w": (s.debugOpen ? s.rightWidth : 0) + "px", "--st-term-h": s.terminalHeight + "px" }}
+      style={{
+        "--st-left-w": s.leftWidth + "px",
+        // studioV2 has no right column at all (§3, §8).
+        "--st-right-w": (!isV2 && s.debugOpen ? s.rightWidth : 0) + "px",
+        "--st-term-h": (isV2 ? (s.dockOpen ? s.dockHeight : 0) : s.terminalHeight) + "px",
+      }}
     >
       <StudioHeader
         wid={wid}
         pushToast={studio.pushToast}
         onTogglePalette={studio.togglePalette}
         onSelectWorkspace={selectWorkspace}
-        terminalOpen={s.terminalOpen}
-        onToggleTerminal={studio.toggleTerminal}
+        terminalOpen={isV2 ? s.dockOpen : s.terminalOpen}
+        onToggleTerminal={isV2 ? studio.toggleDock : studio.toggleTerminal}
         debugOpen={s.debugOpen}
         onToggleDebug={studio.toggleDebug}
+        hideDebugToggle={isV2}
         onToggleLeftPanel={function () { setRightPanelOpen(false); setLeftPanelOpen(function (o) { return !o; }); }}
         onToggleRightPanel={function () { setLeftPanelOpen(false); setRightPanelOpen(function (o) { return !o; }); }}
       />
@@ -828,7 +888,7 @@ function Studio({ wid, pushToast, initialOpen }) {
           collapses. Strictly opt-in while the revamp is incomplete - the graph
           builder shipped inert behind a permissive `!== false` guard, so this
           one must refuse to appear until it is finished. */}
-      {studioV2 === true && typeof window.AttentionBar === "function" ? (
+      {isV2 && typeof window.AttentionBar === "function" ? (
         <window.AttentionBar wid={wid} studio={studio} />
       ) : null}
 
@@ -855,26 +915,46 @@ function Studio({ wid, pushToast, initialOpen }) {
           <StudioCenter wid={wid} studio={studio} />
           {/* Horizontal splitter: drag to resize the terminal (writes
               terminalHeight → --st-term-h). Mirrors the column handles. */}
-          {s.terminalOpen && (
-            <div className="st-term-resize" data-testid="terminal-resize" onMouseDown={startTermResize} />
+          {(isV2 ? s.dockOpen : s.terminalOpen) && (
+            <div
+              className="st-term-resize"
+              data-testid={isV2 ? "dock-resize" : "terminal-resize"}
+              onMouseDown={startTermResize}
+            />
           )}
           {/* Collapsible bottom terminal panel (Ctrl-` / the header toggle
               flip terminalOpen). Only mounted while open — unmounting tears
               down every tab's xterm instance + WS (see studio-terminal.jsx),
               which matches the terminal's ephemeral, no-reconnect v1 design. */}
-          {s.terminalOpen && <TerminalPanel wid={wid} studio={studio} />}
+          {!isV2 && s.terminalOpen && <TerminalPanel wid={wid} studio={studio} />}
+
+          {/* studioV2: the dock supersedes the bottom terminal panel and hosts
+              the tap + terminal + Problems behind one tab strip (§8). */}
+          {isV2 && s.dockOpen && typeof window.InvestigateDock === "function" ? (
+            <window.InvestigateDock
+              wid={wid}
+              studio={studio}
+              sessionId={activeSessionId}
+            />
+          ) : null}
         </div>
 
-        <div className="st-resize desktop-only" onMouseDown={function (e) { startResize("right", e); }} data-testid="studio-resize-right" />
+        {!isV2 && (
+          <div className="st-resize desktop-only" onMouseDown={function (e) { startResize("right", e); }} data-testid="studio-resize-right" />
+        )}
 
         {/* ---- RIGHT: B4 StudioActivity (action required + workspace tap) ----
-            Off-canvas sheet on phones (right edge); static column on desktop. */}
-        <div
-          className={"st-col st-col-right" + (rightPanelOpen ? " is-drawer-open" : "")}
-          data-testid="studio-activity"
-        >
-          <StudioActivity wid={wid} studio={studio} />
-        </div>
+            Off-canvas sheet on phones (right edge); static column on desktop.
+            Retired under studioV2: Action Required moved to the attention bar
+            (§3) and the tap moved into the dock (§8). ---- */}
+        {!isV2 && (
+          <div
+            className={"st-col st-col-right" + (rightPanelOpen ? " is-drawer-open" : "")}
+            data-testid="studio-activity"
+          >
+            <StudioActivity wid={wid} studio={studio} />
+          </div>
+        )}
       </div>
 
       {/* B5: Command palette overlay (⌘K). Rendered at Studio root so it sits

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -860,6 +860,9 @@ function Studio({ wid, pushToast, initialOpen }) {
   // below so the incomplete shell is strictly opt-in. The bar fetches its own
   // data, so nothing extra is polled while the revamp is off.
   var isV2 = (window.primerApi.useTweaks()[0] || {}).studioV2 === true;
+  // §11 keeps useViewport's isMobile fork; the phone layout is a different
+  // screen, not a narrower one, so it is chosen here rather than in CSS.
+  var isMobileView = window.primerApi.useViewport().isMobile;
 
   // The session the primary pane is showing, so the dock's Events tab can offer
   // a "this session only" filter without a second source of truth.
@@ -1025,6 +1028,12 @@ function Studio({ wid, pushToast, initialOpen }) {
         <window.AttentionBar wid={wid} studio={studio} />
       ) : null}
 
+      {/* Phones get triage + unblock, not a shrunk three-column shell (§11).
+          The desktop body is not rendered at all there - a hidden file editor
+          and a hidden terminal would still open their websockets. */}
+      {isV2 && isMobileView && typeof window.StudioMobile === "function" ? (
+        <window.StudioMobile wid={wid} studio={studio} />
+      ) : (
       <div className="st-body">
         {/* Mobile backdrop: dims the center doc while a panel drawer is open.
             Desktop never shows this (st-panel-overlay is mobile-only in CSS). */}
@@ -1100,6 +1109,7 @@ function Studio({ wid, pushToast, initialOpen }) {
           </div>
         )}
       </div>
+      )}
 
       {/* B5: Command palette overlay (⌘K). Rendered at Studio root so it sits
           above all three columns. paletteMode "command" vs "quickopen" selects

--- a/ui/components/studio.jsx
+++ b/ui/components/studio.jsx
@@ -655,7 +655,7 @@ function useStudioState(wid, initialOpen) {
 // collapse to a single document there.
 // ---------------------------------------------------------------------------
 
-function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, debugOpen, onToggleDebug, onToggleLeftPanel, onToggleRightPanel, hideDebugToggle }) {
+function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, terminalOpen, onToggleTerminal, debugOpen, onToggleDebug, onToggleLeftPanel, onToggleRightPanel, hideDebugToggle, onOpenChanges }) {
   var { useResource, apiFetch } = window.primerApi;
   var [menuOpen, setMenuOpen] = React.useState(false);
   // Workspace Settings overlay — restores the orphaned WorkspaceDetail tabs
@@ -800,6 +800,21 @@ function StudioHeader({ wid, pushToast, onTogglePalette, onSelectWorkspace, term
           panel icon (not a bell — per earlier feedback). */}
       {/* Retired under studioV2: Action Required lives in the attention bar and
           the tap lives in the dock, so there is no right rail to toggle. */}
+      {/* studioV2: the turn trail. A center tab, not a rail mode - it is a
+          two-column surface (WIRING §7.2). Opened from here because a changed
+          file nobody can find is a changed file nobody reviews. */}
+      {onOpenChanges && (
+        <button
+          className="st-hbtn touch-target desktop-only"
+          data-testid="studio-changes-toggle"
+          title="Changes (what the agents wrote)"
+          aria-label="Open the changes view"
+          onClick={onOpenChanges}
+        >
+          <Icon name="git-commit" size={15} />
+        </button>
+      )}
+
       {!hideDebugToggle && (
         <button
           className={"st-hbtn touch-target desktop-only" + (debugOpen ? " is-active" : "")}
@@ -1016,6 +1031,9 @@ function Studio({ wid, pushToast, initialOpen }) {
         debugOpen={s.debugOpen}
         onToggleDebug={studio.toggleDebug}
         hideDebugToggle={isV2}
+        onOpenChanges={isV2 ? function () {
+          studio.openTab({ id: "changes", kind: "changes", ref: wid, title: "Changes" });
+        } : null}
         onToggleLeftPanel={function () { setRightPanelOpen(false); setLeftPanelOpen(function (o) { return !o; }); }}
         onToggleRightPanel={function () { setLeftPanelOpen(false); setRightPanelOpen(function (o) { return !o; }); }}
       />

--- a/ui/components/studio/st-api.jsx
+++ b/ui/components/studio/st-api.jsx
@@ -85,6 +85,7 @@ var ST2_api = {
     sessionPending: function (sid) { return "session-adapter:pending:" + sid; },
     sessions: function (wid) { return "studio-sessions:" + wid; },
     log: function (wid) { return "studio-log:" + wid; },
+    nodeStates: function (gid, rid) { return "graph-node-states:" + gid + ":" + rid; },
   },
 };
 

--- a/ui/components/studio/st-api.jsx
+++ b/ui/components/studio/st-api.jsx
@@ -1,0 +1,91 @@
+// Studio revamp - the only file that names a URL (ui/studio/STUDIO-WIRING.md §2.3).
+//
+// Bodies are exactly what the shipped endpoints accept; do not "improve" them.
+// Every read takes an optional AbortSignal so useResource can cancel it.
+
+var ST2_api = {
+  // ---- reads ---------------------------------------------------------------
+
+  // Workspace-wide pending yields - what the attention bar counts.
+  // primer/api/routers/workspaces.py:1564
+  pendingYields: function (wid, signal) {
+    return window.primerApi.apiFetch(
+      "GET", "/workspaces/" + encodeURIComponent(wid) + "/yields/pending",
+      null, { signal: signal });
+  },
+
+  // Pending yields for one session - what the inline transcript card reads.
+  // primer/api/routers/workspaces.py:1646
+  sessionPendingYields: function (wid, sid, signal) {
+    return window.primerApi.apiFetch(
+      "GET", "/workspaces/" + encodeURIComponent(wid) + "/sessions/"
+        + encodeURIComponent(sid) + "/yields/pending",
+      null, { signal: signal });
+  },
+
+  sessions: function (wid, signal) {
+    return window.primerApi.apiFetch(
+      "GET", "/workspaces/" + encodeURIComponent(wid) + "/sessions?limit=200",
+      null, { signal: signal });
+  },
+
+  // The .state git trail. Deliberately unpolled (WS_LogTab is manual-refresh).
+  // NOTE: CommitInfo carries sha/subject/committed_at + the X-Primer-* trailers
+  // only - there is NO per-commit file list or +n/-m stat, so a Changes view
+  // cannot enumerate changed paths from this alone. See the plan's §0.2.
+  workspaceLog: function (wid, limit, signal) {
+    return window.primerApi.apiFetch(
+      "GET", "/workspaces/" + encodeURIComponent(wid) + "/log?limit="
+        + (limit || 100),
+      null, { signal: signal });
+  },
+
+  // Graph run node states. This is the TOP-LEVEL compute route
+  // (primer/api/routers/compute.py:249), not a workspace-scoped one - for a
+  // graph-bound session the run id IS the session id.
+  nodeStates: function (graphId, runId, signal) {
+    return window.primerApi.apiFetch(
+      "GET", "/graphs/" + encodeURIComponent(graphId) + "/runs/"
+        + encodeURIComponent(runId) + "/node_states",
+      null, { signal: signal });
+  },
+
+  // ---- yield writes (bodies unchanged from the shipped handlers) -----------
+
+  approve: function (sid, tcid) {
+    return window.primerApi.apiFetch(
+      "POST", "/sessions/" + encodeURIComponent(sid) + "/tool_approval/respond",
+      { tool_call_id: tcid, decision: "approved" });
+  },
+
+  deny: function (sid, tcid, reason) {
+    return window.primerApi.apiFetch(
+      "POST", "/sessions/" + encodeURIComponent(sid) + "/tool_approval/respond",
+      { tool_call_id: tcid, decision: "rejected", reason: reason || "" });
+  },
+
+  answer: function (sid, tcid, response) {
+    return window.primerApi.apiFetch(
+      "POST", "/sessions/" + encodeURIComponent(sid) + "/ask_user/respond",
+      { tool_call_id: tcid, response: response });
+  },
+
+  cancelYield: function (sid, tcid, reason) {
+    return window.primerApi.apiFetch(
+      "POST", "/sessions/" + encodeURIComponent(sid) + "/yields/"
+        + encodeURIComponent(tcid) + "/cancel",
+      { reason: reason || "operator cancelled" });
+  },
+
+  // ---- cache keys ---------------------------------------------------------
+  // One place so a mutation's `invalidates` can never drift from the resource
+  // key the reader registered.
+  keys: {
+    pending: function (wid) { return "studio-yields-pending:" + wid; },
+    sessionPending: function (sid) { return "session-adapter:pending:" + sid; },
+    sessions: function (wid) { return "studio-sessions:" + wid; },
+    log: function (wid) { return "studio-log:" + wid; },
+  },
+};
+
+window.ST2_api = ST2_api;

--- a/ui/components/studio/st-api.jsx
+++ b/ui/components/studio/st-api.jsx
@@ -43,6 +43,27 @@ var ST2_api = {
   // Graph run node states. This is the TOP-LEVEL compute route
   // (primer/api/routers/compute.py:249), not a workspace-scoped one - for a
   // graph-bound session the run id IS the session id.
+  // The turn trail. `with_files=1` adds per-file {path, additions, deletions,
+  // binary}; without it every commit's `files` is null. Deliberately unpolled
+  // by the caller (WIRING §7.1 keeps WS_LogTab's manual-refresh behaviour) -
+  // history does not change under you, and a poll here would refetch the whole
+  // page on a timer for no reason.
+  trail: function (wid, limit, withFiles, signal) {
+    return window.primerApi.apiFetch(
+      "GET", "/workspaces/" + encodeURIComponent(wid) + "/log?limit="
+        + encodeURIComponent(limit) + (withFiles ? "&with_files=1" : ""),
+      null, { signal: signal });
+  },
+
+  // One commit's per-file unified patches. Fetched only when a reader opens a
+  // row, which is why the trail carries counts and not content.
+  commit: function (wid, sha, signal) {
+    return window.primerApi.apiFetch(
+      "GET", "/workspaces/" + encodeURIComponent(wid) + "/commit/"
+        + encodeURIComponent(sha),
+      null, { signal: signal });
+  },
+
   nodeStates: function (graphId, runId, signal) {
     return window.primerApi.apiFetch(
       "GET", "/graphs/" + encodeURIComponent(graphId) + "/runs/"
@@ -86,6 +107,13 @@ var ST2_api = {
     sessions: function (wid) { return "studio-sessions:" + wid; },
     log: function (wid) { return "studio-log:" + wid; },
     nodeStates: function (gid, rid) { return "graph-node-states:" + gid + ":" + rid; },
+    // Same key shape WS_LogTab uses, so the two views share one cache entry
+    // when their limits agree. with_files varies the key: the two responses
+    // differ in shape, so they must not alias.
+    trail: function (wid, limit, withFiles) {
+      return "workspace-log:" + wid + ":" + limit + (withFiles ? ":files" : "");
+    },
+    commit: function (wid, sha) { return "workspace-commit:" + wid + ":" + sha; },
   },
 };
 

--- a/ui/components/studio/st-attention.jsx
+++ b/ui/components/studio/st-attention.jsx
@@ -27,6 +27,143 @@ function ST2_kindCopy(kind) {
 }
 
 // ---------------------------------------------------------------------------
+// ?focus=<tool_call_id> deep links (§9, §2.3)
+//
+// The point is a URL you can paste into Slack: "this needs you". That makes the
+// link's lifetime longer than the yield's, so the id is very often stale by the
+// time someone clicks - already approved, denied, or the session ended. A stale
+// link must land somewhere useful and SAY it is stale; silently opening an empty
+// focus panel, or worse the wrong item, is what makes a feature like this
+// untrustworthy.
+//
+// The Studio is a hash router, so the query lives in the hash fragment.
+// ---------------------------------------------------------------------------
+
+// The parse/serialise pair is deliberately pure string work rather than
+// URL / URLSearchParams. Those are Web APIs, not ECMAScript, so anything built
+// on them is only exercisable in a real browser - which for a query-string
+// edge case ("does writing focus drop ?open=") means it effectively is not
+// exercised at all. Keeping the logic pure puts it under test; the Web API stays
+// at the boundary in ST2_syncFocusUrl / ST2_copyFocusLink.
+
+function ST2_splitHash(hash) {
+  var h = String(hash == null ? "" : hash) || "#/";
+  var qIdx = h.indexOf("?");
+  return {
+    path: qIdx >= 0 ? h.slice(0, qIdx) : h,
+    query: qIdx >= 0 ? h.slice(qIdx + 1) : "",
+  };
+}
+
+// [[key, value], ...] preserving order, so rewriting one param cannot reorder
+// or drop the others.
+function ST2_parseQuery(query) {
+  if (!query) return [];
+  return String(query).split("&").filter(Boolean).map(function (pair) {
+    var eq = pair.indexOf("=");
+    var k = eq < 0 ? pair : pair.slice(0, eq);
+    var v = eq < 0 ? "" : pair.slice(eq + 1);
+    try { return [decodeURIComponent(k), decodeURIComponent(v)]; }
+    catch (_e) { return [k, v]; }
+  });
+}
+
+function ST2_buildQuery(pairs) {
+  return pairs.map(function (p) {
+    return encodeURIComponent(p[0]) + "=" + encodeURIComponent(p[1]);
+  }).join("&");
+}
+
+// ST2_focusFromHash(hash) -> the ?focus= value, or null.
+function ST2_focusFromHash(hash) {
+  var found = null;
+  ST2_parseQuery(ST2_splitHash(hash).query).forEach(function (p) {
+    if (p[0] === "focus") found = p[1];
+  });
+  return found || null;
+}
+
+// ST2_hashWithFocus(hash, tcid) -> the hash with focus set (or removed when
+// tcid is falsy), every other param preserved in place.
+function ST2_hashWithFocus(hash, tcid) {
+  var parts = ST2_splitHash(hash);
+  var pairs = ST2_parseQuery(parts.query).filter(function (p) { return p[0] !== "focus"; });
+  if (tcid) pairs.push(["focus", String(tcid)]);
+  var qs = ST2_buildQuery(pairs);
+  return qs ? parts.path + "?" + qs : parts.path;
+}
+
+function ST2_focusFromUrl() {
+  try {
+    return ST2_focusFromHash(window.location.hash);
+  } catch (_e) {
+    return null;
+  }
+}
+
+// Mirror the focused item into the URL with replaceState - no history entry per
+// focus change, same idiom as the Studio's ?open= mirroring.
+function ST2_syncFocusUrl(tcid) {
+  try {
+    var next = ST2_hashWithFocus(window.location.hash, tcid);
+    window.history.replaceState(null, "", ST2_baseUrl() + next);
+    return next;
+  } catch (_e) {
+    return null;
+  }
+}
+
+function ST2_baseUrl() {
+  var loc = window.location;
+  return loc.origin + loc.pathname + (loc.search || "");
+}
+
+// Build the shareable URL for a tool_call_id WITHOUT navigating, so "Copy link"
+// cannot move the reader off the panel they are answering.
+function ST2_focusLinkFor(tcid) {
+  try {
+    return ST2_baseUrl() + ST2_hashWithFocus(window.location.hash, tcid);
+  } catch (_e) {
+    return null;
+  }
+}
+
+function ST2_copyFocusLink(tcid) {
+  var link = ST2_focusLinkFor(tcid);
+  if (!link) return;
+  var toast = window.primerApi && window.primerApi.toastPush;
+  var ok = function () {
+    if (toast) toast({ kind: "success", title: "Link copied", detail: tcid });
+  };
+  var fail = function () {
+    // Clipboard access is refused outside a secure context, so surface the URL
+    // rather than reporting a copy that did not happen.
+    if (toast) toast({ kind: "error", title: "Could not copy", detail: link });
+  };
+  try {
+    if (navigator.clipboard && navigator.clipboard.writeText) {
+      navigator.clipboard.writeText(link).then(ok, fail);
+    } else {
+      fail();
+    }
+  } catch (_e) {
+    fail();
+  }
+}
+
+// ST2_resolveFocusTarget(tcid, items, loading) -> {kind, item?}
+//   "wait"    - still loading, decide nothing yet
+//   "none"    - no ?focus= in the URL
+//   "focus"   - the id is live; open it
+//   "stale"   - the id is gone; open the queue and say so
+function ST2_resolveFocusTarget(tcid, items, loading) {
+  if (!tcid) return { kind: "none" };
+  if (loading) return { kind: "wait" };
+  var match = (items || []).filter(function (i) { return i.tool_call_id === tcid; })[0];
+  return match ? { kind: "focus", item: match } : { kind: "stale" };
+}
+
+// ---------------------------------------------------------------------------
 // Data: one resource, one tap listener, informs in local state
 // ---------------------------------------------------------------------------
 
@@ -274,6 +411,34 @@ function AttentionBar({ wid, studio }) {
   var queueOpen = ui.queue;
   var focusItem = ui.focus;
 
+  // Resolve ?focus= once the pending snapshot has actually landed. Applied at
+  // most once per distinct URL value (appliedFocusRef), so the mirroring below
+  // cannot feed itself: focusing an item writes the URL, and without this guard
+  // that write would be read straight back as a fresh deep-link.
+  var appliedFocusRef = React.useRef(null);
+  React.useEffect(function () {
+    var tcid = ST2_focusFromUrl();
+    if (!tcid || appliedFocusRef.current === tcid) return;
+    var target = ST2_resolveFocusTarget(tcid, visible, att.loading);
+    if (target.kind === "wait") return;
+    appliedFocusRef.current = tcid;
+    if (target.kind === "focus") {
+      setUi({ queue: false, focus: target.item, staleFocus: null });
+    } else if (target.kind === "stale") {
+      // Land on the queue rather than an empty panel, and name the reason.
+      setUi({ queue: true, focus: null, staleFocus: tcid });
+      ST2_syncFocusUrl(null);
+    }
+  }, [att.loading, visible.length]); // eslint-disable-line
+
+  // Keep the URL pointing at whatever is focused, so the address bar is always
+  // the shareable link without a separate "copy link" round trip.
+  React.useEffect(function () {
+    var tcid = focusItem && focusItem.tool_call_id;
+    if (tcid) appliedFocusRef.current = tcid;
+    ST2_syncFocusUrl(tcid || null);
+  }, [focusItem]);
+
   // Keyboard is registered ONLY while an overlay is open - j/k/d/c would
   // otherwise eat typing anywhere in Studio.
   React.useEffect(function () {
@@ -338,9 +503,10 @@ function AttentionBar({ wid, studio }) {
         {queueOpen ? (
           <AttentionQueue
             items={visible} informs={att.informs} actions={actions}
+            staleFocus={ui.staleFocus}
             onDismissInform={att.dismissInform}
             onFocus={function (it) { setUi({ queue: false, focus: it }); }}
-            onClose={function () { setUi({ queue: false, focus: null }); }}
+            onClose={function () { setUi({ queue: false, focus: null, staleFocus: null }); }}
           />
         ) : null}
       </div>
@@ -403,9 +569,10 @@ function AttentionBar({ wid, studio }) {
       {queueOpen ? (
         <AttentionQueue
           items={visible} informs={att.informs} actions={actions}
+          staleFocus={ui.staleFocus}
           onDismissInform={att.dismissInform}
           onFocus={function (it) { setUi({ queue: false, focus: it }); }}
-          onClose={function () { setUi({ queue: false, focus: null }); }}
+          onClose={function () { setUi({ queue: false, focus: null, staleFocus: null }); }}
         />
       ) : null}
       {focusItem ? (
@@ -426,7 +593,7 @@ function AttentionBar({ wid, studio }) {
 // Queue popover
 // ---------------------------------------------------------------------------
 
-function AttentionQueue({ items, informs, actions, onDismissInform, onFocus, onClose }) {
+function AttentionQueue({ items, informs, actions, staleFocus, onDismissInform, onFocus, onClose }) {
   return (
     <div
       data-testid="attention-queue"
@@ -440,6 +607,21 @@ function AttentionQueue({ items, informs, actions, onDismissInform, onFocus, onC
         <span style={{ fontSize: "var(--fs-12)", fontWeight: 600 }}>Needs you</span>
         <span className="muted" style={{ marginLeft: "auto", fontSize: "var(--fs-11)", cursor: "pointer" }} onClick={onClose}>esc</span>
       </div>
+      {/* A shared ?focus= link outlives the yield it points at, so say plainly
+          that this one is already handled rather than showing an empty panel
+          and letting the reader assume the link was broken (§9). */}
+      {staleFocus ? (
+        <div
+          data-testid="focus-resolved-note"
+          style={{
+            padding: "8px 13px", fontSize: "var(--fs-11)",
+            background: "var(--bg-1)", color: "var(--text-2)",
+            borderBottom: "1px solid var(--border)",
+          }}
+        >
+          That request was already handled. Here is what still needs you.
+        </div>
+      ) : null}
       <div data-testid="action-required-list" style={{ maxHeight: 320, overflow: "auto" }}>
         {!items.length ? (
           <div data-testid="action-required-empty" className="muted" style={{ padding: 14, fontSize: "var(--fs-12)" }}>
@@ -529,7 +711,20 @@ function UnblockFocus({ wid, item, queue, actions, onAdvance, onClose }) {
         <div className="row" style={{ padding: 14, borderBottom: "1px solid var(--border)", alignItems: "center", gap: 9 }}>
           <span style={{ fontSize: "var(--fs-13)", fontWeight: 600 }}>{item.session_name || item.session_id}</span>
           <span style={{ fontSize: "var(--fs-11)", color: "var(--amber)" }}>{ST2_kindCopy(item.kind)}</span>
-          <span className="muted mono" style={{ marginLeft: "auto", fontSize: "var(--fs-11)" }}>
+          {/* The address bar already carries ?focus= for whatever is open here,
+              so this is a convenience over the same URL, not a second source. */}
+          {actionable ? (
+            <span
+              data-testid="focus-copy-link"
+              title="Copy a link to this request"
+              onClick={function () { ST2_copyFocusLink(item.tool_call_id); }}
+              style={{ marginLeft: "auto", fontSize: "var(--fs-11)", color: "var(--text-3)", cursor: "pointer" }}
+            >Copy link</span>
+          ) : null}
+          <span
+            className="muted mono"
+            style={{ marginLeft: actionable ? 0 : "auto", fontSize: "var(--fs-11)" }}
+          >
             {item.tool_call_id || "no tool_call_id"}
           </span>
         </div>
@@ -598,3 +793,9 @@ window.UnblockFocus = UnblockFocus;
 window.ST2_useAttention = ST2_useAttention;
 window.ST2_useYieldActions = ST2_useYieldActions;
 window.ST2_kindCopy = ST2_kindCopy;
+window.ST2_focusFromUrl = ST2_focusFromUrl;
+window.ST2_syncFocusUrl = ST2_syncFocusUrl;
+window.ST2_resolveFocusTarget = ST2_resolveFocusTarget;
+window.ST2_focusLinkFor = ST2_focusLinkFor;
+window.ST2_focusFromHash = ST2_focusFromHash;
+window.ST2_hashWithFocus = ST2_hashWithFocus;

--- a/ui/components/studio/st-attention.jsx
+++ b/ui/components/studio/st-attention.jsx
@@ -1,0 +1,600 @@
+/* global React, Icon, ST2_api, ST2_bucketOf, SA_informFromEvent, ST_sessionTranscriptRows */
+// Studio revamp - the attention bar (ui/studio/STUDIO-WIRING.md §3, §9).
+//
+// Replaces the right rail's ActionRequired housing. The bar is ALWAYS mounted
+// between the header and the body, including when empty: "Nothing needs you"
+// is the feature, not an empty state to be collapsed away.
+//
+// Handlers and the inform capture are ported from studio-activity.jsx
+// unchanged in behaviour; what changes is that the writes now go through
+// useMutation with `invalidates` instead of a hand-rolled
+// SA_invalidateSessionPending + setTimeout(refetch, 800) pair.
+
+var ST2_PROMPT_CHARS = 80;
+var ST2_INFORM_CAP = 30;
+
+function ST2_clip(text, max) {
+  var s = String(text == null ? "" : text).replace(/\s+/g, " ").trim();
+  return s.length > max ? s.slice(0, max - 1) + "…" : s;
+}
+
+function ST2_kindCopy(kind) {
+  if (kind === "approval" || kind === "ask_approval") return "wants approval";
+  if (kind === "ask_user") return "asked a question";
+  if (kind === "watch_files") return "waiting on a file";
+  if (kind === "sleep") return "sleeping";
+  return kind ? String(kind) : "parked";
+}
+
+// ---------------------------------------------------------------------------
+// Data: one resource, one tap listener, informs in local state
+// ---------------------------------------------------------------------------
+
+function ST2_useAttention(wid) {
+  var api = window.primerApi;
+  var useResource = api.useResource;
+
+  var pending = useResource(
+    ST2_api.keys.pending(wid),
+    function (signal) { return ST2_api.pendingYields(wid, signal); },
+    { pollMs: 15000, deps: [wid] }
+  );
+
+  var items = (pending.data && Array.isArray(pending.data.items)) ? pending.data.items : [];
+
+  // Oldest first. Never sort by session name - the queue is a work order.
+  var ordered = React.useMemo(function () {
+    var copy = items.slice();
+    copy.sort(function (a, b) {
+      var av = a && a.waiting_since ? String(a.waiting_since) : "";
+      var bv = b && b.waiting_since ? String(b.waiting_since) : "";
+      if (av && bv) return av < bv ? -1 : (av > bv ? 1 : 0);
+      return 0; // fall back to the server's order
+    });
+    return copy;
+  }, [pending.data]); // eslint-disable-line
+
+  // inform_user rows captured live from the tap. They have no pending-yield
+  // backing, so they live here, are capped, and "Dismiss" is client-side only.
+  var informs = React.useState([]);
+  var informList = informs[0];
+  var setInformList = informs[1];
+
+  var debounceRef = React.useRef(null);
+  window.useWorkspaceTapListener(wid, function (ev) {
+    var inform = typeof SA_informFromEvent === "function" ? SA_informFromEvent(ev) : null;
+    if (inform) {
+      setInformList(function (prev) {
+        if (prev.some(function (x) { return x.key === inform.key; })) return prev;
+        return prev.concat([inform]).slice(-ST2_INFORM_CAP);
+      });
+      return;
+    }
+    var cls = ev && (ev.class || ev.cls);
+    if (cls !== "yielded" && cls !== "done") return;
+    // Wake the poll rather than replacing it; the 15s pollMs is the backstop.
+    if (debounceRef.current) clearTimeout(debounceRef.current);
+    debounceRef.current = setTimeout(function () { pending.refetch(); }, 300);
+  });
+
+  React.useEffect(function () {
+    return function () { if (debounceRef.current) clearTimeout(debounceRef.current); };
+  }, []);
+
+  var dismissInform = function (key) {
+    setInformList(function (prev) { return prev.filter(function (x) { return x.key !== key; }); });
+  };
+
+  return {
+    items: ordered,
+    loading: pending.loading,
+    refetch: pending.refetch,
+    informs: informList,
+    dismissInform: dismissInform,
+  };
+}
+
+// Writes. One mutation per action so each row can show its own error inline
+// without losing a typed draft.
+function ST2_useYieldActions(wid) {
+  var api = window.primerApi;
+  var useMutation = api.useMutation;
+  var errs = React.useState({});
+  var errors = errs[0];
+  var setErrors = errs[1];
+  var hidden = React.useState({});
+  var hiddenMap = hidden[0];
+  var setHidden = hidden[1];
+
+  var invalidates = [ST2_api.keys.pending(wid)];
+
+  // Also refetch the per-session pending cache the inline transcript card
+  // reads, so answering in one place updates the other.
+  var alsoSession = function (sid) {
+    var r = window.primerApi._resource;
+    if (!r || !sid) return;
+    var key = ST2_api.keys.sessionPending(sid);
+    (r.findKeys(key) || [key]).forEach(function (k) { r.refetchKey(k); });
+  };
+
+  var fail = function (tcid, label) {
+    return function (err) {
+      setHidden(function (p) { var n = Object.assign({}, p); delete n[tcid]; return n; });
+      setErrors(function (p) {
+        var n = Object.assign({}, p);
+        n[tcid] = (err && (err.detail || err.title || err.message)) || (label + " failed");
+        return n;
+      });
+    };
+  };
+  var start = function (tcid) {
+    setHidden(function (p) { var n = Object.assign({}, p); n[tcid] = true; return n; });
+    setErrors(function (p) { var n = Object.assign({}, p); delete n[tcid]; return n; });
+  };
+
+  var approve = useMutation(
+    function (v) { return ST2_api.approve(v.sid, v.tcid); },
+    { invalidates: invalidates }
+  );
+  var deny = useMutation(
+    function (v) { return ST2_api.deny(v.sid, v.tcid, v.reason); },
+    { invalidates: invalidates }
+  );
+  var answer = useMutation(
+    function (v) { return ST2_api.answer(v.sid, v.tcid, v.response); },
+    { invalidates: invalidates }
+  );
+  var cancel = useMutation(
+    function (v) { return ST2_api.cancelYield(v.sid, v.tcid, v.reason); },
+    { invalidates: invalidates }
+  );
+
+  var run = function (m, label) {
+    return function (item, extra) {
+      // Every action guards on tool_call_id: the /yields/pending item shape
+      // allows null (malformed or legacy parks), and such a row must render
+      // but never POST.
+      if (!item || !item.tool_call_id) return;
+      var tcid = item.tool_call_id;
+      start(tcid);
+      m.mutate(Object.assign({ sid: item.session_id, tcid: tcid }, extra || {}))
+        .then(function () { alsoSession(item.session_id); }, fail(tcid, label));
+    };
+  };
+
+  return {
+    approve: run(approve, "Approve"),
+    deny: run(deny, "Deny"),
+    answer: run(answer, "Send"),
+    cancel: run(cancel, "Cancel"),
+    errors: errors,
+    hidden: hiddenMap,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Per-kind controls
+// ---------------------------------------------------------------------------
+
+function ST2_YieldControls({ item, actions, compact }) {
+  var actionable = !!(item && item.tool_call_id);
+  var draft = React.useState("");
+  var text = draft[0];
+  var setText = draft[1];
+  var kind = item && item.kind;
+  var dis = { opacity: actionable ? 1 : 0.45, cursor: actionable ? "pointer" : "not-allowed" };
+  var btn = function (extra) {
+    return Object.assign({
+      padding: compact ? "3px 9px" : "5px 11px", borderRadius: 7,
+      fontSize: "var(--fs-12)", border: "1px solid var(--border-strong)",
+      background: "var(--bg-active)", color: "var(--text)",
+    }, dis, extra || {});
+  };
+
+  if (kind === "approval" || kind === "ask_approval") {
+    return (
+      <div className="row" style={{ gap: 6, alignItems: "center" }}>
+        <button
+          data-testid="approve" disabled={!actionable}
+          title={actionable ? "Approve (Enter)" : "This park has no tool_call_id and cannot be answered"}
+          onClick={function () { actions.approve(item); }}
+          style={btn({ background: "var(--green-dim)", borderColor: "var(--green)", color: "var(--green)" })}
+        >Approve ⏎</button>
+        <button
+          data-testid="reject" disabled={!actionable}
+          onClick={function () { actions.deny(item, { reason: "" }); }}
+          style={btn()}
+        >Deny</button>
+      </div>
+    );
+  }
+
+  if (kind === "ask_user") {
+    var send = function () {
+      if (!actionable || !text.trim()) return;
+      actions.answer(item, { response: text });
+      setText("");
+    };
+    return (
+      <div className="row" style={{ gap: 6, alignItems: "center", flex: "1 1 auto", minWidth: 0 }}>
+        <input
+          data-testid="respond-input"
+          value={text}
+          disabled={!actionable}
+          placeholder="Type a reply…"
+          onChange={function (e) { setText(e.target.value); }}
+          onKeyDown={function (e) {
+            // Enter sends, Shift+Enter newlines - matches the shipped
+            // handleRespondKeyDown behaviour.
+            if (e.key === "Enter" && !e.shiftKey) { e.preventDefault(); send(); }
+          }}
+          style={{
+            flex: "1 1 auto", minWidth: 0, background: "var(--bg-1)",
+            border: "1px solid var(--border)", borderRadius: 7,
+            padding: "5px 9px", color: "var(--text)", fontSize: "var(--fs-12)",
+          }}
+        />
+        <button data-testid="respond" disabled={!actionable} onClick={send} style={btn()}>Send ⏎</button>
+      </div>
+    );
+  }
+
+  // watch_files / sleep: nothing to answer, only to abandon.
+  return (
+    <button
+      data-testid="cancel-yield" disabled={!actionable}
+      onClick={function () { actions.cancel(item, { reason: "operator cancelled" }); }}
+      style={btn()}
+    >Cancel</button>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// The bar
+// ---------------------------------------------------------------------------
+
+function AttentionBar({ wid, studio }) {
+  var att = ST2_useAttention(wid);
+  var actions = ST2_useYieldActions(wid);
+  // The calm state reports how many runs are working. The bar owns this fetch
+  // so nothing extra is polled while the revamp is switched off.
+  var sessionsRes = window.primerApi.useResource(
+    ST2_api.keys.sessions(wid),
+    function (signal) { return ST2_api.sessions(wid, signal); },
+    { pollMs: 5000, deps: [wid] }
+  );
+  var sessions = (sessionsRes.data && sessionsRes.data.items) || [];
+  var open = React.useState({ queue: false, focus: null });
+  var ui = open[0];
+  var setUi = open[1];
+
+  var visible = att.items.filter(function (i) { return !actions.hidden[i.tool_call_id]; });
+  var count = visible.length;
+  var head = visible[0] || null;
+  var queueOpen = ui.queue;
+  var focusItem = ui.focus;
+
+  // Keyboard is registered ONLY while an overlay is open - j/k/d/c would
+  // otherwise eat typing anywhere in Studio.
+  React.useEffect(function () {
+    if (!queueOpen && !focusItem) return undefined;
+    var onKey = function (e) {
+      var tag = (e.target && e.target.tagName) || "";
+      var typing = tag === "INPUT" || tag === "TEXTAREA";
+      if (e.key === "Escape") { setUi({ queue: false, focus: null }); return; }
+      if (typing) return;
+      var item = focusItem || head;
+      if (!item) return;
+      if (e.key === "Enter" && (item.kind === "approval" || item.kind === "ask_approval")) {
+        e.preventDefault(); actions.approve(item);
+      } else if (e.key === "d") { e.preventDefault(); actions.deny(item, { reason: "" }); }
+      else if (e.key === "c") { e.preventDefault(); actions.cancel(item, {}); }
+    };
+    window.addEventListener("keydown", onKey);
+    return function () { window.removeEventListener("keydown", onKey); };
+  }, [queueOpen, focusItem, head]); // eslint-disable-line
+
+  var workingCount = (sessions || []).filter(function (s) {
+    return ST2_bucketOf(s, {}).bucket === "working";
+  }).length;
+
+  var barBase = {
+    height: 44, flex: "0 0 auto", gap: 10, alignItems: "center",
+    padding: "0 14px", borderBottom: "1px solid var(--border)", position: "relative",
+  };
+
+  // First paint: hold the calm height rather than reflowing.
+  if (att.loading && !att.items.length) {
+    return (
+      <div className="row" data-testid="attention-bar" style={Object.assign({ background: "var(--bg-2)" }, barBase)}>
+        <span className="muted" style={{ fontSize: "var(--fs-12)" }}>…</span>
+      </div>
+    );
+  }
+
+  if (count === 0) {
+    return (
+      <div
+        className="row" data-testid="attention-bar"
+        style={Object.assign({ background: "var(--bg-2)" }, barBase)}
+      >
+        <span data-testid="attention-bar-calm" className="row" style={{ gap: 8, alignItems: "center" }}>
+          <span style={{ width: 7, height: 7, borderRadius: "50%", background: "var(--green)" }} />
+          <span style={{ fontSize: "var(--fs-12)", color: "var(--text)" }}>Nothing needs you.</span>
+        </span>
+        <span className="muted" style={{ fontSize: "var(--fs-11)" }}>
+          {workingCount ? workingCount + (workingCount === 1 ? " run working" : " runs working") : "no runs working"}
+        </span>
+        {att.informs.length ? (
+          <span
+            className="row" style={{ marginLeft: "auto", gap: 6, cursor: "pointer" }}
+            onClick={function () { setUi({ queue: true, focus: null }); }}
+          >
+            <span style={{ fontSize: "var(--fs-11)", color: "var(--violet)" }}>
+              {att.informs.length} update{att.informs.length === 1 ? "" : "s"}
+            </span>
+          </span>
+        ) : null}
+        {queueOpen ? (
+          <AttentionQueue
+            items={visible} informs={att.informs} actions={actions}
+            onDismissInform={att.dismissInform}
+            onFocus={function (it) { setUi({ queue: false, focus: it }); }}
+            onClose={function () { setUi({ queue: false, focus: null }); }}
+          />
+        ) : null}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="row" data-testid="attention-bar"
+      style={Object.assign({
+        background: "var(--amber-dim)", borderBottom: "1px solid var(--amber)",
+      }, barBase)}
+    >
+      {/* action-required kept so existing journeys still resolve (§13). */}
+      <span
+        data-testid="action-required-count"
+        style={{
+          padding: "2px 9px", borderRadius: 999, background: "var(--amber)",
+          color: "var(--bg-1)", fontSize: "var(--fs-11)", fontWeight: 600,
+        }}
+      >
+        <span data-testid="attention-count">{count}</span>
+      </span>
+      <span data-testid="action-required" className="row" style={{ gap: 8, alignItems: "center", minWidth: 0, flex: "1 1 auto" }}>
+        <span data-testid="attention-head-item" className="row" style={{ gap: 8, alignItems: "center", minWidth: 0 }}>
+          <span data-testid="action-session-link" style={{ fontSize: "var(--fs-12)", fontWeight: 600, color: "var(--text)", whiteSpace: "nowrap" }}>
+            {head.session_name || head.session_id}
+          </span>
+          <span data-testid="user-interaction-label" style={{ fontSize: "var(--fs-11)", color: "var(--amber)" }}>
+            {ST2_kindCopy(head.kind)}
+          </span>
+          <span className="muted" style={{ fontSize: "var(--fs-11)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", minWidth: 0 }}>
+            {ST2_clip(head.prompt || head.command || "", ST2_PROMPT_CHARS)}
+          </span>
+        </span>
+      </span>
+      <div data-testid="action-item" className="row" style={{ gap: 6, alignItems: "center", flex: "0 1 auto" }}>
+        <ST2_YieldControls item={head} actions={actions} compact />
+        {actions.errors[head.tool_call_id] ? (
+          <span style={{ fontSize: "var(--fs-11)", color: "var(--red)" }}>{actions.errors[head.tool_call_id]}</span>
+        ) : null}
+        <button
+          onClick={function () { setUi({ queue: false, focus: head }); }}
+          style={{
+            padding: "3px 9px", borderRadius: 7, background: "var(--bg-active)",
+            border: "1px solid var(--border-strong)", color: "var(--text)",
+            fontSize: "var(--fs-12)", cursor: "pointer",
+          }}
+        >See context</button>
+        <button
+          onClick={function () { setUi({ queue: !queueOpen, focus: null }); }}
+          style={{
+            padding: "3px 9px", borderRadius: 7, background: "transparent",
+            border: "1px solid var(--border)", color: "var(--text-2)",
+            fontSize: "var(--fs-12)", cursor: "pointer",
+          }}
+        >Inbox ▾</button>
+      </div>
+
+      {queueOpen ? (
+        <AttentionQueue
+          items={visible} informs={att.informs} actions={actions}
+          onDismissInform={att.dismissInform}
+          onFocus={function (it) { setUi({ queue: false, focus: it }); }}
+          onClose={function () { setUi({ queue: false, focus: null }); }}
+        />
+      ) : null}
+      {focusItem ? (
+        <UnblockFocus
+          wid={wid} item={focusItem} queue={visible} actions={actions}
+          onAdvance={function () {
+            var next = visible.filter(function (i) { return i.tool_call_id !== focusItem.tool_call_id; })[0] || null;
+            setUi({ queue: false, focus: next });
+          }}
+          onClose={function () { setUi({ queue: false, focus: null }); }}
+        />
+      ) : null}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Queue popover
+// ---------------------------------------------------------------------------
+
+function AttentionQueue({ items, informs, actions, onDismissInform, onFocus, onClose }) {
+  return (
+    <div
+      data-testid="attention-queue"
+      style={{
+        position: "absolute", top: 44, right: 12, zIndex: 40, width: 460,
+        background: "var(--bg-elev)", border: "1px solid var(--border-strong)",
+        borderRadius: 12, boxShadow: "0 30px 60px -20px rgba(0,0,0,.75)", overflow: "hidden",
+      }}
+    >
+      <div className="row" style={{ padding: "10px 13px", borderBottom: "1px solid var(--border)", alignItems: "center" }}>
+        <span style={{ fontSize: "var(--fs-12)", fontWeight: 600 }}>Needs you</span>
+        <span className="muted" style={{ marginLeft: "auto", fontSize: "var(--fs-11)", cursor: "pointer" }} onClick={onClose}>esc</span>
+      </div>
+      <div data-testid="action-required-list" style={{ maxHeight: 320, overflow: "auto" }}>
+        {!items.length ? (
+          <div data-testid="action-required-empty" className="muted" style={{ padding: 14, fontSize: "var(--fs-12)" }}>
+            Nothing needs you.
+          </div>
+        ) : null}
+        {items.map(function (it) {
+          return (
+            <div
+              key={it.tool_call_id || it.session_id}
+              data-testid="attention-queue-item"
+              className="col"
+              style={{ gap: 7, padding: "11px 13px", borderBottom: "1px solid var(--bg-active)" }}
+            >
+              <div className="row" style={{ gap: 8, alignItems: "center", minWidth: 0 }}>
+                <span style={{ fontSize: "var(--fs-12)", fontWeight: 600 }}>{it.session_name || it.session_id}</span>
+                <span style={{ fontSize: "var(--fs-11)", color: "var(--amber)" }}>{ST2_kindCopy(it.kind)}</span>
+                <span
+                  className="muted" style={{ marginLeft: "auto", fontSize: "var(--fs-11)", cursor: "pointer" }}
+                  onClick={function () { onFocus(it); }}
+                >See context</span>
+              </div>
+              {it.prompt ? (
+                <div className="muted" style={{ fontSize: "var(--fs-11)", lineHeight: 1.5 }}>{ST2_clip(it.prompt, 160)}</div>
+              ) : null}
+              <ST2_YieldControls item={it} actions={actions} />
+              {actions.errors[it.tool_call_id] ? (
+                <div style={{ fontSize: "var(--fs-11)", color: "var(--red)" }}>{actions.errors[it.tool_call_id]}</div>
+              ) : null}
+            </div>
+          );
+        })}
+
+        {/* Informs are one-way: no pending-yield backing, never counted as
+            "needs you", dismissal is client-side only. */}
+        {informs.map(function (inf) {
+          return (
+            <div
+              key={inf.key} data-testid="inform-item" className="row"
+              style={{ gap: 8, padding: "9px 13px", alignItems: "flex-start", background: "var(--bg-2)" }}
+            >
+              <span style={{ width: 6, height: 6, borderRadius: "50%", background: "var(--violet)", marginTop: 5, flex: "0 0 auto" }} />
+              <span data-testid="inform-message" className="muted" style={{ fontSize: "var(--fs-11)", lineHeight: 1.5, minWidth: 0 }}>
+                {inf.message}
+              </span>
+              <span
+                data-testid="inform-dismiss"
+                onClick={function () { onDismissInform(inf.key); }}
+                style={{ marginLeft: "auto", fontSize: "var(--fs-11)", color: "var(--text-3)", cursor: "pointer", flex: "0 0 auto" }}
+              >Dismiss</span>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Unblock focus (§9)
+// ---------------------------------------------------------------------------
+
+function UnblockFocus({ wid, item, queue, actions, onAdvance, onClose }) {
+  var actionable = !!(item && item.tool_call_id);
+  var nextUp = (queue || []).filter(function (i) { return i.tool_call_id !== item.tool_call_id; });
+
+  // Consequences, derived honestly: for a shell/file tool show the command and
+  // its arguments; for anything else show the raw arguments JSON. There is no
+  // backend preview API and this must not pretend otherwise.
+  var args = item && (item.arguments || item.args) || null;
+  var argsText = null;
+  if (args) {
+    try { argsText = typeof args === "string" ? args : JSON.stringify(args, null, 2); }
+    catch (_e) { argsText = String(args); }
+  }
+
+  return (
+    <div
+      className="modal-overlay" data-testid="unblock-focus"
+      onClick={function (e) { if (e.target === e.currentTarget) onClose(); }}
+      style={{ alignItems: "flex-start", paddingTop: 80 }}
+    >
+      <div
+        className="modal col"
+        style={{ width: "min(720px, 94vw)", gap: 0, background: "var(--bg-elev)", border: "1px solid var(--border-strong)", borderRadius: 12, overflow: "hidden" }}
+      >
+        <div className="row" style={{ padding: 14, borderBottom: "1px solid var(--border)", alignItems: "center", gap: 9 }}>
+          <span style={{ fontSize: "var(--fs-13)", fontWeight: 600 }}>{item.session_name || item.session_id}</span>
+          <span style={{ fontSize: "var(--fs-11)", color: "var(--amber)" }}>{ST2_kindCopy(item.kind)}</span>
+          <span className="muted mono" style={{ marginLeft: "auto", fontSize: "var(--fs-11)" }}>
+            {item.tool_call_id || "no tool_call_id"}
+          </span>
+        </div>
+
+        <div className="col" style={{ gap: 14, padding: 14, maxHeight: "58vh", overflow: "auto" }}>
+          {item.prompt ? (
+            <div style={{ fontSize: "var(--fs-13)", lineHeight: 1.6, color: "var(--text)" }}>{item.prompt}</div>
+          ) : null}
+
+          <div className="col" data-testid="unblock-consequences" style={{ gap: 6 }}>
+            <div style={{ fontSize: "var(--fs-11)", textTransform: "uppercase", letterSpacing: ".07em", color: "var(--text-3)", fontWeight: 600 }}>
+              What it will do
+            </div>
+            {item.command ? (
+              <div className="mono" style={{ fontSize: "var(--fs-12)", background: "var(--bg-1)", border: "1px solid var(--border)", borderRadius: 8, padding: "9px 11px", color: "var(--text)" }}>
+                $ {item.command}
+              </div>
+            ) : argsText ? (
+              <pre className="mono" style={{ margin: 0, fontSize: "var(--fs-11)", background: "var(--bg-1)", border: "1px solid var(--border)", borderRadius: 8, padding: "9px 11px", color: "var(--text-2)", overflow: "auto", maxHeight: 200 }}>
+                {argsText}
+              </pre>
+            ) : (
+              <div className="muted" style={{ fontSize: "var(--fs-11)" }}>
+                This park carries no arguments to preview.
+              </div>
+            )}
+          </div>
+
+          {nextUp.length ? (
+            <div className="col" data-testid="unblock-next" style={{ gap: 6 }}>
+              <div style={{ fontSize: "var(--fs-11)", textTransform: "uppercase", letterSpacing: ".07em", color: "var(--text-3)", fontWeight: 600 }}>
+                Next in queue · {nextUp.length}
+              </div>
+              {nextUp.slice(0, 3).map(function (n) {
+                return (
+                  <div key={n.tool_call_id || n.session_id} className="row muted" style={{ gap: 8, fontSize: "var(--fs-11)" }}>
+                    <span>{n.session_name || n.session_id}</span>
+                    <span style={{ color: "var(--amber)" }}>{ST2_kindCopy(n.kind)}</span>
+                  </div>
+                );
+              })}
+            </div>
+          ) : null}
+        </div>
+
+        <div className="row" style={{ padding: 13, borderTop: "1px solid var(--border)", gap: 8, alignItems: "center", background: "var(--bg-2)" }}>
+          <ST2_YieldControls item={item} actions={actions} />
+          {!actionable ? (
+            <span className="muted" style={{ fontSize: "var(--fs-11)" }}>
+              This park has no tool_call_id, so it cannot be answered from here.
+            </span>
+          ) : null}
+          <span
+            className="muted" style={{ marginLeft: "auto", fontSize: "var(--fs-11)", cursor: "pointer" }}
+            onClick={onAdvance}
+          >Skip</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.AttentionBar = AttentionBar;
+window.AttentionQueue = AttentionQueue;
+window.UnblockFocus = UnblockFocus;
+window.ST2_useAttention = ST2_useAttention;
+window.ST2_useYieldActions = ST2_useYieldActions;
+window.ST2_kindCopy = ST2_kindCopy;

--- a/ui/components/studio/st-changes.jsx
+++ b/ui/components/studio/st-changes.jsx
@@ -1,0 +1,450 @@
+/* global React, Icon, Btn, ST2_api, ST2_bucketOf, DiffView */
+// Studio revamp - the Changes view (ui/studio/STUDIO-WIRING.md §7).
+//
+// The promoted .state trail: what the agents actually did to the workspace,
+// grouped by the session that did it, with the diff beside it.
+//
+// Data, and how it differs from what the spec assumed:
+//
+//   trail  = GET .../log?limit=&with_files=1  (the endpoint added for this)
+//   diff   = GET .../commit/{sha}             (already existed)
+//
+// The spec proposed a new /turns pair plus a client-side fallback that read
+// current bytes from /files/read and diffed them against the previous commit.
+// That fallback cannot work: /files/read serves the WORKING TREE, so there is
+// no way to obtain "the file as it was two commits ago", and diffing the
+// current file against anything else would show the wrong change. The commit
+// endpoint already returns git's own unified patch per file, which is both
+// correct and one request - so this parses that (ST2_parseUnifiedDiff) instead.
+//
+// Manual refresh, no polling: history does not change under the reader, and
+// WS_LogTab's deliberate unpolled behaviour is kept (§7.1).
+
+var ST2_CHANGES_LIMIT = 100;
+var ST2_REVIEWED_KEY = "studio:reviewed:";
+
+// Op tone from the commit's X-Primer-Op trailer. A write and a delete are not
+// the same event and should not read the same.
+function ST2_opTone(op) {
+  var o = String(op || "");
+  if (o === "tool_result" || o === "tool_call") return "--blue";
+  if (o === "rename") return "--amber";
+  if (o === "status_change") return "--text-3";
+  return "--text-3";
+}
+
+// A file row's tone comes from what happened to the FILE, which the counts
+// already tell us - added-only is a create, removed-only a delete.
+function ST2_fileTone(file) {
+  var f = file || {};
+  if (f.binary) return "--text-3";
+  if (f.additions && !f.deletions) return "--green";
+  if (f.deletions && !f.additions) return "--red";
+  return "--blue";
+}
+
+// Reviewed is client-side until there is somewhere server-side to put it, and
+// the chip says "Unreviewed" so the local-only semantics stay honest (§7.4).
+function ST2_loadReviewed(wid) {
+  try {
+    var raw = window.localStorage.getItem(ST2_REVIEWED_KEY + wid);
+    var parsed = raw ? JSON.parse(raw) : null;
+    return parsed && typeof parsed === "object" ? parsed : {};
+  } catch (_e) {
+    return {};
+  }
+}
+
+function ST2_saveReviewed(wid, map) {
+  try {
+    window.localStorage.setItem(ST2_REVIEWED_KEY + wid, JSON.stringify(map));
+  } catch (_e) {
+    /* quota / disabled storage - non-fatal */
+  }
+}
+
+// ST2_groupTrail(commits, opts) -> [{ session_id, label, commits, files }]
+// Grouped by session because "who did this" is the question a changed file
+// raises. Commits with no session trailer (platform writes) collect under one
+// group rather than being dropped.
+function ST2_groupTrail(commits, opts) {
+  var o = opts || {};
+  var order = [];
+  var bySession = {};
+  (commits || []).forEach(function (c) {
+    var key = c.session_id || "__workspace__";
+    if (!bySession[key]) {
+      bySession[key] = { session_id: c.session_id || null, commits: [], fileCount: 0 };
+      order.push(key);
+    }
+    var g = bySession[key];
+    g.commits.push(c);
+    // files is null when the backend cannot supply it (the sandbox backend
+    // never can). Null is not zero, so it must not be counted as zero.
+    if (c.files) g.fileCount += c.files.length;
+  });
+  return order.map(function (key) {
+    var g = bySession[key];
+    var session = (o.sessionsById || {})[key] || null;
+    return {
+      session_id: g.session_id,
+      label: (session && (session.name || session.session_id)) || g.session_id || "workspace",
+      bucket: session ? ST2_bucketOf(session, o).bucket : null,
+      commits: g.commits,
+      fileCount: g.fileCount,
+      unknownFiles: g.commits.some(function (c) { return !c.files; }),
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+
+function ST2_TrailFileRow({ commit, file, active, reviewed, onOpen }) {
+  var tone = ST2_fileTone(file);
+  return (
+    <div
+      data-testid="changes-file-row"
+      data-path={file.path}
+      onClick={function () { onOpen(commit, file); }}
+      className="row"
+      style={{
+        gap: 8, alignItems: "center", padding: "5px 10px 5px 22px", cursor: "pointer",
+        background: active ? "var(--bg-active)" : "transparent",
+        borderLeft: "2px solid " + (active ? "var(--accent)" : "transparent"),
+        opacity: reviewed ? 0.55 : 1,
+      }}
+    >
+      <span className="mono" style={{
+        flex: 1, minWidth: 0, fontSize: "var(--fs-11)", color: "var(" + tone + ")",
+        overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap", direction: "rtl",
+        textAlign: "left",
+      }}>{file.path}</span>
+      {file.binary ? (
+        <span className="muted" style={{ fontSize: "var(--fs-11)", flex: "0 0 auto" }}>bin</span>
+      ) : (
+        <span style={{ display: "flex", gap: 5, flex: "0 0 auto", fontSize: "var(--fs-11)" }}>
+          <span style={{ color: "var(--green)" }}>+{file.additions}</span>
+          <span style={{ color: "var(--red)" }}>-{file.deletions}</span>
+        </span>
+      )}
+      {reviewed ? <Icon name="check" size={11} /> : null}
+    </div>
+  );
+}
+
+function ST2_ChangesTrail({ groups, live, activeKey, reviewed, onOpen }) {
+  if (!groups.length) {
+    return (
+      <div data-testid="changes-empty" className="muted" style={{ padding: 16, fontSize: "var(--fs-12)" }}>
+        No changes yet. Anything an agent writes shows up here.
+      </div>
+    );
+  }
+  return (
+    <div data-testid="changes-trail" className="col" style={{ gap: 0, overflow: "auto", minHeight: 0 }}>
+      {groups.map(function (g) {
+        var isLive = !!(g.session_id && live[g.session_id]);
+        return (
+          <div key={g.session_id || "__workspace__"} data-testid="changes-session-group">
+            <div
+              className="row"
+              style={{
+                gap: 7, alignItems: "center", padding: "6px 10px", position: "sticky", top: 0,
+                background: "var(--bg-2)", borderBottom: "1px solid var(--bg-active)", zIndex: 1,
+              }}
+            >
+              {/* A live session's file counts are still moving, so show the
+                  pulsing dot instead of a number that is about to be wrong. */}
+              {isLive ? (
+                <span
+                  data-testid="changes-live-dot"
+                  style={{
+                    width: 7, height: 7, borderRadius: "50%", background: "var(--blue)",
+                    animation: "pulse 1.8s ease-in-out infinite", flex: "0 0 auto",
+                  }}
+                />
+              ) : null}
+              <span style={{ fontSize: "var(--fs-12)", fontWeight: 600, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {g.label}
+              </span>
+              <span className="muted" style={{ marginLeft: "auto", fontSize: "var(--fs-11)", flex: "0 0 auto" }}>
+                {isLive
+                  ? "working"
+                  : g.unknownFiles
+                    ? g.commits.length + (g.commits.length === 1 ? " turn" : " turns")
+                    : g.fileCount + (g.fileCount === 1 ? " file" : " files")}
+              </span>
+            </div>
+            {g.commits.map(function (c) {
+              // No file list for this commit: the backend cannot supply one.
+              // Say that rather than rendering an empty turn.
+              if (!c.files) {
+                return (
+                  <div
+                    key={c.sha}
+                    data-testid="changes-files-unavailable"
+                    className="muted"
+                    style={{ padding: "5px 10px 5px 22px", fontSize: "var(--fs-11)" }}
+                  >
+                    {c.subject} - file list not available on this backend
+                  </div>
+                );
+              }
+              return c.files.map(function (f) {
+                var key = c.sha + ":" + f.path;
+                return (
+                  <ST2_TrailFileRow
+                    key={key}
+                    commit={c}
+                    file={f}
+                    active={activeKey === key}
+                    reviewed={!!reviewed[key]}
+                    onOpen={onOpen}
+                  />
+                );
+              });
+            })}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function ST2_ChangesDetail({ wid, sel, reviewed, onToggleReviewed, onShowTurn }) {
+  var api = window.primerApi;
+  // Only the opened commit's patches are fetched, which is the whole reason the
+  // trail carries counts rather than content.
+  var res = api.useResource(
+    ST2_api.keys.commit(wid, sel.commit.sha),
+    function (signal) { return ST2_api.commit(wid, sel.commit.sha, signal); },
+    { deps: [wid, sel.commit.sha] }
+  );
+
+  var entry = null;
+  var files = (res.data && res.data.files) || [];
+  for (var i = 0; i < files.length; i++) {
+    if (files[i].path === sel.file.path) { entry = files[i]; break; }
+  }
+
+  var key = sel.commit.sha + ":" + sel.file.path;
+  var isReviewed = !!reviewed[key];
+  // Revert needs a backend op that does not exist. Hidden behind the flag
+  // rather than faked with a file write (§7.4).
+  var revertEnabled = (api.useTweaks()[0] || {})["studio.revert"] === true;
+
+  return (
+    <div className="col" data-testid="changes-detail" style={{ flex: 1, minHeight: 0, gap: 0 }}>
+      <div
+        className="row"
+        style={{
+          gap: 8, alignItems: "center", padding: "7px 11px", flex: "0 0 auto",
+          borderBottom: "1px solid var(--border)", background: "var(--bg-elev)", flexWrap: "wrap",
+        }}
+      >
+        <span className="mono" style={{ fontSize: "var(--fs-12)", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis" }}>
+          {sel.file.path}
+        </span>
+        <span className="muted" style={{ fontSize: "var(--fs-11)" }}>
+          {sel.commit.agent_id || sel.commit.session_id || "workspace"}
+        </span>
+        <span className="muted mono" style={{ fontSize: "var(--fs-11)" }}>{sel.commit.sha.slice(0, 8)}</span>
+        <span style={{ marginLeft: "auto", display: "flex", gap: 5, flex: "0 0 auto" }}>
+          <Btn size="sm" kind="ghost" data-testid="changes-show-turn"
+               onClick={function () { onShowTurn(sel.commit); }}>Why? Show the turn</Btn>
+          {revertEnabled ? (
+            <Btn size="sm" kind="danger" data-testid="changes-revert">Revert turn</Btn>
+          ) : null}
+          <Btn size="sm" kind={isReviewed ? "primary" : "ghost"} data-testid="changes-mark-reviewed"
+               onClick={function () { onToggleReviewed(key); }}>
+            {isReviewed ? "Reviewed" : "Mark reviewed"}
+          </Btn>
+        </span>
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+        {res.loading && !res.data ? (
+          <div className="muted" style={{ padding: 14, fontSize: "var(--fs-12)" }}>Loading diff...</div>
+        ) : entry ? (
+          <DiffView patch={entry.patch} path={sel.file.path} />
+        ) : (
+          <div data-testid="changes-no-diff" className="muted" style={{ padding: 14, fontSize: "var(--fs-12)" }}>
+            {res.error
+              ? (res.error.detail || res.error.title || "Could not load this commit.")
+              : "No diff recorded for this path in that commit."}
+          </div>
+        )}
+      </div>
+
+      {/* The turn's rationale is the assistant text from that turn, i.e. the
+          commit subject the runtime already writes. No backend "rationale"
+          field is invented for it (§7.2). */}
+      {sel.commit.subject ? (
+        <div
+          data-testid="changes-rationale"
+          className="muted"
+          style={{
+            flex: "0 0 auto", padding: "7px 11px", fontSize: "var(--fs-11)",
+            borderTop: "1px solid var(--border)", background: "var(--bg-2)",
+            lineHeight: 1.5,
+          }}
+        >{sel.commit.subject}</div>
+      ) : null}
+    </div>
+  );
+}
+
+function ChangesView({ wid, studio }) {
+  var api = window.primerApi;
+
+  var trail = api.useResource(
+    ST2_api.keys.trail(wid, ST2_CHANGES_LIMIT, true),
+    function (signal) { return ST2_api.trail(wid, ST2_CHANGES_LIMIT, true, signal); },
+    { deps: [wid] }
+  );
+  var commits = (trail.data && trail.data.commits) || [];
+
+  var sessionsRes = api.useResource(
+    ST2_api.keys.sessions(wid),
+    function (signal) { return ST2_api.sessions(wid, signal); },
+    { pollMs: 5000, deps: [wid] }
+  );
+  var sessions = (sessionsRes.data && sessionsRes.data.items) || [];
+
+  var sessionsById = React.useMemo(function () {
+    var map = {};
+    sessions.forEach(function (s) { map[s.session_id || s.id] = s; });
+    return map;
+  }, [sessionsRes.data]);
+
+  // Which sessions are still working, so their groups show the dot rather than
+  // a count that is about to change.
+  var live = React.useMemo(function () {
+    var map = {};
+    sessions.forEach(function (s) {
+      if (ST2_bucketOf(s, {}).bucket === "working") map[s.session_id || s.id] = true;
+    });
+    return map;
+  }, [sessionsRes.data]);
+
+  var revState = React.useState(function () { return ST2_loadReviewed(wid); });
+  var reviewed = revState[0];
+  var setReviewed = revState[1];
+  React.useEffect(function () { setReviewed(ST2_loadReviewed(wid)); }, [wid]);
+
+  var selState = React.useState(null);
+  var sel = selState[0];
+  var setSel = selState[1];
+
+  var onlyUnreviewed = React.useState(false);
+  var unreviewedOnly = onlyUnreviewed[0];
+  var setUnreviewedOnly = onlyUnreviewed[1];
+
+  var groups = React.useMemo(function () {
+    var built = ST2_groupTrail(commits, { sessionsById: sessionsById });
+    if (!unreviewedOnly) return built;
+    return built
+      .map(function (g) {
+        return Object.assign({}, g, {
+          commits: g.commits
+            .map(function (c) {
+              if (!c.files) return c;
+              return Object.assign({}, c, {
+                files: c.files.filter(function (f) {
+                  return !reviewed[c.sha + ":" + f.path];
+                }),
+              });
+            })
+            .filter(function (c) { return !c.files || c.files.length; }),
+        });
+      })
+      .filter(function (g) { return g.commits.length; });
+  }, [commits, sessionsById, unreviewedOnly, reviewed]);
+
+  function toggleReviewed(key) {
+    setReviewed(function (prev) {
+      var next = Object.assign({}, prev);
+      if (next[key]) delete next[key];
+      else next[key] = true;
+      ST2_saveReviewed(wid, next);
+      return next;
+    });
+  }
+
+  // "Why? Show the turn" opens the session transcript in the OTHER pane, so the
+  // diff you are reading stays on screen next to its explanation (§7.2).
+  function showTurn(commit) {
+    if (!commit.session_id) return;
+    var tab = {
+      id: "session:" + commit.session_id,
+      kind: "session",
+      ref: commit.session_id,
+      title: commit.session_id,
+    };
+    if (typeof studio.openAside === "function") studio.openAside(tab);
+    else studio.openTab(tab);
+  }
+
+  return (
+    <div className="row" data-testid="changes-view" style={{ flex: 1, minHeight: 0, gap: 0, alignItems: "stretch" }}>
+      <div
+        className="col"
+        style={{
+          width: 320, flex: "0 0 auto", minHeight: 0, gap: 0,
+          borderRight: "1px solid var(--border)", background: "var(--bg-2)",
+        }}
+      >
+        <div className="row" style={{ gap: 6, alignItems: "center", padding: "7px 10px", flex: "0 0 auto" }}>
+          <span className="muted" style={{ fontSize: "var(--fs-11)", fontWeight: 600, letterSpacing: "0.04em" }}>
+            CHANGES
+          </span>
+          <button
+            data-testid="changes-unreviewed-chip"
+            aria-pressed={unreviewedOnly}
+            onClick={function () { setUnreviewedOnly(function (v) { return !v; }); }}
+            style={{
+              marginLeft: "auto", padding: "3px 9px", borderRadius: 999, cursor: "pointer",
+              border: "1px solid " + (unreviewedOnly ? "var(--border-strong)" : "var(--border)"),
+              background: unreviewedOnly ? "var(--bg-active)" : "transparent",
+              color: unreviewedOnly ? "var(--text)" : "var(--text-3)",
+              fontSize: "var(--fs-11)",
+            }}
+          >Unreviewed</button>
+          <Btn size="sm" kind="ghost" icon="refresh" data-testid="changes-refresh"
+               onClick={trail.refetch}>Refresh</Btn>
+        </div>
+        <ST2_ChangesTrail
+          groups={groups}
+          live={live}
+          activeKey={sel ? sel.commit.sha + ":" + sel.file.path : null}
+          reviewed={reviewed}
+          onOpen={function (commit, file) { setSel({ commit: commit, file: file }); }}
+        />
+      </div>
+
+      <div style={{ flex: 1, minWidth: 0, display: "flex" }}>
+        {sel ? (
+          <ST2_ChangesDetail
+            wid={wid}
+            sel={sel}
+            reviewed={reviewed}
+            onToggleReviewed={toggleReviewed}
+            onShowTurn={showTurn}
+          />
+        ) : (
+          <div data-testid="changes-no-selection" className="muted" style={{ padding: 20, fontSize: "var(--fs-12)" }}>
+            Pick a changed file to see what happened to it.
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+window.ChangesView = ChangesView;
+window.ST2_groupTrail = ST2_groupTrail;
+window.ST2_opTone = ST2_opTone;
+window.ST2_fileTone = ST2_fileTone;
+window.ST2_loadReviewed = ST2_loadReviewed;
+window.ST2_saveReviewed = ST2_saveReviewed;
+window.ST2_CHANGES_LIMIT = ST2_CHANGES_LIMIT;

--- a/ui/components/studio/st-diff.jsx
+++ b/ui/components/studio/st-diff.jsx
@@ -1,0 +1,259 @@
+/* global React */
+// Studio revamp - line diffing (ui/studio/STUDIO-WIRING.md §7).
+//
+// No library: the console ships no bundler, so a diff view either vendors
+// another UMD blob into ui/vendor or computes its own. Line-level LCS is ~80
+// lines and this is the whole requirement, so it computes its own.
+//
+// Two guards matter more than the algorithm, because both failure modes hang
+// the browser tab rather than degrading:
+//
+//   1. Byte cap. A 5 MB generated file is not something anyone reads as a diff.
+//   2. Cell cap. LCS is O(n*m); two 20k-line files are 400M cells. Common
+//      prefix/suffix trimming usually collapses that to nothing, but a file
+//      rewritten wholesale does not trim, so the DP itself needs a ceiling
+//      beyond which the middle is reported as one replaced block.
+//
+// Pure logic, no React, so it can be exercised for real.
+
+var ST2_DIFF_MAX_BYTES = 200 * 1024;
+var ST2_DIFF_MAX_CELLS = 4000000;
+
+function ST2_splitLines(text) {
+  var s = String(text == null ? "" : text);
+  if (s === "") return [];
+  // A trailing newline denotes "file ends with a newline", not a final empty
+  // line - otherwise every whole-file diff reports a phantom last line.
+  if (s.charAt(s.length - 1) === "\n") s = s.slice(0, -1);
+  return s.split("\n");
+}
+
+// ST2_diffLines(before, after) ->
+//   { tooLarge: true, reason }                                   (capped)
+// | { rows: [{ kind: "same"|"add"|"del", a, b, text }], stats: {added, removed} }
+//
+// `a` / `b` are 1-based line numbers in the before / after file, or null on the
+// side where the line does not exist - which is what the gutter renders.
+function ST2_diffLines(before, after) {
+  var beforeStr = String(before == null ? "" : before);
+  var afterStr = String(after == null ? "" : after);
+
+  if (beforeStr.length > ST2_DIFF_MAX_BYTES || afterStr.length > ST2_DIFF_MAX_BYTES) {
+    return {
+      tooLarge: true,
+      reason: "too large to diff here (over " + Math.round(ST2_DIFF_MAX_BYTES / 1024) + " KB)",
+    };
+  }
+
+  var A = ST2_splitLines(beforeStr);
+  var B = ST2_splitLines(afterStr);
+
+  // Trim the common prefix / suffix. Almost every real edit is local, so this
+  // is what keeps the DP small enough to run at all.
+  var start = 0;
+  while (start < A.length && start < B.length && A[start] === B[start]) start++;
+  var endA = A.length;
+  var endB = B.length;
+  while (endA > start && endB > start && A[endA - 1] === B[endB - 1]) { endA--; endB--; }
+
+  var midA = A.slice(start, endA);
+  var midB = B.slice(start, endB);
+
+  var rows = [];
+  var added = 0;
+  var removed = 0;
+
+  for (var i = 0; i < start; i++) {
+    rows.push({ kind: "same", a: i + 1, b: i + 1, text: A[i] });
+  }
+
+  if (midA.length * midB.length > ST2_DIFF_MAX_CELLS) {
+    // Past the ceiling: report the changed middle as one replaced block rather
+    // than freezing the tab. Honest about what it is - the counts stay exact.
+    for (var d = 0; d < midA.length; d++) {
+      rows.push({ kind: "del", a: start + d + 1, b: null, text: midA[d] });
+      removed++;
+    }
+    for (var e = 0; e < midB.length; e++) {
+      rows.push({ kind: "add", a: null, b: start + e + 1, text: midB[e] });
+      added++;
+    }
+    for (var t = 0; t < A.length - endA; t++) {
+      rows.push({ kind: "same", a: endA + t + 1, b: endB + t + 1, text: A[endA + t] });
+    }
+    return { rows: rows, stats: { added: added, removed: removed }, coarse: true };
+  }
+
+  // LCS length table over the trimmed middle.
+  var n = midA.length;
+  var m = midB.length;
+  var lcs = [];
+  for (var r = 0; r <= n; r++) {
+    lcs.push(new Array(m + 1).fill(0));
+  }
+  for (var x = n - 1; x >= 0; x--) {
+    for (var y = m - 1; y >= 0; y--) {
+      lcs[x][y] = midA[x] === midB[y]
+        ? lcs[x + 1][y + 1] + 1
+        : Math.max(lcs[x + 1][y], lcs[x][y + 1]);
+    }
+  }
+
+  // Walk it. Deletions before insertions at the same position, so a changed
+  // line reads as del-then-add rather than interleaved.
+  var p = 0;
+  var q = 0;
+  while (p < n && q < m) {
+    if (midA[p] === midB[q]) {
+      rows.push({ kind: "same", a: start + p + 1, b: start + q + 1, text: midA[p] });
+      p++; q++;
+    } else if (lcs[p + 1][q] >= lcs[p][q + 1]) {
+      rows.push({ kind: "del", a: start + p + 1, b: null, text: midA[p] });
+      removed++; p++;
+    } else {
+      rows.push({ kind: "add", a: null, b: start + q + 1, text: midB[q] });
+      added++; q++;
+    }
+  }
+  while (p < n) {
+    rows.push({ kind: "del", a: start + p + 1, b: null, text: midA[p] });
+    removed++; p++;
+  }
+  while (q < m) {
+    rows.push({ kind: "add", a: null, b: start + q + 1, text: midB[q] });
+    added++; q++;
+  }
+
+  for (var s2 = 0; s2 < A.length - endA; s2++) {
+    rows.push({ kind: "same", a: endA + s2 + 1, b: endB + s2 + 1, text: A[endA + s2] });
+  }
+
+  return { rows: rows, stats: { added: added, removed: removed } };
+}
+
+// Collapse long unchanged stretches to a "@@ N unchanged lines" marker, the way
+// every diff viewer does - a 2-line change in a 900-line file should not be 900
+// rows of scrolling.
+function ST2_collapseContext(rows, context) {
+  var ctx = context == null ? 3 : context;
+  var keep = {};
+  (rows || []).forEach(function (row, i) {
+    if (row.kind === "same") return;
+    for (var j = Math.max(0, i - ctx); j <= Math.min(rows.length - 1, i + ctx); j++) {
+      keep[j] = true;
+    }
+  });
+  var out = [];
+  var run = 0;
+  (rows || []).forEach(function (row, i) {
+    if (keep[i]) {
+      if (run) { out.push({ kind: "gap", count: run }); run = 0; }
+      out.push(row);
+    } else {
+      run++;
+    }
+  });
+  if (run) out.push({ kind: "gap", count: run });
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+var ST2_DIFF_ROW_BG = {
+  add: "var(--green-dim)",
+  del: "var(--red-dim)",
+  same: "transparent",
+};
+
+function ST2_DiffRow({ row }) {
+  if (row.kind === "gap") {
+    return (
+      <div
+        className="mono muted"
+        data-testid="diff-gap"
+        style={{
+          padding: "2px 10px", fontSize: "var(--fs-11)",
+          background: "var(--bg-1)", borderTop: "1px solid var(--bg-active)",
+          borderBottom: "1px solid var(--bg-active)",
+        }}
+      >{"@@ " + row.count + " unchanged line" + (row.count === 1 ? "" : "s")}</div>
+    );
+  }
+  var sign = row.kind === "add" ? "+" : row.kind === "del" ? "-" : " ";
+  return (
+    <div
+      className="mono"
+      data-testid={"diff-row-" + row.kind}
+      style={{
+        display: "flex", fontSize: "var(--fs-11)", lineHeight: 1.55,
+        background: ST2_DIFF_ROW_BG[row.kind] || "transparent",
+        whiteSpace: "pre",
+      }}
+    >
+      <span style={{ width: 40, flex: "0 0 auto", textAlign: "right", paddingRight: 7, color: "var(--text-4)" }}>
+        {row.a == null ? "" : row.a}
+      </span>
+      <span style={{ width: 40, flex: "0 0 auto", textAlign: "right", paddingRight: 7, color: "var(--text-4)" }}>
+        {row.b == null ? "" : row.b}
+      </span>
+      <span style={{ width: 14, flex: "0 0 auto", color: "var(--text-3)" }}>{sign}</span>
+      <span style={{ flex: 1, minWidth: 0, overflow: "auto" }}>{row.text}</span>
+    </div>
+  );
+}
+
+function DiffView({ before, after, path, context }) {
+  var diff = React.useMemo(
+    function () { return ST2_diffLines(before, after); },
+    [before, after]
+  );
+
+  if (diff.tooLarge) {
+    return (
+      <div data-testid="diff-too-large" className="muted" style={{ padding: 14, fontSize: "var(--fs-12)" }}>
+        {path ? path + ": " : ""}{diff.reason}
+      </div>
+    );
+  }
+
+  var rows = React.useMemo(
+    function () { return ST2_collapseContext(diff.rows, context); },
+    [diff, context]
+  );
+
+  return (
+    <div data-testid="diff-view" className="col" style={{ gap: 0, minHeight: 0, overflow: "auto" }}>
+      <div
+        className="row"
+        style={{
+          padding: "5px 10px", gap: 8, alignItems: "center", flex: "0 0 auto",
+          borderBottom: "1px solid var(--border)", background: "var(--bg-elev)",
+          position: "sticky", top: 0, zIndex: 1,
+        }}
+      >
+        {path ? <span className="mono" style={{ fontSize: "var(--fs-11)" }}>{path}</span> : null}
+        <span style={{ marginLeft: "auto", display: "flex", gap: 7, fontSize: "var(--fs-11)" }}>
+          <span style={{ color: "var(--green)" }} data-testid="diff-added">+{diff.stats.added}</span>
+          <span style={{ color: "var(--red)" }} data-testid="diff-removed">-{diff.stats.removed}</span>
+        </span>
+      </div>
+      {diff.coarse ? (
+        <div className="muted" data-testid="diff-coarse" style={{ padding: "4px 10px", fontSize: "var(--fs-11)" }}>
+          Rewritten wholesale - shown as a replaced block.
+        </div>
+      ) : null}
+      {rows.map(function (row, i) {
+        return <ST2_DiffRow key={i} row={row} />;
+      })}
+    </div>
+  );
+}
+
+window.DiffView = DiffView;
+window.ST2_diffLines = ST2_diffLines;
+window.ST2_collapseContext = ST2_collapseContext;
+window.ST2_splitLines = ST2_splitLines;
+window.ST2_DIFF_MAX_BYTES = ST2_DIFF_MAX_BYTES;
+window.ST2_DIFF_MAX_CELLS = ST2_DIFF_MAX_CELLS;

--- a/ui/components/studio/st-diff.jsx
+++ b/ui/components/studio/st-diff.jsx
@@ -131,6 +131,85 @@ function ST2_diffLines(before, after) {
   return { rows: rows, stats: { added: added, removed: removed } };
 }
 
+// ---------------------------------------------------------------------------
+// The other producer: git's own unified diff
+//
+// ST2_diffLines computes a diff when the caller holds BOTH sides. For history
+// that is not the case, and cannot be: /files/read serves the working tree, so
+// there is no way to fetch "the file as it was at commit N-1". What IS
+// available is the unified patch git already computed, per file, from
+// GET /v1/workspaces/{wid}/commit/{sha}.
+//
+// So this parses that instead of reconstructing the two sides. It is also
+// strictly better than reconstructing: the counts and hunk boundaries are
+// git's, not an approximation of git's, and it costs one request rather than
+// two-plus-a-guess. Both producers emit the SAME row shape, so DiffView renders
+// either without knowing which it got.
+// ---------------------------------------------------------------------------
+
+var ST2_HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+
+// ST2_parseUnifiedDiff(patch) ->
+//   { rows, stats: {added, removed}, binary?: true }
+function ST2_parseUnifiedDiff(patch) {
+  var text = String(patch == null ? "" : patch);
+  if (!text) return { rows: [], stats: { added: 0, removed: 0 } };
+
+  var rows = [];
+  var added = 0;
+  var removed = 0;
+  var oldLine = 0;
+  var newLine = 0;
+  var inHunk = false;
+  // Drop ONE trailing newline before splitting. Otherwise the final "\n"
+  // yields an empty last element, which reads as a blank context line and
+  // advances both line counters - so every row after a patch that ends
+  // normally would be numbered one too high. An INTERIOR "" is a real blank
+  // context line and must survive, which is why this trims rather than filters.
+  if (text.charAt(text.length - 1) === "\n") text = text.slice(0, -1);
+  var lines = text.split("\n");
+
+  for (var i = 0; i < lines.length; i++) {
+    var line = lines[i];
+
+    // git reports a non-text blob instead of hunks.
+    if (!inHunk && line.indexOf("Binary files") === 0) {
+      return { rows: [], stats: { added: 0, removed: 0 }, binary: true };
+    }
+
+    var hunk = ST2_HUNK_RE.exec(line);
+    if (hunk) {
+      // A gap between hunks is unchanged context git chose not to send. Say
+      // how far it jumped rather than silently butting two hunks together.
+      if (inHunk) rows.push({ kind: "gap", count: null });
+      oldLine = parseInt(hunk[1], 10);
+      newLine = parseInt(hunk[3], 10);
+      inHunk = true;
+      continue;
+    }
+    if (!inHunk) continue; // diff --git / index / --- / +++ preamble
+
+    var head = line.charAt(0);
+    if (head === "\\") continue; // "\ No newline at end of file"
+    if (head === "+") {
+      rows.push({ kind: "add", a: null, b: newLine, text: line.slice(1) });
+      newLine++; added++;
+    } else if (head === "-") {
+      rows.push({ kind: "del", a: oldLine, b: null, text: line.slice(1) });
+      oldLine++; removed++;
+    } else if (head === " " || line === "") {
+      // A fully-empty context line arrives as "" rather than " ".
+      rows.push({ kind: "same", a: oldLine, b: newLine, text: line.slice(1) });
+      oldLine++; newLine++;
+    } else {
+      // Anything else means the hunk ended (a trailing "diff --git" for the
+      // next file, say). Stop rather than mis-numbering the rest.
+      inHunk = false;
+    }
+  }
+  return { rows: rows, stats: { added: added, removed: removed } };
+}
+
 // Collapse long unchanged stretches to a "@@ N unchanged lines" marker, the way
 // every diff viewer does - a 2-line change in a 900-line file should not be 900
 // rows of scrolling.
@@ -169,6 +248,11 @@ var ST2_DIFF_ROW_BG = {
 
 function ST2_DiffRow({ row }) {
   if (row.kind === "gap") {
+    // count is null for a hunk boundary in a git patch: the unchanged run was
+    // never sent, so its length is genuinely unknown. Do not print "null".
+    var label = row.count == null
+      ? "@@ unchanged lines"
+      : "@@ " + row.count + " unchanged line" + (row.count === 1 ? "" : "s");
     return (
       <div
         className="mono muted"
@@ -178,7 +262,7 @@ function ST2_DiffRow({ row }) {
           background: "var(--bg-1)", borderTop: "1px solid var(--bg-active)",
           borderBottom: "1px solid var(--bg-active)",
         }}
-      >{"@@ " + row.count + " unchanged line" + (row.count === 1 ? "" : "s")}</div>
+      >{label}</div>
     );
   }
   var sign = row.kind === "add" ? "+" : row.kind === "del" ? "-" : " ";
@@ -204,11 +288,94 @@ function ST2_DiffRow({ row }) {
   );
 }
 
-function DiffView({ before, after, path, context }) {
-  var diff = React.useMemo(
-    function () { return ST2_diffLines(before, after); },
-    [before, after]
+// Side-by-side needs both gutters plus two text columns; below this the columns
+// are too narrow to read and unified wins. Switched on measured width, never a
+// user toggle (WIRING §7.3) - the right answer is a property of the container,
+// so making the reader choose is making them do the layout's job.
+var ST2_SIDE_BY_SIDE_MIN_W = 900;
+
+// Past this many rows the DOM cost shows. Rather than a virtualiser (which
+// needs fixed row heights the diff does not have), cap and say so: a reader who
+// needs line 3000 of a diff wants the file, not this pane.
+var ST2_DIFF_ROW_CAP = 500;
+
+// Pair rows into {left, right} for the side-by-side layout: a del/add run
+// becomes one row per pair so a changed line sits opposite its replacement.
+function ST2_pairRows(rows) {
+  var out = [];
+  var i = 0;
+  while (i < rows.length) {
+    var row = rows[i];
+    if (row.kind === "same" || row.kind === "gap") {
+      out.push({ left: row, right: row, both: true });
+      i++;
+      continue;
+    }
+    // Collect the contiguous del run, then the contiguous add run, and zip.
+    var dels = [];
+    var adds = [];
+    while (i < rows.length && rows[i].kind === "del") { dels.push(rows[i]); i++; }
+    while (i < rows.length && rows[i].kind === "add") { adds.push(rows[i]); i++; }
+    var n = Math.max(dels.length, adds.length);
+    for (var j = 0; j < n; j++) {
+      out.push({ left: dels[j] || null, right: adds[j] || null, both: false });
+    }
+  }
+  return out;
+}
+
+function ST2_SideCell({ row, side }) {
+  var bg = "transparent";
+  if (row) bg = ST2_DIFF_ROW_BG[row.kind] || "transparent";
+  var num = row ? (side === "left" ? row.a : row.b) : null;
+  return (
+    <div
+      className="mono"
+      style={{
+        display: "flex", flex: "1 1 50%", minWidth: 0,
+        fontSize: "var(--fs-11)", lineHeight: 1.55, whiteSpace: "pre",
+        background: row ? bg : "var(--bg-1)",
+      }}
+    >
+      <span style={{ width: 40, flex: "0 0 auto", textAlign: "right", paddingRight: 7, color: "var(--text-4)" }}>
+        {num == null ? "" : num}
+      </span>
+      <span style={{ flex: 1, minWidth: 0, overflow: "hidden" }}>{row ? row.text : ""}</span>
+    </div>
   );
+}
+
+// DiffView takes EITHER a git patch (history: git already did the diff) or a
+// before/after pair (a dirty buffer against saved content). One renderer, two
+// producers - see the header comment on ST2_parseUnifiedDiff.
+function DiffView({ before, after, patch, path, context }) {
+  var hostRef = React.useRef(null);
+  var wState = React.useState(0);
+  var width = wState[0];
+  var setWidth = wState[1];
+
+  React.useEffect(function () {
+    var el = hostRef.current;
+    if (!el || typeof window.ResizeObserver !== "function") return undefined;
+    var ro = new window.ResizeObserver(function (entries) {
+      if (entries && entries[0]) setWidth(entries[0].contentRect.width);
+    });
+    ro.observe(el);
+    setWidth(el.clientWidth);
+    return function () { ro.disconnect(); };
+  }, []);
+
+  var diff = React.useMemo(function () {
+    return patch != null
+      ? ST2_parseUnifiedDiff(patch)
+      : ST2_diffLines(before, after);
+  }, [patch, before, after]);
+
+  var rows = React.useMemo(function () {
+    // A parsed patch already omits its unchanged runs, so re-collapsing it
+    // would only re-collapse git's own context lines.
+    return patch != null ? diff.rows : ST2_collapseContext(diff.rows, context);
+  }, [diff, patch, context]);
 
   if (diff.tooLarge) {
     return (
@@ -217,14 +384,30 @@ function DiffView({ before, after, path, context }) {
       </div>
     );
   }
+  if (diff.binary) {
+    return (
+      <div data-testid="diff-binary" className="muted" style={{ padding: 14, fontSize: "var(--fs-12)" }}>
+        {path ? path + ": " : ""}binary file - no line diff to show.
+      </div>
+    );
+  }
 
-  var rows = React.useMemo(
-    function () { return ST2_collapseContext(diff.rows, context); },
-    [diff, context]
+  var capped = rows.length > ST2_DIFF_ROW_CAP;
+  var shown = capped ? rows.slice(0, ST2_DIFF_ROW_CAP) : rows;
+  var wide = width >= ST2_SIDE_BY_SIDE_MIN_W;
+  var paired = React.useMemo(
+    function () { return wide ? ST2_pairRows(shown) : null; },
+    [wide, shown]
   );
 
   return (
-    <div data-testid="diff-view" className="col" style={{ gap: 0, minHeight: 0, overflow: "auto" }}>
+    <div
+      ref={hostRef}
+      data-testid="diff-view"
+      data-layout={wide ? "side-by-side" : "unified"}
+      className="col"
+      style={{ gap: 0, minHeight: 0, overflow: "auto" }}
+    >
       <div
         className="row"
         style={{
@@ -244,16 +427,45 @@ function DiffView({ before, after, path, context }) {
           Rewritten wholesale - shown as a replaced block.
         </div>
       ) : null}
-      {rows.map(function (row, i) {
-        return <ST2_DiffRow key={i} row={row} />;
-      })}
+
+      {wide
+        ? paired.map(function (pair, i) {
+            if (pair.both && pair.left.kind === "gap") {
+              return <ST2_DiffRow key={i} row={pair.left} />;
+            }
+            return (
+              <div key={i} data-testid="diff-pair" style={{ display: "flex", minWidth: 0 }}>
+                <ST2_SideCell row={pair.left} side="left" />
+                <span style={{ width: 1, flex: "0 0 auto", background: "var(--border)" }} />
+                <ST2_SideCell row={pair.right} side="right" />
+              </div>
+            );
+          })
+        : shown.map(function (row, i) {
+            return <ST2_DiffRow key={i} row={row} />;
+          })}
+
+      {capped ? (
+        <div
+          data-testid="diff-truncated"
+          className="muted"
+          style={{ padding: "8px 10px", fontSize: "var(--fs-11)", borderTop: "1px solid var(--border)" }}
+        >
+          Showing the first {ST2_DIFF_ROW_CAP} of {rows.length} lines. Open the
+          file to read the rest.
+        </div>
+      ) : null}
     </div>
   );
 }
 
 window.DiffView = DiffView;
 window.ST2_diffLines = ST2_diffLines;
+window.ST2_parseUnifiedDiff = ST2_parseUnifiedDiff;
 window.ST2_collapseContext = ST2_collapseContext;
+window.ST2_pairRows = ST2_pairRows;
 window.ST2_splitLines = ST2_splitLines;
 window.ST2_DIFF_MAX_BYTES = ST2_DIFF_MAX_BYTES;
 window.ST2_DIFF_MAX_CELLS = ST2_DIFF_MAX_CELLS;
+window.ST2_DIFF_ROW_CAP = ST2_DIFF_ROW_CAP;
+window.ST2_SIDE_BY_SIDE_MIN_W = ST2_SIDE_BY_SIDE_MIN_W;

--- a/ui/components/studio/st-dock.jsx
+++ b/ui/components/studio/st-dock.jsx
@@ -1,0 +1,214 @@
+/* global React, Icon, ST2_api, ST2_bucketOf, WorkspaceTap, TerminalPanel */
+// Studio revamp - the investigate dock (ui/studio/STUDIO-WIRING.md §8).
+//
+// Replaces the right rail as the home for "things you look at when something is
+// wrong": the live event tap, the terminal, and a derived Problems list. It sits
+// below the center, is closed by default, and is toggled with Ctrl-`.
+//
+// The tap and the terminal are re-housed VERBATIM - same components, same
+// props, same chip keys - so the server-side class filter
+// (WTP_buildSelector) and the terminal's ephemeral mount semantics are
+// unchanged. Problems is new and needs no endpoint: it is derived from the
+// session list and the tap's error rows.
+
+var ST2_PROBLEM_CAP = 40;
+
+function ST2_DockTab({ id, label, active, count, tone, onClick }) {
+  return (
+    <button
+      data-testid={"dock-tab-" + id}
+      onClick={onClick}
+      style={{
+        padding: "5px 11px", borderRadius: 7, border: "1px solid " + (active ? "var(--border-strong)" : "transparent"),
+        background: active ? "var(--bg-active)" : "transparent",
+        color: active ? "var(--text)" : "var(--text-3)",
+        fontSize: "var(--fs-12)", cursor: "pointer", display: "flex",
+        alignItems: "center", gap: 6, whiteSpace: "nowrap",
+      }}
+    >
+      {label}
+      {count ? (
+        <span
+          style={{
+            padding: "0 6px", borderRadius: 999, fontSize: "var(--fs-11)",
+            background: tone ? "var(" + tone + "-dim)" : "var(--bg-1)",
+            color: tone ? "var(" + tone + ")" : "var(--text-3)",
+          }}
+        >{count}</span>
+      ) : null}
+    </button>
+  );
+}
+
+// Problems: derived, no endpoint. Failed runs + error-class tap rows + the last
+// failed save. This is what makes the dock worth opening when nothing is
+// actively being debugged.
+function ST2_ProblemsList({ wid, sessions, errors, onOpenSession }) {
+  var broken = (sessions || []).filter(function (s) {
+    return ST2_bucketOf(s, {}).bucket === "broken";
+  });
+
+  if (!broken.length && !errors.length) {
+    return (
+      <div className="muted" style={{ padding: 14, fontSize: "var(--fs-12)" }}>
+        No problems. Failed runs and errors show up here.
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="problems-list" className="col" style={{ gap: 0, overflow: "auto", height: "100%" }}>
+      {broken.map(function (s) {
+        var b = ST2_bucketOf(s, {});
+        return (
+          <div
+            key={"s:" + s.id}
+            className="row"
+            onClick={function () { if (onOpenSession) onOpenSession(s.id); }}
+            style={{
+              gap: 9, alignItems: "center", padding: "9px 13px", cursor: "pointer",
+              borderBottom: "1px solid var(--bg-active)",
+            }}
+          >
+            <span style={{ width: 7, height: 7, borderRadius: "50%", background: "var(--red)", flex: "0 0 auto" }} />
+            <span style={{ fontSize: "var(--fs-12)", fontWeight: 500 }}>{s.name || s.id}</span>
+            <span className="mono muted" style={{ fontSize: "var(--fs-11)", minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+              {b.detail}
+            </span>
+            <span className="muted" style={{ marginLeft: "auto", fontSize: "var(--fs-11)", flex: "0 0 auto" }}>open run</span>
+          </div>
+        );
+      })}
+      {errors.map(function (e) {
+        return (
+          <div
+            key={"e:" + e.key}
+            className="row"
+            onClick={function () { if (onOpenSession && e.session_id) onOpenSession(e.session_id); }}
+            style={{
+              gap: 9, alignItems: "flex-start", padding: "9px 13px",
+              cursor: e.session_id ? "pointer" : "default",
+              borderBottom: "1px solid var(--bg-active)",
+            }}
+          >
+            <span style={{ fontSize: "var(--fs-11)", color: "var(--red)", flex: "0 0 auto", marginTop: 1 }}>err</span>
+            <span className="mono" style={{ fontSize: "var(--fs-11)", color: "var(--text-2)", minWidth: 0, lineHeight: 1.5 }}>
+              {e.message}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function InvestigateDock({ wid, studio, sessionId }) {
+  var s = studio.state;
+  var api = window.primerApi;
+  var dockTab = s.dockTab || "events";
+
+  // Shared key with the attention bar's fetch, so useResource dedupes it.
+  var sessionsRes = api.useResource(
+    ST2_api.keys.sessions(wid),
+    function (signal) { return ST2_api.sessions(wid, signal); },
+    { pollMs: 5000, deps: [wid] }
+  );
+  var sessions = (sessionsRes.data && sessionsRes.data.items) || [];
+
+  // Error rows harvested from the one shared tap listener.
+  var errState = React.useState([]);
+  var errors = errState[0];
+  var setErrors = errState[1];
+  window.useWorkspaceTapListener(wid, function (ev) {
+    var cls = ev && (ev.class || ev.cls);
+    if (cls !== "error") return;
+    var payload = (ev && ev.payload) || {};
+    var msg = payload.message || payload.error || payload.detail || "error";
+    var key = (ev.session_id || "") + ":" + (ev.seq != null ? ev.seq : Math.random());
+    setErrors(function (prev) {
+      if (prev.some(function (x) { return x.key === key; })) return prev;
+      return prev.concat([{ key: key, session_id: ev.session_id || null, message: String(msg) }]).slice(-ST2_PROBLEM_CAP);
+    });
+  });
+
+  var brokenCount = sessions.filter(function (x) { return ST2_bucketOf(x, {}).bucket === "broken"; }).length;
+  var problemCount = brokenCount + errors.length;
+
+  var termTabs = s.termTabs || [];
+  var isTerm = String(dockTab).indexOf("term:") === 0;
+
+  var openSession = function (sid) {
+    if (studio.openTab) studio.openTab({ kind: "session", ref: sid, title: sid });
+  };
+
+  return (
+    <div
+      data-testid="investigate-dock"
+      // studio-activity kept as an alias for one release so journeys that
+      // locate the old right rail still resolve (WIRING §13).
+      data-legacy-testid="studio-activity"
+      className="col"
+      style={{
+        height: s.dockHeight || 268, flex: "0 0 auto", minHeight: 0,
+        borderTop: "1px solid var(--border)", background: "var(--bg-2)", overflow: "hidden",
+      }}
+    >
+      <div
+        className="row"
+        style={{
+          height: 38, flex: "0 0 auto", gap: 4, alignItems: "center",
+          padding: "0 10px", borderBottom: "1px solid var(--border)", background: "var(--bg-elev)",
+        }}
+      >
+        <ST2_DockTab
+          id="events" label="Events" active={dockTab === "events"}
+          onClick={function () { studio.setDockTab("events"); }}
+        />
+        {termTabs.map(function (t) {
+          return (
+            <ST2_DockTab
+              key={t.id}
+              id={termTabs.length > 1 ? "terminal-" + t.id : "terminal"}
+              label={t.title || t.id}
+              active={dockTab === "term:" + t.id}
+              onClick={function () { studio.setDockTab("term:" + t.id); }}
+            />
+          );
+        })}
+        {/* Always expose a stable terminal tab id even with several terminals,
+            so test_studio_terminal.py has one locator to hold. */}
+        {termTabs.length > 1 ? (
+          <span data-testid="dock-tab-terminal" style={{ display: "none" }} />
+        ) : null}
+        <ST2_DockTab
+          id="problems" label="Problems" active={dockTab === "problems"}
+          count={problemCount} tone={problemCount ? "--red" : null}
+          onClick={function () { studio.setDockTab("problems"); }}
+        />
+        <span
+          data-testid="dock-close"
+          title="Collapse the dock (Ctrl-`)"
+          onClick={studio.toggleDock}
+          style={{ marginLeft: "auto", cursor: "pointer", color: "var(--text-3)", fontSize: "var(--fs-12)", padding: "4px 8px" }}
+        >Hide</span>
+      </div>
+
+      <div style={{ flex: 1, minHeight: 0, overflow: "hidden" }}>
+        {dockTab === "events" ? (
+          <WorkspaceTap wid={wid} sessionId={sessionId} fillHeight />
+        ) : null}
+        {isTerm ? (
+          // Mounted only while the dock is open, which is what unmounts every
+          // xterm + WS on close - the intended ephemeral v1 (studio-terminal.jsx).
+          <TerminalPanel wid={wid} studio={studio} />
+        ) : null}
+        {dockTab === "problems" ? (
+          <ST2_ProblemsList wid={wid} sessions={sessions} errors={errors} onOpenSession={openSession} />
+        ) : null}
+      </div>
+    </div>
+  );
+}
+
+window.InvestigateDock = InvestigateDock;
+window.ST2_ProblemsList = ST2_ProblemsList;

--- a/ui/components/studio/st-files-rail.jsx
+++ b/ui/components/studio/st-files-rail.jsx
@@ -1,0 +1,36 @@
+/* global React, FilesTree */
+// Studio revamp - the Files rail (ui/studio/STUDIO-WIRING.md §5).
+//
+// FilesTree moves over UNCHANGED. It is ~1000 lines carrying the lazy one-level
+// tree fetch, drag-move, upload, the 9-action context menu, collection-origin
+// marking with its dirty dot, and the mount/apply modals - all of which already
+// work and all of which are already covered by tests. Re-hosting it means
+// wrapping it, not copying it: it is a bundle global, so this file is the seam
+// where the rail's chrome goes, not a second implementation.
+//
+// WIRING also specifies a "Changed by agents" lens here, which filters the tree
+// to paths in the turn trail and annotates each with its +/-. That trail does
+// not exist yet: CommitInfo carries no file list and there is no diff route (see
+// the plan's §0.2), so the lens would have nothing to filter on. It lands with
+// Task 7, together with the endpoint it depends on - not as a chip that lies.
+
+function ST2_FilesRail({ wid, studio }) {
+  // FilesTree still gates its body on the persisted `filesOpen` from the v1
+  // two-section sidebar. In the rail, Files IS the mode - so an operator who
+  // had collapsed the section in v1 would switch modes and land on an empty
+  // panel. Open it once on mount; the collapse chevron still works after that.
+  var opened = React.useRef(false);
+  React.useEffect(function () {
+    if (opened.current) return;
+    opened.current = true;
+    if (!studio.state.filesOpen && studio.toggleFiles) studio.toggleFiles();
+  }, []);
+
+  return (
+    <div className="col" data-testid="rail-files" style={{ flex: 1, minHeight: 0, gap: 0 }}>
+      <FilesTree wid={wid} studio={studio} />
+    </div>
+  );
+}
+
+window.ST2_FilesRail = ST2_FilesRail;

--- a/ui/components/studio/st-graph-run.jsx
+++ b/ui/components/studio/st-graph-run.jsx
@@ -1,0 +1,247 @@
+/* global React, ST2_api */
+// Studio revamp - the graph run screen (ui/studio/STUDIO-WIRING.md §10).
+//
+// The superstep strip is DOM chrome ABOVE the canvas, never a second canvas:
+// GR_Canvas already owns node rendering, and the mockup's absolutely-positioned
+// cards are a drawing of that, not an instruction to reimplement it. This module
+// contributes the strip, the lane routing, and nothing else.
+//
+// SUPERSTEPS ARE DERIVED. WIRING §10 says "one segment per superstep", but
+// node_states (compute.py:234 _NodeStateOut) carries no superstep field - the
+// fields are node_id, kind, status, iteration, last_run_at, tokens_in,
+// tokens_out, duration_ms, error. `iteration` IS the superstep index
+// (last_run_iteration), so the grouping is derived from it. Nodes that have not
+// run carry no iteration at all and cannot be placed in a numbered superstep;
+// they collect into a trailing "upcoming" segment rather than being silently
+// dropped (which would make the strip claim a graph is smaller than it is).
+
+// Node statuses are pending|running|completed|failed|skipped - NOT session
+// statuses, so ST2_bucketOf does not apply. Nodes also have a state sessions do
+// not: not started yet. It stays distinct because folding it into "working"
+// would paint an idle segment as live, which is the one thing the strip exists
+// to tell you.
+function ST2_nodeBucket(status) {
+  var s = String(status || "pending");
+  if (s === "failed") return "broken";
+  if (s === "running") return "working";
+  // A skipped node is resolved, not pending: its branch condition excluded it.
+  if (s === "completed" || s === "skipped") return "done";
+  return "pending";
+}
+
+var ST2_NODE_TONE = {
+  broken: "--red",
+  working: "--blue",
+  done: "--green",
+  pending: "--border-strong",
+};
+
+// A superstep is as bad as its worst node: one failure defines the segment even
+// if nine siblings completed, because that is what the operator has to act on.
+var ST2_STEP_PRECEDENCE = ["broken", "working", "pending", "done"];
+
+function ST2_stepBucket(nodes) {
+  var present = {};
+  (nodes || []).forEach(function (n) { present[ST2_nodeBucket(n.status)] = true; });
+  for (var i = 0; i < ST2_STEP_PRECEDENCE.length; i++) {
+    if (present[ST2_STEP_PRECEDENCE[i]]) return ST2_STEP_PRECEDENCE[i];
+  }
+  return "pending";
+}
+
+// ST2_supersteps(items) -> [{ index, nodes, bucket, tone, width, label, upcoming }]
+//   `width` is the fan-out width k (how many nodes ran in that superstep).
+//   `upcoming` marks the trailing not-yet-run group, which has no index.
+function ST2_supersteps(items) {
+  var byIter = {};
+  var order = [];
+  var upcoming = [];
+
+  (items || []).forEach(function (n) {
+    var it = n && n.iteration;
+    if (it == null) { upcoming.push(n); return; }
+    var key = String(it);
+    if (!byIter[key]) { byIter[key] = []; order.push(it); }
+    byIter[key].push(n);
+  });
+
+  order.sort(function (a, b) { return a - b; });
+
+  var out = order.map(function (it) {
+    var nodes = byIter[String(it)];
+    var bucket = ST2_stepBucket(nodes);
+    return {
+      index: it,
+      nodes: nodes,
+      bucket: bucket,
+      tone: ST2_NODE_TONE[bucket],
+      width: nodes.length,
+      label: ST2_stepLabel(nodes),
+      upcoming: false,
+    };
+  });
+
+  if (upcoming.length) {
+    out.push({
+      index: null,
+      nodes: upcoming,
+      bucket: "pending",
+      tone: ST2_NODE_TONE.pending,
+      width: upcoming.length,
+      label: "upcoming",
+      upcoming: true,
+    });
+  }
+  return out;
+}
+
+// One node names the segment; a fan-out is named by its shared node id.
+function ST2_stepLabel(nodes) {
+  if (!nodes || !nodes.length) return "";
+  if (nodes.length === 1) return String(nodes[0].node_id || nodes[0].kind || "node");
+  var ids = {};
+  nodes.forEach(function (n) { ids[n.node_id] = true; });
+  var keys = Object.keys(ids);
+  return keys.length === 1 ? keys[0] : keys.length + " nodes";
+}
+
+// The caption WIRING asks for: `n · label ×k`, with the multiplier only when the
+// step actually fanned out.
+function ST2_stepCaption(step) {
+  var head = (step.index == null ? "" : step.index + " ") + step.label;
+  return step.width > 1 ? head + " x" + step.width : head;
+}
+
+// A skipped node was excluded by a branch condition. Say which, when the run
+// recorded it; never invent one.
+function ST2_skipReason(node) {
+  var n = node || {};
+  if (ST2_nodeBucket(n.status) !== "done" || n.status !== "skipped") return null;
+  return n.error ? "condition false - " + n.error : "condition false";
+}
+
+// ---------------------------------------------------------------------------
+// Rendering
+// ---------------------------------------------------------------------------
+
+function ST2_SuperstepStrip({ steps, activeIndex, onPick }) {
+  if (!steps || !steps.length) return null;
+  return (
+    <div
+      data-testid="superstep-strip"
+      className="row"
+      style={{
+        height: 34, flex: "0 0 auto", gap: 3, alignItems: "stretch",
+        padding: "5px 10px", borderBottom: "1px solid var(--border)",
+        background: "var(--bg-2)",
+      }}
+    >
+      {steps.map(function (step, i) {
+        var live = step.bucket === "working";
+        var selected = activeIndex != null && step.index === activeIndex;
+        return (
+          <div
+            key={step.index == null ? "upcoming" : step.index}
+            data-testid={step.upcoming ? "superstep-upcoming" : "superstep-" + step.index}
+            data-bucket={step.bucket}
+            title={ST2_stepCaption(step)}
+            onClick={function () { if (onPick) onPick(step); }}
+            // Weighted by node count, so a wide fan-out reads as the bulk of
+            // the work it is.
+            style={{
+              flex: step.width + " 1 0", minWidth: 26, cursor: onPick ? "pointer" : "default",
+              borderRadius: 5, overflow: "hidden", position: "relative",
+              display: "flex", alignItems: "center", justifyContent: "center",
+              background: "var(" + step.tone + "-dim, var(--bg-1))",
+              border: "1px solid " + (selected ? "var(--text-3)" : "var(" + step.tone + ")"),
+              opacity: step.upcoming ? 0.55 : 1,
+            }}
+          >
+            {live ? (
+              <span
+                data-testid="superstep-sweep"
+                className="st-sweep"
+                style={{ position: "absolute", inset: 0 }}
+              />
+            ) : null}
+            <span
+              className="mono"
+              style={{
+                fontSize: "var(--fs-11)", color: "var(" + step.tone + ")",
+                whiteSpace: "nowrap", overflow: "hidden", textOverflow: "ellipsis",
+                padding: "0 5px", position: "relative",
+              }}
+            >{ST2_stepCaption(step)}</span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// GraphRunPanel: the strip + whatever canvas the caller renders, plus lane
+// routing into the companion pane. It deliberately does NOT re-render the run
+// view; SessionGraphPanel keeps owning that, and this wraps it.
+// Owns the node_states fetch. Split out so the hook is only ever mounted with a
+// real gid/rid: useResource has no null-key guard, so a null key would compose
+// to the string "null", create a cache entry, and fire a request at
+// /graphs/null/runs/null/node_states.
+function ST2_RunSteps({ gid, rid, onPickNode }) {
+  var res = window.primerApi.useResource(
+    ST2_api.keys.nodeStates(gid, rid),
+    function (signal) { return ST2_api.nodeStates(gid, rid, signal); },
+    { pollMs: 4000, deps: [gid, rid] }
+  );
+  var steps = React.useMemo(
+    function () { return ST2_supersteps((res.data && res.data.items) || []); },
+    [res.data]
+  );
+  return (
+    <ST2_SuperstepStrip
+      steps={steps}
+      onPick={function (step) {
+        // Selecting a step selects its first node, which is what the lane
+        // inspector keys off.
+        if (onPickNode && step.nodes.length) onPickNode(step.nodes[0].node_id);
+      }}
+    />
+  );
+}
+
+function GraphRunPanel({ wid, gid, rid, studio, children, onPickNode }) {
+  return (
+    <div className="col" data-testid="graph-run-panel" style={{ flex: 1, minHeight: 0, gap: 0 }}>
+      {gid && rid ? <ST2_RunSteps gid={gid} rid={rid} onPickNode={onPickNode} /> : null}
+      <div style={{ flex: 1, minHeight: 0 }}>{children}</div>
+    </div>
+  );
+}
+
+// ST2_openLane: the lane inspector is the companion pane, not a drawer (§10).
+// Falls back to the caller's in-place filter when the pane does not exist,
+// which is what keeps the v1 shell working.
+function ST2_openLane(studio, sid, nodeId, onFallback) {
+  if (studio && typeof studio.openAside === "function" && nodeId) {
+    studio.openAside({
+      id: "session:" + sid,
+      kind: "session",
+      ref: sid,
+      title: nodeId,
+      glyph: "*",
+      node: nodeId,
+    });
+    return true;
+  }
+  if (onFallback) onFallback(nodeId);
+  return false;
+}
+
+window.GraphRunPanel = GraphRunPanel;
+window.ST2_SuperstepStrip = ST2_SuperstepStrip;
+window.ST2_supersteps = ST2_supersteps;
+window.ST2_nodeBucket = ST2_nodeBucket;
+window.ST2_stepBucket = ST2_stepBucket;
+window.ST2_stepCaption = ST2_stepCaption;
+window.ST2_stepLabel = ST2_stepLabel;
+window.ST2_skipReason = ST2_skipReason;
+window.ST2_openLane = ST2_openLane;

--- a/ui/components/studio/st-mobile.jsx
+++ b/ui/components/studio/st-mobile.jsx
@@ -1,0 +1,252 @@
+/* global React, Icon, ST2_api, ST2_bucketOf, ST2_kindCopy, ST2_useAttention,
+   ST2_useYieldActions, ST2_YieldControls, ST_sessionSort */
+// Studio revamp - the phone layout (ui/studio/STUDIO-WIRING.md §11).
+//
+// Triage and unblock, NOT a three-column shrink. The things a three-column
+// shrink would give you on a phone - a file editor, a terminal, a live event
+// feed - are all unusable at that width, and shipping them cramped is worse
+// than saying they are desktop-only, because a cramped editor invites an edit
+// you cannot review.
+//
+// So: answer what is blocking, read what happened, and nothing else.
+//
+// The bottom bar keeps the studio-left-toggle / studio-right-toggle testids on
+// its items (§13). The drawers they used to open are gone, but the shipped
+// mobile journeys locate the bar by them, and a testid is a contract with those
+// journeys, not a description of the drawer that once existed.
+
+var ST2_MOBILE_TABS = [
+  { id: "needs", label: "Needs you", icon: "bell", testId: "studio-left-toggle" },
+  { id: "runs", label: "Runs", icon: "agent", testId: "studio-right-toggle" },
+  { id: "changes", label: "Changes", icon: "git-commit", testId: "studio-changes-toggle" },
+];
+
+// Suggestion chips so answering an ask_user is one tap. Only for ask_user:
+// offering "Yes" on an approval would put a one-tap authorisation of an
+// arbitrary command behind a chip, which is the last thing this should do.
+var ST2_ASK_SUGGESTIONS = ["Yes", "No", "Go ahead"];
+
+function ST2_MobileBottomBar({ tab, counts, onPick }) {
+  return (
+    <div
+      data-testid="studio-mobile-bar"
+      className="row mobile-only"
+      style={{
+        flex: "0 0 auto", height: 56, alignItems: "stretch",
+        borderTop: "1px solid var(--border)", background: "var(--bg-elev)",
+      }}
+    >
+      {ST2_MOBILE_TABS.map(function (t) {
+        var active = tab === t.id;
+        var n = counts[t.id];
+        return (
+          <button
+            key={t.id}
+            data-testid={t.testId}
+            aria-pressed={active}
+            onClick={function () { onPick(t.id); }}
+            style={{
+              // 44px minimum target (§11); the bar is 56 tall and each item
+              // takes an equal share of the width.
+              flex: 1, minHeight: 44, border: "none", background: "transparent",
+              display: "flex", flexDirection: "column", alignItems: "center",
+              justifyContent: "center", gap: 2, cursor: "pointer",
+              color: active ? "var(--accent)" : "var(--text-3)",
+            }}
+          >
+            <span style={{ position: "relative" }}>
+              <Icon name={t.icon} size={17} />
+              {n ? (
+                <span
+                  data-testid={"mobile-badge-" + t.id}
+                  style={{
+                    position: "absolute", top: -4, right: -9, minWidth: 15,
+                    padding: "0 3px", borderRadius: 999, background: "var(--amber)",
+                    color: "var(--bg-1)", fontSize: 9, fontWeight: 700, lineHeight: "15px",
+                  }}
+                >{n}</span>
+              ) : null}
+            </span>
+            <span style={{ fontSize: "var(--fs-11)" }}>{t.label}</span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// Full-bleed cards, one per blocking request - the home view on a phone.
+function ST2_MobileNeeds({ items, actions }) {
+  if (!items.length) {
+    return (
+      <div data-testid="mobile-needs-empty" className="col" style={{ padding: 24, gap: 6, alignItems: "center" }}>
+        <span style={{ fontSize: "var(--fs-13)", fontWeight: 600 }}>Nothing needs you.</span>
+        <span className="muted" style={{ fontSize: "var(--fs-12)", textAlign: "center" }}>
+          Anything waiting on an answer shows up here.
+        </span>
+      </div>
+    );
+  }
+  return (
+    <div data-testid="mobile-needs" className="col" style={{ gap: 10, padding: 10 }}>
+      {items.map(function (item) {
+        return (
+          <div
+            key={item.tool_call_id || item.session_id}
+            data-testid="mobile-needs-card"
+            className="col"
+            style={{
+              gap: 9, padding: 13, borderRadius: 11,
+              background: "var(--bg-elev)", border: "1px solid var(--amber)",
+            }}
+          >
+            <div className="row" style={{ gap: 7, alignItems: "baseline", flexWrap: "wrap" }}>
+              <span style={{ fontSize: "var(--fs-13)", fontWeight: 600 }}>
+                {item.session_name || item.session_id}
+              </span>
+              <span style={{ fontSize: "var(--fs-11)", color: "var(--amber)" }}>
+                {ST2_kindCopy(item.kind)}
+              </span>
+            </div>
+            {item.prompt ? (
+              <div style={{ fontSize: "var(--fs-12)", lineHeight: 1.5, color: "var(--text-2)" }}>
+                {item.prompt}
+              </div>
+            ) : null}
+            {item.kind === "ask_user" ? (
+              <div className="row" data-testid="mobile-suggestions" style={{ gap: 6, flexWrap: "wrap" }}>
+                {ST2_ASK_SUGGESTIONS.map(function (s) {
+                  return (
+                    <button
+                      key={s}
+                      onClick={function () { actions.answer(item, { response: s }); }}
+                      style={{
+                        minHeight: 44, padding: "0 15px", borderRadius: 9,
+                        border: "1px solid var(--border-strong)", background: "var(--bg-1)",
+                        color: "var(--text)", fontSize: "var(--fs-12)", cursor: "pointer",
+                      }}
+                    >{s}</button>
+                  );
+                })}
+              </div>
+            ) : null}
+            <ST2_YieldControls item={item} actions={actions} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// Read-only list; tapping a run opens its transcript. No editing on a phone.
+function ST2_MobileRuns({ sessions, pendingBySession, onOpen }) {
+  var rows = ST_sessionSort(sessions || []);
+  if (!rows.length) {
+    return (
+      <div data-testid="mobile-runs-empty" className="muted" style={{ padding: 24, fontSize: "var(--fs-12)", textAlign: "center" }}>
+        No runs yet.
+      </div>
+    );
+  }
+  return (
+    <div data-testid="mobile-runs" className="col" style={{ gap: 0 }}>
+      {rows.map(function (s) {
+        var sid = s.session_id || s.id;
+        var b = ST2_bucketOf(s, { pendingBySession: pendingBySession });
+        return (
+          <div
+            key={sid}
+            data-testid="mobile-run-row"
+            onClick={function () { if (onOpen) onOpen(sid); }}
+            className="row"
+            style={{
+              gap: 10, minHeight: 56, alignItems: "center", padding: "0 14px",
+              borderBottom: "1px solid var(--bg-active)", cursor: "pointer",
+            }}
+          >
+            <span style={{
+              width: 8, height: 8, borderRadius: "50%", flex: "0 0 auto",
+              background: "var(" + b.tone + ")",
+            }} />
+            <span className="col" style={{ gap: 1, flex: 1, minWidth: 0 }}>
+              <span style={{ fontSize: "var(--fs-13)", overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                {s.name || sid}
+              </span>
+              <span className="muted" style={{ fontSize: "var(--fs-11)" }}>{b.label}{b.detail ? " - " + b.detail : ""}</span>
+            </span>
+            <Icon name="chevron-right" size={14} />
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+// A one-line note beats a cramped implementation (§11).
+function ST2_MobileDesktopOnly({ what }) {
+  return (
+    <div
+      data-testid="mobile-desktop-only"
+      className="muted"
+      style={{ padding: 24, fontSize: "var(--fs-12)", textAlign: "center", lineHeight: 1.6 }}
+    >
+      {what} is desktop only.
+    </div>
+  );
+}
+
+function StudioMobile({ wid, studio }) {
+  var att = ST2_useAttention(wid);
+  var actions = ST2_useYieldActions(wid);
+  var api = window.primerApi;
+
+  var sessionsRes = api.useResource(
+    ST2_api.keys.sessions(wid),
+    function (signal) { return ST2_api.sessions(wid, signal); },
+    { pollMs: 5000, deps: [wid] }
+  );
+  var sessions = (sessionsRes.data && sessionsRes.data.items) || [];
+
+  var visible = att.items.filter(function (i) { return !actions.hidden[i.tool_call_id]; });
+  var pendingBySession = React.useMemo(function () {
+    var map = {};
+    visible.forEach(function (i) { if (i.session_id) map[i.session_id] = true; });
+    return map;
+  }, [att.items, actions.hidden]); // eslint-disable-line
+
+  var tabState = React.useState("needs");
+  var tab = tabState[0];
+  var setTab = tabState[1];
+
+  var counts = { needs: visible.length, runs: 0, changes: 0 };
+
+  return (
+    <div className="col" data-testid="studio-mobile" style={{ height: "100%", minHeight: 0, gap: 0 }}>
+      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+        {tab === "needs" ? <ST2_MobileNeeds items={visible} actions={actions} /> : null}
+        {tab === "runs" ? (
+          <ST2_MobileRuns
+            sessions={sessions}
+            pendingBySession={pendingBySession}
+            onOpen={function (sid) {
+              studio.openTab({ id: "session:" + sid, kind: "session", ref: sid, title: sid });
+              setTab("runs");
+            }}
+          />
+        ) : null}
+        {/* Changes needs the per-turn file trail, which has no endpoint yet;
+            saying so is better than an empty tab that reads as broken. */}
+        {tab === "changes" ? <ST2_MobileDesktopOnly what="Changes" /> : null}
+      </div>
+      <ST2_MobileBottomBar tab={tab} counts={counts} onPick={setTab} />
+    </div>
+  );
+}
+
+window.StudioMobile = StudioMobile;
+window.ST2_MobileBottomBar = ST2_MobileBottomBar;
+window.ST2_MobileNeeds = ST2_MobileNeeds;
+window.ST2_MobileRuns = ST2_MobileRuns;
+window.ST2_MobileDesktopOnly = ST2_MobileDesktopOnly;
+window.ST2_MOBILE_TABS = ST2_MOBILE_TABS;
+window.ST2_ASK_SUGGESTIONS = ST2_ASK_SUGGESTIONS;

--- a/ui/components/studio/st-panes.jsx
+++ b/ui/components/studio/st-panes.jsx
@@ -1,0 +1,184 @@
+/* global React, Icon, StudioCenter */
+// Studio revamp - the two-pane center (ui/studio/STUDIO-WIRING.md §6).
+//
+// A diff that replaces the transcript that produced it destroys the context you
+// opened it from. PaneHost adds a companion pane so the two sit side by side.
+//
+// It wraps two instances of the EXISTING StudioCenter body, parameterised on
+// which tab array each renders - so SessionAgentPanel, SessionGraphPanel,
+// FilePanel and the _SLS_Frame transcript renderer are all untouched, and both
+// panes get the same CenterTabs with the same testids.
+//
+// There is no asideOpen flag: the pane is open exactly when it holds tabs.
+
+// Below this width a second column cannot hold a transcript AND a diff, so the
+// companion becomes an overlay sheet. useViewport()'s width is enough - no
+// isMobile fork.
+var ST2_PANE_STACK_W = 1280;
+
+function ST2_AsideHeader({ narrow, onClose, onMoveBack }) {
+  return (
+    <div
+      className="row"
+      style={{
+        height: 30, flex: "0 0 auto", alignItems: "center", gap: 6,
+        padding: "0 8px", borderBottom: "1px solid var(--border)",
+        background: "var(--bg-elev)",
+      }}
+    >
+      <span className="muted" style={{ fontSize: "var(--fs-11)", fontWeight: 600, letterSpacing: "0.04em" }}>
+        {narrow ? "BESIDE" : "COMPANION"}
+      </span>
+      <span style={{ marginLeft: "auto", display: "flex", gap: 2 }}>
+        <button
+          className="st-row-action"
+          data-testid="aside-move-back"
+          title="Move back to the main pane (Alt-\)"
+          aria-label="Move back to the main pane"
+          onClick={onMoveBack}
+        >
+          <Icon name="panel-left" size={12} />
+        </button>
+        <button
+          className="st-row-action"
+          data-testid="aside-close"
+          title="Close the companion pane"
+          aria-label="Close the companion pane"
+          onClick={onClose}
+        >
+          <Icon name="x" size={12} />
+        </button>
+      </span>
+    </div>
+  );
+}
+
+function PaneHost({ wid, studio }) {
+  var s = studio.state;
+  var asideTabs = s.asideTabs || [];
+  var asideOpen = asideTabs.length > 0;
+
+  // Unconditional hook call - useViewport is a foundation export, registered
+  // before any component runs.
+  var vp = window.primerApi.useViewport();
+  var narrow = (vp.width || window.innerWidth || 1440) < ST2_PANE_STACK_W;
+
+  // Drag the divider. Widening the companion means dragging LEFT, so the delta
+  // is inverted relative to the left rail's handle.
+  var dragRef = React.useRef(null);
+  function startAsideResize(e) {
+    dragRef.current = { startX: e.clientX, startW: s.asideWidth || 520 };
+    e.preventDefault();
+  }
+  React.useEffect(function () {
+    function onMove(e) {
+      if (!dragRef.current) return;
+      studio.setAsideWidth(dragRef.current.startW + (dragRef.current.startX - e.clientX));
+    }
+    function onUp() { dragRef.current = null; }
+    window.addEventListener("mousemove", onMove);
+    window.addEventListener("mouseup", onUp);
+    return function () {
+      window.removeEventListener("mousemove", onMove);
+      window.removeEventListener("mouseup", onUp);
+    };
+  }, [studio]);
+
+  var aside = asideOpen ? (
+    <div
+      data-testid="studio-aside"
+      className="col"
+      style={narrow ? {
+        // Overlay sheet: same content, laid over the primary pane rather than
+        // squeezing it into unusability.
+        position: "absolute", top: 0, right: 0, bottom: 0,
+        width: "min(560px, 92%)", zIndex: 30, gap: 0,
+        background: "var(--bg-2)", borderLeft: "1px solid var(--border)",
+        boxShadow: "-8px 0 24px rgba(0,0,0,0.28)",
+      } : {
+        flex: "0 0 auto", width: s.asideWidth || 520, minWidth: 0, gap: 0,
+        borderLeft: "1px solid var(--border)", background: "var(--bg-2)",
+      }}
+    >
+      <ST2_AsideHeader
+        narrow={narrow}
+        onClose={studio.closeAllAsideTabs}
+        onMoveBack={studio.moveTabAcross}
+      />
+      <div style={{ flex: 1, minHeight: 0 }}>
+        <StudioCenter
+          wid={wid}
+          studio={studio}
+          testId="studio-aside-inner"
+          tabs={asideTabs}
+          activeId={s.activeAsideTabId}
+          onFocus={studio.focusAsideTab}
+          onClose={studio.closeAsideTab}
+          onCloseAll={studio.closeAllAsideTabs}
+        />
+      </div>
+    </div>
+  ) : null;
+
+  return (
+    <div
+      data-testid="studio-panes"
+      style={{
+        display: "flex", flex: 1, minHeight: 0, minWidth: 0,
+        position: "relative", overflow: "hidden",
+      }}
+    >
+      <div style={{ flex: 1, minWidth: 0, display: "flex", flexDirection: "column" }}>
+        <StudioCenter wid={wid} studio={studio} />
+      </div>
+      {asideOpen && !narrow ? (
+        <div
+          className="st-resize desktop-only"
+          data-testid="aside-resize"
+          onMouseDown={startAsideResize}
+        />
+      ) : null}
+      {aside}
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// WROTE-row derivation (§6.1)
+//
+// Which tool calls actually wrote a file, and to what path. Kept as pure logic
+// separate from any rendering because the two halves unblock at different
+// times: this half is decidable from the tool call alone, while the row's
+// "+n/-m  open diff" needs the per-turn file trail that no endpoint exposes yet
+// (see the plan's §0.2). Task 7 lands the row against this function.
+//
+// The allowlist is deliberate. workspace__exec can obviously write files - via
+// a redirect, a heredoc, sed -i, a build step - but its argv cannot be read
+// reliably enough to say WHICH file, and a WROTE row pointing at the wrong path
+// is worse than no row. Inferring is out; only tools whose contract names the
+// path count.
+//
+// These are the SCOPED ids the runtime emits (`workspace__<bare>`, see
+// tool_manager.WORKSPACE_TOOLSET_ID + SandboxWrite/SandboxEdit.id). WIRING §6
+// names `fs__write_file` / `fs__apply_patch`, which do not exist in this
+// codebase - matching on those would have quietly matched nothing forever.
+var ST2_WRITE_TOOLS = {
+  workspace__write: 1,
+  workspace__edit: 1,
+};
+
+// ST2_wroteFromToolCall(row) -> { path } | null
+function ST2_wroteFromToolCall(row) {
+  var m = row || {};
+  var name = m.name || m.tool_name || "";
+  if (!ST2_WRITE_TOOLS[name]) return null;
+  var args = m.args || m.arguments || {};
+  var path = args.path || args.file_path || args.file || null;
+  if (!path || typeof path !== "string") return null;
+  return { path: path };
+}
+
+window.PaneHost = PaneHost;
+window.ST2_PANE_STACK_W = ST2_PANE_STACK_W;
+window.ST2_wroteFromToolCall = ST2_wroteFromToolCall;
+window.ST2_WRITE_TOOLS = ST2_WRITE_TOOLS;

--- a/ui/components/studio/st-rail.jsx
+++ b/ui/components/studio/st-rail.jsx
@@ -1,0 +1,75 @@
+/* global React, ST2_RunsRail, ST2_FilesRail */
+// Studio revamp - the rail shell (ui/studio/STUDIO-WIRING.md §5).
+//
+// StudioSidebar stacked Sessions above Files, so both were half-height and both
+// were always half-collapsed. One rail with two modes gives whichever one you
+// are actually using the full column, at the cost of a click to switch - and
+// switching is rare, because runs and files are different jobs.
+//
+// leftWidth's drag + 180..480 clamp are unchanged and still live in studio.jsx;
+// this component only owns which mode is showing.
+
+var ST2_RAIL_MODES = [
+  { id: "runs", label: "Runs" },
+  { id: "files", label: "Files" },
+];
+
+function ST2_RailModeSwitch({ mode, onPick }) {
+  return (
+    <div
+      className="row"
+      style={{
+        margin: "8px 8px 4px", padding: 2, gap: 2, flex: "0 0 auto",
+        background: "var(--bg-1)", borderRadius: 7,
+        border: "1px solid var(--border)",
+      }}
+    >
+      {ST2_RAIL_MODES.map(function (m) {
+        var active = mode === m.id;
+        return (
+          <button
+            key={m.id}
+            data-testid={"rail-mode-" + m.id}
+            aria-pressed={active}
+            onClick={function () { onPick(m.id); }}
+            style={{
+              flex: 1, padding: "4px 0", borderRadius: 5, cursor: "pointer",
+              border: "none",
+              background: active ? "var(--bg-elev)" : "transparent",
+              color: active ? "var(--text)" : "var(--text-3)",
+              fontSize: "var(--fs-12)",
+              fontWeight: active ? 600 : 400,
+              boxShadow: active ? "0 1px 2px rgba(0,0,0,0.18)" : "none",
+            }}
+          >{m.label}</button>
+        );
+      })}
+    </div>
+  );
+}
+
+function StudioRail({ wid, studio }) {
+  var mode = studio.state.railMode || "runs";
+  return (
+    <div
+      data-testid="studio-rail"
+      // studio-sidebar-inner kept as an alias so the shipped journeys that
+      // locate the v1 sidebar still resolve while both shells exist.
+      data-legacy-testid="studio-sidebar-inner"
+      className="col"
+      style={{ height: "100%", minHeight: 0, gap: 0, overflow: "hidden" }}
+    >
+      <ST2_RailModeSwitch
+        mode={mode}
+        onPick={function (id) { studio.setRailMode(id); }}
+      />
+      {mode === "files"
+        ? <ST2_FilesRail wid={wid} studio={studio} />
+        : <ST2_RunsRail wid={wid} studio={studio} />}
+    </div>
+  );
+}
+
+window.StudioRail = StudioRail;
+window.ST2_RailModeSwitch = ST2_RailModeSwitch;
+window.ST2_RAIL_MODES = ST2_RAIL_MODES;

--- a/ui/components/studio/st-runs-rail.jsx
+++ b/ui/components/studio/st-runs-rail.jsx
@@ -1,0 +1,388 @@
+/* global React, Icon, ST2_api, ST2_bucketOf, ST2_BUCKET_ORDER, ST_sessionSort,
+   ST_sessionKind, ST_sessionGlyph, ST_dotStyle, ST_onRowKey, NewSessionForm,
+   ST_SessionDeleteDialog, ST_SessionRenameDialog */
+// Studio revamp - the Runs rail (ui/studio/STUDIO-WIRING.md §5).
+//
+// Replaces SessionsSection. Same endpoint, same row actions, same create form
+// and dialogs (reused, not copied - they are already bundle globals). What
+// changes is the ordering axis: a flat status-sorted list becomes four groups in
+// the fixed needs -> working -> broken -> done order, so "what needs me" is a
+// position on screen instead of a badge you have to notice.
+//
+// ST_sessionSort stays INSIDE each group, so the within-group ordering rule
+// still lives in exactly one place.
+
+var ST2_BUCKET_LABEL = {
+  needs: "Needs you",
+  working: "Working",
+  broken: "Broken",
+  done: "Done",
+};
+
+// Bucket -> the tone vocabulary ST_dotStyle actually implements
+// ("green-pulse" / "amber" / "red" / "gray"; anything else is a dim dot).
+var ST2_BUCKET_DOT = {
+  needs: "amber",
+  working: "green-pulse",
+  broken: "red",
+  done: "gray",
+};
+
+// Only these chips are backed by data. See ST2_RunsRail for why there is no
+// "mine".
+var ST2_RAIL_FILTERS = [
+  { id: "all", label: "All" },
+  { id: "needs", label: "Needs you" },
+  { id: "open", label: "Open" },
+];
+
+function ST2_RailFilterChips({ value, counts, onPick }) {
+  return (
+    <div className="row" style={{ gap: 4, padding: "6px 8px", flexWrap: "wrap" }}>
+      {ST2_RAIL_FILTERS.map(function (f) {
+        var active = (value || "all") === f.id;
+        var n = counts[f.id];
+        return (
+          <button
+            key={f.id}
+            data-testid={"rail-filter-" + f.id}
+            onClick={function () { onPick(f.id); }}
+            style={{
+              padding: "3px 9px", borderRadius: 999, cursor: "pointer",
+              border: "1px solid " + (active ? "var(--border-strong)" : "var(--border)"),
+              background: active ? "var(--bg-active)" : "transparent",
+              color: active ? "var(--text)" : "var(--text-3)",
+              fontSize: "var(--fs-11)",
+            }}
+          >
+            {f.label}{n ? " " + n : ""}
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+function ST2_RunRow({ session, bucket, isActive, onOpen, onOpenAside, onRename, onDelete }) {
+  var sid = session.session_id || session.id;
+  var isGraph = ST_sessionKind(session) === "graph";
+  var isNeeds = bucket.bucket === "needs";
+
+  return (
+    <div
+      className="st-session-row"
+      data-testid="session-row"
+      data-session-id={sid}
+      data-bucket={bucket.bucket}
+      role="button"
+      tabIndex={0}
+      onClick={function (e) {
+        // Cmd/Ctrl-click opens beside, mirroring the editor convention. Falls
+        // through to a normal open until the companion pane exists (Task 6).
+        if ((e.metaKey || e.ctrlKey) && onOpenAside) onOpenAside(session);
+        else onOpen(session);
+      }}
+      onKeyDown={ST_onRowKey(function () { onOpen(session); })}
+      style={{
+        display: "flex", alignItems: "center", gap: 7,
+        height: "var(--row-h, 34px)", padding: "0 10px", cursor: "pointer",
+        // The amber edge is what makes a needs-you row findable without
+        // reading it. An active tab still wins the border.
+        borderLeft: "2px solid " + (
+          isActive ? "var(--accent)" : isNeeds ? "var(--amber)" : "transparent"
+        ),
+        background: isActive ? "var(--bg-active)" : "transparent",
+      }}
+    >
+      <span
+        className="st-session-dot"
+        data-testid="session-status-dot"
+        // ST_dotStyle's vocabulary, not the bucket's CSS var: it has no "blue",
+        // and an unknown tone falls through to the inert dim dot - which would
+        // render a live run as though nothing were happening.
+        style={ST_dotStyle(ST2_BUCKET_DOT[bucket.bucket] || "dim")}
+      />
+      <span
+        className="col"
+        style={{ flex: 1, minWidth: 0, gap: 0 }}
+      >
+        <span style={{
+          overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap",
+          color: bucket.bucket === "done" ? "var(--text-3)" : "var(--text)",
+          fontSize: "var(--fs-12)",
+        }}>{session.name || sid}</span>
+        {bucket.detail ? (
+          <span className="muted" style={{
+            fontSize: "var(--fs-11)", overflow: "hidden",
+            textOverflow: "ellipsis", whiteSpace: "nowrap",
+          }}>{bucket.detail}</span>
+        ) : null}
+      </span>
+      <span className="st-row-actions">
+        {onOpenAside ? (
+          <button
+            className="st-row-action"
+            data-testid="session-open-aside"
+            title="Open beside"
+            aria-label="Open beside"
+            onClick={function (e) { e.stopPropagation(); onOpenAside(session); }}
+          >
+            <Icon name="panel-right" size={12} />
+          </button>
+        ) : null}
+        <button
+          className="st-row-action"
+          data-testid="session-rename"
+          title="Rename session"
+          aria-label="Rename session"
+          onClick={function (e) { e.stopPropagation(); onRename(session); }}
+        >
+          <Icon name="edit" size={12} />
+        </button>
+        <button
+          className="st-row-action is-danger"
+          data-testid="session-delete"
+          title="Delete session"
+          aria-label="Delete session"
+          onClick={function (e) { e.stopPropagation(); onDelete(session); }}
+        >
+          <Icon name="trash" size={12} />
+        </button>
+      </span>
+      <span style={{
+        fontSize: 9, fontWeight: 700, letterSpacing: "0.05em",
+        color: "var(--text-4)", border: "1px solid var(--border)",
+        borderRadius: 4, padding: "0 4px", flexShrink: 0,
+      }}>{isGraph ? "GRAPH" : "AGENT"}</span>
+    </div>
+  );
+}
+
+function ST2_RunsRail({ wid, studio }) {
+  var api = window.primerApi;
+  var s = studio.state;
+
+  // Same cache key the v1 section and the attention bar use, so all three
+  // dedupe onto one poll.
+  var sessionsRes = api.useResource(
+    ST2_api.keys.sessions(wid),
+    function (signal) { return ST2_api.sessions(wid, signal); },
+    { pollMs: 3000, deps: [wid] }
+  );
+  var raw = (sessionsRes.data && Array.isArray(sessionsRes.data.items))
+    ? sessionsRes.data.items
+    : (Array.isArray(sessionsRes.data) ? sessionsRes.data : []);
+
+  // The pending-yield snapshot promotes a RUNNING session with an unanswered
+  // yield into "needs". Shares the attention bar's key, so no extra request.
+  var pendingRes = api.useResource(
+    ST2_api.keys.pending(wid),
+    function (signal) { return ST2_api.pending(wid, signal); },
+    { pollMs: 15000, deps: [wid] }
+  );
+  var pendingBySession = React.useMemo(function () {
+    var map = {};
+    var items = (pendingRes.data && pendingRes.data.items) || [];
+    items.forEach(function (it) { if (it.session_id) map[it.session_id] = true; });
+    return map;
+  }, [pendingRes.data]);
+
+  var [pendingDelete, setPendingDelete] = React.useState(null);
+  var [renaming, setRenaming] = React.useState(null);
+  var pushToast = studio.pushToast || (api && api.toastPush) || null;
+
+  var openIds = React.useMemo(function () {
+    var map = {};
+    (s.openTabs || []).forEach(function (t) {
+      if (t.kind === "session" && t.ref) map[t.ref] = true;
+    });
+    (s.asideTabs || []).forEach(function (t) {
+      if (t.kind === "session" && t.ref) map[t.ref] = true;
+    });
+    return map;
+  }, [s.openTabs, s.asideTabs]);
+
+  function openSession(session) {
+    var sid = session.session_id || session.id;
+    studio.openTab({
+      id: "session:" + sid,
+      kind: "session",
+      ref: sid,
+      title: session.name || sid,
+      glyph: ST_sessionGlyph(session),
+    });
+  }
+
+  // Open beside only exists once the companion pane does (Task 6). Guarded
+  // rather than stubbed, so the affordance appears when it actually works.
+  var openAside = typeof studio.openAside === "function"
+    ? function (session) {
+        var sid = session.session_id || session.id;
+        studio.openAside({
+          id: "session:" + sid,
+          kind: "session",
+          ref: sid,
+          title: session.name || sid,
+          glyph: ST_sessionGlyph(session),
+        });
+      }
+    : null;
+
+  function onSessionDeleted(sid) {
+    setPendingDelete(null);
+    // Close BOTH panes' matching tabs - a deleted session left open in the
+    // companion pane would keep 404ing.
+    if (studio.closeTab) studio.closeTab("session:" + sid);
+    if (studio.closeAsideTab) studio.closeAsideTab("session:" + sid);
+    if (sessionsRes.refetch) sessionsRes.refetch();
+  }
+
+  function onSessionRenamed() {
+    setRenaming(null);
+    if (sessionsRes.refetch) sessionsRes.refetch();
+  }
+
+  var filter = s.railFilter || "all";
+  var groups = React.useMemo(function () {
+    var out = { needs: [], working: [], broken: [], done: [] };
+    raw.forEach(function (item) {
+      out[ST2_bucketOf(item, { pendingBySession: pendingBySession }).bucket].push(item);
+    });
+    // Sort within each group, never across - the group order IS the priority.
+    ST2_BUCKET_ORDER.forEach(function (k) { out[k] = ST_sessionSort(out[k]); });
+    return out;
+  }, [raw, pendingBySession]);
+
+  var counts = {
+    all: raw.length,
+    needs: groups.needs.length,
+    open: raw.filter(function (x) { return openIds[x.session_id || x.id]; }).length,
+  };
+
+  function visible(list) {
+    if (filter === "needs") return list === groups.needs ? list : [];
+    if (filter === "open") return list.filter(function (x) { return openIds[x.session_id || x.id]; });
+    return list;
+  }
+
+  var total = raw.length;
+
+  return (
+    <div className="col" data-testid="rail-runs" style={{ flex: 1, minHeight: 0, gap: 0 }}>
+      <div
+        className="row"
+        style={{
+          padding: "0 8px 0 10px", height: 30, flex: "0 0 auto",
+          alignItems: "center", gap: 6,
+        }}
+      >
+        <span className="muted" style={{ fontSize: "var(--fs-11)", fontWeight: 600, letterSpacing: "0.04em" }}>
+          RUNS
+        </span>
+        <span className="muted" style={{ fontSize: "var(--fs-11)" }}>{total || ""}</span>
+        <button
+          style={{
+            marginLeft: "auto", width: 20, height: 20, display: "grid",
+            placeItems: "center", borderRadius: 5, border: "none",
+            background: "none", color: "var(--text-3)", fontSize: 14, cursor: "pointer",
+          }}
+          title="New session"
+          data-testid="new-session-btn"
+          onClick={function () {
+            if (studio.newSessionOpen) studio.closeNewSession();
+            else studio.openNewSession();
+          }}
+        >+</button>
+      </div>
+
+      <ST2_RailFilterChips
+        value={filter}
+        counts={counts}
+        onPick={function (id) { studio.setRailFilter(id); }}
+      />
+
+      {studio.newSessionOpen && (
+        <NewSessionForm
+          wid={wid}
+          onClose={function () { studio.closeNewSession(); }}
+          onCreated={function (session) {
+            studio.closeNewSession();
+            if (sessionsRes.refetch) sessionsRes.refetch();
+            openSession(session);
+          }}
+        />
+      )}
+
+      {pendingDelete && (
+        <ST_SessionDeleteDialog
+          wid={wid}
+          session={pendingDelete}
+          pushToast={pushToast}
+          onClose={function () { setPendingDelete(null); }}
+          onDeleted={onSessionDeleted}
+        />
+      )}
+
+      {renaming && (
+        <ST_SessionRenameDialog
+          wid={wid}
+          session={renaming}
+          pushToast={pushToast}
+          onClose={function () { setRenaming(null); }}
+          onRenamed={onSessionRenamed}
+        />
+      )}
+
+      <div style={{ flex: 1, minHeight: 0, overflow: "auto" }}>
+        {sessionsRes.loading && !total ? (
+          <div className="muted" style={{ padding: "8px 12px", fontSize: "var(--fs-11)" }}>Loading...</div>
+        ) : null}
+        {!sessionsRes.loading && !total ? (
+          <div className="muted" style={{ padding: "8px 12px", fontSize: "var(--fs-11)" }}>No sessions yet.</div>
+        ) : null}
+
+        {ST2_BUCKET_ORDER.map(function (key) {
+          var rows = visible(groups[key]);
+          if (!rows.length) return null;
+          return (
+            <div key={key} data-testid={"rail-group-" + key}>
+              <div
+                className="row"
+                style={{
+                  padding: "0 10px", height: 24, alignItems: "center", gap: 6,
+                  position: "sticky", top: 0, background: "var(--bg-2)",
+                  borderBottom: "1px solid var(--bg-active)", zIndex: 1,
+                }}
+              >
+                <span style={{
+                  fontSize: "var(--fs-11)", fontWeight: 600,
+                  color: key === "needs" ? "var(--amber)" : "var(--text-3)",
+                }}>{ST2_BUCKET_LABEL[key]}</span>
+                <span className="muted" style={{ fontSize: "var(--fs-11)" }}>{rows.length}</span>
+              </div>
+              {rows.map(function (session) {
+                var sid = session.session_id || session.id;
+                return (
+                  <ST2_RunRow
+                    key={sid}
+                    session={session}
+                    bucket={ST2_bucketOf(session, { pendingBySession: pendingBySession })}
+                    isActive={s.activeTabId === "session:" + sid}
+                    onOpen={openSession}
+                    onOpenAside={openAside}
+                    onRename={setRenaming}
+                    onDelete={setPendingDelete}
+                  />
+                );
+              })}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+window.ST2_RunsRail = ST2_RunsRail;
+window.ST2_RunRow = ST2_RunRow;
+window.ST2_RAIL_FILTERS = ST2_RAIL_FILTERS;

--- a/ui/components/studio/st-status.jsx
+++ b/ui/components/studio/st-status.jsx
@@ -35,7 +35,12 @@ function ST2_bucketOf(session, opts) {
   var o = opts || {};
   var status = String(s.status || "unknown");
   var reason = s.park_reason || s.parked_reason || (s.parked && s.parked.kind) || null;
-  var hasPendingYield = !!(o.pendingBySession && s.id && o.pendingBySession[s.id]);
+  // The list endpoint returns SessionInfo, which carries `session_id`; the
+  // create-response / detail shapes carry `id`. The pending snapshot is keyed
+  // by `session_id`, so resolving only `id` would silently never promote a
+  // row that came from the list - i.e. every row in the rail.
+  var sid = s.session_id || s.id || null;
+  var hasPendingYield = !!(o.pendingBySession && sid && o.pendingBySession[sid]);
 
   if ((status === "parked" && ST2_NEEDS_REASONS[reason]) || hasPendingYield) {
     return {

--- a/ui/components/studio/st-status.jsx
+++ b/ui/components/studio/st-status.jsx
@@ -1,0 +1,97 @@
+// Studio revamp - the four-state status language (ui/studio/STUDIO-WIRING.md §4).
+//
+// Wraps, does not replace, ST_sessionStatus: the ~16 lifecycle/park values the
+// backend can report collapse into four buckets an operator can scan, with the
+// raw value kept in `detail` so an unmapped backend state is visible rather
+// than silently rendering as "done".
+//
+// Pure logic, no React - so the mapping table can be exercised for real.
+
+var ST2_BUCKET_ORDER = ["needs", "working", "broken", "done"];
+
+// Park reasons where a HUMAN is the blocker.
+var ST2_NEEDS_REASONS = { ask_user: 1, approval: 1, ask_approval: 1 };
+// Park reasons that are technically parked but wait on a machine, not a person.
+var ST2_QUIET_PARKS = { watch: 1, watch_files: 1, sleep: 1 };
+
+function ST2_reasonCopy(reason, session) {
+  var s = session || {};
+  if (reason === "ask_user") return "asked a question";
+  if (reason === "approval" || reason === "ask_approval") {
+    var cmd = s.pending_command || s.tool || null;
+    return cmd ? "approve · " + cmd : "waiting for approval";
+  }
+  if (reason === "watch" || reason === "watch_files") return "waiting on a file";
+  if (reason === "sleep") return "sleeping until a timer fires";
+  return reason ? String(reason) : "";
+}
+
+// ST2_bucketOf(session, opts) -> { bucket, tone, label, detail }
+//   opts.pendingBySession: { [session_id]: true } from the workspace
+//   pending-yield snapshot. A session can be RUNNING and still have an
+//   unanswered yield, which is why the snapshot can promote it to "needs".
+function ST2_bucketOf(session, opts) {
+  var s = session || {};
+  var o = opts || {};
+  var status = String(s.status || "unknown");
+  var reason = s.park_reason || s.parked_reason || (s.parked && s.parked.kind) || null;
+  var hasPendingYield = !!(o.pendingBySession && s.id && o.pendingBySession[s.id]);
+
+  if ((status === "parked" && ST2_NEEDS_REASONS[reason]) || hasPendingYield) {
+    return {
+      bucket: "needs",
+      tone: "--amber",
+      label: "needs you",
+      detail: ST2_reasonCopy(reason || "approval", s),
+    };
+  }
+
+  var errCode = s.ended_detail || s.error_code || null;
+  if (status === "failed" || ((status === "ended" || status === "cancelled") && errCode)) {
+    return {
+      bucket: "broken",
+      tone: "--red",
+      label: "broken",
+      detail: errCode
+        ? (s.tool ? String(errCode) + " · " + s.tool : String(errCode))
+        : "run failed",
+    };
+  }
+
+  if (status === "completed" || status === "ended" || status === "cancelled") {
+    return {
+      bucket: "done",
+      tone: "--text-3",
+      label: "done",
+      detail: s.files_touched != null ? s.files_touched + " files touched" : "",
+    };
+  }
+
+  // Everything else is "working", including the quiet parks and any value the
+  // frontend has never heard of (kept verbatim in `detail`).
+  var detail;
+  if (status === "parked" && ST2_QUIET_PARKS[reason]) {
+    detail = ST2_reasonCopy(reason, s);
+  } else if (status === "running" || status === "created" || status === "resumable") {
+    detail = s.substep || s.tool || "";
+  } else {
+    detail = status;
+  }
+  return { bucket: "working", tone: "--blue", label: "working", detail: detail || "" };
+}
+
+// Group a session list into the fixed bucket order. Callers sort WITHIN a
+// group (ST_sessionSort) so the ordering rule stays in one place.
+function ST2_groupSessions(sessions, opts) {
+  var out = { needs: [], working: [], broken: [], done: [] };
+  (sessions || []).forEach(function (s) {
+    var b = ST2_bucketOf(s, opts);
+    out[b.bucket].push(s);
+  });
+  return out;
+}
+
+window.ST2_bucketOf = ST2_bucketOf;
+window.ST2_BUCKET_ORDER = ST2_BUCKET_ORDER;
+window.ST2_reasonCopy = ST2_reasonCopy;
+window.ST2_groupSessions = ST2_groupSessions;

--- a/ui/foundation/tweaks.js
+++ b/ui/foundation/tweaks.js
@@ -30,6 +30,10 @@
     // replaces. Flip on to use the new builder; the switch lives in
     // GraphDetail so turning it back off is a flag flip, not a revert.
     graphBuilderV2: true,
+    // Studio revamp (ui/studio/STUDIO-WIRING.md). Off until the shell is
+    // complete; both shells coexist in one build so QA can A/B. Read with
+    // `=== true` so an incomplete revamp cannot appear by accident.
+    studioV2: false,
   };
 
   // Subset of keys whose user choice we persist across reloads via

--- a/ui/index.html
+++ b/ui/index.html
@@ -136,6 +136,8 @@
 <!-- PaneHost mounts two StudioCenter bodies, so it loads after that file. -->
 <script type="text/babel" src="components/studio/st-panes.jsx"></script>
 <script type="text/babel" src="components/studio/st-diff.jsx"></script>
+<!-- ChangesView renders DiffView, so it loads after it. -->
+<script type="text/babel" src="components/studio/st-changes.jsx"></script>
 <script type="text/babel" src="components/studio/st-graph-run.jsx"></script>
 <script type="text/babel" src="components/studio/st-mobile.jsx"></script>
 <script type="text/babel" src="components/studio-activity.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -127,6 +127,11 @@
 <script type="text/babel" src="components/studio/st-attention.jsx"></script>
 <script type="text/babel" src="components/studio/st-dock.jsx"></script>
 <script type="text/babel" src="components/studio-sidebar.jsx"></script>
+<!-- The rail reuses studio-sidebar.jsx's FilesTree / NewSessionForm / dialogs
+     rather than copying them, so it is registered after that file. -->
+<script type="text/babel" src="components/studio/st-runs-rail.jsx"></script>
+<script type="text/babel" src="components/studio/st-files-rail.jsx"></script>
+<script type="text/babel" src="components/studio/st-rail.jsx"></script>
 <script type="text/babel" src="components/studio-center.jsx"></script>
 <script type="text/babel" src="components/studio-activity.jsx"></script>
 <script type="text/babel" src="components/studio-palette.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -122,6 +122,9 @@
 <script type="text/babel" src="components/session-adapter.jsx"></script>
 <script type="text/babel" src="components/use-session-controls.jsx"></script>
 <script type="text/babel" src="components/new-session-form.jsx"></script>
+<script type="text/babel" src="components/studio/st-status.jsx"></script>
+<script type="text/babel" src="components/studio/st-api.jsx"></script>
+<script type="text/babel" src="components/studio/st-attention.jsx"></script>
 <script type="text/babel" src="components/studio-sidebar.jsx"></script>
 <script type="text/babel" src="components/studio-center.jsx"></script>
 <script type="text/babel" src="components/studio-activity.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -133,6 +133,8 @@
 <script type="text/babel" src="components/studio/st-files-rail.jsx"></script>
 <script type="text/babel" src="components/studio/st-rail.jsx"></script>
 <script type="text/babel" src="components/studio-center.jsx"></script>
+<!-- PaneHost mounts two StudioCenter bodies, so it loads after that file. -->
+<script type="text/babel" src="components/studio/st-panes.jsx"></script>
 <script type="text/babel" src="components/studio-activity.jsx"></script>
 <script type="text/babel" src="components/studio-palette.jsx"></script>
 <script type="text/babel" src="components/studio-terminal.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -135,6 +135,7 @@
 <script type="text/babel" src="components/studio-center.jsx"></script>
 <!-- PaneHost mounts two StudioCenter bodies, so it loads after that file. -->
 <script type="text/babel" src="components/studio/st-panes.jsx"></script>
+<script type="text/babel" src="components/studio/st-diff.jsx"></script>
 <script type="text/babel" src="components/studio-activity.jsx"></script>
 <script type="text/babel" src="components/studio-palette.jsx"></script>
 <script type="text/babel" src="components/studio-terminal.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -125,6 +125,7 @@
 <script type="text/babel" src="components/studio/st-status.jsx"></script>
 <script type="text/babel" src="components/studio/st-api.jsx"></script>
 <script type="text/babel" src="components/studio/st-attention.jsx"></script>
+<script type="text/babel" src="components/studio/st-dock.jsx"></script>
 <script type="text/babel" src="components/studio-sidebar.jsx"></script>
 <script type="text/babel" src="components/studio-center.jsx"></script>
 <script type="text/babel" src="components/studio-activity.jsx"></script>

--- a/ui/index.html
+++ b/ui/index.html
@@ -136,6 +136,8 @@
 <!-- PaneHost mounts two StudioCenter bodies, so it loads after that file. -->
 <script type="text/babel" src="components/studio/st-panes.jsx"></script>
 <script type="text/babel" src="components/studio/st-diff.jsx"></script>
+<script type="text/babel" src="components/studio/st-graph-run.jsx"></script>
+<script type="text/babel" src="components/studio/st-mobile.jsx"></script>
 <script type="text/babel" src="components/studio-activity.jsx"></script>
 <script type="text/babel" src="components/studio-palette.jsx"></script>
 <script type="text/babel" src="components/studio-terminal.jsx"></script>

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -1431,6 +1431,15 @@ input, textarea, select { font: inherit; color: inherit; }
 .skel { background: linear-gradient(90deg, var(--bg-2) 0%, var(--bg-hover) 50%, var(--bg-2) 100%); background-size: 200% 100%; animation: shimmer 1.4s infinite linear; border-radius: 4px; }
 @keyframes shimmer { from { background-position: 100% 0; } to { background-position: -100% 0; } }
 
+/* Studio revamp: the live segment of the graph superstep strip. Reuses the
+   shimmer keyframes above rather than adding a second sweep animation. */
+.st-sweep {
+  background: linear-gradient(90deg, transparent 0%, var(--bg-hover) 50%, transparent 100%);
+  background-size: 200% 100%;
+  animation: shimmer 1.6s infinite linear;
+  pointer-events: none;
+}
+
 /* ---------- Modal ---------- */
 
 .modal-overlay {


### PR DESCRIPTION
**HELD** - do not merge. Opened for review and CI only.

Rebuilds the Studio shell behind the `studioV2` runtime tweak, which
**defaults to off**. Every existing journey exercises the v1 shell
unchanged; the new shell is reachable only by flipping the tweak.

## What changes when the tweak is on

- **A persistent attention bar.** Always mounted, including when empty -
  "Nothing needs you" is the feature, not an empty state to collapse. The
  old right rail hid Action Required behind a toggle most operators never
  flipped.
- **A four-state status language.** ~16 backend lifecycle/park values
  collapse into needs / working / broken / done, with the raw value kept in
  `detail` so an unmapped state stays visible instead of rendering as
  "done".
- **One rail, two modes.** Sessions-above-Files made both permanently
  half-height. Runs now group by bucket, so "what needs me" is a position
  on screen rather than a badge you have to notice.
- **An investigate dock.** The event tap, the terminal and a derived
  Problems list behind one `Ctrl-\`` surface, replacing three separate
  toggles and the whole right column.
- **A companion pane.** A diff opens beside the transcript that produced it
  instead of replacing it. `Alt-\` moves the active tab across; both panes
  mirror to the URL.
- **Shareable `?focus=` links** for "this needs you", with the stale case
  treated as the common one.
- **A graph superstep strip**, weighted by node count, only the live
  segment sweeping.
- **A phone layout that is triage**, not a shrunk three-column shell.

## Bugs found and fixed on the way

- `ST2_bucketOf` resolved the pending-yield snapshot against `session.id`,
  but `/sessions` returns `SessionInfo`, which carries `session_id`. Every
  row in the rail comes from that endpoint, so promoting a RUNNING session
  with an unanswered yield never fired - and it failed invisibly, rendering
  a needs-you row as "working".
- `FilePanel` mirrored its dirty flag into `openTabs` only, so a file
  edited in the companion pane would have had no dirty dot and no close
  confirmation. Silent data loss.
- The `?focus=` helpers were first written on `URL` / `URLSearchParams`.
  Those are Web APIs, not ECMAScript: every test passed while asserting on
  a swallowed `ReferenceError`, because bare V8 has neither. The
  parse/serialise core is now pure string work and genuinely under test -
  including that writing `focus` preserves `?open=`, which would otherwise
  close the reader's tab as a side effect.
- `useResource` has no null-key guard: a null key composes to the string
  `"null"`, creates a cache entry, and fires
  `GET /graphs/null/runs/null/node_states`. The node-states hook now only
  mounts with a real gid/rid.

## Where the spec was wrong about the code

Three places, each of which would have shipped something inert:

- The WROTE row's tool allowlist is specified as `fs__write_file` /
  `fs__apply_patch`. The runtime emits `workspace__write` /
  `workspace__edit` - the spec's names would have matched nothing, forever.
- The superstep strip is specified as one segment per superstep.
  `node_states` has no superstep field; `iteration` is the superstep index,
  so the grouping is derived from it, with a test pinning the endpoint's
  field set so this gets revisited if a real field lands.
- The transcript is specified as `_SLS_Frame`. The Studio renders
  `chat/transcript.jsx`'s `Message`, which is shared with Chats.

## Deliberately absent rather than faked

- **The Changes view is not here.** It needs per-commit file stats and a
  diff route: `CommitInfo` carries only `sha / subject / committed_at` plus
  trailers, and `GET /workspaces/{wid}/log` is the only history endpoint.
  The diff engine it will use is included and fully tested; the view lands
  with the endpoint. Unblocking it means touching `CommitInfo`, the
  `StateRepo` ABC and every concrete implementation - a backend change I
  did not fold into a UI branch without asking.
- **The WROTE transcript row.** Its `+n/-m` needs the same missing trail,
  and it renders in a component shared with Chats. The derivation ships and
  is tested; the row ships with the endpoint.
- **The rail's "mine" filter chip.** `SessionInfo` has no owner field, so
  the chip could only lie. The third chip is "Open", derived from the tabs
  actually open.
- **The "Changed by agents" files lens.** Same missing trail.

## Tests

573 UI tests pass locally across every studio-related suite plus the
bundle-order and graph-builder suites. The pure logic - status buckets,
superstep grouping, the LCS diff and both its size guards, the pane
move/close state machine, and the focus-link URL handling - runs for real
in MiniRacer rather than being grepped for. The full JSX bundle builds
(2.49 MB) with all nine new/changed modules transpiled.

e2e journeys were not run locally; CI covers them.
