### PR TITLE
feat(ui): make the revamped Studio the default shell [HELD]

### DIFF
--- a/tests/ui/test_studio_attention.py
+++ b/tests/ui/test_studio_attention.py
@@ -314,3 +314,40 @@ def test_every_studio_file_transpiles() -> None:
         rel = f"components/studio/{f.name}"
         code = b._transform(f.read_text(encoding="utf-8"), rel)
         assert code, rel
+
+
+def test_every_st2_api_call_names_a_function_that_exists() -> None:
+    """Guard the class of bug that froze the attention bar in CI.
+
+    ``ST2_RunsRail`` called ``ST2_api.pending(...)``. That name exists on
+    ``ST2_api.keys``, not on ``ST2_api`` itself - the fetcher is
+    ``pendingYields``. Nothing failed loudly: ``useResource`` is latest-wins on
+    the fetcher, so the rail replaced the attention bar's working fetcher with
+    one that threw, every poll after the first failed, and stale-on-error kept
+    rendering the last good snapshot. The bar stopped updating and said nothing.
+
+    A typo in a fetcher name is invisible to a static test and to a MiniRacer
+    test that never executes the fetcher, so it is checked here directly.
+    """
+    import re
+
+    api_src = API.read_text(encoding="utf-8")
+    # Top-level ST2_api members (two-space indent inside the object literal).
+    defined = set(re.findall(r"^  (\w+): function", api_src, re.M))
+    # Nested key builders live under `keys:` and are NOT callable as ST2_api.X.
+    keys_block = api_src[api_src.index("keys: {"):]
+    key_names = set(re.findall(r"^    (\w+): function", keys_block, re.M))
+
+    assert "pendingYields" in defined, "sanity: the fetcher surface was not parsed"
+    assert "pending" in key_names, "sanity: the key builders were not parsed"
+
+    bad: list[str] = []
+    for f in sorted(STUDIO.glob("st-*.jsx")):
+        if f.name == "st-api.jsx":
+            continue
+        for called in re.findall(r"ST2_api\.(\w+)\(", f.read_text(encoding="utf-8")):
+            if called == "keys":
+                continue
+            if called not in defined:
+                bad.append(f"{f.name}: ST2_api.{called}()")
+    assert not bad, "calls to ST2_api members that do not exist: " + ", ".join(bad)

--- a/tests/ui/test_studio_attention.py
+++ b/tests/ui/test_studio_attention.py
@@ -264,11 +264,29 @@ def test_studio_mounts_the_bar_behind_the_v2_tweak() -> None:
     assert "studioV2:" in tweaks
 
 
-def test_v2_is_strictly_opt_in_while_incomplete() -> None:
-    # === true, not !== false: the graph builder shipped inert behind a
-    # permissive guard, so this one must refuse to appear until finished.
+def test_v2_is_read_with_a_strict_comparison() -> None:
+    # === true, not !== false. The revamp is now the default, but the strict
+    # read still matters: a malformed persisted tweaks blob (a string, a null,
+    # anything truthy-but-not-true) must fall back to the shipped shell rather
+    # than half-rendering a surface nobody chose.
     studio = (UI / "components" / "studio.jsx").read_text(encoding="utf-8")
     assert "studioV2 === true" in studio
+
+
+def test_the_revamp_is_the_default_shell() -> None:
+    # The rollout gate. Flipping this back to false is a deliberate act (the
+    # old shell is still in the build for exactly that), not something that
+    # should happen by accident during a merge.
+    tweaks = (UI / "foundation" / "tweaks.js").read_text(encoding="utf-8")
+    assert "studioV2: true" in tweaks
+
+
+def test_both_shells_are_still_in_the_build() -> None:
+    # Turning the revamp back off has to stay a flag flip rather than a revert
+    # until the old shell is deleted the release after.
+    studio = (UI / "components" / "studio.jsx").read_text(encoding="utf-8")
+    assert "<StudioSidebar wid={wid} studio={studio} />" in studio
+    assert "<StudioActivity wid={wid} studio={studio} />" in studio
 
 
 def test_new_files_are_registered_in_index_html_before_studio() -> None:

--- a/tests/ui/test_studio_attention.py
+++ b/tests/ui/test_studio_attention.py
@@ -214,7 +214,10 @@ def test_attention_bar_keeps_the_shipped_testids() -> None:
     for tid in (
         "action-required", "action-item", "approve", "reject", "respond",
         "cancel-yield", "action-required-count", "attention-count",
-        "attention-queue", "attention-queue-item", "unblock-focus",
+        # Queue rows carry `action-item`, not a queue-specific id: they ARE
+        # the pending-item list v1 rendered in the rail, and the shipped
+        # journeys reach the non-head items through it.
+        "attention-queue", "action-item", "unblock-focus",
         "inform-item", "inform-dismiss",
     ):
         assert f'"{tid}"' in src, tid

--- a/tests/ui/test_studio_attention.py
+++ b/tests/ui/test_studio_attention.py
@@ -351,3 +351,27 @@ def test_every_st2_api_call_names_a_function_that_exists() -> None:
             if called not in defined:
                 bad.append(f"{f.name}: ST2_api.{called}()")
     assert not bad, "calls to ST2_api members that do not exist: " + ", ".join(bad)
+
+
+def test_yield_controls_are_keyed_by_tool_call_id() -> None:
+    """The reply draft lives in ST2_YieldControls' local state.
+
+    Without a key, React reuses the instance when the pending snapshot swaps
+    one yield for another, and the half-typed reply to the OLD question is
+    sitting in the box attached to the new one - one keystroke from being sent
+    as an answer it was not written for. Changing identity resets the state.
+
+    Static, because the failure needs a real render plus a snapshot swap to
+    reproduce; e2e (u0058) covers the behaviour, this covers the regression.
+    """
+    import re
+
+    mounts: list[str] = []
+    for f in sorted(STUDIO.glob("st-*.jsx")):
+        mounts += re.findall(r"<ST2_YieldControls\b[^>]*>", f.read_text(encoding="utf-8"))
+    assert mounts, "sanity: no ST2_YieldControls mounts found"
+    unkeyed = [m for m in mounts if "key={" not in m]
+    assert not unkeyed, "ST2_YieldControls mounted without a key: " + "; ".join(unkeyed)
+    assert all("tool_call_id" in m for m in mounts), (
+        "the key must be the tool_call_id - the yield's identity, not its position"
+    )

--- a/tests/ui/test_studio_graph_run_panel.py
+++ b/tests/ui/test_studio_graph_run_panel.py
@@ -317,7 +317,7 @@ def test_suggestion_chips_are_offered_for_questions_only() -> None:
 
 def test_mobile_reuses_the_shared_yield_controls_and_actions() -> None:
     src = MOBILE.read_text(encoding="utf-8")
-    assert "<ST2_YieldControls item={item} actions={actions} />" in src
+    assert "<ST2_YieldControls key={item.tool_call_id} item={item} actions={actions} />" in src
     assert "ST2_useYieldActions(wid)" in src
     # Not a second implementation of the write path.
     assert "useMutation" not in src

--- a/tests/ui_e2e/_studio_helpers.py
+++ b/tests/ui_e2e/_studio_helpers.py
@@ -102,31 +102,6 @@ _V2_KIND_COPY = {
 }
 
 
-def show_all_action_items(page: Page, *, timeout: int = 10_000) -> None:
-    """Make every pending action item reachable, on either shell.
-
-    v1 listed all of them in the right rail at once. The revamp shows the
-    oldest in the always-visible bar and puts the rest behind an inbox - one
-    thing needing you is the common case, and a rail-length list of them is
-    not something to render permanently. Any journey that asserts across more
-    than one pending item has to open the inbox first; with one item, the bar
-    alone is enough and this is still safe to call.
-    """
-    if not is_studio_v2(page):
-        return
-    # Wait for the bar to actually have something in it first. The pending
-    # snapshot arrives after mount, so the bar is briefly in its calm state -
-    # and the calm bar has no inbox, so checking too early finds nothing, skips
-    # silently, and leaves every item past the first unreachable.
-    page.locator("[data-testid='action-item']").first.wait_for(
-        state="attached", timeout=timeout,
-    )
-    inbox = page.locator("[data-testid='attention-inbox']")
-    if inbox.count() and inbox.get_attribute("aria-expanded") != "true":
-        inbox.click()
-        expect(page.locator("[data-testid='attention-queue']")).to_be_visible(timeout=timeout)
-
-
 def kind_text(page: Page, kind: str) -> str:
     """The text an action item renders for a park ``kind`` on this shell."""
     return _V2_KIND_COPY.get(kind, kind) if is_studio_v2(page) else kind

--- a/tests/ui_e2e/_studio_helpers.py
+++ b/tests/ui_e2e/_studio_helpers.py
@@ -114,6 +114,13 @@ def show_all_action_items(page: Page, *, timeout: int = 10_000) -> None:
     """
     if not is_studio_v2(page):
         return
+    # Wait for the bar to actually have something in it first. The pending
+    # snapshot arrives after mount, so the bar is briefly in its calm state -
+    # and the calm bar has no inbox, so checking too early finds nothing, skips
+    # silently, and leaves every item past the first unreachable.
+    page.locator("[data-testid='action-item']").first.wait_for(
+        state="attached", timeout=timeout,
+    )
     inbox = page.locator("[data-testid='attention-inbox']")
     if inbox.count() and inbox.get_attribute("aria-expanded") != "true":
         inbox.click()

--- a/tests/ui_e2e/_studio_helpers.py
+++ b/tests/ui_e2e/_studio_helpers.py
@@ -79,9 +79,50 @@ def is_studio_v2(page: Page) -> bool:
     keep working for whichever shell is actually rendered - the flag is a
     runtime tweak, so one build serves both and a test may pin either.
     ``studio-rail`` exists only in the revamp; ``studio-sidebar-inner`` only in
-    the v1 sidebar.
+    the v1 sidebar. Waits for whichever appears first, because counting before
+    the shell has mounted answers "not v2" for both shells - which would send a
+    v2 caller looking for v1 testids that will never arrive.
     """
+    either = page.locator(
+        '[data-testid="studio-rail"], [data-testid="studio-sidebar-inner"]'
+    )
+    either.first.wait_for(state="attached", timeout=20_000)
     return page.locator('[data-testid="studio-rail"]').count() > 0
+
+
+# The revamp replaced raw park kinds with copy an operator can read: an item
+# says "asked a question", not "ask_user". Journeys assert the item identifies
+# its kind, not which vocabulary happens to be shipped, so they ask here.
+_V2_KIND_COPY = {
+    "ask_user": "asked a question",
+    "approval": "wants approval",
+    "ask_approval": "wants approval",
+    "watch_files": "waiting on a file",
+    "sleep": "sleeping",
+}
+
+
+def show_all_action_items(page: Page, *, timeout: int = 10_000) -> None:
+    """Make every pending action item reachable, on either shell.
+
+    v1 listed all of them in the right rail at once. The revamp shows the
+    oldest in the always-visible bar and puts the rest behind an inbox - one
+    thing needing you is the common case, and a rail-length list of them is
+    not something to render permanently. Any journey that asserts across more
+    than one pending item has to open the inbox first; with one item, the bar
+    alone is enough and this is still safe to call.
+    """
+    if not is_studio_v2(page):
+        return
+    inbox = page.locator("[data-testid='attention-inbox']")
+    if inbox.count() and inbox.get_attribute("aria-expanded") != "true":
+        inbox.click()
+        expect(page.locator("[data-testid='attention-queue']")).to_be_visible(timeout=timeout)
+
+
+def kind_text(page: Page, kind: str) -> str:
+    """The text an action item renders for a park ``kind`` on this shell."""
+    return _V2_KIND_COPY.get(kind, kind) if is_studio_v2(page) else kind
 
 
 def sessions_list(page: Page):

--- a/tests/ui_e2e/_studio_helpers.py
+++ b/tests/ui_e2e/_studio_helpers.py
@@ -72,16 +72,65 @@ def studio_url(console_url: str, wid: str) -> str:
     return f"{console_url}#/workspaces/{wid}"
 
 
+def is_studio_v2(page: Page) -> bool:
+    """True when the page is showing the revamped Studio shell.
+
+    Detected from the DOM rather than from the tweak default, so these helpers
+    keep working for whichever shell is actually rendered - the flag is a
+    runtime tweak, so one build serves both and a test may pin either.
+    ``studio-rail`` exists only in the revamp; ``studio-sidebar-inner`` only in
+    the v1 sidebar.
+    """
+    return page.locator('[data-testid="studio-rail"]').count() > 0
+
+
+def sessions_list(page: Page):
+    """The list of session rows, whichever shell is rendered.
+
+    v1 stacked a ``sessions-section`` above a ``files-section``; the revamp
+    replaces both with one rail in two modes, so the runs list is ``rail-runs``.
+    """
+    return page.locator(
+        '[data-testid="rail-runs"]' if is_studio_v2(page) else '[data-testid="sessions-section"]'
+    )
+
+
+def files_list(page: Page, *, timeout: int = 10_000):
+    """The file tree, switching the rail into Files mode first when needed.
+
+    On v1 the tree is always mounted below the sessions section. In the revamp
+    Files is one of two rail modes and Runs is the default, so a caller that
+    wants the tree has to ask for it - which is the trade the single rail makes
+    for giving whichever list you are using the full column height.
+    """
+    if not is_studio_v2(page):
+        return page.locator('[data-testid="files-section"]')
+    rail_files = page.locator('[data-testid="rail-files"]')
+    if rail_files.count() == 0:
+        page.locator('[data-testid="rail-mode-files"]').click()
+    expect(rail_files).to_be_visible(timeout=timeout)
+    return rail_files
+
+
 def open_studio(page: Page, console_url: str, wid: str, *, timeout: int = 20_000) -> None:
     """Navigate to a workspace's Studio and wait for the shell to mount.
 
-    Confirms all three region wrappers render so callers can immediately
-    reach the sidebar / center / activity columns.
+    Confirms the region wrappers render so callers can immediately reach the
+    left rail and the center.
+
+    studioV2 has no right column: Action Required moved into the always-mounted
+    attention bar and the event tap into the investigate dock, so
+    ``studio-activity`` is asserted only on the v1 shell (see
+    ``expand_debug_sidebar``).
     """
     page.goto(studio_url(console_url, wid), wait_until="domcontentloaded")
     expect(page.locator('[data-testid="studio-root"]')).to_be_visible(timeout=timeout)
-    for region in ("studio-sidebar", "studio-center", "studio-activity"):
+    for region in ("studio-sidebar", "studio-center"):
         expect(page.locator(f'[data-testid="{region}"]')).to_be_visible(timeout=10_000)
+    if is_studio_v2(page):
+        expect(page.locator('[data-testid="attention-bar"]')).to_be_visible(timeout=10_000)
+    else:
+        expect(page.locator('[data-testid="studio-activity"]')).to_be_visible(timeout=10_000)
 
 
 def open_session_in_studio(
@@ -188,6 +237,13 @@ def expand_debug_sidebar(page: Page, *, timeout: int = 10_000) -> None:
     must call this first — right after ``open_studio`` /
     ``open_session_in_studio`` / ``open_session_via_sidebar``.
     """
+    if is_studio_v2(page):
+        # Nothing to expand: the attention bar is mounted between the header
+        # and the body at all times, including when empty. That IS the revamp's
+        # premise - "nothing needs you" is a state worth showing - so the v1
+        # open-the-panel-first step becomes a visibility assertion.
+        expect(page.locator("[data-testid='attention-bar']")).to_be_visible(timeout=timeout)
+        return
     toggle = page.locator("[data-testid='studio-debug-toggle']")
     expect(toggle).to_be_visible(timeout=timeout)
     if toggle.get_attribute("aria-pressed") != "true":

--- a/tests/ui_e2e/test_ask_user_panel.py
+++ b/tests/ui_e2e/test_ask_user_panel.py
@@ -32,7 +32,7 @@ import json
 import httpx
 from playwright.sync_api import expect
 
-from tests.ui_e2e._studio_helpers import expand_debug_sidebar, open_studio
+from tests.ui_e2e._studio_helpers import kind_text, expand_debug_sidebar, open_studio
 
 
 # ---------------------------------------------------------------------------
@@ -186,7 +186,7 @@ def test_u0048_ask_user_panel_renders_when_pending_returns_200(
         item = page.locator("[data-testid='action-item']").first
         expect(item).to_be_visible(timeout=10_000)
         expect(item).to_contain_text("What is your name?")
-        expect(item).to_contain_text("ask_user")
+        expect(item).to_contain_text(kind_text(page, "ask_user"))
         # The ask_user variant renders a respond text input (Enter to send).
         expect(item.locator("[data-testid='action-ask-controls']")).to_be_visible()
         expect(item.locator("[data-testid='respond']")).to_be_visible()

--- a/tests/ui_e2e/test_panel_polling_and_signals.py
+++ b/tests/ui_e2e/test_panel_polling_and_signals.py
@@ -22,6 +22,7 @@ from tests.ui_e2e._studio_helpers import (
     expand_debug_sidebar,
     open_session_in_studio,
     open_studio,
+    show_all_action_items,
 )
 
 
@@ -217,6 +218,10 @@ def test_u0058_draft_clears_when_new_tool_call_id_arrives(
         # The right-sidebar debug panel (Action Required) starts collapsed;
         # expand it before looking for action-item content.
         expand_debug_sidebar(page)
+        # Two pending items at once: v1 listed both in the rail, the revamp
+        # shows the oldest in the bar and the rest behind the inbox. No-op on v1.
+        show_all_action_items(page)
+
         item = page.locator("[data-testid='action-item']").first
         expect(item).to_be_visible(timeout=10_000)
         expect(item).to_contain_text("What is your name?")

--- a/tests/ui_e2e/test_panel_polling_and_signals.py
+++ b/tests/ui_e2e/test_panel_polling_and_signals.py
@@ -22,7 +22,6 @@ from tests.ui_e2e._studio_helpers import (
     expand_debug_sidebar,
     open_session_in_studio,
     open_studio,
-    show_all_action_items,
 )
 
 
@@ -218,10 +217,6 @@ def test_u0058_draft_clears_when_new_tool_call_id_arrives(
         # The right-sidebar debug panel (Action Required) starts collapsed;
         # expand it before looking for action-item content.
         expand_debug_sidebar(page)
-        # Two pending items at once: v1 listed both in the rail, the revamp
-        # shows the oldest in the bar and the rest behind the inbox. No-op on v1.
-        show_all_action_items(page)
-
         item = page.locator("[data-testid='action-item']").first
         expect(item).to_be_visible(timeout=10_000)
         expect(item).to_contain_text("What is your name?")
@@ -235,7 +230,14 @@ def test_u0058_draft_clears_when_new_tool_call_id_arrives(
         # the next reconcile poll (15s) or a manual wait surfaces item B.
         state["items"] = [_ask_item(sid, tool_call_id="tc-B", prompt="Pick a color?")]
         item_b = page.locator("[data-testid='action-item']").filter(has_text="Pick a color?").first
-        expect(item_b).to_be_visible(timeout=20_000)
+        # Two full poll periods. The pending snapshot polls every 15s on both
+        # shells, woken early by a workspace tap - but the tap never fires here
+        # because /yields/pending is route-mocked, so the backstop poll is the
+        # only thing that can surface the swap. v1 mounted ActionRequired when
+        # this test expanded the rail, starting its timer at that moment; the
+        # revamp's bar mounts with the page, so the tick lands on a different
+        # phase and one period is no longer reliably enough.
+        expect(item_b).to_be_visible(timeout=35_000)
         # Item B's respond input is empty — the draft was scoped to item A.
         inp_b = item_b.locator("[data-testid='respond']")
         assert (inp_b.input_value() or "") == "", (

--- a/tests/ui_e2e/test_polling_cadences.py
+++ b/tests/ui_e2e/test_polling_cadences.py
@@ -28,7 +28,7 @@ import time
 import httpx
 import pytest
 
-from tests.ui_e2e._studio_helpers import open_studio, session_row
+from tests.ui_e2e._studio_helpers import open_studio, session_row, sessions_list
 
 
 def test_u0002_sessions_sidebar_count_polls_after_api_create(
@@ -109,7 +109,7 @@ def test_u0002_sessions_sidebar_count_polls_after_api_create(
         # Baseline: a brand-new workspace has zero session rows. Wait for
         # the Sessions section to have finished its first poll (the empty
         # "No sessions yet." copy is present).
-        page.locator('[data-testid="sessions-section"]').wait_for(
+        sessions_list(page).wait_for(
             state="visible", timeout=15_000,
         )
         baseline = _row_count()

--- a/tests/ui_e2e/test_session_files_toast_lasterr.py
+++ b/tests/ui_e2e/test_session_files_toast_lasterr.py
@@ -37,6 +37,7 @@ from playwright.sync_api import expect
 
 
 from tests._support.smk import smk  # noqa: E402
+from tests.ui_e2e._studio_helpers import files_list
 pytestmark = smk("SMK-UI-06", status="partial")
 
 
@@ -290,6 +291,11 @@ def test_u0080_workspace_files_dir_drilldown_renders_children(
         page.locator(".nav-item").first.wait_for(
             state="visible", timeout=20_000,
         )
+
+        # v1 stacked Files under Sessions so the tree was always on screen; the
+        # revamp's single rail defaults to Runs, so ask for Files first. No-op
+        # on v1.
+        files_list(page)
 
         # Wait for the file tree to render - the dir1 row must show up.
         dir1_row = page.get_by_text("dir1", exact=False).first

--- a/tests/ui_e2e/test_session_lifecycle_journey.py
+++ b/tests/ui_e2e/test_session_lifecycle_journey.py
@@ -31,7 +31,7 @@ import time
 import httpx
 from playwright.sync_api import expect
 
-from tests.ui_e2e._studio_helpers import open_studio, session_row
+from tests.ui_e2e._studio_helpers import open_studio, session_row, sessions_list
 
 
 # ---------------------------------------------------------------------------
@@ -313,11 +313,11 @@ def test_u0104_workspace_sessions_tab_reflects_api_seeded_session(
 
         # --- 2. Sessions section shows the empty state ----------------------
         # SessionsSection renders "No sessions yet." before any is seeded.
-        expect(page.locator('[data-testid="sessions-section"]')).to_be_visible(
+        expect(sessions_list(page)).to_be_visible(
             timeout=15_000,
         )
         expect(
-            page.locator('[data-testid="sessions-section"]').get_by_text(
+            sessions_list(page).get_by_text(
                 "No sessions yet", exact=False,
             )
         ).to_be_visible(timeout=15_000)

--- a/tests/ui_e2e/test_studio.py
+++ b/tests/ui_e2e/test_studio.py
@@ -40,7 +40,7 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
-from tests.ui_e2e._studio_helpers import session_row
+from tests.ui_e2e._studio_helpers import files_list, is_studio_v2, session_row
 
 
 from tests._support.smk import smk  # noqa: E402
@@ -206,10 +206,19 @@ def test_studio_shell_sidebar_center_and_palette(
         expect(page.locator('[data-testid="studio-root"]')).to_be_visible(
             timeout=20_000,
         )
-        for region in ("studio-sidebar", "studio-center", "studio-activity"):
+        for region in ("studio-sidebar", "studio-center"):
             expect(page.locator(f'[data-testid="{region}"]')).to_be_visible(
                 timeout=10_000,
             )
+        # studioV2 has no right column - Action Required moved into the
+        # always-mounted attention bar and the tap into the dock.
+        expect(
+            page.locator(
+                '[data-testid="attention-bar"]'
+                if is_studio_v2(page)
+                else '[data-testid="studio-activity"]'
+            )
+        ).to_be_visible(timeout=10_000)
 
         # --- 2. Left sidebar lists the seeded session ------------------
         # Locate the SEEDED row by its data-session-id (the visible row text
@@ -229,10 +238,12 @@ def test_studio_shell_sidebar_center_and_palette(
         )
 
         # --- 4. Open the file row → file panel in preview --------------
-        # The Files section defaults to open (studio.jsx filesOpen: true,
-        # no persisted state in a fresh browser context), so the seeded
-        # file surfaces directly as a file-row.
+        # v1 stacked Files under Sessions so the tree was always on screen.
+        # The revamp gives one rail two modes with Runs as the default, so the
+        # tree has to be asked for; files_list() switches the rail when needed
+        # and is a no-op on v1.
         if have_file:
+            files_list(page)
             file_row = page.locator(
                 '[data-testid="file-row"]', has_text=file_name,
             ).first

--- a/tests/ui_e2e/test_workspace_destroy_graph_provider.py
+++ b/tests/ui_e2e/test_workspace_destroy_graph_provider.py
@@ -21,7 +21,12 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
-from tests.ui_e2e._studio_helpers import open_studio, open_workspace_settings
+from tests.ui_e2e._studio_helpers import (
+    files_list,
+    open_studio,
+    open_workspace_settings,
+    sessions_list,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -131,8 +136,8 @@ def test_u0077_workspace_detail_tabs_all_reachable(
     try:
         open_studio(page, console_url, wid)
         # Files + Sessions are left-sidebar sections in the Studio.
-        expect(page.locator("[data-testid='sessions-section']")).to_be_visible(timeout=15_000)
-        expect(page.locator("[data-testid='files-section']")).to_be_visible(timeout=15_000)
+        expect(sessions_list(page)).to_be_visible(timeout=15_000)
+        expect(files_list(page)).to_be_visible(timeout=15_000)
 
         # Log / Config / Destroy (+ Channels) live in the Settings modal.
         gear = page.locator("[data-testid='studio-settings-btn']")

--- a/tests/ui_e2e/test_workspace_file_download_journey.py
+++ b/tests/ui_e2e/test_workspace_file_download_journey.py
@@ -39,7 +39,7 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
-from tests.ui_e2e._studio_helpers import open_studio
+from tests.ui_e2e._studio_helpers import files_list, open_studio
 
 
 from tests._support.smk import smk  # noqa: E402
@@ -171,8 +171,10 @@ def test_u0106_workspace_file_inspect_and_download_journey(
         page.wait_for_url(f"**/console/#/workspaces/{wid}**", timeout=15_000)
         open_studio(page, console_url, wid)
 
-        # The Files section defaults open; the seeded file surfaces as a
-        # sidebar file-row within its lazy tree fetch.
+        # v1 kept the tree always on screen; the revamp's rail defaults to
+        # Runs, so ask for Files first (no-op on v1) before the seeded file
+        # surfaces as a file-row within its lazy tree fetch.
+        files_list(page)
         file_row = page.locator(
             '[data-testid="file-row"]', has_text=file_name,
         ).first

--- a/ui/components/studio/st-attention.jsx
+++ b/ui/components/studio/st-attention.jsx
@@ -565,7 +565,13 @@ function AttentionBar({ wid, studio }) {
         </span>
       </span>
       <div className="row" style={{ gap: 6, alignItems: "center", flex: "0 1 auto" }}>
-        <ST2_YieldControls item={head} actions={actions} compact />
+        {/* Keyed by tool_call_id: the draft lives in this component's
+            local state, so without a key React reuses the instance when the
+            pending snapshot swaps one yield for another and the half-typed
+            reply to the OLD question is sitting in the box for the new one,
+            one keystroke from being sent as an answer it was not written
+            for. Changing identity resets the state. */}
+        <ST2_YieldControls key={head.tool_call_id} item={head} actions={actions} compact />
         {actions.errors[head.tool_call_id] ? (
           <span style={{ fontSize: "var(--fs-11)", color: "var(--red)" }}>{actions.errors[head.tool_call_id]}</span>
         ) : null}
@@ -675,7 +681,7 @@ function AttentionQueue({ items, informs, actions, staleFocus, onDismissInform, 
               {it.prompt ? (
                 <div className="muted" style={{ fontSize: "var(--fs-11)", lineHeight: 1.5 }}>{ST2_clip(it.prompt, 160)}</div>
               ) : null}
-              <ST2_YieldControls item={it} actions={actions} />
+              <ST2_YieldControls key={it.tool_call_id} item={it} actions={actions} />
               {actions.errors[it.tool_call_id] ? (
                 <div style={{ fontSize: "var(--fs-11)", color: "var(--red)" }}>{actions.errors[it.tool_call_id]}</div>
               ) : null}
@@ -799,7 +805,7 @@ function UnblockFocus({ wid, item, queue, actions, onAdvance, onClose }) {
         </div>
 
         <div className="row" style={{ padding: 13, borderTop: "1px solid var(--border)", gap: 8, alignItems: "center", background: "var(--bg-2)" }}>
-          <ST2_YieldControls item={item} actions={actions} />
+          <ST2_YieldControls key={item.tool_call_id} item={item} actions={actions} />
           {!actionable ? (
             <span className="muted" style={{ fontSize: "var(--fs-11)" }}>
               This park has no tool_call_id, so it cannot be answered from here.

--- a/ui/components/studio/st-attention.jsx
+++ b/ui/components/studio/st-attention.jsx
@@ -330,7 +330,11 @@ function ST2_YieldControls({ item, actions, compact }) {
 
   if (kind === "approval" || kind === "ask_approval") {
     return (
-      <div className="row" style={{ gap: 6, alignItems: "center" }}>
+      <div
+        className="row"
+        data-testid="action-approval-controls"
+        style={{ gap: 6, alignItems: "center" }}
+      >
         <button
           data-testid="approve" disabled={!actionable}
           title={actionable ? "Approve (Enter)" : "This park has no tool_call_id and cannot be answered"}
@@ -353,7 +357,11 @@ function ST2_YieldControls({ item, actions, compact }) {
       setText("");
     };
     return (
-      <div className="row" style={{ gap: 6, alignItems: "center", flex: "1 1 auto", minWidth: 0 }}>
+      <div
+        className="row"
+        data-testid="action-ask-controls"
+        style={{ gap: 6, alignItems: "center", flex: "1 1 auto", minWidth: 0 }}
+      >
         <input
           data-testid="respond-input"
           value={text}
@@ -637,7 +645,11 @@ function AttentionQueue({ items, informs, actions, staleFocus, onDismissInform, 
               style={{ gap: 7, padding: "11px 13px", borderBottom: "1px solid var(--bg-active)" }}
             >
               <div className="row" style={{ gap: 8, alignItems: "center", minWidth: 0 }}>
-                <span style={{ fontSize: "var(--fs-12)", fontWeight: 600 }}>{it.session_name || it.session_id}</span>
+                <span
+                  data-testid="action-session-link"
+                  style={{ fontSize: "var(--fs-12)", fontWeight: 600, cursor: "pointer" }}
+                  onClick={function () { onFocus(it); }}
+                >{it.session_name || it.session_id}</span>
                 <span style={{ fontSize: "var(--fs-11)", color: "var(--amber)" }}>{ST2_kindCopy(it.kind)}</span>
                 <span
                   className="muted" style={{ marginLeft: "auto", fontSize: "var(--fs-11)", cursor: "pointer" }}

--- a/ui/components/studio/st-attention.jsx
+++ b/ui/components/studio/st-attention.jsx
@@ -363,7 +363,7 @@ function ST2_YieldControls({ item, actions, compact }) {
         style={{ gap: 6, alignItems: "center", flex: "1 1 auto", minWidth: 0 }}
       >
         <input
-          data-testid="respond-input"
+          data-testid="respond"
           value={text}
           disabled={!actionable}
           placeholder="Type a reply…"
@@ -379,7 +379,7 @@ function ST2_YieldControls({ item, actions, compact }) {
             padding: "5px 9px", color: "var(--text)", fontSize: "var(--fs-12)",
           }}
         />
-        <button data-testid="respond" disabled={!actionable} onClick={send} style={btn()}>Send ⏎</button>
+        <button data-testid="ask-user-send" disabled={!actionable} onClick={send} style={btn()}>Send ⏎</button>
       </div>
     );
   }
@@ -528,7 +528,11 @@ function AttentionBar({ wid, studio }) {
         background: "var(--amber-dim)", borderBottom: "1px solid var(--amber)",
       }, barBase)}
     >
-      {/* action-required kept so existing journeys still resolve (§13). */}
+      {/* action-required / action-required-count / action-item keep the names
+          the shipped journeys locate. action-item is the WHOLE item - prompt
+          and controls - exactly as the v1 rail's row was; scoping it to the
+          controls alone silently breaks every "the item shows the prompt"
+          assertion. */}
       <span
         data-testid="action-required-count"
         style={{
@@ -538,6 +542,7 @@ function AttentionBar({ wid, studio }) {
       >
         <span data-testid="attention-count">{count}</span>
       </span>
+      <div data-testid="action-item" className="row" style={{ gap: 8, alignItems: "center", minWidth: 0, flex: "1 1 auto" }}>
       <span data-testid="action-required" className="row" style={{ gap: 8, alignItems: "center", minWidth: 0, flex: "1 1 auto" }}>
         <span data-testid="attention-head-item" className="row" style={{ gap: 8, alignItems: "center", minWidth: 0 }}>
           <span data-testid="action-session-link" style={{ fontSize: "var(--fs-12)", fontWeight: 600, color: "var(--text)", whiteSpace: "nowrap" }}>
@@ -551,7 +556,7 @@ function AttentionBar({ wid, studio }) {
           </span>
         </span>
       </span>
-      <div data-testid="action-item" className="row" style={{ gap: 6, alignItems: "center", flex: "0 1 auto" }}>
+      <div className="row" style={{ gap: 6, alignItems: "center", flex: "0 1 auto" }}>
         <ST2_YieldControls item={head} actions={actions} compact />
         {actions.errors[head.tool_call_id] ? (
           <span style={{ fontSize: "var(--fs-11)", color: "var(--red)" }}>{actions.errors[head.tool_call_id]}</span>
@@ -565,6 +570,8 @@ function AttentionBar({ wid, studio }) {
           }}
         >See context</button>
         <button
+          data-testid="attention-inbox"
+          aria-expanded={queueOpen ? "true" : "false"}
           onClick={function () { setUi({ queue: !queueOpen, focus: null }); }}
           style={{
             padding: "3px 9px", borderRadius: 7, background: "transparent",
@@ -572,6 +579,7 @@ function AttentionBar({ wid, studio }) {
             fontSize: "var(--fs-12)", cursor: "pointer",
           }}
         >Inbox ▾</button>
+      </div>
       </div>
 
       {queueOpen ? (
@@ -640,7 +648,7 @@ function AttentionQueue({ items, informs, actions, staleFocus, onDismissInform, 
           return (
             <div
               key={it.tool_call_id || it.session_id}
-              data-testid="attention-queue-item"
+              data-testid="action-item"
               className="col"
               style={{ gap: 7, padding: "11px 13px", borderBottom: "1px solid var(--bg-active)" }}
             >

--- a/ui/components/studio/st-attention.jsx
+++ b/ui/components/studio/st-attention.jsx
@@ -245,6 +245,14 @@ function ST2_useYieldActions(wid) {
 
   var invalidates = [ST2_api.keys.pending(wid)];
 
+  // useMutation pushes an error toast unless an onError is supplied. Every call
+  // below already attaches `fail()`, which writes the reason onto the item
+  // itself - so without this a failed answer reports TWICE: once inline and
+  // once as a toast that slides away carrying the only copy the operator might
+  // have read. Inline wins: the error belongs next to the thing that failed,
+  // and it persists until the retry succeeds.
+  var opts = { invalidates: invalidates, onError: function () {} };
+
   // Also refetch the per-session pending cache the inline transcript card
   // reads, so answering in one place updates the other.
   var alsoSession = function (sid) {
@@ -271,19 +279,19 @@ function ST2_useYieldActions(wid) {
 
   var approve = useMutation(
     function (v) { return ST2_api.approve(v.sid, v.tcid); },
-    { invalidates: invalidates }
+    opts
   );
   var deny = useMutation(
     function (v) { return ST2_api.deny(v.sid, v.tcid, v.reason); },
-    { invalidates: invalidates }
+    opts
   );
   var answer = useMutation(
     function (v) { return ST2_api.answer(v.sid, v.tcid, v.response); },
-    { invalidates: invalidates }
+    opts
   );
   var cancel = useMutation(
     function (v) { return ST2_api.cancelYield(v.sid, v.tcid, v.reason); },
-    { invalidates: invalidates }
+    opts
   );
 
   var run = function (m, label) {

--- a/ui/components/studio/st-dock.jsx
+++ b/ui/components/studio/st-dock.jsx
@@ -144,9 +144,6 @@ function InvestigateDock({ wid, studio, sessionId }) {
   return (
     <div
       data-testid="investigate-dock"
-      // studio-activity kept as an alias for one release so journeys that
-      // locate the old right rail still resolve (WIRING §13).
-      data-legacy-testid="studio-activity"
       className="col"
       style={{
         height: s.dockHeight || 268, flex: "0 0 auto", minHeight: 0,

--- a/ui/components/studio/st-mobile.jsx
+++ b/ui/components/studio/st-mobile.jsx
@@ -130,7 +130,7 @@ function ST2_MobileNeeds({ items, actions }) {
                 })}
               </div>
             ) : null}
-            <ST2_YieldControls item={item} actions={actions} />
+            <ST2_YieldControls key={item.tool_call_id} item={item} actions={actions} />
           </div>
         );
       })}

--- a/ui/components/studio/st-rail.jsx
+++ b/ui/components/studio/st-rail.jsx
@@ -53,9 +53,6 @@ function StudioRail({ wid, studio }) {
   return (
     <div
       data-testid="studio-rail"
-      // studio-sidebar-inner kept as an alias so the shipped journeys that
-      // locate the v1 sidebar still resolve while both shells exist.
-      data-legacy-testid="studio-sidebar-inner"
       className="col"
       style={{ height: "100%", minHeight: 0, gap: 0, overflow: "hidden" }}
     >

--- a/ui/components/studio/st-runs-rail.jsx
+++ b/ui/components/studio/st-runs-rail.jsx
@@ -177,7 +177,13 @@ function ST2_RunsRail({ wid, studio }) {
   // yield into "needs". Shares the attention bar's key, so no extra request.
   var pendingRes = api.useResource(
     ST2_api.keys.pending(wid),
-    function (signal) { return ST2_api.pending(wid, signal); },
+    // pendingYields, not pending: `pending` is only the KEY builder. Naming a
+    // function that does not exist here did not fail loudly - useResource is
+    // latest-wins on the fetcher, so the rail replaced the attention bar's
+    // working fetcher with one that throws, every poll after the first failed,
+    // and stale-on-error kept rendering the last good snapshot. The bar simply
+    // stopped updating.
+    function (signal) { return ST2_api.pendingYields(wid, signal); },
     { pollMs: 15000, deps: [wid] }
   );
   var pendingBySession = React.useMemo(function () {

--- a/ui/foundation/tweaks.js
+++ b/ui/foundation/tweaks.js
@@ -30,10 +30,11 @@
     // replaces. Flip on to use the new builder; the switch lives in
     // GraphDetail so turning it back off is a flag flip, not a revert.
     graphBuilderV2: true,
-    // Studio revamp (ui/studio/STUDIO-WIRING.md). Off until the shell is
-    // complete; both shells coexist in one build so QA can A/B. Read with
-    // `=== true` so an incomplete revamp cannot appear by accident.
-    studioV2: false,
+    // Studio revamp (ui/studio/STUDIO-WIRING.md). ON: the shell is complete
+    // (attention bar, rail, dock, panes, Changes, graph strip, mobile). Both
+    // shells still coexist in one build, so turning it back off is a flag flip
+    // rather than a revert; the old shell goes the release after.
+    studioV2: true,
   };
 
   // Subset of keys whose user choice we persist across reloads via


### PR DESCRIPTION
**HELD** - do not merge until CI + E2E are green.

Flips `studioV2` on, so the revamped Studio is what you get without touching
anything. Both shells stay in the build - turning it back off is a flag flip,
not a revert - and the old one goes the release after.

## Why you weren't seeing it

Not an oversight: `studioV2` shipped `false` on purpose in #169, and there was
never a UI to turn it on - only `window.primerApi.setTweak("studioV2", true)`
from the console. Shipping a flag whose only switch is a console command, then
saying "it's behind a flag", is not much better than not shipping it. Hence
this PR.

## A defect in #169 I need to flag

Two elements carried `data-legacy-testid`, with comments claiming the shipped
journeys would "still resolve" through them. **They would not.** Playwright
resolves `data-testid`, no custom `testIdAttribute` is configured, so those
attributes were decorative and the comments were wrong. I removed them and
migrated the journeys properly rather than leaving a compatibility story that
does not compile.

That mattered here specifically because it is the same failure mode as the
graph builder: a surface that looks wired and is not.

## What actually breaks under v2, and where it goes

Eight testids the v1 shell owned do not exist in the revamp. Two were genuine
omissions on my side and are now rendered by the equivalent v2 element:

| missing | fix |
| --- | --- |
| `action-approval-controls` | added to `ST2_YieldControls` - the same approval control group |
| `action-ask-controls` | added to `ST2_YieldControls` - the same ask control group |
| `action-session-link` (in queue rows) | added, so a row can be scoped to one session |

The rest are structural, so the journeys move to the new surface:

| v1 | v2 |
| --- | --- |
| `studio-activity` | `attention-bar` - there is no right column |
| `studio-debug-toggle` | nothing to expand; the bar is always mounted |
| `debug-sidebar-body` | same |
| `sessions-section` | `rail-runs` |
| `files-section` | `rail-files`, after switching the rail's mode |

## Journey migration

`_studio_helpers` gains `is_studio_v2` / `sessions_list` / `files_list`, which
detect the rendered shell **from the DOM** rather than assuming the tweak
default - so the same journeys pass against either shell while both exist, and
nothing has to be re-migrated when the old one is deleted.

`files_list()` switches the rail into Files mode when needed and is a no-op on
v1. That is the one real behavioural difference a journey has to account for:
one rail with two modes means the file tree is no longer permanently on screen.
It is the trade that gives whichever list you are using the full column height.

`expand_debug_sidebar()` becomes a visibility assertion under v2 instead of a
click - "nothing needs you" being always visible is the revamp's premise, so
there is no panel left to open.

## Tests

567 UI unit tests green locally, including three new pins: the default is
`true`, the guard stays a strict `=== true` (a malformed persisted tweaks blob
must fall back to the shipped shell rather than half-render), and both shells
are still in the build.

E2E was not run locally - CI covers it, and it is the real verdict on this PR.
