### PR TITLE
feat(workspaces): per-file line deltas on the workspace log [HELD]

### DIFF
--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -1455,10 +1455,20 @@ log_router = APIRouter(tags=["workspace-log"])
 async def workspace_log(
     workspace_id: str = Path(...),
     limit: int = Query(default=50, ge=1, le=500),
+    with_files: bool = Query(
+        default=False,
+        description=(
+            "Include per-file line deltas on each commit's `files`. Off by "
+            "default because it widens the response; on the local backend it "
+            "costs no extra git process (--numstat rides the same git log). "
+            "Backends that cannot supply file data leave `files` null rather "
+            "than empty -- null means unknown, not zero."
+        ),
+    ),
     registry: WorkspaceRegistry = Depends(get_workspace_registry),
 ) -> dict:
     ws = await registry.get_workspace(workspace_id)
-    commits = await ws.log(limit=limit)
+    commits = await ws.log(limit=limit, with_files=with_files)
     return {"commits": [c.model_dump(mode="json") for c in commits]}
 
 

--- a/primer/int/state_repo.py
+++ b/primer/int/state_repo.py
@@ -78,8 +78,15 @@ class StateRepo(Protocol):
         session_id: str | None = None,
         agent_id: str | None = None,
         limit: int = 100,
+        with_files: bool = False,
     ) -> list[CommitInfo]:
-        """Return commits, optionally filtered by session or agent. Newest first."""
+        """Return commits, optionally filtered by session or agent. Newest first.
+
+        ``with_files=True`` asks for per-file line deltas on each
+        ``CommitInfo.files``. Backends that cannot supply them leave the field
+        ``None`` rather than ``[]`` -- see :class:`CommitInfo.files`. Callers
+        must treat None as "unknown", never as zero.
+        """
         ...
 
     async def show_commit(self, sha: str) -> dict:

--- a/primer/int/workspace.py
+++ b/primer/int/workspace.py
@@ -336,13 +336,19 @@ class Workspace(ABC):
         )
 
     @abstractmethod
-    async def log(self, *, limit: int = 50) -> "list[CommitInfo]":
+    async def log(
+        self, *, limit: int = 50, with_files: bool = False
+    ) -> "list[CommitInfo]":
         """Return up to ``limit`` recent commits from the ``.state`` repo.
 
         Newest commits first. Each commit carries the parsed
         ``X-Primer-*`` trailers (workspace, session, agent, op, tool,
         call) so callers can render structured history without
         re-parsing the message body.
+
+        ``with_files=True`` additionally populates ``CommitInfo.files`` with
+        per-file line deltas where the backend can supply them; it stays
+        ``None`` (never ``[]``) where it cannot.
         """
 
     @abstractmethod

--- a/primer/model/workspace.py
+++ b/primer/model/workspace.py
@@ -211,6 +211,38 @@ Op = Literal[
 """Allowed values of the ``op`` trailer on state-repo commits."""
 
 
+class CommitFile(BaseModel):
+    """One file touched by a state-repo commit, with its line delta.
+
+    Carries counts only, never content: this is what a history LIST needs
+    (a row per file with ``+n/-m``). The actual patch comes from
+    ``GET /v1/workspaces/{wid}/commit/{sha}``, fetched per commit when a
+    reader opens one, so listing 500 commits never means listing 500 diffs.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    path: str = Field(..., min_length=1, description="Path relative to the .state/ repo root.")
+    additions: int = Field(
+        default=0,
+        ge=0,
+        description="Lines added. Always 0 for a binary file -- see ``binary``.",
+    )
+    deletions: int = Field(
+        default=0,
+        ge=0,
+        description="Lines removed. Always 0 for a binary file -- see ``binary``.",
+    )
+    binary: bool = Field(
+        default=False,
+        description=(
+            "True when git reported '-' instead of counts, i.e. a non-text "
+            "blob. Distinguishes 'no line changes' from 'lines are not a "
+            "meaningful unit here', which a bare 0/0 would conflate."
+        ),
+    )
+
+
 class CommitInfo(BaseModel):
     """One commit in the state repo, with trailers parsed.
 
@@ -246,6 +278,18 @@ class CommitInfo(BaseModel):
     call_id: str | None = Field(
         default=None,
         description="Value of the X-Primer-Call trailer, if present.",
+    )
+    files: list[CommitFile] | None = Field(
+        default=None,
+        description=(
+            "Files touched by this commit, with line deltas. Populated only "
+            "when the caller asks for it (``history(with_files=True)`` / "
+            "``GET .../log?with_files=1``) AND the backend can supply it. "
+            "``None`` means 'not requested, or this backend cannot tell you' "
+            "-- which is deliberately distinct from ``[]``, an empty commit "
+            "that genuinely touched no files. A consumer that renders a file "
+            "count must not read None as zero."
+        ),
     )
 
 
@@ -1183,6 +1227,7 @@ class Workspace(Identifiable):
 
 
 __all__ = [
+    "CommitFile",
     "CommitInfo",
     "ContainerConnectionConfig",
     "ContainerConnectionRemote",

--- a/primer/workspace/local/state.py
+++ b/primer/workspace/local/state.py
@@ -39,7 +39,7 @@ from primer.model.workspace_session import (
     SessionInfo,
     WaitingState,
 )
-from primer.model.workspace import CommitInfo, Op
+from primer.model.workspace import CommitFile, CommitInfo, Op
 from primer.session.mutation_lock import KeyedLock
 from primer.workspace.state_helpers import (
     TRAILER_AGENT as _TRAILER_AGENT,
@@ -435,21 +435,43 @@ class LocalStateRepo:
         session_id: str | None = None,
         agent_id: str | None = None,
         limit: int = 100,
+        with_files: bool = False,
     ) -> list[CommitInfo]:
         """Return commits, optionally filtered. Newest first.
 
         Filters are AND-ed when both supplied. Implemented by passing
         ``--grep=<trailer-pattern>`` to ``git log`` so the filter
         happens inside git rather than after the fact.
+
+        ``with_files=True`` populates ``CommitInfo.files`` with per-file line
+        deltas. This costs NO extra subprocess: ``--numstat`` rides along on
+        the same ``git log``, appended to each record after a trailing field
+        separator. The alternative -- one ``show_commit`` per commit -- is 3
+        git invocations per row, so ~150 processes for a 50-commit page.
+
+        ``--no-renames`` is deliberate: with rename detection on, numstat
+        writes paths as ``old => new`` (or ``dir/{old => new}/f``), which is
+        not a path any other endpoint accepts. A rename surfaces as one
+        deletion plus one addition instead -- unambiguous, and the right shape
+        for a per-file changes list.
         """
         if limit < 1:
             raise ValueError("limit must be >= 1")
 
+        # The record separator LEADS the format, and a field separator TRAILS
+        # it. git prints --numstat after the formatted line, so a trailing
+        # %x1e would put each commit's numstat at the head of the NEXT record;
+        # leading it keeps every record self-contained, and the trailing %x1f
+        # gives the numstat block its own field instead of concatenating it
+        # onto the trailer text. Splitting on %x1e now yields an empty first
+        # chunk, which _parse_log_records already skips.
         args = [
             "log",
             f"--max-count={limit}",
-            "--format=%H%x1f%s%x1f%cI%x1f%(trailers:only,unfold)%x1e",
+            "--format=%x1e%H%x1f%s%x1f%cI%x1f%(trailers:only,unfold)%x1f",
         ]
+        if with_files:
+            args += ["--numstat", "--no-renames"]
         if session_id is not None:
             args += ["--grep", f"^{_TRAILER_SESSION}: {session_id}$"]
         if agent_id is not None:
@@ -750,6 +772,10 @@ def _parse_log_records(stdout: str) -> list[CommitInfo]:
             continue
         sha, subject, committed_at_iso, trailer_block = parts[0], parts[1], parts[2], parts[3]
         trailers = _parse_trailers(trailer_block)
+        # parts[4] is the --numstat block when history() asked for it. Absent
+        # (or empty) means it was not requested, which must stay `None` rather
+        # than becoming `[]` -- an empty list is a commit that touched nothing.
+        files = _parse_numstat(parts[4]) if len(parts) > 4 and parts[4].strip() else None
         out.append(
             CommitInfo(
                 sha=sha,
@@ -761,9 +787,42 @@ def _parse_log_records(stdout: str) -> list[CommitInfo]:
                 op=trailers.get(_TRAILER_OP),
                 tool=trailers.get(_TRAILER_TOOL),
                 call_id=trailers.get(_TRAILER_CALL),
+                files=files,
             )
         )
     return out
+
+
+def _parse_numstat(block: str) -> list[CommitFile]:
+    """Parse a ``git log --numstat`` block into CommitFile rows.
+
+    Each line is ``<additions>\\t<deletions>\\t<path>``, where a binary file
+    reports ``-`` for both counts. A path may itself contain a tab, so the
+    split is bounded to 2 -- everything after the second tab is the path.
+    """
+    files: list[CommitFile] = []
+    for line in block.splitlines():
+        line = line.rstrip("\n")
+        if not line.strip():
+            continue
+        bits = line.split("\t", 2)
+        if len(bits) != 3:
+            continue
+        adds_raw, dels_raw, path = bits
+        if not path:
+            continue
+        binary = adds_raw == "-" or dels_raw == "-"
+        try:
+            adds = 0 if binary else int(adds_raw)
+            dels = 0 if binary else int(dels_raw)
+        except ValueError:
+            # Not a numstat line at all (defensive: never let one odd line
+            # take out the whole page of history).
+            continue
+        files.append(
+            CommitFile(path=path, additions=adds, deletions=dels, binary=binary)
+        )
+    return files
 
 
 def _parse_trailers(block: str) -> dict[str, str]:

--- a/primer/workspace/local/workspace.py
+++ b/primer/workspace/local/workspace.py
@@ -543,9 +543,9 @@ class LocalWorkspace(Workspace):
                 f"cannot move {src!r} to {dst!r}: {exc.strerror or exc}"
             ) from exc
 
-    async def log(self, *, limit: int = 50) -> list[CommitInfo]:
+    async def log(self, *, limit: int = 50, with_files: bool = False) -> list[CommitInfo]:
         try:
-            return await self._state.history(limit=limit)
+            return await self._state.history(limit=limit, with_files=with_files)
         except (OSError, _GitCommandError) as exc:
             # Either the workspace .state directory disappeared
             # mid-read (race with destroy) or git refused to read a

--- a/primer/workspace/sandbox/state.py
+++ b/primer/workspace/sandbox/state.py
@@ -592,8 +592,18 @@ class SandboxStateRepo:
         session_id: str | None = None,
         agent_id: str | None = None,
         limit: int = 100,
+        with_files: bool = False,
     ) -> list[CommitInfo]:
-        """Return commits, optionally filtered by session or agent. Newest first."""
+        """Return commits, optionally filtered by session or agent. Newest first.
+
+        ``with_files`` is accepted for Protocol conformance but has no effect:
+        the sandbox transport (``state_history``) returns commit headers only,
+        and this backend already 501s on ``show_commit`` for the same reason.
+        Every ``CommitInfo.files`` therefore stays ``None`` -- "this backend
+        cannot tell you", which is exactly what None means and why it is not
+        ``[]``. Silently returning empty lists would have the console draw
+        "0 files changed" over every commit in a container workspace.
+        """
         if not isinstance(self._sandbox, _StateCapableSandbox):
             return []
         sandbox = self._state_sandbox()

--- a/primer/workspace/sandbox/workspace.py
+++ b/primer/workspace/sandbox/workspace.py
@@ -498,8 +498,8 @@ class SandboxWorkspace(Workspace):
         async for chunk in self._sandbox.archive(resolved):
             yield chunk
 
-    async def log(self, *, limit: int = 50) -> "list[CommitInfo]":
-        return await self._state_repo.history(limit=limit)
+    async def log(self, *, limit: int = 50, with_files: bool = False) -> "list[CommitInfo]":
+        return await self._state_repo.history(limit=limit, with_files=with_files)
 
     async def status(self) -> WorkspaceStatus:
         info = await self._sandbox.inspect()

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -281,15 +281,23 @@ class _FakeWorkspace:
             return
         raise NotFoundError(f"{path!r} not found")
 
-    async def log(self, *, limit=50):
-        from primer.model.workspace import CommitInfo
+    async def log(self, *, limit=50, with_files=False):
+        from primer.model.workspace import CommitFile, CommitInfo
 
         return [
             CommitInfo(
                 sha="a" * 40,
                 subject="init",
-                committed_at=datetime.now(timezone.utc),
+                # Fixed, not datetime.now(): a fake that mints a new timestamp
+                # per call makes any test comparing two responses flaky.
+                committed_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
                 workspace_id=self.workspace_id,
+                # Mirrors the real contract: None unless asked for.
+                files=(
+                    [CommitFile(path="a.txt", additions=3, deletions=1)]
+                    if with_files
+                    else None
+                ),
             )
         ][:limit]
 
@@ -1506,6 +1514,84 @@ class TestLogSubResource:
         body = resp.json()
         assert "commits" in body
         assert len(body["commits"]) >= 1
+
+    @pytest.mark.asyncio
+    async def test_log_omits_files_by_default(self, client, wsr) -> None:
+        """`files` stays null unless asked for, so the default response shape
+        (and its size) is unchanged for every existing caller."""
+        await client.post(
+            "/v1/workspace_providers", json=_provider().model_dump(mode="json")
+        )
+        await client.post(
+            "/v1/workspace_templates", json=_template().model_dump(mode="json")
+        )
+        post = await client.post("/v1/workspaces", json={"template_id": "tpl-1"})
+        wid = post.json()["id"]
+
+        resp = await client.get(f"/v1/workspaces/{wid}/log")
+        assert resp.status_code == 200
+        commits = resp.json()["commits"]
+        assert commits
+        # null, NOT [] - "not requested" must not read as "touched no files".
+        assert all(c["files"] is None for c in commits)
+
+    @pytest.mark.asyncio
+    async def test_log_with_files_serialises_the_file_rows(self, client, wsr) -> None:
+        """`?with_files=1` reaches `ws.log(with_files=...)` and CommitFile
+        serialises with the field names the console reads.
+
+        This covers the ROUTE: the query param, the passthrough, and the JSON
+        shape. Real `--numstat` behaviour (counts, binaries, per-commit
+        attribution) is exercised against a real git repo in
+        tests/workspace/test_state_repo_log_files.py.
+        """
+        await client.post(
+            "/v1/workspace_providers", json=_provider().model_dump(mode="json")
+        )
+        await client.post(
+            "/v1/workspace_templates", json=_template().model_dump(mode="json")
+        )
+        post = await client.post("/v1/workspaces", json={"template_id": "tpl-1"})
+        wid = post.json()["id"]
+
+        resp = await client.get(f"/v1/workspaces/{wid}/log", params={"with_files": 1})
+        assert resp.status_code == 200, resp.text
+        commits = resp.json()["commits"]
+        assert commits
+        files = commits[0]["files"]
+        assert files, "with_files=1 must reach the workspace and return rows"
+        entry = files[0]
+        assert set(entry) == {"path", "additions", "deletions", "binary"}
+        assert isinstance(entry["path"], str) and entry["path"]
+        assert isinstance(entry["additions"], int)
+        assert isinstance(entry["deletions"], int)
+        assert isinstance(entry["binary"], bool)
+
+    @pytest.mark.asyncio
+    async def test_log_with_files_accepts_the_usual_boolean_spellings(self, client, wsr) -> None:
+        # A pasted link says with_files=true; a hand-built one says 1.
+        await client.post(
+            "/v1/workspace_providers", json=_provider().model_dump(mode="json")
+        )
+        await client.post(
+            "/v1/workspace_templates", json=_template().model_dump(mode="json")
+        )
+        post = await client.post("/v1/workspaces", json={"template_id": "tpl-1"})
+        wid = post.json()["id"]
+
+        for spelling in ("1", "true", "True"):
+            resp = await client.get(
+                f"/v1/workspaces/{wid}/log", params={"with_files": spelling}
+            )
+            assert resp.status_code == 200, (spelling, resp.text)
+            assert resp.json()["commits"][0]["files"], spelling
+
+        for spelling in ("0", "false"):
+            resp = await client.get(
+                f"/v1/workspaces/{wid}/log", params={"with_files": spelling}
+            )
+            assert resp.status_code == 200, (spelling, resp.text)
+            assert resp.json()["commits"][0]["files"] is None, spelling
 
     @pytest.mark.asyncio
     async def test_show_commit_returns_diff(self, client, wsr) -> None:

--- a/tests/toolset/test_workspaces.py
+++ b/tests/toolset/test_workspaces.py
@@ -201,7 +201,7 @@ class _LiveWorkspace:
             raise NotFoundError(f"{path!r} not found")
         del self._files[path]
 
-    async def log(self, *, limit=50):
+    async def log(self, *, limit=50, with_files=False):
         from datetime import datetime, timezone
         from primer.model.workspace import CommitInfo
 

--- a/tests/workspace/test_state_repo_log_files.py
+++ b/tests/workspace/test_state_repo_log_files.py
@@ -1,0 +1,238 @@
+"""Per-file line deltas on ``history(with_files=True)``.
+
+The Studio's Changes view needs a file list with ``+n/-m`` per commit. Before
+this, the only way to get one was ``show_commit`` per commit -- three git
+invocations each, so ~150 processes for a 50-commit page. ``--numstat`` rides
+along on the existing ``git log`` instead, at the cost of one format change.
+
+That format change is the risk this file is really guarding: the record
+separator had to move to the FRONT of the format string, because git prints
+numstat AFTER the formatted line and a trailing separator would file each
+commit's numstat under the next commit. These tests pin both the new field and
+the untouched header parsing that shares the format with it.
+"""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from primer.model.workspace import CommitFile
+from primer.workspace.local.state import LocalStateRepo, _parse_numstat
+
+pytestmark = pytest.mark.skipif(
+    shutil.which("git") is None,
+    reason="git CLI not available on PATH (StateRepo needs it)",
+)
+
+
+@pytest.fixture
+async def repo(tmp_path: Path) -> LocalStateRepo:
+    r = LocalStateRepo(tmp_path / ".state", workspace_id="ws-test")
+    await r.initialize()
+    return r
+
+
+# ---------------------------------------------------------------------------
+# The default is unchanged
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_files_is_none_when_not_requested(repo: LocalStateRepo) -> None:
+    # None means "not requested / cannot tell", and must not become [].
+    await repo.commit_arbitrary(summary="a", files={"a.txt": "x\n"})
+    commits = await repo.history(limit=10)
+    assert commits
+    assert all(c.files is None for c in commits)
+
+
+@pytest.mark.asyncio
+async def test_header_fields_survive_the_format_change(repo: LocalStateRepo) -> None:
+    # The numstat field shares the format string with the header, so a mistake
+    # there corrupts sha/subject/date/trailers for every existing caller.
+    await repo.commit_arbitrary(
+        summary="feat: a subject line",
+        files={"a.txt": "x\n"},
+        trailers={"X-Primer-Session": "sess-1", "X-Primer-Op": "tool_call"},
+    )
+    for with_files in (False, True):
+        commits = await repo.history(limit=10, with_files=with_files)
+        head = commits[0]
+        assert len(head.sha) == 40, with_files
+        assert head.subject == "feat: a subject line", with_files
+        assert head.committed_at is not None, with_files
+        assert head.session_id == "sess-1", with_files
+        assert head.op == "tool_call", with_files
+
+
+@pytest.mark.asyncio
+async def test_multiple_trailers_still_all_parse(repo: LocalStateRepo) -> None:
+    # The trailer block is multi-line and sits immediately before the numstat
+    # field; an off-by-one separator would swallow the second trailer.
+    await repo.commit_arbitrary(
+        summary="s",
+        files={"a.txt": "x\n"},
+        trailers={
+            "X-Primer-Session": "sess-9",
+            "X-Primer-Agent": "agent-9",
+            "X-Primer-Tool": "write",
+        },
+    )
+    head = (await repo.history(limit=1, with_files=True))[0]
+    assert head.session_id == "sess-9"
+    assert head.agent_id == "agent-9"
+    assert head.tool == "write"
+
+
+# ---------------------------------------------------------------------------
+# With files
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_additions_are_counted_on_a_new_file(repo: LocalStateRepo) -> None:
+    await repo.commit_arbitrary(summary="add", files={"a.txt": "1\n2\n3\n"})
+    head = (await repo.history(limit=1, with_files=True))[0]
+    assert head.files is not None
+    entry = next(f for f in head.files if f.path == "a.txt")
+    assert entry.additions == 3
+    assert entry.deletions == 0
+    assert entry.binary is False
+
+
+@pytest.mark.asyncio
+async def test_a_modification_counts_both_directions(repo: LocalStateRepo) -> None:
+    await repo.commit_arbitrary(summary="first", files={"a.txt": "1\n2\n3\n"})
+    await repo.commit_arbitrary(summary="second", files={"a.txt": "1\nX\n3\n4\n"})
+    head = (await repo.history(limit=1, with_files=True))[0]
+    entry = next(f for f in head.files if f.path == "a.txt")
+    assert entry.additions == 2
+    assert entry.deletions == 1
+
+
+@pytest.mark.asyncio
+async def test_a_deletion_is_reported(repo: LocalStateRepo) -> None:
+    await repo.commit_arbitrary(summary="first", files={"a.txt": "1\n2\n"})
+    await repo.commit_arbitrary(summary="drop", delete_files=["a.txt"])
+    head = (await repo.history(limit=1, with_files=True))[0]
+    entry = next(f for f in head.files if f.path == "a.txt")
+    assert entry.additions == 0
+    assert entry.deletions == 2
+
+
+@pytest.mark.asyncio
+async def test_every_file_in_a_multi_file_commit_appears(repo: LocalStateRepo) -> None:
+    await repo.commit_arbitrary(
+        summary="three",
+        files={"a.txt": "1\n", "b.txt": "1\n2\n", "sub/c.txt": "1\n2\n3\n"},
+    )
+    head = (await repo.history(limit=1, with_files=True))[0]
+    got = {f.path: f.additions for f in head.files}
+    assert got == {"a.txt": 1, "b.txt": 2, "sub/c.txt": 3}
+
+
+@pytest.mark.asyncio
+async def test_a_binary_file_is_flagged_not_zero_counted(repo: LocalStateRepo) -> None:
+    # git reports '-' for both counts. Reporting a bare 0/0 would read as
+    # "changed nothing" rather than "lines are not the unit here".
+    await repo.commit_arbitrary(summary="bin", files={"blob.bin": b"\x00\x01\x02binary"})
+    head = (await repo.history(limit=1, with_files=True))[0]
+    entry = next(f for f in head.files if f.path == "blob.bin")
+    assert entry.binary is True
+    assert entry.additions == 0
+    assert entry.deletions == 0
+
+
+@pytest.mark.asyncio
+async def test_each_commit_keeps_its_own_files(repo: LocalStateRepo) -> None:
+    # THE regression this format change exists to avoid: with a trailing
+    # separator, commit N's numstat lands on commit N+1.
+    await repo.commit_arbitrary(summary="first", files={"only-in-first.txt": "1\n"})
+    await repo.commit_arbitrary(summary="second", files={"only-in-second.txt": "1\n2\n"})
+    commits = await repo.history(limit=10, with_files=True)
+    by_subject = {c.subject: c for c in commits}
+    first_paths = {f.path for f in by_subject["first"].files}
+    second_paths = {f.path for f in by_subject["second"].files}
+    assert "only-in-first.txt" in first_paths
+    assert "only-in-first.txt" not in second_paths
+    assert "only-in-second.txt" in second_paths
+    assert "only-in-second.txt" not in first_paths
+
+
+@pytest.mark.asyncio
+async def test_with_files_still_honours_the_session_filter(repo: LocalStateRepo) -> None:
+    await repo.commit_arbitrary(
+        summary="mine", files={"a.txt": "1\n"},
+        trailers={"X-Primer-Session": "sess-keep"},
+    )
+    await repo.commit_arbitrary(
+        summary="theirs", files={"b.txt": "1\n"},
+        trailers={"X-Primer-Session": "sess-drop"},
+    )
+    commits = await repo.history(session_id="sess-keep", limit=10, with_files=True)
+    assert [c.subject for c in commits] == ["mine"]
+    assert {f.path for f in commits[0].files} == {"a.txt"}
+
+
+@pytest.mark.asyncio
+async def test_with_files_still_honours_the_limit(repo: LocalStateRepo) -> None:
+    for i in range(5):
+        await repo.commit_arbitrary(summary=f"c{i}", files={f"f{i}.txt": "1\n"})
+    commits = await repo.history(limit=2, with_files=True)
+    assert len(commits) == 2
+
+
+@pytest.mark.asyncio
+async def test_a_rename_is_reported_as_paths_that_exist(repo: LocalStateRepo) -> None:
+    # --no-renames is deliberate: rename detection writes "old => new", which
+    # is not a path any other endpoint accepts. Both sides must be real paths.
+    await repo.commit_arbitrary(summary="first", files={"old.txt": "1\n2\n3\n"})
+    await repo.commit_arbitrary(
+        summary="move", files={"new.txt": "1\n2\n3\n"}, delete_files=["old.txt"]
+    )
+    head = (await repo.history(limit=1, with_files=True))[0]
+    paths = {f.path for f in head.files}
+    assert paths == {"old.txt", "new.txt"}
+    assert not any("=>" in p for p in paths)
+
+
+# ---------------------------------------------------------------------------
+# The numstat parser in isolation
+# ---------------------------------------------------------------------------
+
+
+def test_numstat_parser_handles_a_path_containing_a_tab() -> None:
+    # The split is bounded to 2, so a tab inside the path stays in the path.
+    out = _parse_numstat("1\t2\tdir/we\taird.txt\n")
+    assert out == [CommitFile(path="dir/we\taird.txt", additions=1, deletions=2)]
+
+
+def test_numstat_parser_skips_blank_and_malformed_lines() -> None:
+    # One odd line must never take out a whole page of history.
+    out = _parse_numstat("\n\n5\t1\tgood.txt\nnot-a-numstat-line\n\t\t\n")
+    assert [f.path for f in out] == ["good.txt"]
+
+
+def test_numstat_parser_skips_non_integer_counts() -> None:
+    out = _parse_numstat("x\ty\tbad.txt\n3\t0\tgood.txt\n")
+    assert [f.path for f in out] == ["good.txt"]
+
+
+def test_numstat_parser_on_an_empty_block_is_empty() -> None:
+    assert _parse_numstat("") == []
+    assert _parse_numstat("\n\n") == []
+
+
+def test_commit_file_rejects_unknown_fields() -> None:
+    # extra="forbid", so a backend that starts sending a differently-named
+    # field fails loudly instead of dropping it.
+    with pytest.raises(Exception):
+        CommitFile(path="a", additions=1, deletions=0, adds=5)  # type: ignore[call-arg]
+
+
+def test_commit_file_rejects_negative_counts() -> None:
+    with pytest.raises(Exception):
+        CommitFile(path="a", additions=-1, deletions=0)


### PR DESCRIPTION
**HELD** - do not merge. Opened for review and CI only.

Unblocks the Studio Changes view (the one piece left out of #169).

## What it adds

`GET /v1/workspaces/{wid}/log?with_files=1` populates a new
`CommitInfo.files` with `{path, additions, deletions, binary}` per commit.

That is what a per-file changes list needs: a row per file with `+n/-m`.
Patches still come from the existing `GET .../commit/{sha}`, fetched only
when a reader opens a row - so listing 500 commits never means listing 500
diffs.

## Cost

None on the local backend. `--numstat` rides along on the `git log` that
`history()` already runs. The alternative - one `show_commit` per commit -
is 3 git invocations per row, so roughly 150 processes for a 50-commit page.

## The actual risk, and what guards it

The git format string had to change. git prints `--numstat` **after** the
formatted line, so with a trailing record separator each commit's numstat
lands under the **next** commit - a silent, plausible-looking
misattribution. The separator now leads the format and a field separator
trails it, which keeps every record self-contained and gives the numstat
block its own field instead of concatenating it onto the trailer text.

The header fields share that format string, so the tests assert:

- `sha` / `subject` / `committed_at` / every trailer parse identically with
  and without the flag,
- multi-trailer commits still yield all their trailers (the trailer block
  sits immediately before the new field),
- each commit keeps its own file list - the misattribution case directly.

## Two nulls that are not zeros

- `files` is `None`, never `[]`, when not requested or unsupported. The
  sandbox backend cannot supply file data, for the same reason it already
  501s on `show_commit`. Returning `[]` would have the console draw
  "0 files changed" over every commit in a container workspace.
- `binary` is a flag rather than 0/0. git reports `-` where lines are not a
  meaningful unit, and a bare 0/0 reads as "changed nothing".

## One deliberate limitation

`--no-renames`. With rename detection on, numstat writes paths as
`old => new` (or `dir/{old => new}/f`), which is not a path any other
endpoint accepts. A rename surfaces as one deletion plus one addition -
unambiguous, and the right shape for a per-file list.

## Correction to what #169 claimed

#169's description said there was "no diff route". That was wrong:
`GET /v1/workspaces/{wid}/commit/{sha}` already returns per-file unified
diffs on the local backend, and `StateRepo.show_commit` has been in the
Protocol all along. The real gap was narrower than I described - only the
per-commit file summary was missing, which is what this adds. I have
corrected the note in #169.

## Tests

132 pass across `tests/workspace/test_state_repo_log_files.py` (18 new,
against a real git repo), `tests/api/test_workspaces.py`, the state-repo
conformance suite, and the toolset workspace tests. Also fixes the api test
fake's `log()`, which minted `datetime.now()` per call and made any test
comparing two responses flaky.
