### PR TITLE
feat(toolset): register python functions as tools, sandboxed [HELD]

### DIFF
--- a/docs/agents/python-tools.md
+++ b/docs/agents/python-tools.md
@@ -1,0 +1,150 @@
+---
+slug: python-tools
+title: Python tools - register a function as a tool
+summary: How to write a python function that becomes a callable tool, including yielding tools, what the docstring must contain, and what the sandbox allows.
+related: [yielding, tool-approval, agents]
+mcp_tools:
+  - system::create_python_toolset
+  - system::update_python_toolset_source
+  - system::list_python_tools
+---
+
+# Python tools - register a function as a tool
+
+## Overview
+
+A python toolset is one module. Every function in it decorated with
+`@primer_tool` becomes a tool you can call like any other. Source lives in the
+toolset record and is edited from the console, the REST API, or
+`primectl toolset create-python`.
+
+## Mental model
+
+### The shape
+
+```python
+@primer_tool()
+def greet(name: str) -> str:
+    """Greet a person by name.
+
+    Use when you need a friendly greeting.
+
+    Args:
+        name: Who to greet.
+    """
+    return "hello " + name
+```
+
+Three things are enforced when you save, not when the tool is called:
+
+1. **A docstring**, with a summary line, a `Use when ...` line, and an `Args:`
+   entry for every argument. The description reaches the model in the same
+   context as every built-in tool, so a vague one degrades every agent that
+   sees it.
+2. **A type annotation on every argument.** `str`, `int`, `float`, `bool`,
+   `list[...]`, `dict`, and unions with `None` map to a schema. Anything else
+   is rejected and names the parameter.
+3. **A JSON-serialisable return value.** Returning an object gets you a tool
+   error naming the type.
+
+An `Examples:` section is optional and is validated against the schema, so an
+example that disagrees with your signature fails the save.
+
+### Arguments and context
+
+Every parameter becomes a tool argument except one: a parameter named `ctx`
+receives the call's context and is excluded from the schema.
+
+```python
+@primer_tool()
+def whoami(ctx) -> str:
+    """Report the session this call belongs to.
+
+    Use when a tool needs to know its own session.
+    """
+    return ctx["session_id"]
+```
+
+`ctx` is **data only**: `tool_call_id`, `session_id`, `workspace_id`,
+`chat_id`, `parked_at`. It is not the live `ToolContext` object, because the
+tool runs in a separate process. `ctx.inform` is not available.
+
+### Yielding tools
+
+A tool that waits for a human is a pair: the function that asks, and a
+companion that handles the answer.
+
+```python
+@primer_tool(timeout_seconds=60)
+async def ask_the_operator(question: str, ctx) -> str:
+    """Ask the operator a question and wait for their reply.
+
+    Use when a decision needs a human and cannot be inferred.
+
+    Args:
+        question: What to ask, in one sentence.
+    """
+    return ask_user(question)
+
+
+@resumes(ask_the_operator)
+def _answer(payload: dict, meta: dict) -> str:
+    """Return the operator's answer.
+
+    Use when resuming the ask.
+
+    Args:
+        payload: The response payload.
+        meta: The resume metadata.
+    """
+    return payload["response"]
+```
+
+The `@resumes` companion is what makes a tool yielding. Helpers available:
+`ask_user(question)`, `sleep_for(seconds)`, `watch_files(paths)`.
+
+**Nothing survives in memory across the park.** The two halves are separate
+process invocations, possibly minutes apart. Anything the companion needs must
+travel in the metadata:
+
+```python
+    return ask_user(question, meta={"ticket": ticket_id})
+```
+
+### Timeouts
+
+`@primer_tool(timeout_seconds=...)` per tool, defaulting to the toolset's
+setting (30s) and capped at 300s. The process is killed at the limit, so an
+infinite loop returns a timeout error rather than wedging a worker.
+
+## Gotchas
+
+### What the sandbox allows
+
+Tools run in a separate process with resource limits. What else is enforced
+depends on the deployment; `primectl toolset list-python-tools --id <id>`
+reports the level, and the console shows it beside the editor.
+
+- The standard library is available. Third-party packages are only available
+  on container backends, from the toolset's image.
+- Primer's own modules are never importable.
+- Outbound network is denied unless the toolset sets `allow_network`.
+- Spawning subprocesses is denied where the syscall filter is active.
+
+See `docs/dev/architecture/python-tool-isolation.md` for exactly what each
+level does and does not cover.
+
+### Three that bite
+
+- **Nothing survives across a park.** The two halves of a yielding tool are
+  separate process invocations; put anything the companion needs in `meta`.
+- **`ctx` is data, not the live object.** No `inform`, no graph services.
+- **The return value must be JSON-serialisable.** Returning an object is a
+  tool error naming the type.
+
+## Related
+
+- `docs/dev/architecture/python-tool-isolation.md` - what each isolation level
+  does and does not cover.
+- `docs/dev/subsystems/python-runner-toolset.md` - how registration and the
+  runner work.

--- a/docs/dev/architecture/python-tool-isolation.md
+++ b/docs/dev/architecture/python-tool-isolation.md
@@ -1,0 +1,59 @@
+# Python tool isolation
+
+A python tool runs code an operator, or an agent, supplied. This page states
+what each deployment actually enforces, and what it does not.
+
+## Levels
+
+The level is computed at startup, reported on
+`GET /v1/toolsets/{id}/runtime`, and shown in the console.
+
+| Level | Enforced by | Where |
+| --- | --- | --- |
+| `container` | namespaces and cgroups, via the workspace `Sandbox` | container / k8s backends |
+| `seccomp` | syscall filter via libseccomp, plus rlimits | Linux with libseccomp |
+| `sandbox-exec` | macOS sandbox profile, plus rlimits | macOS with sandbox-exec |
+| `rlimit-only` | resource limits only | anywhere else |
+
+## What `rlimit-only` does NOT cover
+
+It bounds CPU, memory, file size, descriptors and core dumps. It does **not**
+stop a tool reading the filesystem, and it does **not** stop outbound network.
+Treat a `rlimit-only` deployment as running the tool with the same filesystem
+and network reach as the primer process itself.
+
+The console labels this level explicitly rather than showing a generic
+"sandboxed" badge, because that badge would be untrue here.
+
+## What holds at every level
+
+Primer's own packages are never importable from a tool. The local runner
+executes `python -I -S` with no `PYTHONPATH`, so `sys.path` carries the
+standard library and nothing else. This matters more than the resource limits:
+a tool that could `import primer.storage` would reach the database with
+ambient credentials, and no rlimit or syscall filter touches that.
+
+Resource limits are set by the shim itself, before it compiles the user
+module, with soft equal to hard. A soft-only limit is decorative, because the
+tool could raise it straight back to the hard value.
+
+## Notes on the syscall filter
+
+It is driven through `ctypes` against the system libseccomp rather than a
+Python seccomp package. It has to be: the shim runs under `-I -S`, so no
+site-package is importable there, and a pip dependency would never load.
+
+The filter is default-allow with a deny list. A default-deny filter would have
+to enumerate everything CPython touches to start, and one omission is a crash
+rather than a contained tool.
+
+`socket()` and `socketpair()` are deliberately allowed even when network is
+denied. They create a descriptor and move no data, and asyncio builds its
+event-loop self-pipe from one, so denying them breaks every async tool while
+adding no safety. `connect`, `bind`, `listen`, `accept`, `sendto` and `sendmsg`
+are denied instead.
+
+`RLIMIT_NPROC` is not used: it caps processes per real UID rather than per
+process tree, so a value low enough to stop forking would be tripped by
+unrelated primer processes under the same UID. Forking is denied by the
+syscall filter and by container process limits instead.

--- a/docs/dev/subsystems/python-runner-toolset.md
+++ b/docs/dev/subsystems/python-runner-toolset.md
@@ -1,0 +1,68 @@
+# Python-runner toolset
+
+Registers a python module as a toolset. Source lives in the toolset record;
+tools are derived from it by AST; calls execute out of process.
+
+## Modules
+
+| File | Responsibility |
+| --- | --- |
+| `docstring.py` | Google docstring to the purpose/when/args anatomy `make_tool` enforces. Pure. |
+| `schema.py` | Function signature to a self-contained JSON Schema. Pure, AST-based. |
+| `registration.py` | Collects `@primer_tool` / `@resumes` and builds `Tool` descriptors. |
+| `protocol.py` | The host side of the shim wire format. |
+| `_shim.py` | The in-sandbox runner, shipped as a source string. |
+| `runners.py` | `LocalHardenedRunner`, `SandboxRunner`, isolation detection. |
+| `yielding.py` | Yield request to `Yielded`, with host-built event keys. |
+| `provider.py` | `PythonToolsetProvider` plus the shared resume hook. |
+
+## Registration never executes the module
+
+The source is untrusted: agents can reach `create_python_toolset`, so an agent
+can author a tool. The host therefore inspects it structurally and never
+imports it. Annotations are mapped over the AST rather than evaluated, for the
+same reason. A module that raises at import time still registers cleanly, and
+there is a test asserting that.
+
+## Wire protocol
+
+One JSON round trip over stdin/stdout:
+
+```
+host   -> {module, fn, phase: "call"|"resume", args, ctx, payload, meta,
+           limits, allow_network}
+sandbox -> {ok: true, value}
+         | {ok: true, yield: {kind, params, meta}}
+         | {ok: false, error: {type, message, traceback}}
+```
+
+Output that is not exactly one response object is an error, never a value: a
+runner that died half way must not be able to look like a tool that succeeded.
+
+## Yielding and resume
+
+The tool names a *kind*; the host builds the `event_key` from the real
+`ToolContext`. A function that could supply its own key could name
+`ask_user:{another_session}:{their_tcid}` and resume a park it does not own.
+
+Tools park under a **scoped** name, `{toolset_id}__{tool_id}`. The resume
+registry is keyed by tool name process-wide and python tool names are
+operator-chosen, so two toolsets both defining `ask` would otherwise collide.
+
+One module-level `python_tool_resume` serves every python tool rather than a
+closure per tool: `register_resume_hook` is idempotent on the (name, hook)
+pair, so a shared function lets a provider rebuild re-register harmlessly
+where a closure would trip the overwrite guard every time.
+
+Resume hooks receive a `ResumeContext` (see
+`primer/worker/yield_resume_registry.py`) carrying the tool name, call id,
+session and an async `resolve_provider`. That is how the shared hook finds
+which toolset's source to run.
+
+## source_version
+
+Stamped into `resume_metadata` at park time and checked on resume. If the
+source moved, the resume refuses: running current code against an answer to
+the old question is worse than refusing, because the operator answered a
+prompt the new code may no longer ask. The server owns the bump, so two
+concurrent editors cannot land on the same number.

--- a/primectl/primectl/commands/toolset.py
+++ b/primectl/primectl/commands/toolset.py
@@ -1,0 +1,144 @@
+"""Python-toolset commands, keeping primectl in parity with the REST surface.
+
+Source is read from a FILE rather than an argument. A python module is
+multi-line and quoting one through a shell is how you end up registering
+something subtly different from what you wrote.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+import typer
+
+from primectl.client import ApiError, ConnectionFailed
+from primectl.commands.crud import _fail, _session
+from primectl.output import render
+
+toolset_app = typer.Typer(
+    name="toolset",
+    help="Toolset convenience commands (python toolset authoring).",
+    no_args_is_help=True,
+)
+
+
+def _emit(sess, data) -> None:
+    fmt = sess.output if sess.output in ("json", "yaml") else "yaml"
+    typer.echo(render(data, fmt=fmt))
+
+
+def _read_source(source_file: str) -> str:
+    path = pathlib.Path(source_file)
+    if not path.is_file():
+        typer.echo(f"no such file: {source_file}", err=True)
+        raise typer.Exit(2)
+    return path.read_text(encoding="utf-8")
+
+
+@toolset_app.command("create-python")
+def create_python(
+    ctx: typer.Context,
+    toolset_id: str = typer.Option(..., "--id", help="Id for the new toolset."),
+    source_file: str = typer.Option(
+        ..., "--source-file", help="Path to the python module to register."
+    ),
+    timeout_seconds: float = typer.Option(
+        30.0,
+        "--timeout-seconds",
+        help="Default wall-clock ceiling for tools that declare none.",
+    ),
+    allow_network: bool = typer.Option(
+        False, "--allow-network", help="Permit outbound network from the tools."
+    ),
+    dry_run: bool = typer.Option(
+        False,
+        "--dry-run",
+        help="Read and validate the file locally without calling the server.",
+    ),
+) -> None:
+    """Register a python module as a toolset."""
+    source = _read_source(source_file)
+    body = {
+        "id": toolset_id,
+        "provider": "python",
+        "config": {
+            "source": source,
+            "source_version": 1,
+            "default_timeout_seconds": timeout_seconds,
+            "allow_network": allow_network,
+        },
+    }
+    if dry_run:
+        _emit(
+            _session(ctx),
+            {"ok": True, "dry_run": True, "id": toolset_id,
+             "source_bytes": len(source)},
+        )
+        return
+    sess = _session(ctx)
+    try:
+        resp = sess.client.request("post", "/v1/toolsets", json=body)
+    except (ApiError, ConnectionFailed) as exc:
+        _fail(sess, exc)
+        return
+    _emit(sess, resp.json())
+
+
+@toolset_app.command("update-python-source")
+def update_python_source(
+    ctx: typer.Context,
+    toolset_id: str = typer.Option(..., "--id", help="Id of the toolset to edit."),
+    source_file: str = typer.Option(
+        ..., "--source-file", help="Path to the replacement python module."
+    ),
+    dry_run: bool = typer.Option(
+        False, "--dry-run", help="Read the file without calling the server."
+    ),
+) -> None:
+    """Replace a python toolset's source.
+
+    The server owns ``source_version`` and bumps it when the source actually
+    changes, so a session parked in one of these tools resumes against the code
+    that parked.
+    """
+    source = _read_source(source_file)
+    if dry_run:
+        _emit(
+            _session(ctx),
+            {"ok": True, "dry_run": True, "id": toolset_id,
+             "source_bytes": len(source)},
+        )
+        return
+    sess = _session(ctx)
+    try:
+        existing = sess.client.request("get", f"/v1/toolsets/{toolset_id}").json()
+        config = dict(existing.get("config") or {})
+        config["source"] = source
+        resp = sess.client.request(
+            "put",
+            f"/v1/toolsets/{toolset_id}",
+            json={"id": toolset_id, "provider": "python", "config": config},
+        )
+    except (ApiError, ConnectionFailed) as exc:
+        _fail(sess, exc)
+        return
+    _emit(sess, resp.json())
+
+
+@toolset_app.command("list-python-tools")
+def list_python_tools(
+    ctx: typer.Context,
+    toolset_id: str = typer.Option(..., "--id", help="Id of the toolset."),
+) -> None:
+    """Show the tools a python toolset derives, plus its isolation level."""
+    sess = _session(ctx)
+    try:
+        resp = sess.client.request("get", f"/v1/toolsets/{toolset_id}/runtime")
+    except (ApiError, ConnectionFailed) as exc:
+        _fail(sess, exc)
+        return
+    _emit(sess, resp.json())
+
+
+def register(app: typer.Typer) -> None:
+    app.add_typer(toolset_app, name="toolset")

--- a/primectl/primectl/main.py
+++ b/primectl/primectl/main.py
@@ -24,6 +24,7 @@ from primectl.commands import workspace as _workspace  # noqa: E402
 from primectl.commands import chat as _chat  # noqa: E402
 from primectl.commands import session as _session  # noqa: E402
 from primectl.commands import tap as _tap  # noqa: E402
+from primectl.commands import toolset as _toolset  # noqa: E402
 from primectl.commands.config_cmd import config_app  # noqa: E402
 
 _crud.register(app)
@@ -33,6 +34,7 @@ _meta.register(app)
 _doc.register(app)
 _channel.register(app)
 _workspace.register(app)
+_toolset.register(app)
 _chat.register(app)
 _session.register(app)
 _tap.register(app)

--- a/primer/api/registries/provider_registry.py
+++ b/primer/api/registries/provider_registry.py
@@ -274,6 +274,20 @@ def _build_default_toolset_factory(
                 config=toolset.config,
                 allowed_stdio_commands=allowed_stdio_commands,
             )
+        if toolset.provider == ToolsetProviderType.PYTHON:
+            from primer.toolset.python_runner.provider import PythonToolsetProvider
+            from primer.toolset.python_runner.runners import LocalHardenedRunner
+
+            return PythonToolsetProvider(
+                toolset_id=toolset.id,
+                config=toolset.config,
+                runner=LocalHardenedRunner(
+                    env={
+                        k: v.get_secret_value()
+                        for k, v in (toolset.config.env or {}).items()
+                    }
+                ),
+            )
         if toolset.provider == ToolsetProviderType.INTERNAL:
             raise ConfigError(
                 f"toolset {toolset.id!r} declares provider='internal' "

--- a/primer/api/routers/providers.py
+++ b/primer/api/routers/providers.py
@@ -698,6 +698,9 @@ async def _toolset_on_pre_create(entity: Toolset, request: Request) -> None:
     """
     if _toolset_probe_bypassed(request):
         return
+    if entity.provider == ToolsetProviderType.PYTHON:
+        _validate_python_toolset(entity)
+        return
     if entity.provider != ToolsetProviderType.MCP:
         return
     config = entity.config
@@ -707,6 +710,56 @@ async def _toolset_on_pre_create(entity: Toolset, request: Request) -> None:
     ):
         return
     await _probe_mcp_reachable(entity, request)
+
+
+def _validate_python_toolset(entity: Toolset) -> None:
+    """Reject a python toolset whose source cannot produce tools.
+
+    Registration is where a bad tool must fail. Calling time is too late: an
+    agent mid-turn should never be the thing that discovers a docstring is
+    missing. The RFC7807 extensions carry ``field`` and ``lineno`` so the
+    console can point at the offending line.
+    """
+    from primer.toolset.python_runner.registration import (
+        RegistrationError,
+        register_module,
+    )
+
+    config = entity.config
+    try:
+        register_module(
+            config.source, entity.id, config.default_timeout_seconds
+        )
+    except RegistrationError as exc:
+        raise HTTPException(
+            status_code=422,
+            detail={
+                "error": "invalid_python_toolset",
+                "message": str(exc),
+                "field": exc.field,
+                "lineno": exc.lineno,
+            },
+        ) from exc
+
+
+async def _toolset_on_pre_update(
+    entity: Toolset, existing: Toolset, request: Request
+) -> None:
+    """Validate python source and own ``source_version`` server-side.
+
+    The client's version is advisory. If two operators edit concurrently they
+    both send the version they read, and a parked resume could not tell which
+    code it was about to run. The server bumps instead, so the number always
+    moves when the source does.
+    """
+    if entity.provider != ToolsetProviderType.PYTHON:
+        return
+    _validate_python_toolset(entity)
+    prior = existing.config if existing is not None else None
+    if prior is not None and getattr(prior, "source", None) == entity.config.source:
+        entity.config.source_version = prior.source_version
+    elif prior is not None:
+        entity.config.source_version = prior.source_version + 1
 
 
 # ---- Toolset router --------------------------------------------------------
@@ -719,6 +772,7 @@ toolset_router = make_crud_router(
     on_update=_invalidate_toolset,
     on_delete=_invalidate_toolset,
     on_pre_create=_toolset_on_pre_create,
+    on_pre_update=_toolset_on_pre_update,
     managed_by_field="harness_id",
     references=[
         ReferenceCheck(
@@ -1089,3 +1143,38 @@ __all__ = [
     "llm_provider_router",
     "toolset_router",
 ]
+
+
+@toolset_router.get(
+    "/toolsets/{toolset_id}/runtime",
+    summary="Runtime facts about a toolset: isolation level and derived tools",
+    responses=common_responses(404, 500),
+)
+async def toolset_runtime(
+    toolset_id: str = Path(..., description="Toolset id"),
+    registry: ProviderRegistry = Depends(get_provider_registry),
+) -> dict:
+    """What a python toolset actually is at runtime.
+
+    ``isolation_level`` is what this deployment ENFORCES, not what the
+    strongest backend could: ``rlimit-only`` bounds CPU and memory but stops
+    neither filesystem reads nor egress, and the console shows that rather
+    than a generic "sandboxed" badge.
+    """
+    provider = await registry.get_toolset(toolset_id)
+    tools = [t.model_dump(mode="json") async for t in provider.list_tools()]
+    error = getattr(provider, "registration_error", None)
+    return {
+        "toolset_id": toolset_id,
+        "isolation_level": getattr(provider, "isolation_level", None),
+        "tools": tools,
+        "registration_error": (
+            {
+                "message": str(error),
+                "field": error.field,
+                "lineno": error.lineno,
+            }
+            if error is not None
+            else None
+        ),
+    }

--- a/primer/graph/_node_refs.py
+++ b/primer/graph/_node_refs.py
@@ -304,10 +304,23 @@ def _resume_value_yield_toolcall(
     the tool result the node's downstream consumers read via ``nodes.<id>.text``.
     """
     from primer.model.chat import ToolResultPart
-    from primer.worker.yield_resume_registry import get_resume_hook
+    from primer.worker.yield_resume_registry import ResumeContext, get_resume_hook
 
     hook = get_resume_hook(tool_name)
-    hook_result = hook(resume_metadata or {}, payload)
+    # resolve_provider is None here: this path holds only the parked blob, so
+    # a hook that needs to reach its toolset (a python tool) must say it
+    # cannot rather than assume a resolver is present. Threading one from the
+    # caller is the follow-up if graph tool_call nodes need python tools.
+    hook_result = hook(
+        resume_metadata or {},
+        payload,
+        ResumeContext(
+            tool_name=tool_name,
+            tool_call_id=tool_call_id,
+            session_id=None,
+            resolve_provider=None,
+        ),
+    )
     # The resume hooks in-tree are synchronous; guard against an async hook
     # to keep this helper usable if one is added later.
     if asyncio.iscoroutine(hook_result):  # pragma: no cover -- all hooks sync

--- a/primer/model/providers/toolset.py
+++ b/primer/model/providers/toolset.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from enum import Enum
 from typing import ClassVar, Literal
 
-from pydantic import BaseModel, Field, HttpUrl, SecretStr, model_validator
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl, SecretStr, model_validator
 
 from primer.model.common import Identifiable
 
@@ -97,6 +97,7 @@ class ToolsetProviderType(str, Enum):
 
     INTERNAL = "internal"
     MCP = "mcp"
+    PYTHON = "python"
 
 
 class TransportType(str, Enum):
@@ -194,6 +195,62 @@ class McpConfig(BaseModel):
         return self
 
 
+class PythonConfig(BaseModel):
+    """Config for a ``python`` toolset: one module's source plus its limits.
+
+    The whole toolset is a single module. Every function in it decorated with
+    ``@primer_tool`` becomes a tool; see
+    :mod:`primer.toolset.python_runner.registration`.
+    """
+
+    model_config = ConfigDict(extra="forbid")
+
+    source: str = Field(
+        ...,
+        description="Python module source. Not a secret; returned on read.",
+    )
+    source_version: int = Field(
+        ...,
+        ge=1,
+        description=(
+            "Bumped on every source edit. Stamped into a park's resume "
+            "metadata so a resume runs the version that parked, not whatever "
+            "the source says now."
+        ),
+    )
+    default_timeout_seconds: float = Field(
+        default=30.0,
+        gt=0.0,
+        le=300.0,
+        description=(
+            "Wall-clock ceiling for a tool that does not declare its own. "
+            "300s is the hard server ceiling."
+        ),
+    )
+    env: dict[str, SecretStr] = Field(
+        default_factory=dict,
+        description=(
+            "Environment variables for the runner process. Secrets: masked on "
+            "every API read path, same as the MCP stdio env."
+        ),
+    )
+    image: str | None = Field(
+        default=None,
+        description=(
+            "Container image for the runner on container/k8s backends. None "
+            "uses the default runner image. Ignored by the local runner, "
+            "which is stdlib-only by construction."
+        ),
+    )
+    allow_network: bool = Field(
+        default=False,
+        description=(
+            "Permit outbound sockets from the tool. Enforceable only at "
+            "isolation levels above 'rlimit-only'."
+        ),
+    )
+
+
 class Toolset(Identifiable):
     """A configured tool source.
 
@@ -218,7 +275,7 @@ class Toolset(Identifiable):
         ...,
         description="Which toolset provider backend this entry targets.",
     )
-    config: McpConfig | None = Field(
+    config: McpConfig | PythonConfig | None = Field(
         default=None,
         description="Provider-specific config. Required for 'mcp', must be omitted for 'internal'.",
     )
@@ -233,9 +290,17 @@ class Toolset(Identifiable):
 
     @model_validator(mode="after")
     def _validate_config_matches_provider(self) -> "Toolset":
-        if self.provider == ToolsetProviderType.MCP and self.config is None:
+        if self.provider == ToolsetProviderType.MCP and not isinstance(
+            self.config, McpConfig
+        ):
             raise ValueError(
                 "provider='mcp' requires a McpConfig in 'config'"
+            )
+        if self.provider == ToolsetProviderType.PYTHON and not isinstance(
+            self.config, PythonConfig
+        ):
+            raise ValueError(
+                "provider='python' requires a PythonConfig in 'config'"
             )
         if self.provider == ToolsetProviderType.INTERNAL and self.config is not None:
             raise ValueError(

--- a/primer/toolset/_system_tools.py
+++ b/primer/toolset/_system_tools.py
@@ -13,6 +13,11 @@ its per-build dependencies).
 
 from __future__ import annotations
 
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from primer.worker.yield_resume_registry import ResumeContext
+
 from typing import TYPE_CHECKING, Any
 
 from pydantic import BaseModel, Field, ValidationError
@@ -94,6 +99,7 @@ class _AskUserArgs(BaseModel):
 def ask_user_resume(
     yield_metadata: dict[str, Any],
     event_payload: Any,
+    ctx: "ResumeContext",
 ) -> ToolCallResult:
     """Resume hook for ask_user - translate payload into tool result.
 

--- a/primer/toolset/mcp.py
+++ b/primer/toolset/mcp.py
@@ -555,6 +555,7 @@ class McpToolsetProvider(ToolsetProvider):
 def mcp_task_resume(
     yield_metadata: dict[str, Any],
     event_payload: Any,
+    ctx: "ResumeContext",
 ) -> ToolCallResult:
     """Resume hook for MCP-task yields.
 

--- a/primer/toolset/misc.py
+++ b/primer/toolset/misc.py
@@ -144,7 +144,11 @@ class _SleepArgs(BaseModel):
     )
 
 
-def sleep_resume(yield_metadata: dict[str, Any], event_payload: Any) -> ToolCallResult:
+def sleep_resume(
+    yield_metadata: dict[str, Any],
+    event_payload: Any,
+    ctx: "ResumeContext",
+) -> ToolCallResult:
     """Resume hook for sleep — synthesise elapsed-seconds.
 
     Sleep's event payload is empty (the timer scheduler just fires);

--- a/primer/toolset/python_runner/__init__.py
+++ b/primer/toolset/python_runner/__init__.py
@@ -1,0 +1,6 @@
+"""Python-runner toolset: register a python function as a callable tool.
+
+See docs/dev/subsystems/python-runner-toolset.md. The source is untrusted
+(agents can reach the toolset-management tools), so registration inspects it
+by AST only and execution happens behind isolation in `runners`.
+"""

--- a/primer/toolset/python_runner/__init__.py
+++ b/primer/toolset/python_runner/__init__.py
@@ -4,3 +4,7 @@ See docs/dev/subsystems/python-runner-toolset.md. The source is untrusted
 (agents can reach the toolset-management tools), so registration inspects it
 by AST only and execution happens behind isolation in `runners`.
 """
+
+from primer.toolset.python_runner.provider import PythonToolsetProvider
+
+__all__ = ["PythonToolsetProvider"]

--- a/primer/toolset/python_runner/_shim.py
+++ b/primer/toolset/python_runner/_shim.py
@@ -41,6 +41,81 @@ def _apply_limits(limits):
             pass
 
 
+def _apply_seccomp(allow_network):
+    """Install a syscall filter via libseccomp, if this host has it.
+
+    Driven through ctypes rather than a Python seccomp package on purpose:
+    the shim runs under -I -S, so NO site-package is importable here. A
+    dependency would simply never load. libseccomp is a system library, so
+    ctypes reaches it while sys.path stays empty.
+
+    Default-allow with a deny list, because a default-deny filter has to
+    enumerate everything CPython touches to start up and one omission is a
+    crash rather than a contained tool.
+
+    Returns True when a filter was loaded.
+    """
+    import ctypes
+    import ctypes.util
+
+    name = ctypes.util.find_library("seccomp")
+    if not name:
+        return False
+    try:
+        lib = ctypes.CDLL(name, use_errno=True)
+    except OSError:
+        return False
+
+    SCMP_ACT_ALLOW = 0x7FFF0000
+    EPERM = 1
+    SCMP_ACT_ERRNO = 0x00050000 | (EPERM & 0x0000FFFF)
+
+    denied = [
+        "ptrace", "process_vm_readv", "process_vm_writev",
+        "fork", "vfork", "execve", "execveat",
+        "mount", "umount2", "pivot_root", "chroot",
+        "init_module", "finit_module", "delete_module",
+        "kexec_load", "reboot", "swapon", "swapoff",
+    ]
+    if not allow_network:
+        # socket() and socketpair() are deliberately NOT denied: they create
+        # an fd and move no data, and asyncio builds its event loop self-pipe
+        # from one. Denying them blocks every async tool while adding no
+        # safety. What actually reaches the network is denied instead.
+        denied += [
+            "connect", "bind", "listen", "accept", "accept4",
+            "sendto", "sendmsg", "recvfrom", "recvmsg",
+        ]
+
+    lib.seccomp_init.restype = ctypes.c_void_p
+    lib.seccomp_syscall_resolve_name.restype = ctypes.c_int
+    lib.seccomp_syscall_resolve_name.argtypes = [ctypes.c_char_p]
+    lib.seccomp_rule_add.restype = ctypes.c_int
+    lib.seccomp_rule_add.argtypes = [
+        ctypes.c_void_p, ctypes.c_uint32, ctypes.c_int, ctypes.c_uint,
+    ]
+    lib.seccomp_load.restype = ctypes.c_int
+    lib.seccomp_load.argtypes = [ctypes.c_void_p]
+    lib.seccomp_release.argtypes = [ctypes.c_void_p]
+
+    ctx = lib.seccomp_init(ctypes.c_uint32(SCMP_ACT_ALLOW))
+    if not ctx:
+        return False
+    try:
+        for sysname in denied:
+            nr = lib.seccomp_syscall_resolve_name(sysname.encode())
+            if nr < 0:
+                # Not present on this architecture; nothing to deny.
+                continue
+            lib.seccomp_rule_add(
+                ctypes.c_void_p(ctx), ctypes.c_uint32(SCMP_ACT_ERRNO),
+                ctypes.c_int(nr), ctypes.c_uint(0),
+            )
+        return lib.seccomp_load(ctypes.c_void_p(ctx)) == 0
+    finally:
+        lib.seccomp_release(ctypes.c_void_p(ctx))
+
+
 class _Yield(Exception):
     def __init__(self, kind, params, meta):
         self.kind = kind
@@ -91,6 +166,7 @@ def _err(kind, message, tb=""):
 def _main():
     req = json.loads(sys.stdin.read())
     _apply_limits(req.get("limits") or {})
+    _apply_seccomp(bool(req.get("allow_network")))
 
     ns = _build_namespace()
     try:

--- a/primer/toolset/python_runner/_shim.py
+++ b/primer/toolset/python_runner/_shim.py
@@ -1,0 +1,154 @@
+"""The in-sandbox runner, shipped as source so a bare interpreter can run it.
+
+Executed as ``python -I -S -c SHIM_SOURCE``. It sets its own resource limits as
+its first real work, before the user module is compiled or run: an unprivileged
+process can lower a limit but never raise the hard limit again, so user code
+cannot undo them. Every limit is set with soft equal to hard, because a
+soft-only limit is decorative - user code can raise it straight back to the
+hard value.
+
+RLIMIT_NPROC is deliberately absent. It caps processes per real UID rather than
+per process tree, so a value low enough to stop forking would also be tripped
+by unrelated primer processes running under the same UID. Forking is denied by
+the seccomp filter and by the container backend's process limits instead.
+"""
+
+from __future__ import annotations
+
+SHIM_SOURCE = r'''
+import json, sys, traceback
+
+
+def _apply_limits(limits):
+    try:
+        import resource
+    except ImportError:
+        return
+    cpu = int(limits.get("cpu_seconds", 30))
+    mem = int(limits.get("address_space_bytes", 512 * 1024 * 1024))
+    wanted = [
+        (resource.RLIMIT_CPU, cpu),
+        (resource.RLIMIT_AS, mem),
+        (resource.RLIMIT_FSIZE, 8 * 1024 * 1024),
+        (resource.RLIMIT_NOFILE, 64),
+        (resource.RLIMIT_CORE, 0),
+    ]
+    for res, val in wanted:
+        try:
+            # soft == hard: a soft-only limit can be raised back by the tool.
+            resource.setrlimit(res, (val, val))
+        except (ValueError, OSError):
+            pass
+
+
+class _Yield(Exception):
+    def __init__(self, kind, params, meta):
+        self.kind = kind
+        self.params = params
+        self.meta = meta
+
+
+def _build_namespace():
+    def ask_user(question, meta=None):
+        raise _Yield("ask_user", {"question": question}, meta or {})
+
+    def sleep_for(seconds, meta=None):
+        raise _Yield("timer", {"seconds": seconds}, meta or {})
+
+    def watch_files(paths, meta=None):
+        raise _Yield("watch", {"paths": list(paths)}, meta or {})
+
+    def primer_tool(*a, **k):
+        if len(a) == 1 and not k and callable(a[0]):
+            return a[0]
+
+        def deco(fn):
+            return fn
+
+        return deco
+
+    def resumes(_target):
+        def deco(fn):
+            return fn
+
+        return deco
+
+    return {
+        "__name__": "primer_python_tool",
+        "ask_user": ask_user,
+        "sleep_for": sleep_for,
+        "watch_files": watch_files,
+        "primer_tool": primer_tool,
+        "resumes": resumes,
+    }
+
+
+def _err(kind, message, tb=""):
+    return {"ok": False, "error": {"type": kind, "message": message,
+                                   "traceback": tb}}
+
+
+def _main():
+    req = json.loads(sys.stdin.read())
+    _apply_limits(req.get("limits") or {})
+
+    ns = _build_namespace()
+    try:
+        exec(compile(req["module"], "<tool>", "exec"), ns)
+    except _Yield:
+        return _err("RuntimeError",
+                    "a yield helper was called at module scope")
+    except Exception as exc:
+        return _err(type(exc).__name__,
+                    "the toolset module failed to load: %s" % exc,
+                    traceback.format_exc()[-4000:])
+
+    fn = ns.get(req["fn"])
+    if fn is None:
+        return _err("NameError",
+                    "no function named %r in this toolset" % req["fn"])
+
+    if req.get("phase") == "resume":
+        kwargs = {"payload": req.get("payload"), "meta": req.get("meta")}
+    else:
+        kwargs = dict(req.get("args") or {})
+        try:
+            import inspect
+            if "ctx" in inspect.signature(fn).parameters:
+                kwargs["ctx"] = req.get("ctx")
+        except (TypeError, ValueError):
+            pass
+
+    try:
+        result = fn(**kwargs)
+        if hasattr(result, "__await__"):
+            import asyncio
+            loop = asyncio.new_event_loop()
+            try:
+                result = loop.run_until_complete(result)
+            finally:
+                loop.close()
+    except _Yield as y:
+        return {"ok": True, "yield": {"kind": y.kind, "params": y.params,
+                                      "meta": y.meta}}
+    except Exception as exc:
+        return _err(type(exc).__name__, str(exc),
+                    traceback.format_exc()[-4000:])
+
+    try:
+        json.dumps(result)
+    except (TypeError, ValueError):
+        return _err("TypeError",
+                    "the tool returned a value that is not JSON "
+                    "serialisable: %s" % type(result).__name__)
+    return {"ok": True, "value": result}
+
+
+try:
+    _out = _main()
+except Exception as _exc:
+    _out = {"ok": False, "error": {"type": type(_exc).__name__,
+                                   "message": str(_exc),
+                                   "traceback": traceback.format_exc()[-4000:]}}
+sys.stdout.write(json.dumps(_out))
+'''

--- a/primer/toolset/python_runner/docstring.py
+++ b/primer/toolset/python_runner/docstring.py
@@ -1,0 +1,139 @@
+"""Google-style docstring to the description anatomy make_tool enforces.
+
+A python tool's description lands in the same LLM context as every built-in
+tool, so it is held to the same bar: one imperative purpose sentence, a
+"use when" clause, and a documented entry per argument. Enforcing that at
+registration means a bad docstring fails when the operator saves, not when an
+agent is mid-turn and the only signal is a confused model.
+"""
+
+from __future__ import annotations
+
+import json
+import textwrap
+from dataclasses import dataclass, field
+from typing import Any
+
+_SECTIONS = ("args:", "arguments:", "when:", "examples:", "returns:", "raises:")
+
+# An arg description continued on the next line is indented past the name.
+# Google style puts names at 4 and continuations at 8 relative to the block,
+# which after dedent lands at 8 and 12 respectively.
+_CONTINUATION_INDENT = 12
+
+
+class DocstringError(ValueError):
+    """A docstring that cannot produce a usable tool description.
+
+    ``field`` names the offending part so the API can point the operator at
+    it rather than returning "invalid docstring".
+    """
+
+    def __init__(self, message: str, *, field: str) -> None:
+        super().__init__(message)
+        self.field = field
+
+
+@dataclass
+class ParsedDocstring:
+    purpose: str
+    when: str
+    args: dict[str, str] = field(default_factory=dict)
+    examples: list[dict[str, Any]] = field(default_factory=list)
+
+
+def _split_sections(body: str) -> tuple[str, dict[str, list[str]]]:
+    """Split a dedented docstring into its head and its named sections."""
+    head: list[str] = []
+    sections: dict[str, list[str]] = {}
+    current: str | None = None
+    for raw in body.splitlines():
+        stripped = raw.strip()
+        if stripped.lower() in _SECTIONS:
+            current = stripped.lower().rstrip(":")
+            sections[current] = []
+            continue
+        if current is None:
+            head.append(raw)
+        else:
+            sections[current].append(raw)
+    return "\n".join(head), sections
+
+
+def _parse_args(lines: list[str]) -> dict[str, str]:
+    """Parse an ``Args:`` block into {name: description}.
+
+    A line indented past the name continues the previous description, which is
+    how Google style wraps a long one.
+    """
+    out: dict[str, str] = {}
+    name: str | None = None
+    for raw in lines:
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        is_continuation = name is not None and indent >= _CONTINUATION_INDENT
+        if ":" in stripped and not is_continuation:
+            key, _, desc = stripped.partition(":")
+            # "name (str)" -> "name"; the type comes from the annotation, not
+            # from prose that can disagree with it.
+            name = key.split("(")[0].strip()
+            out[name] = desc.strip()
+        elif name is not None:
+            out[name] = (out[name] + " " + stripped).strip()
+    return out
+
+
+def parse_docstring(text: str) -> ParsedDocstring:
+    """Parse ``text`` into the anatomy make_tool needs.
+
+    Raises :class:`DocstringError` naming the offending field.
+    """
+    if not text or not text.strip():
+        raise DocstringError("the function needs a docstring", field="docstring")
+
+    body = textwrap.dedent(text.strip("\n"))
+    head, sections = _split_sections(body)
+
+    head_lines = [ln.strip() for ln in head.splitlines() if ln.strip()]
+    if not head_lines:
+        raise DocstringError("the docstring needs a summary line", field="purpose")
+    purpose = head_lines[0]
+
+    when = ""
+    for line in head_lines[1:]:
+        if line.lower().startswith("use when"):
+            when = line
+            break
+    if not when and "when" in sections:
+        joined = " ".join(x.strip() for x in sections["when"] if x.strip())
+        if joined:
+            when = f"Use when {joined}"
+    if not when:
+        raise DocstringError(
+            "the docstring needs a 'Use when ...' line or a 'When:' section",
+            field="when",
+        )
+
+    arg_lines = sections.get("args") or sections.get("arguments") or []
+    args = _parse_args(arg_lines)
+
+    examples: list[dict[str, Any]] = []
+    for raw in sections.get("examples", []):
+        stripped = raw.strip()
+        if not stripped:
+            continue
+        try:
+            parsed = json.loads(stripped)
+        except json.JSONDecodeError as exc:
+            raise DocstringError(
+                f"example is not valid JSON: {stripped!r}", field="examples"
+            ) from exc
+        if not isinstance(parsed, dict):
+            raise DocstringError(
+                "each example must be a JSON object of arguments", field="examples"
+            )
+        examples.append(parsed)
+
+    return ParsedDocstring(purpose=purpose, when=when, args=args, examples=examples)

--- a/primer/toolset/python_runner/protocol.py
+++ b/primer/toolset/python_runner/protocol.py
@@ -1,0 +1,86 @@
+"""The host side of the shim's wire format.
+
+One JSON round trip: the host writes a request on stdin, the shim writes
+exactly one response object on stdout. Anything else the process emits is
+treated as a failure, never as a value.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+
+PHASE_CALL = "call"
+PHASE_RESUME = "resume"
+
+
+@dataclass
+class ShimResponse:
+    ok: bool
+    value: Any = None
+    yield_request: dict[str, Any] | None = None
+    error: dict[str, Any] | None = None
+
+
+def build_request(
+    *,
+    module: str,
+    fn: str,
+    phase: str,
+    args: dict[str, Any] | None,
+    ctx: dict[str, Any],
+    payload: Any = None,
+    meta: Any = None,
+    cpu_seconds: int,
+    address_space_bytes: int,
+) -> dict[str, Any]:
+    """Build the request object the shim reads from stdin."""
+    return {
+        "module": module,
+        "fn": fn,
+        "phase": phase,
+        "args": args or {},
+        "ctx": ctx,
+        "payload": payload,
+        "meta": meta,
+        "limits": {
+            "cpu_seconds": cpu_seconds,
+            "address_space_bytes": address_space_bytes,
+        },
+    }
+
+
+def parse_response(raw: str) -> ShimResponse:
+    """Parse the shim's stdout.
+
+    Malformed output is an error result, never a value. A tool whose runner
+    crashed half way through must not be able to look like a tool that
+    returned successfully.
+    """
+    try:
+        data = json.loads(raw)
+    except json.JSONDecodeError:
+        return ShimResponse(
+            ok=False,
+            error={
+                "type": "ProtocolError",
+                "message": "the runner produced output that is not JSON",
+                "traceback": raw[:2000],
+            },
+        )
+    if not isinstance(data, dict) or "ok" not in data:
+        return ShimResponse(
+            ok=False,
+            error={
+                "type": "ProtocolError",
+                "message": "malformed runner response",
+                "traceback": raw[:2000],
+            },
+        )
+    return ShimResponse(
+        ok=bool(data["ok"]),
+        value=data.get("value"),
+        yield_request=data.get("yield"),
+        error=data.get("error"),
+    )

--- a/primer/toolset/python_runner/provider.py
+++ b/primer/toolset/python_runner/provider.py
@@ -1,0 +1,288 @@
+"""ToolsetProvider over a python module.
+
+Registration is done once at construction: the AST pass is pure, and the source
+only changes when the toolset record does, at which point the provider is
+rebuilt.
+
+Yielding tools register a single module-level resume hook per scoped tool name.
+The hook is a module global on purpose - registration is idempotent on the
+(name, hook) pair, so rebuilding a provider re-registers the same object rather
+than tripping the registry's overwrite guard.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from collections.abc import AsyncIterator
+from typing import Any
+
+from primer.int.toolset import ToolsetProvider
+from primer.model.chat import Tool, ToolCallResult
+from primer.model.providers.toolset import PythonConfig
+from primer.model.yield_ import ToolContext, YieldToWorker
+from primer.toolset.python_runner.protocol import (
+    PHASE_CALL,
+    PHASE_RESUME,
+    build_request,
+)
+from primer.toolset.python_runner.registration import (
+    RegisteredTool,
+    RegistrationError,
+    register_module,
+)
+from primer.toolset.python_runner.runners import Runner
+from primer.toolset.python_runner.yielding import YieldKindError, to_yielded
+from primer.worker.yield_resume_registry import ResumeContext, register_resume_hook
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_ADDRESS_SPACE_BYTES = 512 * 1024 * 1024
+
+
+def scoped_tool_name(toolset_id: str, tool_id: str) -> str:
+    """The name a python tool parks under.
+
+    Scoped because the resume registry is keyed by tool name process-wide and
+    python tool names are operator-chosen: two toolsets both defining ``ask``
+    would otherwise collide and the second registration would raise.
+    """
+    return f"{toolset_id}__{tool_id}"
+
+
+async def python_tool_resume(
+    yield_metadata: dict[str, Any],
+    event_payload: Any,
+    ctx: ResumeContext,
+) -> ToolCallResult:
+    """Resume hook shared by every python tool.
+
+    One module-level function rather than a closure per tool, so re-registering
+    after a provider rebuild is idempotent. Everything it needs to find the
+    right toolset comes from the metadata the park stamped.
+    """
+    toolset_id = (yield_metadata or {}).get("toolset_id")
+    tool_id = (yield_metadata or {}).get("tool_id")
+    if not toolset_id or not tool_id:
+        return ToolCallResult(
+            output="this park is missing its toolset attribution and cannot "
+            "be resumed",
+            is_error=True,
+        )
+    if ctx.resolve_provider is None:
+        return ToolCallResult(
+            output=(
+                f"{tool_id!r} cannot be resumed from here: this resume path "
+                f"has no toolset registry in scope"
+            ),
+            is_error=True,
+        )
+    try:
+        provider = await ctx.resolve_provider(toolset_id)
+    except Exception as exc:  # noqa: BLE001 - surfaced as a tool error
+        return ToolCallResult(
+            output=f"could not reach toolset {toolset_id!r}: {exc}", is_error=True
+        )
+    if not isinstance(provider, PythonToolsetProvider):
+        return ToolCallResult(
+            output=f"toolset {toolset_id!r} is no longer a python toolset",
+            is_error=True,
+        )
+    return await provider.resume_tool(
+        tool_id=tool_id,
+        payload=event_payload,
+        resume_metadata=yield_metadata,
+    )
+
+
+class PythonToolsetProvider(ToolsetProvider):
+    def __init__(
+        self, *, toolset_id: str, config: PythonConfig, runner: Runner
+    ) -> None:
+        self._toolset_id = toolset_id
+        self._config = config
+        self._runner = runner
+        self._registered: dict[str, RegisteredTool] = {}
+        self.registration_error: RegistrationError | None = None
+
+        try:
+            for reg in register_module(
+                config.source, toolset_id, config.default_timeout_seconds
+            ):
+                self._registered[reg.tool.id] = reg
+        except RegistrationError as exc:
+            # A toolset whose source no longer registers lists NOTHING rather
+            # than exposing a partial, misleading tool set. The error is kept
+            # so the API can show it instead of an empty toolset.
+            self.registration_error = exc
+            logger.warning(
+                "python toolset %s failed to register: %s", toolset_id, exc
+            )
+            return
+
+        for reg in self._registered.values():
+            if reg.resume_fn_name is not None:
+                register_resume_hook(
+                    scoped_tool_name(toolset_id, reg.tool.id), python_tool_resume
+                )
+
+    @property
+    def isolation_level(self) -> str:
+        return self._runner.isolation_level.value
+
+    async def list_tools(self, *, principal: str | None = None) -> AsyncIterator[Tool]:
+        for reg in self._registered.values():
+            yield reg.tool
+
+    async def call(
+        self,
+        *,
+        tool_name: str,
+        arguments: dict[str, Any],
+        principal: str | None = None,
+        ctx: ToolContext | None = None,
+    ) -> ToolCallResult:
+        reg = self._registered.get(tool_name)
+        if reg is None:
+            return ToolCallResult(
+                output=f"no tool named {tool_name!r} in toolset {self._toolset_id!r}",
+                is_error=True,
+            )
+        return await self._invoke(reg, phase=PHASE_CALL, arguments=arguments, ctx=ctx)
+
+    async def resume_tool(
+        self,
+        *,
+        tool_id: str,
+        payload: Any,
+        resume_metadata: dict[str, Any],
+    ) -> ToolCallResult:
+        """Second half of a yielding tool. Runs the version that parked."""
+        reg = self._registered.get(tool_id)
+        if reg is None or reg.resume_fn_name is None:
+            return ToolCallResult(
+                output=f"{tool_id!r} has no resume hook in toolset "
+                f"{self._toolset_id!r}",
+                is_error=True,
+            )
+        parked_version = (resume_metadata or {}).get("source_version")
+        if parked_version != self._config.source_version:
+            # Running the current source against an answer to the old
+            # question is worse than refusing: the operator answered a
+            # prompt this code may no longer ask.
+            return ToolCallResult(
+                output=(
+                    f"{tool_id!r} was edited while this call was parked "
+                    f"(parked on v{parked_version}, now "
+                    f"v{self._config.source_version}); the answer was not "
+                    f"applied"
+                ),
+                is_error=True,
+            )
+        return await self._invoke(
+            reg,
+            phase=PHASE_RESUME,
+            arguments=None,
+            ctx=None,
+            payload=_jsonable(payload),
+            meta=(resume_metadata or {}).get("tool_meta"),
+            fn_name=reg.resume_fn_name,
+        )
+
+    async def _invoke(
+        self,
+        reg: RegisteredTool,
+        *,
+        phase: str,
+        arguments: dict[str, Any] | None,
+        ctx: ToolContext | None,
+        payload: Any = None,
+        meta: Any = None,
+        fn_name: str | None = None,
+    ) -> ToolCallResult:
+        request = build_request(
+            module=self._config.source,
+            fn=fn_name or reg.fn_name,
+            phase=phase,
+            args=arguments,
+            ctx=_ctx_to_json(ctx),
+            payload=payload,
+            meta=meta,
+            cpu_seconds=int(reg.timeout_seconds) + 1,
+            address_space_bytes=_DEFAULT_ADDRESS_SPACE_BYTES,
+        )
+        request["allow_network"] = self._config.allow_network
+        response = await self._runner.run(
+            request, timeout_seconds=reg.timeout_seconds
+        )
+
+        if response.yield_request is not None:
+            if ctx is None:
+                return ToolCallResult(
+                    output=(
+                        f"{reg.tool.id!r} tried to yield outside a session; "
+                        f"yielding tools need a session context"
+                    ),
+                    is_error=True,
+                )
+            try:
+                yielded = to_yielded(
+                    response.yield_request,
+                    tool_name=scoped_tool_name(self._toolset_id, reg.tool.id),
+                    ctx=ctx,
+                    source_version=self._config.source_version,
+                )
+            except YieldKindError as exc:
+                return ToolCallResult(output=str(exc), is_error=True)
+            # The resume hook is module-level and gets no provider, so the
+            # attribution has to travel in the metadata.
+            yielded.resume_metadata["toolset_id"] = self._toolset_id
+            yielded.resume_metadata["tool_id"] = reg.tool.id
+            raise YieldToWorker(yielded, tool_call_id=ctx.tool_call_id)
+
+        if not response.ok:
+            err = response.error or {}
+            return ToolCallResult(
+                output=f"{err.get('type', 'Error')}: {err.get('message', '')}",
+                is_error=True,
+                extended={"traceback": err.get("traceback", "")},
+            )
+
+        value = response.value
+        return ToolCallResult(
+            output=value if isinstance(value, str) else json.dumps(value),
+            is_error=False,
+        )
+
+
+def _jsonable(payload: Any) -> Any:
+    """Reduce a resume payload to something the shim can receive.
+
+    YieldTimeout / YieldCancelled are dataclasses, not dicts; the tool's
+    resume function sees a plain object either way.
+    """
+    if payload is None or isinstance(payload, (dict, list, str, int, float, bool)):
+        return payload
+    out: dict[str, Any] = {"kind": type(payload).__name__}
+    for attr in ("reason", "elapsed_seconds", "cancelled_at"):
+        if hasattr(payload, attr):
+            value = getattr(payload, attr)
+            out[attr] = value.isoformat() if hasattr(value, "isoformat") else value
+    return out
+
+
+def _ctx_to_json(ctx: ToolContext | None) -> dict[str, Any]:
+    """ToolContext crosses as data only.
+
+    ``inform`` is a callable and ``graph_services`` a live bundle; neither can
+    cross a process boundary, so python tools do not receive them.
+    """
+    if ctx is None:
+        return {}
+    return {
+        "tool_call_id": ctx.tool_call_id,
+        "session_id": ctx.session_id,
+        "workspace_id": ctx.workspace_id,
+        "chat_id": ctx.chat_id,
+        "parked_at": ctx.parked_at.isoformat() if ctx.parked_at else None,
+    }

--- a/primer/toolset/python_runner/registration.py
+++ b/primer/toolset/python_runner/registration.py
@@ -1,0 +1,196 @@
+"""Source to Tool descriptors, by AST only.
+
+Registration NEVER executes the module. The source is untrusted - an agent can
+reach the toolset-management tools - so the only safe way to inspect it on the
+host is structurally. Execution happens later, in the runner, behind isolation.
+
+Yielding is declared by a ``@resumes(fn)`` companion, not inferred from a
+return annotation. make_tool's explicit ``yields`` flag replaced exactly that
+kind of source introspection; this keeps the decision explicit while still
+giving authors a decorator to write.
+"""
+
+from __future__ import annotations
+
+import ast
+from dataclasses import dataclass
+
+from jsonschema.exceptions import ValidationError
+
+from primer.model.chat import Tool, ToolExample
+from primer.toolset._describe import make_tool
+from primer.toolset.python_runner.docstring import DocstringError, parse_docstring
+from primer.toolset.python_runner.schema import SchemaError, build_args_schema
+
+TOOL_DECORATOR = "primer_tool"
+RESUME_DECORATOR = "resumes"
+TIMEOUT_CEILING_SECONDS = 300.0
+
+_FunctionNode = ast.FunctionDef | ast.AsyncFunctionDef
+
+
+class RegistrationError(ValueError):
+    """Source that cannot produce a usable toolset.
+
+    ``field`` and ``lineno`` are surfaced in the API's RFC7807 extensions so
+    the console can point at the offending line.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        field: str | None = None,
+        lineno: int | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.field = field
+        self.lineno = lineno
+
+
+@dataclass
+class RegisteredTool:
+    """One decorated function, resolved into everything dispatch needs."""
+
+    tool: Tool
+    fn_name: str
+    resume_fn_name: str | None
+    timeout_seconds: float
+
+
+def _decorator_named(node: ast.expr, name: str) -> ast.Call | ast.Name | None:
+    """Match ``@name`` and ``@name(...)``, ignoring anything else."""
+    if isinstance(node, ast.Name) and node.id == name:
+        return node
+    if (
+        isinstance(node, ast.Call)
+        and isinstance(node.func, ast.Name)
+        and node.func.id == name
+    ):
+        return node
+    return None
+
+
+def _timeout_from(dec: ast.Call | ast.Name, default: float, fn: str) -> float:
+    if not isinstance(dec, ast.Call):
+        return default
+    for kw in dec.keywords:
+        if kw.arg != "timeout_seconds":
+            continue
+        try:
+            value = float(ast.literal_eval(kw.value))
+        except (ValueError, TypeError) as exc:
+            raise RegistrationError(
+                f"{fn}: timeout_seconds must be a literal number",
+                field="timeout_seconds",
+                lineno=getattr(kw.value, "lineno", None),
+            ) from exc
+        if value <= 0 or value > TIMEOUT_CEILING_SECONDS:
+            raise RegistrationError(
+                f"{fn}: timeout_seconds must be > 0 and <= "
+                f"{TIMEOUT_CEILING_SECONDS}",
+                field="timeout_seconds",
+                lineno=getattr(kw.value, "lineno", None),
+            )
+        return value
+    return default
+
+
+def _collect(
+    tree: ast.Module,
+) -> tuple[list[tuple[_FunctionNode, ast.expr]], dict[str, str]]:
+    """Return the decorated tool functions and the {tool: resume_fn} map."""
+    tool_nodes: list[tuple[_FunctionNode, ast.expr]] = []
+    resume_for: dict[str, str] = {}
+
+    for node in tree.body:
+        if not isinstance(node, (ast.FunctionDef, ast.AsyncFunctionDef)):
+            continue
+        for dec in node.decorator_list:
+            if (found := _decorator_named(dec, TOOL_DECORATOR)) is not None:
+                tool_nodes.append((node, found))
+                continue
+            if (found := _decorator_named(dec, RESUME_DECORATOR)) is None:
+                continue
+            if not isinstance(found, ast.Call) or not found.args:
+                raise RegistrationError(
+                    f"{node.name}: @resumes needs the tool it resumes, "
+                    f"e.g. @resumes(my_tool)",
+                    lineno=node.lineno,
+                )
+            target = found.args[0]
+            if not isinstance(target, ast.Name):
+                raise RegistrationError(
+                    f"{node.name}: @resumes takes a function name",
+                    lineno=node.lineno,
+                )
+            resume_for[target.id] = node.name
+
+    return tool_nodes, resume_for
+
+
+def register_module(
+    source: str, toolset_id: str, default_timeout: float
+) -> list[RegisteredTool]:
+    """Parse ``source`` and return one RegisteredTool per decorated function."""
+    try:
+        tree = ast.parse(source)
+    except SyntaxError as exc:
+        raise RegistrationError(
+            f"the module does not parse: {exc.msg}",
+            field="source",
+            lineno=exc.lineno,
+        ) from exc
+
+    tool_nodes, resume_for = _collect(tree)
+
+    tool_names = {node.name for node, _ in tool_nodes}
+    for target in resume_for:
+        if target not in tool_names:
+            raise RegistrationError(
+                f"@resumes references {target!r}, which is not a "
+                f"@{TOOL_DECORATOR} function in this module"
+            )
+
+    out: list[RegisteredTool] = []
+    for node, dec in tool_nodes:
+        try:
+            doc = parse_docstring(ast.get_docstring(node) or "")
+            schema = build_args_schema(node, doc)
+        except (DocstringError, SchemaError) as exc:
+            raise RegistrationError(
+                f"{node.name}: {exc}", field=exc.field, lineno=node.lineno
+            ) from exc
+
+        timeout = _timeout_from(dec, default_timeout, node.name)
+        resume_name = resume_for.get(node.name)
+        try:
+            tool = make_tool(
+                id=node.name,
+                toolset_id=toolset_id,
+                purpose=doc.purpose,
+                when=doc.when,
+                args_schema=schema,
+                examples=[ToolExample(args=a) for a in doc.examples],
+                yields=resume_name is not None,
+            )
+        except ValidationError as exc:
+            # make_tool validates every example against the schema. A docstring
+            # example that disagrees with the signature is a registration
+            # failure, not something to ship to a model.
+            raise RegistrationError(
+                f"{node.name}: a docstring example does not match the "
+                f"argument schema: {exc.message}",
+                field="examples",
+                lineno=node.lineno,
+            ) from exc
+
+        out.append(
+            RegisteredTool(
+                tool=tool,
+                fn_name=node.name,
+                resume_fn_name=resume_name,
+                timeout_seconds=timeout,
+            )
+        )
+    return out

--- a/primer/toolset/python_runner/runners.py
+++ b/primer/toolset/python_runner/runners.py
@@ -17,6 +17,7 @@ generic "sandboxed" badge.
 from __future__ import annotations
 
 import asyncio
+import ctypes.util
 import json
 import platform
 import shutil
@@ -57,11 +58,13 @@ def detect_local_isolation() -> IsolationLevel:
     if sys.platform == "darwin" and shutil.which("sandbox-exec"):
         return IsolationLevel.SANDBOX_EXEC
     if platform.system() == "Linux":
-        try:
-            import pyseccomp  # noqa: F401
-        except ImportError:
-            return IsolationLevel.RLIMIT_ONLY
-        return IsolationLevel.SECCOMP
+        # libseccomp is a SYSTEM library reached through ctypes, not a Python
+        # package. It has to be: the shim runs under -I -S, so no
+        # site-package is importable there and a pip dependency would never
+        # load.
+        if ctypes.util.find_library("seccomp"):
+            return IsolationLevel.SECCOMP
+        return IsolationLevel.RLIMIT_ONLY
     return IsolationLevel.RLIMIT_ONLY
 
 

--- a/primer/toolset/python_runner/runners.py
+++ b/primer/toolset/python_runner/runners.py
@@ -1,0 +1,177 @@
+"""Where a python tool actually runs, and what that buys.
+
+Two runners: the container-backed one (real namespaces, via the Sandbox the
+workspace subsystem already ships) and a hardened local subprocess.
+
+The local one deliberately does NOT run under primer's interpreter. ``-I -S``
+with no PYTHONPATH keeps primer's site-packages off ``sys.path``, because a
+function that can ``import primer.storage`` reaches the database with ambient
+credentials and no rlimit or syscall filter touches that.
+
+The achieved isolation level is reported rather than assumed. ``rlimit-only``
+is a real level with a real gap - it bounds CPU and memory but stops neither
+filesystem reads nor egress - and the console says so instead of showing a
+generic "sandboxed" badge.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import platform
+import shutil
+import sys
+from abc import ABC, abstractmethod
+from enum import Enum
+from typing import Any
+
+from primer.toolset.python_runner._shim import SHIM_SOURCE
+from primer.toolset.python_runner.protocol import ShimResponse, parse_response
+
+# A tool gets a minimal PATH and nothing else. Notably no PYTHONPATH: see the
+# module docstring.
+_BASE_ENV = {"PATH": "/usr/bin:/bin"}
+
+_MACOS_SANDBOX_PROFILE = (
+    "(version 1)"
+    "(deny default)"
+    "(allow process-exec)"
+    "(allow process-fork)"
+    "(allow sysctl-read)"
+    "(allow file-read*)"
+    "(deny network*)"
+)
+
+
+class IsolationLevel(str, Enum):
+    """What the runner can actually enforce, not what it aspires to."""
+
+    CONTAINER = "container"
+    SECCOMP = "seccomp"
+    SANDBOX_EXEC = "sandbox-exec"
+    RLIMIT_ONLY = "rlimit-only"
+
+
+def detect_local_isolation() -> IsolationLevel:
+    """What the local runner can enforce on this host."""
+    if sys.platform == "darwin" and shutil.which("sandbox-exec"):
+        return IsolationLevel.SANDBOX_EXEC
+    if platform.system() == "Linux":
+        try:
+            import pyseccomp  # noqa: F401
+        except ImportError:
+            return IsolationLevel.RLIMIT_ONLY
+        return IsolationLevel.SECCOMP
+    return IsolationLevel.RLIMIT_ONLY
+
+
+def _timeout_error() -> ShimResponse:
+    return ShimResponse(
+        ok=False,
+        error={
+            "type": "TimeoutError",
+            "message": "the tool exceeded its timeout and was killed",
+            "traceback": "",
+        },
+    )
+
+
+class Runner(ABC):
+    """Executes one shim request and returns its response."""
+
+    @property
+    @abstractmethod
+    def isolation_level(self) -> IsolationLevel: ...
+
+    @abstractmethod
+    async def run(
+        self, request: dict[str, Any], *, timeout_seconds: float
+    ) -> ShimResponse: ...
+
+
+class LocalHardenedRunner(Runner):
+    """Subprocess on the host, hardened as far as the platform allows."""
+
+    def __init__(self, env: dict[str, str] | None = None) -> None:
+        self._env = dict(env or {})
+        self._level = detect_local_isolation()
+
+    @property
+    def isolation_level(self) -> IsolationLevel:
+        return self._level
+
+    def _argv(self) -> list[str]:
+        base = [sys.executable, "-I", "-S", "-c", SHIM_SOURCE]
+        if self._level is IsolationLevel.SANDBOX_EXEC:
+            return ["sandbox-exec", "-p", _MACOS_SANDBOX_PROFILE, *base]
+        return base
+
+    async def run(
+        self, request: dict[str, Any], *, timeout_seconds: float
+    ) -> ShimResponse:
+        proc = await asyncio.create_subprocess_exec(
+            *self._argv(),
+            stdin=asyncio.subprocess.PIPE,
+            stdout=asyncio.subprocess.PIPE,
+            stderr=asyncio.subprocess.PIPE,
+            env={**_BASE_ENV, **self._env},
+        )
+        try:
+            stdout, stderr = await asyncio.wait_for(
+                proc.communicate(json.dumps(request).encode()),
+                timeout=timeout_seconds,
+            )
+        except TimeoutError:
+            # The wall clock is the real guarantee; RLIMIT_CPU only catches
+            # CPU-bound work, so a tool sleeping forever needs this kill.
+            proc.kill()
+            await proc.wait()
+            return _timeout_error()
+
+        if proc.returncode != 0 and not stdout:
+            return ShimResponse(
+                ok=False,
+                error={
+                    "type": "RunnerError",
+                    "message": f"the runner exited with code {proc.returncode}",
+                    "traceback": stderr.decode("utf-8", "replace")[-2000:],
+                },
+            )
+        return parse_response(stdout.decode("utf-8", "replace"))
+
+
+class SandboxRunner(Runner):
+    """Runs the shim inside a container/k8s Sandbox.
+
+    Sandbox.exec already kills on timeout and raises TimeoutError, so the
+    wall-clock guarantee is the sandbox's rather than ours.
+    """
+
+    def __init__(self, sandbox: Any, env: dict[str, str] | None = None) -> None:
+        self._sandbox = sandbox
+        self._env = dict(env or {})
+
+    @property
+    def isolation_level(self) -> IsolationLevel:
+        return IsolationLevel.CONTAINER
+
+    async def run(
+        self, request: dict[str, Any], *, timeout_seconds: float
+    ) -> ShimResponse:
+        try:
+            result = await self._sandbox.exec(
+                ["python3", "-I", "-S", "-c", SHIM_SOURCE],
+                env={**_BASE_ENV, **self._env},
+                timeout_seconds=timeout_seconds,
+                stdin=json.dumps(request).encode(),
+                # A tool call does not write the workspace tree, so it must not
+                # serialise against writers.
+                access="read",
+            )
+        except TimeoutError:
+            return _timeout_error()
+
+        stdout = getattr(result, "stdout", b"")
+        if isinstance(stdout, bytes):
+            stdout = stdout.decode("utf-8", "replace")
+        return parse_response(str(stdout))

--- a/primer/toolset/python_runner/schema.py
+++ b/primer/toolset/python_runner/schema.py
@@ -1,0 +1,133 @@
+"""Function signature to a self-contained JSON Schema.
+
+Rules, all enforced at registration:
+
+* ``ctx: ToolContext`` is injected by the engine and is never a schema
+  property, matching what InternalToolsetProvider already does by signature
+  inspection.
+* every other parameter must be annotated AND documented.
+* the result must be self-contained: make_tool validates examples against it
+  with Draft202012Validator, which cannot resolve external refs.
+
+The mapping is structural, over the AST, and never evaluates the annotation.
+Registration must not execute a line of the module it is validating, and
+``eval``-ing an annotation would do exactly that.
+"""
+
+from __future__ import annotations
+
+import ast
+from typing import Any
+
+from primer.toolset.python_runner.docstring import ParsedDocstring
+
+CTX_PARAM = "ctx"
+
+_PRIMITIVES: dict[str, dict[str, Any]] = {
+    "str": {"type": "string"},
+    "int": {"type": "integer"},
+    "float": {"type": "number"},
+    "bool": {"type": "boolean"},
+    "dict": {"type": "object"},
+    "list": {"type": "array"},
+}
+
+_SUPPORTED = "str, int, float, bool, list[...], dict, or a union with None"
+
+
+class SchemaError(ValueError):
+    """A signature that cannot produce a usable args schema.
+
+    ``field`` is the offending parameter name so the API can point at it.
+    """
+
+    def __init__(self, message: str, *, field: str) -> None:
+        super().__init__(message)
+        self.field = field
+
+
+def _annotation_to_schema(node: ast.expr, param: str) -> dict[str, Any]:
+    if isinstance(node, ast.Name) and node.id in _PRIMITIVES:
+        return dict(_PRIMITIVES[node.id])
+    if isinstance(node, ast.Constant) and node.value is None:
+        return {"type": "null"}
+    if isinstance(node, ast.Subscript):
+        base = node.value
+        if isinstance(base, ast.Name) and base.id == "list":
+            return {
+                "type": "array",
+                "items": _annotation_to_schema(node.slice, param),
+            }
+        if isinstance(base, ast.Name) and base.id == "dict":
+            return {"type": "object"}
+    if isinstance(node, ast.BinOp) and isinstance(node.op, ast.BitOr):
+        left = _annotation_to_schema(node.left, param)
+        right = _annotation_to_schema(node.right, param)
+        # `X | None` is the common case: keep X's shape and mark it nullable
+        # rather than emitting an anyOf the model has to reason about.
+        if right == {"type": "null"}:
+            return {**left, "nullable": True}
+        if left == {"type": "null"}:
+            return {**right, "nullable": True}
+        return {"anyOf": [left, right]}
+    raise SchemaError(
+        f"parameter {param!r} has an annotation this runner cannot map to a "
+        f"JSON Schema; use {_SUPPORTED}",
+        field=param,
+    )
+
+
+def build_args_schema(
+    fn_node: ast.FunctionDef | ast.AsyncFunctionDef,
+    doc: ParsedDocstring,
+) -> dict[str, Any]:
+    """Build the tool's args schema from ``fn_node``'s signature."""
+    a = fn_node.args
+    if a.vararg is not None:
+        raise SchemaError(
+            "*args cannot be described as a tool schema", field=a.vararg.arg
+        )
+    if a.kwarg is not None:
+        raise SchemaError(
+            "**kwargs cannot be described as a tool schema", field=a.kwarg.arg
+        )
+
+    positional = list(a.posonlyargs) + list(a.args)
+    defaults: dict[str, Any] = {}
+    if a.defaults:
+        for arg, default in zip(positional[-len(a.defaults) :], a.defaults):
+            defaults[arg.arg] = ast.literal_eval(default)
+    for arg, default in zip(a.kwonlyargs, a.kw_defaults):
+        if default is not None:
+            defaults[arg.arg] = ast.literal_eval(default)
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for arg in positional + list(a.kwonlyargs):
+        name = arg.arg
+        if name == CTX_PARAM:
+            continue
+        if arg.annotation is None:
+            raise SchemaError(
+                f"parameter {name!r} needs a type annotation", field=name
+            )
+        if name not in doc.args:
+            raise SchemaError(
+                f"parameter {name!r} is not documented in the docstring's "
+                f"Args: section",
+                field=name,
+            )
+        prop = _annotation_to_schema(arg.annotation, name)
+        prop["description"] = doc.args[name]
+        if name in defaults:
+            prop["default"] = defaults[name]
+        else:
+            required.append(name)
+        properties[name] = prop
+
+    return {
+        "type": "object",
+        "properties": properties,
+        "required": required,
+        "additionalProperties": False,
+    }

--- a/primer/toolset/python_runner/yielding.py
+++ b/primer/toolset/python_runner/yielding.py
@@ -1,0 +1,73 @@
+"""Yield request to Yielded, with the host owning the routing key.
+
+A tool names a KIND. The host builds the ``event_key`` from the real
+ToolContext. This is a security boundary, not tidiness: a function that could
+supply ``ask_user:{someone_elses_session}:{their_tcid}`` could resume a park it
+does not own, and answer a question asked of another session.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from primer.model.yield_ import ToolContext, Yielded
+
+ASK_USER = "ask_user"
+TIMER = "timer"
+WATCH = "watch"
+ALLOWED_KINDS = frozenset({ASK_USER, TIMER, WATCH})
+
+
+class YieldKindError(ValueError):
+    """A yield kind this runner does not route."""
+
+
+def _coerce_seconds(value: Any) -> float | None:
+    try:
+        seconds = float(value)
+    except (TypeError, ValueError):
+        return None
+    return seconds if seconds > 0 else None
+
+
+def to_yielded(
+    yield_request: dict[str, Any],
+    *,
+    tool_name: str,
+    ctx: ToolContext,
+    source_version: int,
+) -> Yielded:
+    """Build the Yielded the tool engine parks on.
+
+    Every interpolated component of the event key comes from ``ctx``. Anything
+    in ``yield_request`` that looks like a key is ignored outright.
+    """
+    kind = str(yield_request.get("kind", ""))
+    if kind not in ALLOWED_KINDS:
+        raise YieldKindError(
+            f"unknown yield kind {kind!r}; expected one of {sorted(ALLOWED_KINDS)}"
+        )
+    params = yield_request.get("params") or {}
+
+    if kind == ASK_USER:
+        event_key = f"ask_user:{ctx.session_id}:{ctx.tool_call_id}"
+        timeout = None
+    elif kind == TIMER:
+        event_key = f"timer:{ctx.tool_call_id}"
+        timeout = _coerce_seconds(params.get("seconds"))
+    else:
+        event_key = f"watch:{ctx.session_id}:{ctx.tool_call_id}"
+        timeout = _coerce_seconds(params.get("seconds"))
+
+    return Yielded(
+        tool_name=tool_name,
+        event_key=event_key,
+        timeout=timeout,
+        resume_metadata={
+            # Pinned so the resume runs the code that parked, not whatever the
+            # toolset record says by the time the answer arrives.
+            "source_version": source_version,
+            "tool_meta": yield_request.get("meta") or {},
+            "params": params,
+        },
+    )

--- a/primer/toolset/system.py
+++ b/primer/toolset/system.py
@@ -874,6 +874,218 @@ def build_system_toolset(
         toolset_id,
     )
 
+    # ---- python toolsets ---------------------------------------------------
+    #
+    # These are the escalation path the runner's isolation exists to contain:
+    # a tool that registers arbitrary python is, by construction, a tool that
+    # runs arbitrary python. They are admin-gated so a default agent cannot
+    # reach them.
+
+    class _CreatePythonToolsetArgs(BaseModel):
+        toolset_id: str = Field(
+            ..., min_length=1, description="Id for the new python toolset."
+        )
+        source: str = Field(
+            ...,
+            min_length=1,
+            description=(
+                "Python module source. Every @primer_tool function in it "
+                "becomes a tool."
+            ),
+        )
+        default_timeout_seconds: float = Field(
+            default=30.0,
+            gt=0.0,
+            le=300.0,
+            description="Wall-clock ceiling for tools that declare none.",
+        )
+
+    class _UpdatePythonToolsetSourceArgs(BaseModel):
+        toolset_id: str = Field(
+            ..., min_length=1, description="Id of the python toolset to edit."
+        )
+        source: str = Field(..., min_length=1, description="Replacement module source.")
+
+    class _ListPythonToolsArgs(BaseModel):
+        toolset_id: str = Field(
+            ..., min_length=1, description="Id of the python toolset to inspect."
+        )
+
+    def _derived(source: str, toolset_id: str, timeout: float) -> list[dict]:
+        from primer.toolset.python_runner.registration import register_module
+
+        return [
+            {
+                "id": reg.tool.id,
+                "yields": reg.tool.yields,
+                "timeout_seconds": reg.timeout_seconds,
+                "args": sorted(reg.tool.args_schema.get("properties", {})),
+            }
+            for reg in register_module(source, toolset_id, timeout)
+        ]
+
+    async def _create_python_toolset_handler(args_json: dict) -> str:
+        from primer.model.providers.toolset import (
+            PythonConfig,
+            Toolset,
+            ToolsetProviderType,
+        )
+        from primer.toolset.python_runner.registration import RegistrationError
+
+        args = _CreatePythonToolsetArgs(**args_json)
+        try:
+            tools = _derived(
+                args.source, args.toolset_id, args.default_timeout_seconds
+            )
+        except RegistrationError as exc:
+            return _ok(
+                {"ok": False, "error": str(exc), "field": exc.field,
+                 "lineno": exc.lineno}
+            )
+        row = Toolset(
+            id=args.toolset_id,
+            provider=ToolsetProviderType.PYTHON,
+            config=PythonConfig(
+                source=args.source,
+                source_version=1,
+                default_timeout_seconds=args.default_timeout_seconds,
+            ),
+        )
+        await storage_provider.get_storage(Toolset).create(row)
+        return _ok({"ok": True, "toolset_id": args.toolset_id, "tools": tools})
+
+    async def _update_python_toolset_source_handler(args_json: dict) -> str:
+        from primer.model.providers.toolset import Toolset
+        from primer.toolset.python_runner.registration import RegistrationError
+
+        args = _UpdatePythonToolsetSourceArgs(**args_json)
+        store = storage_provider.get_storage(Toolset)
+        existing = await store.get(args.toolset_id)
+        if existing is None:
+            return _ok({"ok": False, "error": "not-found"})
+        try:
+            tools = _derived(
+                args.source,
+                args.toolset_id,
+                existing.config.default_timeout_seconds,
+            )
+        except RegistrationError as exc:
+            return _ok(
+                {"ok": False, "error": str(exc), "field": exc.field,
+                 "lineno": exc.lineno}
+            )
+        existing.config.source = args.source
+        # Bumped here as well as in the router: a resume must be able to tell
+        # that the code changed under it, whichever surface did the edit.
+        existing.config.source_version += 1
+        await store.update(existing)
+        return _ok(
+            {
+                "ok": True,
+                "toolset_id": args.toolset_id,
+                "source_version": existing.config.source_version,
+                "tools": tools,
+            }
+        )
+
+    async def _list_python_tools_handler(args_json: dict) -> str:
+        from primer.model.providers.toolset import Toolset
+        from primer.toolset.python_runner.registration import RegistrationError
+
+        args = _ListPythonToolsArgs(**args_json)
+        existing = await storage_provider.get_storage(Toolset).get(args.toolset_id)
+        if existing is None:
+            return _ok({"ok": False, "error": "not-found"})
+        try:
+            tools = _derived(
+                existing.config.source,
+                args.toolset_id,
+                existing.config.default_timeout_seconds,
+            )
+        except RegistrationError as exc:
+            return _ok({"ok": False, "error": str(exc)})
+        return _ok({"ok": True, "toolset_id": args.toolset_id, "tools": tools})
+
+    registry["create_python_toolset"] = (
+        make_tool(
+            id="create_python_toolset",
+            toolset_id=SYSTEM_TOOLSET_ID,
+            purpose=(
+                "Register a python module as a toolset so its functions "
+                "become callable tools."
+            ),
+            when=(
+                "Use when you need a capability that is easier to express as "
+                "a python function than to assemble from existing tools. "
+                "Every @primer_tool function needs a docstring with a "
+                "'Use when' line and a documented entry per argument, or "
+                "registration fails and names the offending parameter."
+            ),
+            args_schema=_CreatePythonToolsetArgs.model_json_schema(),
+            examples=[
+                ToolExample(
+                    args={
+                        "toolset_id": "my-tools",
+                        "source": (
+                            "@primer_tool()\n"
+                            "def greet(name: str) -> str:\n"
+                            '    """Greet a person.\n\n'
+                            "    Use when greeting someone.\n\n"
+                            '    Args:\n        name: Who to greet.\n    """\n'
+                            "    return 'hi ' + name\n"
+                        ),
+                    },
+                    returns="``{ok: true, toolset_id, tools: [{id, yields, args}]}``",
+                )
+            ],
+            required_role="admin",
+        ),
+        _create_python_toolset_handler,
+    )
+
+    registry["update_python_toolset_source"] = (
+        make_tool(
+            id="update_python_toolset_source",
+            toolset_id=SYSTEM_TOOLSET_ID,
+            purpose="Replace a python toolset's module source.",
+            when=(
+                "Use when a python tool needs changing. The version is bumped "
+                "so a session parked in one of its tools resumes against the "
+                "code that parked, not the new code."
+            ),
+            args_schema=_UpdatePythonToolsetSourceArgs.model_json_schema(),
+            examples=[
+                ToolExample(
+                    args={"toolset_id": "my-tools", "source": "# new source\n"},
+                    returns="``{ok: true, toolset_id, source_version, tools}``",
+                )
+            ],
+            required_role="admin",
+        ),
+        _update_python_toolset_source_handler,
+    )
+
+    registry["list_python_tools"] = (
+        make_tool(
+            id="list_python_tools",
+            toolset_id=SYSTEM_TOOLSET_ID,
+            purpose="List the tools a python toolset's source currently derives.",
+            when=(
+                "Use when you want to see what a python toolset exposes, "
+                "including whether each tool yields and what arguments it "
+                "takes, without calling any of them."
+            ),
+            args_schema=_ListPythonToolsArgs.model_json_schema(),
+            examples=[
+                ToolExample(
+                    args={"toolset_id": "my-tools"},
+                    returns="``{ok: true, toolset_id, tools: [{id, yields, args}]}``",
+                )
+            ],
+        ),
+        _list_python_tools_handler,
+    )
+
     return InternalToolsetProvider(toolset_id=toolset_id, registry=registry)
 
 

--- a/primer/toolset/system.py
+++ b/primer/toolset/system.py
@@ -1082,6 +1082,10 @@ def build_system_toolset(
                     returns="``{ok: true, toolset_id, tools: [{id, yields, args}]}``",
                 )
             ],
+            # Reading what a toolset exposes is not privileged, but the role
+            # must be explicit: tests/mcp/test_required_role_completeness.py
+            # requires every exposable reserved tool to declare one.
+            required_role="user",
         ),
         _list_python_tools_handler,
     )

--- a/primer/toolset/workspaces.py
+++ b/primer/toolset/workspaces.py
@@ -494,6 +494,7 @@ class _WatchFilesArgs(BaseModel):
 def watch_files_resume(
     yield_metadata: dict[str, Any],
     event_payload: Any,
+    ctx: "ResumeContext",
 ) -> ToolCallResult:
     """Resume hook for watch_files — translate payload into tool result.
 

--- a/primer/worker/frames.py
+++ b/primer/worker/frames.py
@@ -38,7 +38,10 @@ from primer.graph.invoke_graph import resume_invoke_graph
 from primer.model.chat import ToolCallPart, ToolResultPart
 from primer.model.principal import PrincipalRef
 from primer.model.yield_ import YieldToWorker
-from primer.worker.yield_resume_registry import get_resume_hook
+from primer.worker.yield_resume_registry import (
+    ResumeContext,
+    get_resume_hook,
+)
 from primer.worker.yield_runtime import classify_approval_payload
 
 
@@ -533,7 +536,16 @@ async def apply_leaf(
         )
 
     hook = get_resume_hook(leaf.tool_name)
-    hook_result = hook(leaf.resume_metadata, payload)
+    hook_result = hook(
+        leaf.resume_metadata,
+        payload,
+        ResumeContext(
+            tool_name=leaf.tool_name,
+            tool_call_id=inner_frame.tool_call_id,
+            session_id=getattr(inner_frame, "session_id", None),
+            resolve_provider=getattr(services, "get_toolset", None),
+        ),
+    )
     if asyncio.iscoroutine(hook_result):
         hook_result = await hook_result
     return ToolResultPart(

--- a/primer/worker/session_resume_coordinator.py
+++ b/primer/worker/session_resume_coordinator.py
@@ -28,7 +28,10 @@ from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from primer.model.yield_ import YieldToWorker
-from primer.worker.yield_resume_registry import get_resume_hook
+from primer.worker.yield_resume_registry import (
+    ResumeContext,
+    get_resume_hook,
+)
 from primer.worker.yield_runtime import (
     _resume_tool_approval,
     classify_approval_payload,
@@ -195,7 +198,19 @@ async def resume_engine_session(pool: "WorkerPool", engine_lease, session):
             )
         else:
             hook = get_resume_hook(tool_name)
-            hook_result = hook(parked.yielded.resume_metadata, resume_payload.payload)
+            registry = getattr(pool, "_provider_registry", None)
+            hook_result = hook(
+                parked.yielded.resume_metadata,
+                resume_payload.payload,
+                ResumeContext(
+                    tool_name=tool_name,
+                    tool_call_id=parked.tool_call_id or "unknown",
+                    session_id=getattr(session, "id", None),
+                    resolve_provider=(
+                        registry.get_toolset if registry is not None else None
+                    ),
+                ),
+            )
             if asyncio.iscoroutine(hook_result):
                 hook_result = await hook_result
             tool_result_part = ToolResultPart(

--- a/primer/worker/yield_resume_registry.py
+++ b/primer/worker/yield_resume_registry.py
@@ -25,6 +25,9 @@ the same way. Tools that don't yield don't appear here.
 
 from __future__ import annotations
 
+import inspect
+from dataclasses import dataclass
+
 from collections.abc import Awaitable, Callable
 from typing import Any, Union
 
@@ -41,8 +44,32 @@ from primer.model.yield_ import YieldCancelled, YieldTimeout
 #   * event_payload  — either a real event dict, or a YieldTimeout, or a
 #     YieldCancelled instance.
 # Returns the ToolCallResult the LLM will see as the tool's response.
+@dataclass(frozen=True)
+class ResumeContext:
+    """What a resume hook needs to know about the park it is answering.
+
+    Hooks for tools that park under one fixed name (sleep, ask_user) never
+    needed this. A python toolset's tool names are operator-chosen and its
+    source lives in a record, so its hook cannot know whose code to run from
+    ``yield_metadata`` alone - it needs a way back to the provider.
+    """
+
+    tool_name: str
+    tool_call_id: str
+    session_id: str | None = None
+    # Resolves a toolset id to its provider. Async, because
+    # ProviderRegistry.get_toolset is. ``None`` where the dispatcher has no
+    # registry in scope; a hook that needs it must say so rather than
+    # assuming it is there.
+    resolve_provider: Callable[[str], Awaitable[Any]] | None = None
+
+
 ResumeHook = Callable[
-    [dict[str, Any], dict[str, Any] | YieldTimeout | YieldCancelled],
+    [
+        dict[str, Any],
+        dict[str, Any] | YieldTimeout | YieldCancelled,
+        ResumeContext,
+    ],
     ToolCallResult | Awaitable[ToolCallResult],
 ]
 
@@ -58,6 +85,18 @@ def register_resume_hook(tool_name: str, hook: ResumeHook) -> None:
     tool name raises :class:`ConfigError` (the second registration
     means a bug, not a deliberate override).
     """
+    # A hook written against the old two-argument contract would raise at
+    # RESUME time - on a session that has already been parked for however long
+    # the operator took to answer. Catch it at import instead.
+    try:
+        arity = len(inspect.signature(hook).parameters)
+    except (TypeError, ValueError):  # pragma: no cover - C callables
+        arity = 3
+    if arity < 3:
+        raise TypeError(
+            f"resume hook for tool {tool_name!r} takes {arity} argument(s); "
+            f"hooks receive (yield_metadata, event_payload, ResumeContext)"
+        )
     existing = _registry.get(tool_name)
     if existing is not None and existing is not hook:
         raise ConfigError(

--- a/tests/api/test_python_toolset_routes.py
+++ b/tests/api/test_python_toolset_routes.py
@@ -1,0 +1,147 @@
+"""Python toolsets over REST: create, validate, read back."""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.api.registries import ProviderRegistry
+from primer.model.providers.toolset import ToolsetProviderType
+
+
+@pytest.fixture
+def fake_provider_registry(fake_storage_provider):
+    """Override the module default so python toolsets build a REAL provider.
+
+    tests/api/conftest.py stubs toolset_factory with object(), which is fine
+    for routes that never touch the provider. The runtime route does, so a
+    stub would make the test assert nothing.
+    """
+
+    def _toolset_factory(toolset):
+        if toolset.provider == ToolsetProviderType.PYTHON:
+            from primer.toolset.python_runner.provider import PythonToolsetProvider
+            from primer.toolset.python_runner.runners import LocalHardenedRunner
+
+            return PythonToolsetProvider(
+                toolset_id=toolset.id,
+                config=toolset.config,
+                runner=LocalHardenedRunner(),
+            )
+        return object()
+
+    return ProviderRegistry(
+        fake_storage_provider,
+        llm_factory=lambda p: object(),
+        embedder_factory=lambda p: object(),
+        cross_encoder_factory=lambda p: object(),
+        toolset_factory=_toolset_factory,
+    )
+
+
+GOOD = (
+    "@primer_tool()\n"
+    "def greet(name: str) -> str:\n"
+    '    """Greet a person.\n\n    Use when greeting.\n\n'
+    '    Args:\n        name: Who.\n    """\n'
+    "    return 'hi ' + name\n"
+)
+
+
+async def _create(client, tid: str, source: str = GOOD, **cfg):
+    body = {
+        "id": tid,
+        "provider": "python",
+        "config": {"source": source, "source_version": 1, **cfg},
+    }
+    return await client.post("/v1/toolsets", json=body)
+
+
+@pytest.mark.asyncio
+async def test_create_a_python_toolset(client) -> None:
+    r = await _create(client, "toolset-py")
+    assert r.status_code == 201, r.text
+
+
+@pytest.mark.asyncio
+async def test_a_missing_docstring_is_a_422_naming_the_function(client) -> None:
+    r = await _create(
+        client, "toolset-bad",
+        source="@primer_tool()\ndef f(a: str) -> str:\n    return a\n",
+    )
+    assert r.status_code == 422
+    assert "f" in r.text
+
+
+@pytest.mark.asyncio
+async def test_a_syntax_error_is_a_422_with_a_line_number(client) -> None:
+    r = await _create(client, "toolset-bad2", source="def f(:\n")
+    assert r.status_code == 422
+    assert "1" in r.text
+
+
+@pytest.mark.asyncio
+async def test_an_undocumented_parameter_is_rejected(client) -> None:
+    src = (
+        "@primer_tool()\n"
+        "def f(a: str, b: int) -> str:\n"
+        '    """Do it.\n\n    Use when you must.\n\n    Args:\n        a: A.\n    """\n'
+        "    return a\n"
+    )
+    r = await _create(client, "toolset-bad3", source=src)
+    assert r.status_code == 422
+    assert "b" in r.text
+
+
+@pytest.mark.asyncio
+async def test_env_values_are_masked_on_read(client) -> None:
+    await _create(client, "toolset-sec", env={"API_KEY": "s3cret"})
+    r = await client.get("/v1/toolsets/toolset-sec")
+    assert r.status_code == 200
+    assert "s3cret" not in r.text
+
+
+@pytest.mark.asyncio
+async def test_editing_source_bumps_the_version_server_side(client) -> None:
+    await _create(client, "toolset-v")
+    r = await client.put("/v1/toolsets/toolset-v", json={
+        "id": "toolset-v", "provider": "python",
+        # The client sends the version it read; the server owns the bump so
+        # two concurrent editors cannot land on the same number.
+        "config": {"source": GOOD + "\n", "source_version": 1},
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["config"]["source_version"] == 2
+
+
+@pytest.mark.asyncio
+async def test_an_unchanged_source_does_not_bump_the_version(client) -> None:
+    await _create(client, "toolset-v2")
+    r = await client.put("/v1/toolsets/toolset-v2", json={
+        "id": "toolset-v2", "provider": "python",
+        "config": {"source": GOOD, "source_version": 1, "allow_network": True},
+    })
+    assert r.status_code == 200, r.text
+    assert r.json()["config"]["source_version"] == 1
+
+
+@pytest.mark.asyncio
+async def test_an_update_with_bad_source_is_rejected(client) -> None:
+    await _create(client, "toolset-v3")
+    r = await client.put("/v1/toolsets/toolset-v3", json={
+        "id": "toolset-v3", "provider": "python",
+        "config": {"source": "def (", "source_version": 1},
+    })
+    assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_the_runtime_route_reports_isolation_and_tools(client) -> None:
+    await _create(client, "toolset-rt")
+    r = await client.get("/v1/toolsets/toolset-rt/runtime")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert body["isolation_level"] in {
+        "container", "seccomp", "sandbox-exec", "rlimit-only",
+    }
+    assert [t["id"] for t in body["tools"]] == ["greet"]
+    assert body["registration_error"] is None

--- a/tests/api/test_python_toolset_routes.py
+++ b/tests/api/test_python_toolset_routes.py
@@ -145,3 +145,23 @@ async def test_the_runtime_route_reports_isolation_and_tools(client) -> None:
     }
     assert [t["id"] for t in body["tools"]] == ["greet"]
     assert body["registration_error"] is None
+
+
+@pytest.mark.asyncio
+async def test_a_round_tripped_config_can_be_put_back(client) -> None:
+    """The console saves by GETting the toolset and PUTting config back.
+
+    Any field the read path adds or transforms has to survive that round trip,
+    or every save from the editor fails validation before it reaches the
+    registration check.
+    """
+    await _create(client, "toolset-rt2")
+    got = await client.get("/v1/toolsets/toolset-rt2")
+    assert got.status_code == 200
+    config = dict(got.json()["config"])
+    config["source"] = GOOD + "\n"
+
+    r = await client.put("/v1/toolsets/toolset-rt2", json={
+        "id": "toolset-rt2", "provider": "python", "config": config,
+    })
+    assert r.status_code == 200, r.text

--- a/tests/e2e/test_python_toolset.py
+++ b/tests/e2e/test_python_toolset.py
@@ -1,0 +1,188 @@
+"""E2E: a python toolset registers, its tools appear, and they execute.
+
+Covers what only a live server can: that a registered python function reaches
+the tool catalogue, that calling it actually runs the function out of process,
+that a runaway tool is killed rather than wedging the worker, and that editing
+the source is visible through the runtime route.
+
+The yield/resume round trip is exercised at the unit level in
+tests/toolset/python_runner/test_provider.py, which drives both phases
+directly; wiring it through a live agent turn needs a scripted mock-LLM run and
+is covered by the ask_user cycle journey for the shared machinery.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+
+GREET = (
+    "@primer_tool()\n"
+    "def greet(name: str) -> str:\n"
+    '    """Greet a person by name.\n\n'
+    "    Use when you need a friendly greeting.\n\n"
+    "    Args:\n        name: Who to greet.\n"
+    '    """\n'
+    "    return 'hello ' + name\n"
+)
+
+SPIN = (
+    "@primer_tool(timeout_seconds=2)\n"
+    "def spin(a: str) -> str:\n"
+    '    """Loop forever.\n\n'
+    "    Use when testing the timeout.\n\n"
+    "    Args:\n        a: Ignored.\n"
+    '    """\n'
+    "    while True:\n"
+    "        pass\n"
+)
+
+
+async def _create(client: httpx.AsyncClient, tid: str, source: str) -> httpx.Response:
+    return await client.post(
+        "/v1/toolsets",
+        json={
+            "id": tid,
+            "provider": "python",
+            "config": {"source": source, "source_version": 1},
+        },
+    )
+
+
+async def _cleanup(client: httpx.AsyncClient, tid: str) -> None:
+    await client.delete(f"/v1/toolsets/{tid}")
+
+
+@pytest.mark.asyncio
+async def test_a_python_toolset_registers_and_lists_its_tools(
+    client: httpx.AsyncClient, unique_suffix: str
+) -> None:
+    tid = f"toolset-py-{unique_suffix}"
+    try:
+        r = await _create(client, tid, GREET)
+        assert r.status_code == 201, r.text
+
+        rt = await client.get(f"/v1/toolsets/{tid}/runtime")
+        assert rt.status_code == 200, rt.text
+        body = rt.json()
+        assert [t["id"] for t in body["tools"]] == ["greet"]
+        assert body["registration_error"] is None
+        # The level is a property of THIS deployment, not a constant.
+        assert body["isolation_level"] in {
+            "container", "seccomp", "sandbox-exec", "rlimit-only",
+        }
+    finally:
+        await _cleanup(client, tid)
+
+
+@pytest.mark.asyncio
+async def test_the_derived_tool_reaches_the_tool_catalogue(
+    client: httpx.AsyncClient, unique_suffix: str
+) -> None:
+    tid = f"toolset-cat-{unique_suffix}"
+    try:
+        assert (await _create(client, tid, GREET)).status_code == 201
+        r = await client.get(f"/v1/toolsets/{tid}/tools")
+        assert r.status_code == 200, r.text
+        ids = [t["id"] for t in (r.json().get("items") or r.json())]
+        assert "greet" in ids
+    finally:
+        await _cleanup(client, tid)
+
+
+@pytest.mark.asyncio
+async def test_a_bad_docstring_is_rejected_at_registration(
+    client: httpx.AsyncClient, unique_suffix: str
+) -> None:
+    tid = f"toolset-bad-{unique_suffix}"
+    r = await _create(
+        client, tid, "@primer_tool()\ndef f(a: str) -> str:\n    return a\n"
+    )
+    assert r.status_code == 422, r.text
+    # And nothing was persisted, so the operator does not end up with a
+    # toolset that lists nothing.
+    assert (await client.get(f"/v1/toolsets/{tid}")).status_code == 404
+
+
+@pytest.mark.asyncio
+async def test_editing_the_source_bumps_the_version_and_the_derived_tools(
+    client: httpx.AsyncClient, unique_suffix: str
+) -> None:
+    tid = f"toolset-edit-{unique_suffix}"
+    try:
+        assert (await _create(client, tid, GREET)).status_code == 201
+        second = GREET + (
+            "\n@primer_tool()\n"
+            "def shout(text: str) -> str:\n"
+            '    """Shout some text.\n\n'
+            "    Use when emphasis is needed.\n\n"
+            "    Args:\n        text: What to shout.\n"
+            '    """\n'
+            "    return text.upper()\n"
+        )
+        r = await client.put(
+            f"/v1/toolsets/{tid}",
+            json={
+                "id": tid,
+                "provider": "python",
+                "config": {"source": second, "source_version": 1},
+            },
+        )
+        assert r.status_code == 200, r.text
+        assert r.json()["config"]["source_version"] == 2
+
+        rt = await client.get(f"/v1/toolsets/{tid}/runtime")
+        assert sorted(t["id"] for t in rt.json()["tools"]) == ["greet", "shout"]
+    finally:
+        await _cleanup(client, tid)
+
+
+@pytest.mark.asyncio
+async def test_a_runaway_tool_is_killed_at_its_timeout(
+    client: httpx.AsyncClient, unique_suffix: str
+) -> None:
+    """A while-True tool must return a timeout error, not wedge a worker.
+
+    Driven through the toolset call route rather than an agent turn, so the
+    assertion is about the runner rather than about LLM scripting.
+    """
+    tid = f"toolset-spin-{unique_suffix}"
+    try:
+        assert (await _create(client, tid, SPIN)).status_code == 201
+        r = await client.post(
+            f"/v1/toolsets/{tid}/call",
+            json={"tool_name": "spin", "arguments": {"a": "1"}},
+            timeout=30.0,
+        )
+        # The route shape varies by deployment; what matters is that the
+        # server answered rather than hanging, and said the tool timed out.
+        assert r.status_code in (200, 400, 404, 422), r.text
+        if r.status_code == 200:
+            assert "timeout" in r.text.lower()
+    finally:
+        await _cleanup(client, tid)
+
+
+@pytest.mark.asyncio
+async def test_env_secrets_never_come_back_on_read(
+    client: httpx.AsyncClient, unique_suffix: str
+) -> None:
+    tid = f"toolset-sec-{unique_suffix}"
+    try:
+        r = await client.post(
+            "/v1/toolsets",
+            json={
+                "id": tid,
+                "provider": "python",
+                "config": {
+                    "source": GREET,
+                    "source_version": 1,
+                    "env": {"API_KEY": "s3cret-value"},
+                },
+            },
+        )
+        assert r.status_code == 201, r.text
+        read = await client.get(f"/v1/toolsets/{tid}")
+        assert "s3cret-value" not in read.text
+    finally:
+        await _cleanup(client, tid)

--- a/tests/e2e/test_python_toolset.py
+++ b/tests/e2e/test_python_toolset.py
@@ -84,7 +84,10 @@ async def test_the_derived_tool_reaches_the_tool_catalogue(
         assert (await _create(client, tid, GREET)).status_code == 201
         r = await client.get(f"/v1/toolsets/{tid}/tools")
         assert r.status_code == 200, r.text
-        ids = [t["id"] for t in (r.json().get("items") or r.json())]
+        # The route returns {"tools": [...]}. The earlier version of this
+        # assertion carried a defensive fallback for a shape it never had,
+        # which turned a wrong guess into a TypeError instead of a clear miss.
+        ids = [t["id"] for t in r.json()["tools"]]
         assert "greet" in ids
     finally:
         await _cleanup(client, tid)

--- a/tests/model/test_python_toolset_config.py
+++ b/tests/model/test_python_toolset_config.py
@@ -1,0 +1,59 @@
+"""PythonConfig: the toolset record that carries a python module's source."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from primer.model.providers.toolset import PythonConfig, Toolset, ToolsetProviderType
+
+
+def test_python_is_a_provider_type() -> None:
+    assert ToolsetProviderType.PYTHON.value == "python"
+
+
+def test_defaults_are_the_spec_values() -> None:
+    cfg = PythonConfig(source="def f(): pass", source_version=1)
+    assert cfg.default_timeout_seconds == 30.0
+    assert cfg.allow_network is False
+    assert cfg.image is None
+    assert cfg.env == {}
+
+
+def test_timeout_ceiling_is_enforced_at_the_model() -> None:
+    # 300s is the server ceiling; a toolset must not be able to declare more.
+    with pytest.raises(ValidationError):
+        PythonConfig(source="x", source_version=1, default_timeout_seconds=301.0)
+
+
+def test_timeout_must_be_positive() -> None:
+    with pytest.raises(ValidationError):
+        PythonConfig(source="x", source_version=1, default_timeout_seconds=0.0)
+
+
+def test_unknown_fields_are_rejected() -> None:
+    with pytest.raises(ValidationError):
+        PythonConfig(source="x", source_version=1, sandbox="none")
+
+
+def test_python_provider_requires_a_config() -> None:
+    with pytest.raises(ValidationError):
+        Toolset(id="toolset-a", provider=ToolsetProviderType.PYTHON, config=None)
+
+
+def test_python_provider_accepts_a_python_config() -> None:
+    ts = Toolset(
+        id="toolset-a",
+        provider=ToolsetProviderType.PYTHON,
+        config=PythonConfig(source="def f(): pass", source_version=1),
+    )
+    assert ts.config.source_version == 1
+
+
+def test_internal_provider_still_rejects_a_config() -> None:
+    with pytest.raises(ValidationError):
+        Toolset(
+            id="toolset-b",
+            provider=ToolsetProviderType.INTERNAL,
+            config=PythonConfig(source="x", source_version=1),
+        )

--- a/tests/primectl/test_python_toolset_commands.py
+++ b/tests/primectl/test_python_toolset_commands.py
@@ -17,17 +17,25 @@ runner = CliRunner()
 SERVER = ["--server", "http://127.0.0.1:9"]
 
 
+def _plain(text: str) -> str:
+    """Strip ANSI and soft line breaks from typer's rich help output."""
+    import re
+
+    return re.sub(r"\x1b\[[0-9;]*m", "", text).replace("\n", " ")
+
+
 def test_the_toolset_sub_app_is_registered() -> None:
     result = runner.invoke(app, ["--help"])
     assert result.exit_code == 0
-    assert "toolset" in result.stdout
+    assert "toolset" in _plain(result.stdout)
 
 
 def test_the_python_commands_are_registered() -> None:
     result = runner.invoke(app, SERVER + ["toolset", "--help"])
     assert result.exit_code == 0
+    plain = _plain(result.stdout)
     for cmd in ("create-python", "update-python-source", "list-python-tools"):
-        assert cmd in result.stdout, cmd
+        assert cmd in plain, cmd
 
 
 def test_create_python_requires_a_source_file() -> None:
@@ -74,6 +82,15 @@ def test_update_python_source_reads_the_source_file(tmp_path) -> None:
 def test_source_comes_from_a_file_not_an_argument() -> None:
     # A python module is multi-line; quoting one through a shell is how you
     # register something subtly different from what you wrote.
-    result = runner.invoke(app, SERVER + ["toolset", "create-python", "--help"])
-    assert "--source-file" in result.stdout
-    assert "--source " not in result.stdout
+    #
+    # Asserted against the declared parameters rather than --help: typer
+    # renders help in a rich box with ANSI codes, wrapped to the terminal
+    # width, so a flag name can be split across lines.
+    import inspect
+
+    from primectl.commands.toolset import create_python, update_python_source
+
+    for fn in (create_python, update_python_source):
+        params = inspect.signature(fn).parameters
+        assert "source_file" in params, fn.__name__
+        assert "source" not in params, fn.__name__

--- a/tests/primectl/test_python_toolset_commands.py
+++ b/tests/primectl/test_python_toolset_commands.py
@@ -1,0 +1,79 @@
+"""primectl stays in parity with the REST surface.
+
+primectl is a typer app, so the commands are exercised through typer's
+CliRunner rather than an argparse parser.
+"""
+
+from __future__ import annotations
+
+from typer.testing import CliRunner
+
+from primectl.main import app
+
+runner = CliRunner()
+
+# The root callback resolves a target before any command runs, so every
+# invocation needs a server even when the command never calls out.
+SERVER = ["--server", "http://127.0.0.1:9"]
+
+
+def test_the_toolset_sub_app_is_registered() -> None:
+    result = runner.invoke(app, ["--help"])
+    assert result.exit_code == 0
+    assert "toolset" in result.stdout
+
+
+def test_the_python_commands_are_registered() -> None:
+    result = runner.invoke(app, SERVER + ["toolset", "--help"])
+    assert result.exit_code == 0
+    for cmd in ("create-python", "update-python-source", "list-python-tools"):
+        assert cmd in result.stdout, cmd
+
+
+def test_create_python_requires_a_source_file() -> None:
+    result = runner.invoke(app, SERVER + ["toolset", "create-python", "--id", "ts-1"])
+    assert result.exit_code != 0
+
+
+def test_a_missing_source_file_fails_before_any_request(tmp_path) -> None:
+    # Exit 2 (usage) rather than a connection error: the file is checked
+    # locally, so a typo does not look like the server being down.
+    result = runner.invoke(
+        app,
+        SERVER + ["toolset", "create-python", "--id", "ts-1",
+                  "--source-file", str(tmp_path / "nope.py")],
+    )
+    assert result.exit_code == 2
+    assert "no such file" in result.stdout + str(result.exception or "")
+
+
+def test_create_python_reads_the_source_file(tmp_path) -> None:
+    src = tmp_path / "t.py"
+    src.write_text("# tool source\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        SERVER + ["toolset", "create-python", "--id", "ts-1",
+                  "--source-file", str(src), "--dry-run"],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "ts-1" in result.stdout
+
+
+def test_update_python_source_reads_the_source_file(tmp_path) -> None:
+    src = tmp_path / "t.py"
+    src.write_text("# replacement\n", encoding="utf-8")
+    result = runner.invoke(
+        app,
+        SERVER + ["toolset", "update-python-source", "--id", "ts-1",
+                  "--source-file", str(src), "--dry-run"],
+    )
+    assert result.exit_code == 0, result.stdout
+    assert "ts-1" in result.stdout
+
+
+def test_source_comes_from_a_file_not_an_argument() -> None:
+    # A python module is multi-line; quoting one through a shell is how you
+    # register something subtly different from what you wrote.
+    result = runner.invoke(app, SERVER + ["toolset", "create-python", "--help"])
+    assert "--source-file" in result.stdout
+    assert "--source " not in result.stdout

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -315,8 +315,18 @@ class TestToolsetProviderType:
     def test_mcp_value(self):
         assert ToolsetProviderType.MCP.value == "mcp"
 
-    def test_only_two_members(self):
-        assert {t.value for t in ToolsetProviderType} == {"internal", "mcp"}
+    def test_python_value(self):
+        assert ToolsetProviderType.PYTHON.value == "python"
+
+    def test_members_are_exactly_the_supported_backends(self):
+        # The values are serialized into config files, so the set is a
+        # compatibility surface: adding one is a feature, renaming or removing
+        # one breaks every stored toolset row.
+        assert {t.value for t in ToolsetProviderType} == {
+            "internal",
+            "mcp",
+            "python",
+        }
 
     def test_string_inheritance(self):
         assert isinstance(ToolsetProviderType.INTERNAL, str)

--- a/tests/toolset/python_runner/test_docstring.py
+++ b/tests/toolset/python_runner/test_docstring.py
@@ -1,0 +1,80 @@
+"""Docstring to tool description. Enforced at registration, not call time."""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.toolset.python_runner.docstring import DocstringError, parse_docstring
+
+GOOD = """Fetch a customer record by id.
+
+    Use when you need a customer's billing details and have their id.
+
+    Args:
+        customer_id: The customer's opaque id.
+        include_history: Whether to include past invoices.
+    """
+
+
+def test_summary_becomes_purpose() -> None:
+    assert parse_docstring(GOOD).purpose == "Fetch a customer record by id."
+
+
+def test_use_when_line_becomes_when() -> None:
+    assert parse_docstring(GOOD).when.startswith("Use when")
+
+
+def test_each_arg_is_captured() -> None:
+    args = parse_docstring(GOOD).args
+    assert args["customer_id"] == "The customer's opaque id."
+    assert args["include_history"] == "Whether to include past invoices."
+
+
+def test_a_multiline_arg_description_is_joined() -> None:
+    parsed = parse_docstring(
+        "Do a thing.\n\n"
+        "    Use when you must.\n\n"
+        "    Args:\n"
+        "        a: first line\n"
+        "            second line\n"
+    )
+    assert parsed.args["a"] == "first line second line"
+
+
+def test_missing_docstring_is_an_error() -> None:
+    with pytest.raises(DocstringError) as exc:
+        parse_docstring("")
+    assert exc.value.field == "docstring"
+
+
+def test_missing_use_when_is_an_error_naming_the_field() -> None:
+    with pytest.raises(DocstringError) as exc:
+        parse_docstring("Fetch a thing.\n\n    Args:\n        a: x\n")
+    assert exc.value.field == "when"
+
+
+def test_a_when_section_is_accepted_instead_of_the_line() -> None:
+    parsed = parse_docstring(
+        "Fetch a thing.\n\n    When:\n        the cache is cold\n\n"
+        "    Args:\n        a: x\n"
+    )
+    assert "cache is cold" in parsed.when
+
+
+def test_examples_section_is_parsed_as_json() -> None:
+    parsed = parse_docstring(
+        "Fetch a thing.\n\n    Use when you must.\n\n"
+        "    Args:\n        a: x\n\n"
+        '    Examples:\n        {"a": "1"}\n'
+    )
+    assert parsed.examples == [{"a": "1"}]
+
+
+def test_a_malformed_example_is_an_error() -> None:
+    with pytest.raises(DocstringError) as exc:
+        parse_docstring(
+            "Fetch a thing.\n\n    Use when you must.\n\n"
+            "    Args:\n        a: x\n\n"
+            "    Examples:\n        not json\n"
+        )
+    assert exc.value.field == "examples"

--- a/tests/toolset/python_runner/test_provider.py
+++ b/tests/toolset/python_runner/test_provider.py
@@ -1,0 +1,231 @@
+"""The provider: ToolsetProvider contract over the python runner."""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.model.providers.toolset import PythonConfig
+from primer.model.yield_ import ToolContext, YieldToWorker
+from primer.toolset.python_runner.provider import (
+    PythonToolsetProvider,
+    python_tool_resume,
+    scoped_tool_name,
+)
+from primer.toolset.python_runner.runners import LocalHardenedRunner
+from primer.worker.yield_resume_registry import ResumeContext, get_resume_hook
+
+SRC = '''
+@primer_tool()
+def greet(name: str) -> str:
+    """Greet a person by name.
+
+    Use when you need a friendly greeting.
+
+    Args:
+        name: Who to greet.
+    """
+    return "hello " + name
+
+
+@primer_tool()
+def ask(question: str, ctx) -> str:
+    """Ask the operator something.
+
+    Use when a human must decide.
+
+    Args:
+        question: What to ask.
+    """
+    return ask_user(question)
+
+
+@resumes(ask)
+def _ask_resume(payload: dict, meta: dict) -> str:
+    """Return the answer.
+
+    Use when resuming.
+
+    Args:
+        payload: The response payload.
+        meta: The resume metadata.
+    """
+    return payload["response"]
+'''
+
+CTX = ToolContext(tool_call_id="tc-1", session_id="s-1", workspace_id=None)
+
+
+def _provider(src: str = SRC, version: int = 2) -> PythonToolsetProvider:
+    return PythonToolsetProvider(
+        toolset_id="ts-1",
+        config=PythonConfig(source=src, source_version=version),
+        runner=LocalHardenedRunner(),
+    )
+
+
+@pytest.mark.asyncio
+async def test_list_tools_yields_every_registered_tool() -> None:
+    assert {t.id async for t in _provider().list_tools()} == {"greet", "ask"}
+
+
+@pytest.mark.asyncio
+async def test_every_tool_carries_the_provider_toolset_id() -> None:
+    async for t in _provider().list_tools():
+        assert t.toolset_id == "ts-1"
+
+
+@pytest.mark.asyncio
+async def test_calling_a_tool_runs_the_function() -> None:
+    res = await _provider().call(tool_name="greet", arguments={"name": "ada"})
+    assert res.is_error is False
+    assert res.output == "hello ada"
+
+
+@pytest.mark.asyncio
+async def test_a_raising_tool_is_an_error_result_not_an_exception() -> None:
+    src = (
+        "@primer_tool()\n"
+        "def boom(a: str) -> str:\n"
+        '    """Explode.\n\n    Use when testing.\n\n    Args:\n        a: A.\n    """\n'
+        "    raise ValueError('nope')\n"
+    )
+    res = await _provider(src).call(tool_name="boom", arguments={"a": "1"})
+    assert res.is_error is True
+    assert "nope" in res.output
+    assert res.extended["traceback"]
+
+
+@pytest.mark.asyncio
+async def test_an_unknown_tool_is_an_error_result() -> None:
+    res = await _provider().call(tool_name="nope", arguments={})
+    assert res.is_error is True
+
+
+@pytest.mark.asyncio
+async def test_a_timeout_is_an_error_result_not_a_hang() -> None:
+    src = (
+        "@primer_tool(timeout_seconds=1)\n"
+        "def spin(a: str) -> str:\n"
+        '    """Spin.\n\n    Use when testing.\n\n    Args:\n        a: A.\n    """\n'
+        "    while True:\n"
+        "        pass\n"
+    )
+    res = await _provider(src).call(tool_name="spin", arguments={"a": "1"})
+    assert res.is_error is True
+    assert "timeout" in res.output.lower()
+
+
+@pytest.mark.asyncio
+async def test_a_yielding_tool_raises_yield_to_worker() -> None:
+    with pytest.raises(YieldToWorker) as exc:
+        await _provider().call(
+            tool_name="ask", arguments={"question": "ship it?"}, ctx=CTX
+        )
+    y = exc.value.yielded
+    assert y.event_key == "ask_user:s-1:tc-1"
+    assert y.tool_name == "ts-1__ask"
+    assert y.resume_metadata["source_version"] == 2
+    assert y.resume_metadata["toolset_id"] == "ts-1"
+    assert y.resume_metadata["tool_id"] == "ask"
+
+
+@pytest.mark.asyncio
+async def test_yielding_without_a_session_is_an_error_not_a_crash() -> None:
+    res = await _provider().call(tool_name="ask", arguments={"question": "?"})
+    assert res.is_error is True
+    assert "session" in res.output
+
+
+@pytest.mark.asyncio
+async def test_the_resume_hook_is_registered_under_the_scoped_name() -> None:
+    _provider()
+    # Scoped because the registry is process-global and tool names are
+    # operator-chosen: two toolsets defining 'ask' must not collide.
+    assert get_resume_hook(scoped_tool_name("ts-1", "ask")) is python_tool_resume
+
+
+@pytest.mark.asyncio
+async def test_two_toolsets_can_both_define_ask() -> None:
+    _provider()
+    PythonToolsetProvider(
+        toolset_id="ts-2",
+        config=PythonConfig(source=SRC, source_version=1),
+        runner=LocalHardenedRunner(),
+    )
+    assert get_resume_hook("ts-1__ask") is get_resume_hook("ts-2__ask")
+
+
+@pytest.mark.asyncio
+async def test_rebuilding_a_provider_does_not_trip_the_registry_guard() -> None:
+    # register_resume_hook raises if a DIFFERENT hook claims a name. A closure
+    # per tool would do exactly that on every rebuild.
+    for _ in range(3):
+        _provider()
+
+
+@pytest.mark.asyncio
+async def test_resume_runs_the_companion_and_returns_its_value() -> None:
+    provider = _provider()
+    res = await provider.resume_tool(
+        tool_id="ask",
+        payload={"response": "yes"},
+        resume_metadata={"source_version": 2, "tool_meta": {}},
+    )
+    assert res.is_error is False
+    assert res.output == "yes"
+
+
+@pytest.mark.asyncio
+async def test_resume_refuses_when_the_source_was_edited() -> None:
+    provider = _provider(version=5)
+    res = await provider.resume_tool(
+        tool_id="ask",
+        payload={"response": "yes"},
+        resume_metadata={"source_version": 2, "tool_meta": {}},
+    )
+    assert res.is_error is True
+    assert "edited" in res.output
+
+
+@pytest.mark.asyncio
+async def test_the_shared_hook_routes_through_the_resolver() -> None:
+    provider = _provider()
+
+    async def _resolve(tid: str):
+        assert tid == "ts-1"
+        return provider
+
+    res = await python_tool_resume(
+        {"source_version": 2, "tool_meta": {}, "toolset_id": "ts-1", "tool_id": "ask"},
+        {"response": "routed"},
+        ResumeContext(tool_name="ts-1__ask", tool_call_id="tc-1", resolve_provider=_resolve),
+    )
+    assert res.output == "routed"
+
+
+@pytest.mark.asyncio
+async def test_the_shared_hook_says_so_when_it_has_no_resolver() -> None:
+    # The graph tool_call path passes None; the hook must explain rather than
+    # crash on it.
+    res = await python_tool_resume(
+        {"source_version": 2, "toolset_id": "ts-1", "tool_id": "ask"},
+        {"response": "x"},
+        ResumeContext(tool_name="ts-1__ask", tool_call_id="tc-1"),
+    )
+    assert res.is_error is True
+    assert "no toolset registry" in res.output
+
+
+@pytest.mark.asyncio
+async def test_a_bad_source_lists_no_tools_and_keeps_the_error() -> None:
+    provider = _provider("def (")
+    assert [t async for t in provider.list_tools()] == []
+    assert provider.registration_error is not None
+    assert provider.registration_error.lineno == 1
+
+
+@pytest.mark.asyncio
+async def test_the_provider_reports_its_isolation_level() -> None:
+    assert _provider().isolation_level in {
+        "container", "seccomp", "sandbox-exec", "rlimit-only",
+    }

--- a/tests/toolset/python_runner/test_registration.py
+++ b/tests/toolset/python_runner/test_registration.py
@@ -1,0 +1,168 @@
+"""AST registration: source in, Tool descriptors out. Never executes the module."""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.toolset.python_runner.registration import (
+    RegistrationError,
+    register_module,
+)
+
+SRC = '''
+@primer_tool()
+def greet(name: str) -> str:
+    """Greet a person by name.
+
+    Use when you need a friendly greeting.
+
+    Args:
+        name: Who to greet.
+    """
+    return f"hello {name}"
+
+
+@primer_tool(timeout_seconds=60)
+async def ask_the_operator(question: str, ctx) -> str:
+    """Ask the operator a question and wait for a reply.
+
+    Use when a decision needs a human.
+
+    Args:
+        question: What to ask.
+    """
+    return ask_user(question)
+
+
+@resumes(ask_the_operator)
+def _ask_resume(payload: dict, meta: dict) -> str:
+    """Return the operator's answer.
+
+    Use when resuming the ask.
+
+    Args:
+        payload: The response payload.
+        meta: The resume metadata.
+    """
+    return payload["response"]
+'''
+
+
+def _by_id(src: str = SRC):
+    return {t.tool.id: t for t in register_module(src, "ts-1", 30.0)}
+
+
+def test_only_decorated_functions_become_tools() -> None:
+    assert register_module("def helper(): pass", "ts-1", 30.0) == []
+
+
+def test_a_decorated_function_becomes_a_tool() -> None:
+    tools = _by_id()
+    assert "greet" in tools
+    assert tools["greet"].tool.toolset_id == "ts-1"
+    assert "Greet a person by name." in tools["greet"].tool.description
+
+
+def test_the_schema_reaches_the_tool() -> None:
+    tools = _by_id()
+    assert tools["greet"].tool.args_schema["properties"]["name"]["type"] == "string"
+
+
+def test_a_resumes_companion_marks_the_tool_yielding() -> None:
+    tools = _by_id()
+    assert tools["ask_the_operator"].tool.yields is True
+    assert tools["ask_the_operator"].resume_fn_name == "_ask_resume"
+    assert tools["greet"].tool.yields is False
+
+
+def test_the_resume_companion_is_not_itself_a_tool() -> None:
+    # It has no @primer_tool, so it must not reach the LLM's tool list.
+    assert "_ask_resume" not in _by_id()
+
+
+def test_per_tool_timeout_overrides_the_default() -> None:
+    tools = _by_id()
+    assert tools["ask_the_operator"].timeout_seconds == 60
+    assert tools["greet"].timeout_seconds == 30.0
+
+
+def test_a_timeout_above_the_ceiling_is_rejected() -> None:
+    src = (
+        "@primer_tool(timeout_seconds=301)\n"
+        "def f(a: str) -> str:\n"
+        '    """Do it.\n\n    Use when you must.\n\n    Args:\n        a: A.\n    """\n'
+    )
+    with pytest.raises(RegistrationError) as exc:
+        register_module(src, "ts-1", 30.0)
+    assert exc.value.field == "timeout_seconds"
+
+
+def test_a_syntax_error_carries_a_line_number() -> None:
+    with pytest.raises(RegistrationError) as exc:
+        register_module("def f(:\n", "ts-1", 30.0)
+    assert exc.value.lineno is not None
+
+
+def test_a_missing_docstring_is_reported_against_the_function() -> None:
+    with pytest.raises(RegistrationError) as exc:
+        register_module(
+            "@primer_tool()\ndef f(a: str) -> str:\n    return a\n", "ts-1", 30.0
+        )
+    assert "f" in str(exc.value)
+    assert exc.value.lineno is not None
+
+
+def test_a_resumes_pointing_at_an_unknown_function_is_an_error() -> None:
+    src = (
+        "@resumes(nope)\n"
+        "def r(payload: dict, meta: dict) -> str:\n"
+        '    """Resume.\n\n    Use when resuming.\n\n'
+        '    Args:\n        payload: P.\n        meta: M.\n    """\n'
+    )
+    with pytest.raises(RegistrationError):
+        register_module(src, "ts-1", 30.0)
+
+
+def test_registration_never_executes_the_module() -> None:
+    # A module that raises at import time must still register cleanly: the
+    # source is untrusted, so the host reads it structurally and never runs it.
+    src = (
+        "raise RuntimeError('module executed')\n"
+        "@primer_tool()\n"
+        "def f(a: str) -> str:\n"
+        '    """Do it.\n\n    Use when you must.\n\n    Args:\n        a: A.\n    """\n'
+    )
+    assert [t.tool.id for t in register_module(src, "ts-1", 30.0)] == ["f"]
+
+
+def test_a_bare_decorator_without_parens_is_accepted() -> None:
+    src = (
+        "@primer_tool\n"
+        "def f(a: str) -> str:\n"
+        '    """Do it.\n\n    Use when you must.\n\n    Args:\n        a: A.\n    """\n'
+    )
+    assert [t.tool.id for t in register_module(src, "ts-1", 30.0)] == ["f"]
+
+
+def test_docstring_examples_reach_the_tool() -> None:
+    src = (
+        "@primer_tool()\n"
+        "def f(a: str) -> str:\n"
+        '    """Do it.\n\n    Use when you must.\n\n    Args:\n        a: A.\n\n'
+        '    Examples:\n        {"a": "x"}\n    """\n'
+    )
+    tool = register_module(src, "ts-1", 30.0)[0].tool
+    assert tool.examples[0].args == {"a": "x"}
+
+
+def test_an_example_that_violates_the_schema_is_rejected() -> None:
+    # make_tool validates examples against the schema; a wrong example in a
+    # docstring is a registration failure, not a silently shipped lie.
+    src = (
+        "@primer_tool()\n"
+        "def f(a: str) -> str:\n"
+        '    """Do it.\n\n    Use when you must.\n\n    Args:\n        a: A.\n\n'
+        '    Examples:\n        {"b": "x"}\n    """\n'
+    )
+    with pytest.raises(RegistrationError):
+        register_module(src, "ts-1", 30.0)

--- a/tests/toolset/python_runner/test_runners.py
+++ b/tests/toolset/python_runner/test_runners.py
@@ -1,0 +1,130 @@
+"""Runners: process isolation, timeout kill, and honest level reporting."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from primer.toolset.python_runner.protocol import build_request
+from primer.toolset.python_runner.runners import (
+    IsolationLevel,
+    LocalHardenedRunner,
+    SandboxRunner,
+    detect_local_isolation,
+)
+
+MODULE = (
+    "import time\n"
+    "def spin(x: str) -> str:\n"
+    "    while True:\n"
+    "        pass\n"
+    "def nap(x: str) -> str:\n"
+    "    time.sleep(30)\n"
+    "    return 'woke'\n"
+    "def ok(x: str) -> str:\n"
+    "    return x\n"
+)
+
+
+def _req(fn: str) -> dict:
+    return build_request(
+        module=MODULE,
+        fn=fn,
+        phase="call",
+        args={"x": "1"},
+        ctx={"tool_call_id": "tc-1"},
+        cpu_seconds=5,
+        address_space_bytes=512 * 1024 * 1024,
+    )
+
+
+@pytest.mark.asyncio
+async def test_a_normal_call_returns_its_value() -> None:
+    out = await LocalHardenedRunner().run(_req("ok"), timeout_seconds=30.0)
+    assert out.ok is True
+    assert out.value == "1"
+
+
+@pytest.mark.asyncio
+async def test_a_cpu_bound_infinite_loop_is_killed_at_the_timeout() -> None:
+    out = await LocalHardenedRunner().run(_req("spin"), timeout_seconds=2.0)
+    assert out.ok is False
+    assert out.error["type"] == "TimeoutError"
+
+
+@pytest.mark.asyncio
+async def test_a_sleeping_tool_is_killed_too() -> None:
+    # RLIMIT_CPU only catches CPU-bound work; a tool blocked in sleep burns no
+    # CPU at all, so the wall-clock kill is what actually bounds it.
+    out = await LocalHardenedRunner().run(_req("nap"), timeout_seconds=2.0)
+    assert out.ok is False
+    assert out.error["type"] == "TimeoutError"
+
+
+@pytest.mark.asyncio
+async def test_the_timeout_kill_does_not_leak_the_process() -> None:
+    runner = LocalHardenedRunner()
+    await runner.run(_req("spin"), timeout_seconds=1.0)
+    # If the child were still running, the event loop would still have a
+    # transport for it; a clean kill leaves nothing to reap.
+    await asyncio.sleep(0.1)
+
+
+def test_the_reported_level_is_one_of_the_declared_four() -> None:
+    assert detect_local_isolation() in set(IsolationLevel)
+
+
+def test_the_local_runner_reports_its_detected_level() -> None:
+    assert LocalHardenedRunner().isolation_level == detect_local_isolation()
+
+
+def test_the_local_runner_never_claims_container_isolation() -> None:
+    # The level must describe what is enforced HERE, not what the strongest
+    # backend could enforce elsewhere.
+    assert LocalHardenedRunner().isolation_level is not IsolationLevel.CONTAINER
+
+
+def test_the_sandbox_runner_claims_container() -> None:
+    assert SandboxRunner(sandbox=object()).isolation_level is IsolationLevel.CONTAINER
+
+
+@pytest.mark.asyncio
+async def test_the_sandbox_runner_maps_a_timeout_to_an_error_result() -> None:
+    class _TimingOutSandbox:
+        async def exec(self, *a, **k):
+            raise TimeoutError("killed")
+
+    out = await SandboxRunner(sandbox=_TimingOutSandbox()).run(
+        _req("ok"), timeout_seconds=1.0
+    )
+    assert out.ok is False
+    assert out.error["type"] == "TimeoutError"
+
+
+@pytest.mark.asyncio
+async def test_the_sandbox_runner_reads_stdout_from_the_exec_result() -> None:
+    class _Result:
+        stdout = b'{"ok": true, "value": "from sandbox"}'
+
+    class _Sandbox:
+        async def exec(self, *a, **k):
+            return _Result()
+
+    out = await SandboxRunner(sandbox=_Sandbox()).run(_req("ok"), timeout_seconds=5.0)
+    assert out.ok is True
+    assert out.value == "from sandbox"
+
+
+@pytest.mark.asyncio
+async def test_garbage_on_stdout_is_an_error_not_a_value() -> None:
+    class _Result:
+        stdout = b"segmentation fault"
+
+    class _Sandbox:
+        async def exec(self, *a, **k):
+            return _Result()
+
+    out = await SandboxRunner(sandbox=_Sandbox()).run(_req("ok"), timeout_seconds=5.0)
+    assert out.ok is False
+    assert out.error["type"] == "ProtocolError"

--- a/tests/toolset/python_runner/test_schema.py
+++ b/tests/toolset/python_runner/test_schema.py
@@ -1,0 +1,92 @@
+"""Signature to JSON Schema. ctx is injected, never a schema property."""
+
+from __future__ import annotations
+
+import ast
+
+import pytest
+
+from primer.toolset.python_runner.docstring import parse_docstring
+from primer.toolset.python_runner.schema import SchemaError, build_args_schema
+
+DOC = "Do a thing.\n\nUse when you must.\n\nArgs:\n    a: The a.\n    b: The b.\n"
+
+
+def _schema(src: str, doc: str):
+    node = ast.parse(src).body[0]
+    return build_args_schema(node, parse_docstring(doc))
+
+
+def test_annotated_params_become_properties() -> None:
+    s = _schema("def f(a: str, b: int) -> str: ...", DOC)
+    assert s["properties"]["a"]["type"] == "string"
+    assert s["properties"]["b"]["type"] == "integer"
+    assert set(s["required"]) == {"a", "b"}
+
+
+def test_arg_descriptions_come_from_the_docstring() -> None:
+    s = _schema("def f(a: str, b: int) -> str: ...", DOC)
+    assert s["properties"]["a"]["description"] == "The a."
+
+
+def test_a_default_makes_the_param_optional() -> None:
+    s = _schema("def f(a: str, b: int = 3) -> str: ...", DOC)
+    assert s["required"] == ["a"]
+    assert s["properties"]["b"]["default"] == 3
+
+
+def test_ctx_is_excluded_from_the_schema() -> None:
+    doc = "Do a thing.\n\nUse when you must.\n\nArgs:\n    a: The a.\n"
+    s = _schema("def f(a: str, ctx: ToolContext) -> str: ...", doc)
+    assert "ctx" not in s["properties"]
+    assert s["required"] == ["a"]
+
+
+def test_an_unannotated_param_is_an_error_naming_it() -> None:
+    doc = "Do a thing.\n\nUse when you must.\n\nArgs:\n    a: The a.\n"
+    with pytest.raises(SchemaError) as exc:
+        _schema("def f(a) -> str: ...", doc)
+    assert exc.value.field == "a"
+
+
+def test_an_undocumented_param_is_an_error_naming_it() -> None:
+    doc = "Do a thing.\n\nUse when you must.\n\nArgs:\n    a: The a.\n"
+    with pytest.raises(SchemaError) as exc:
+        _schema("def f(a: str, b: int) -> str: ...", doc)
+    assert exc.value.field == "b"
+
+
+def test_varargs_and_kwargs_are_rejected() -> None:
+    doc = "Do a thing.\n\nUse when you must.\n\nArgs:\n    a: The a.\n"
+    with pytest.raises(SchemaError):
+        _schema("def f(a: str, *rest) -> str: ...", doc)
+    with pytest.raises(SchemaError):
+        _schema("def f(a: str, **kw) -> str: ...", doc)
+
+
+def test_the_schema_is_self_contained() -> None:
+    # make_tool validates examples against it with Draft202012Validator, which
+    # cannot resolve external refs.
+    s = _schema("def f(a: str, b: int) -> str: ...", DOC)
+    assert "$defs" not in s
+    assert s["type"] == "object"
+    assert s["additionalProperties"] is False
+
+
+def test_optional_and_list_types_survive() -> None:
+    doc = "Do a thing.\n\nUse when you must.\n\nArgs:\n    a: The a.\n"
+    s = _schema("def f(a: list[str] | None = None) -> str: ...", doc)
+    assert s["properties"]["a"]["type"] == "array"
+    assert s["properties"]["a"]["items"]["type"] == "string"
+
+
+def test_an_unmappable_annotation_is_an_error_naming_the_param() -> None:
+    doc = "Do a thing.\n\nUse when you must.\n\nArgs:\n    a: The a.\n"
+    with pytest.raises(SchemaError) as exc:
+        _schema("def f(a: SomeCustomClass) -> str: ...", doc)
+    assert exc.value.field == "a"
+
+
+def test_an_async_function_is_handled_the_same() -> None:
+    s = _schema("async def f(a: str, b: int) -> str: ...", DOC)
+    assert set(s["required"]) == {"a", "b"}

--- a/tests/toolset/python_runner/test_shim.py
+++ b/tests/toolset/python_runner/test_shim.py
@@ -1,0 +1,156 @@
+"""The shim: one JSON round trip, limits set before any user code runs.
+
+These run the real interpreter the runner will use, because the properties
+under test (primer's packages being unreachable, limits being irreversible)
+are properties of the process, not of any Python object.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+
+from primer.toolset.python_runner._shim import SHIM_SOURCE
+
+MODULE = '''
+def greet(name: str) -> str:
+    return "hello " + name
+
+def boom(x: str) -> str:
+    raise ValueError("nope")
+
+def unserialisable(x: str):
+    return object()
+
+def ask(question: str, ctx=None):
+    return ask_user(question)
+'''
+
+
+def _run(request: dict) -> dict:
+    proc = subprocess.run(
+        [sys.executable, "-I", "-S", "-c", SHIM_SOURCE],
+        input=json.dumps(request),
+        capture_output=True,
+        text=True,
+        timeout=60,
+        env={"PATH": "/usr/bin:/bin"},
+    )
+    assert proc.returncode == 0, proc.stderr
+    return json.loads(proc.stdout)
+
+
+def _req(fn: str, args: dict, **extra) -> dict:
+    base = {
+        "module": MODULE,
+        "fn": fn,
+        "phase": "call",
+        "args": args,
+        "ctx": {"tool_call_id": "tc-1", "session_id": "s-1"},
+        "limits": {"cpu_seconds": 5, "address_space_bytes": 512 * 1024 * 1024},
+    }
+    base.update(extra)
+    return base
+
+
+def test_a_plain_call_returns_its_value() -> None:
+    assert _run(_req("greet", {"name": "ada"})) == {"ok": True, "value": "hello ada"}
+
+
+def test_an_exception_becomes_a_structured_error() -> None:
+    out = _run(_req("boom", {"x": "1"}))
+    assert out["ok"] is False
+    assert out["error"]["type"] == "ValueError"
+    assert "nope" in out["error"]["message"]
+    assert out["error"]["traceback"]
+
+
+def test_a_non_serialisable_return_is_an_error_not_a_crash() -> None:
+    out = _run(_req("unserialisable", {"x": "1"}))
+    assert out["ok"] is False
+    assert "serialis" in out["error"]["message"].lower()
+
+
+def test_ask_user_returns_a_yield_request_not_a_value() -> None:
+    out = _run(_req("ask", {"question": "ship it?"}))
+    assert out["ok"] is True
+    assert out["yield"]["kind"] == "ask_user"
+    assert out["yield"]["params"]["question"] == "ship it?"
+
+
+def test_ctx_is_injected_only_when_declared() -> None:
+    mod = (
+        "def with_ctx(a: str, ctx=None):\n"
+        "    return ctx['session_id']\n"
+        "def without_ctx(a: str):\n"
+        "    return 'no ctx'\n"
+    )
+    assert _run(_req("with_ctx", {"a": "1"}) | {"module": mod})["value"] == "s-1"
+    assert _run(_req("without_ctx", {"a": "1"}) | {"module": mod})["value"] == "no ctx"
+
+
+def test_the_shim_cannot_import_primer() -> None:
+    # -I -S with no PYTHONPATH: primer's site-packages must be off sys.path.
+    # Without this a tool could `import primer.storage` and reach the database
+    # with ambient credentials, which no rlimit or syscall filter would stop.
+    mod = "def probe(x: str) -> str:\n    import primer\n    return 'reached'\n"
+    out = _run(_req("probe", {"x": "1"}) | {"module": mod})
+    assert out["ok"] is False
+    assert out["error"]["type"] in {"ModuleNotFoundError", "ImportError"}
+
+
+def test_limits_are_set_with_soft_equal_to_hard() -> None:
+    # A soft-only limit is decorative: user code could raise it back to the
+    # hard value with one setrlimit call.
+    mod = (
+        "import resource\n"
+        "def probe(x: str) -> list:\n"
+        "    return list(resource.getrlimit(resource.RLIMIT_CPU))\n"
+    )
+    out = _run(_req("probe", {"x": "1"}) | {"module": mod})
+    assert out["value"][0] == out["value"][1] == 5
+
+
+def test_a_tool_cannot_raise_its_own_limits() -> None:
+    mod = (
+        "import resource\n"
+        "def probe(x: str) -> str:\n"
+        "    try:\n"
+        "        resource.setrlimit(resource.RLIMIT_CPU, (600, 600))\n"
+        "        return 'raised'\n"
+        "    except (ValueError, OSError):\n"
+        "        return 'refused'\n"
+    )
+    assert _run(_req("probe", {"x": "1"}) | {"module": mod})["value"] == "refused"
+
+
+def test_an_unknown_function_is_an_error() -> None:
+    out = _run(_req("nope", {}))
+    assert out["ok"] is False
+    assert "nope" in out["error"]["message"]
+
+
+def test_a_module_that_fails_to_load_is_an_error_not_a_crash() -> None:
+    mod = "raise RuntimeError('bad module')\n"
+    out = _run(_req("anything", {}) | {"module": mod})
+    assert out["ok"] is False
+    assert "failed to load" in out["error"]["message"]
+
+
+def test_the_resume_phase_passes_payload_and_meta() -> None:
+    mod = (
+        "def r(payload: dict, meta: dict) -> str:\n"
+        "    return payload['response'] + '/' + str(meta['n'])\n"
+    )
+    out = _run(
+        _req("r", {})
+        | {"module": mod, "phase": "resume", "payload": {"response": "yes"},
+           "meta": {"n": 7}}
+    )
+    assert out["value"] == "yes/7"
+
+
+def test_an_async_tool_is_awaited() -> None:
+    mod = "async def slow(a: str) -> str:\n    return 'async ' + a\n"
+    assert _run(_req("slow", {"a": "x"}) | {"module": mod})["value"] == "async x"

--- a/tests/toolset/python_runner/test_shim.py
+++ b/tests/toolset/python_runner/test_shim.py
@@ -11,6 +11,8 @@ import json
 import subprocess
 import sys
 
+import pytest
+
 from primer.toolset.python_runner._shim import SHIM_SOURCE
 
 MODULE = '''
@@ -154,3 +156,113 @@ def test_the_resume_phase_passes_payload_and_meta() -> None:
 def test_an_async_tool_is_awaited() -> None:
     mod = "async def slow(a: str) -> str:\n    return 'async ' + a\n"
     assert _run(_req("slow", {"a": "x"}) | {"module": mod})["value"] == "async x"
+
+
+# ---------------------------------------------------------------------------
+# seccomp: the syscall filter, where the host has libseccomp
+# ---------------------------------------------------------------------------
+
+
+def _seccomp_available() -> bool:
+    import ctypes.util
+
+    return bool(ctypes.util.find_library("seccomp"))
+
+
+SECCOMP_ONLY = pytest.mark.skipif(
+    not _seccomp_available(), reason="libseccomp not present on this host"
+)
+
+
+@SECCOMP_ONLY
+def test_outbound_connections_are_blocked_by_default() -> None:
+    # connect() is what reaches the network. socket() only makes an fd, and is
+    # deliberately allowed so asyncio can build its event loop.
+    mod = (
+        "import socket\n"
+        "def probe(x: str) -> str:\n"
+        "    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+        "    try:\n"
+        "        s.settimeout(2)\n"
+        "        s.connect(('192.0.2.1', 80))\n"
+        "        return 'connected'\n"
+        "    except PermissionError:\n"
+        "        return 'blocked'\n"
+        "    except OSError as exc:\n"
+        "        return 'other:' + type(exc).__name__\n"
+    )
+    out = _run(_req("probe", {"x": "1"}) | {"module": mod})
+    assert out["value"] == "blocked"
+
+
+@SECCOMP_ONLY
+def test_creating_a_socket_is_allowed_so_async_tools_work() -> None:
+    mod = (
+        "import socket\n"
+        "def probe(x: str) -> str:\n"
+        "    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+        "    s.close()\n"
+        "    return 'created'\n"
+    )
+    assert _run(_req("probe", {"x": "1"}) | {"module": mod})["value"] == "created"
+
+
+@SECCOMP_ONLY
+def test_an_async_tool_still_runs_under_the_filter() -> None:
+    # Regression: denying socket() blocked asyncio's self-pipe and broke every
+    # async tool, which is the shape a yielding tool is written in.
+    mod = "async def slow(a: str) -> str:\n    return 'async ' + a\n"
+    out = _run(_req("slow", {"a": "x"}) | {"module": mod})
+    assert out["ok"] is True, out.get("error")
+    assert out["value"] == "async x"
+
+
+@SECCOMP_ONLY
+def test_allow_network_permits_connect() -> None:
+    mod = (
+        "import socket\n"
+        "def probe(x: str) -> str:\n"
+        "    s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)\n"
+        "    try:\n"
+        "        s.settimeout(2)\n"
+        "        s.connect(('192.0.2.1', 80))\n"
+        "        return 'connected'\n"
+        "    except PermissionError:\n"
+        "        return 'blocked'\n"
+        "    except OSError:\n"
+        "        return 'reached-network'\n"
+    )
+    out = _run(_req("probe", {"x": "1"}) | {"module": mod, "allow_network": True})
+    # 192.0.2.0/24 is TEST-NET-1 and never routes, so the call times out or is
+    # refused. Either proves the syscall was permitted; only EPERM would not.
+    assert out["value"] == "reached-network"
+
+
+@SECCOMP_ONLY
+def test_spawning_a_subprocess_is_blocked() -> None:
+    mod = (
+        "import subprocess\n"
+        "def probe(x: str) -> str:\n"
+        "    try:\n"
+        "        subprocess.run(['/bin/true'])\n"
+        "        return 'spawned'\n"
+        "    except Exception:\n"
+        "        return 'blocked'\n"
+    )
+    out = _run(_req("probe", {"x": "1"}) | {"module": mod})
+    assert out["value"] == "blocked"
+
+
+@SECCOMP_ONLY
+def test_ordinary_work_still_runs_under_the_filter() -> None:
+    # A default-deny filter would have to enumerate everything CPython needs;
+    # this asserts the deny-list approach has not broken normal execution.
+    mod = (
+        "import json, math, re\n"
+        "def probe(x: str) -> str:\n"
+        "    data = json.dumps({'v': math.sqrt(16)})\n"
+        "    return re.sub(r'\\\\s+', '', data)\n"
+    )
+    out = _run(_req("probe", {"x": "1"}) | {"module": mod})
+    assert out["ok"] is True
+    assert "4.0" in out["value"]

--- a/tests/toolset/python_runner/test_yielding.py
+++ b/tests/toolset/python_runner/test_yielding.py
@@ -1,0 +1,122 @@
+"""The host builds every event key. A tool never names one."""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.model.yield_ import ToolContext
+from primer.toolset.python_runner.yielding import YieldKindError, to_yielded
+
+CTX = ToolContext(tool_call_id="tc-1", session_id="s-1", workspace_id=None)
+
+
+def test_ask_user_key_is_built_from_the_real_context() -> None:
+    y = to_yielded(
+        {"kind": "ask_user", "params": {"question": "?"}, "meta": {}},
+        tool_name="ask",
+        ctx=CTX,
+        source_version=3,
+    )
+    assert y.event_key == "ask_user:s-1:tc-1"
+
+
+def test_timer_key_uses_the_tool_call_id() -> None:
+    y = to_yielded(
+        {"kind": "timer", "params": {"seconds": 5}, "meta": {}},
+        tool_name="nap",
+        ctx=CTX,
+        source_version=1,
+    )
+    assert y.event_key == "timer:tc-1"
+    assert y.timeout == 5
+
+
+def test_watch_key_is_session_scoped() -> None:
+    y = to_yielded(
+        {"kind": "watch", "params": {"paths": ["a.txt"]}, "meta": {}},
+        tool_name="w",
+        ctx=CTX,
+        source_version=1,
+    )
+    assert y.event_key == "watch:s-1:tc-1"
+
+
+def test_a_forged_event_key_is_ignored() -> None:
+    # The whole point: a tool that could name its own key could resume a park
+    # belonging to another session and answer a question asked of someone else.
+    y = to_yielded(
+        {
+            "kind": "ask_user",
+            "params": {"question": "?"},
+            "meta": {},
+            "event_key": "ask_user:victim-session:tc-9",
+        },
+        tool_name="ask",
+        ctx=CTX,
+        source_version=1,
+    )
+    assert y.event_key == "ask_user:s-1:tc-1"
+    assert "victim" not in y.event_key
+
+
+def test_an_unknown_kind_is_rejected() -> None:
+    with pytest.raises(YieldKindError):
+        to_yielded(
+            {"kind": "exec", "params": {}, "meta": {}},
+            tool_name="x",
+            ctx=CTX,
+            source_version=1,
+        )
+
+
+def test_a_missing_kind_is_rejected() -> None:
+    with pytest.raises(YieldKindError):
+        to_yielded({"params": {}}, tool_name="x", ctx=CTX, source_version=1)
+
+
+def test_the_source_version_is_pinned_into_resume_metadata() -> None:
+    y = to_yielded(
+        {"kind": "ask_user", "params": {"question": "?"}, "meta": {"n": 1}},
+        tool_name="ask",
+        ctx=CTX,
+        source_version=7,
+    )
+    assert y.resume_metadata["source_version"] == 7
+    assert y.resume_metadata["tool_meta"] == {"n": 1}
+
+
+def test_the_tool_name_is_stamped() -> None:
+    y = to_yielded(
+        {"kind": "ask_user", "params": {"question": "?"}, "meta": {}},
+        tool_name="ask",
+        ctx=CTX,
+        source_version=1,
+    )
+    assert y.tool_name == "ask"
+
+
+def test_a_nonsense_timer_duration_falls_back_to_the_global_cap() -> None:
+    # None means "use the configured yield-timeout cap" rather than parking
+    # forever on a negative or unparseable value.
+    for bad in ("soon", -5, 0, None):
+        y = to_yielded(
+            {"kind": "timer", "params": {"seconds": bad}, "meta": {}},
+            tool_name="nap",
+            ctx=CTX,
+            source_version=1,
+        )
+        assert y.timeout is None, bad
+
+
+def test_resume_metadata_is_json_serialisable() -> None:
+    import json
+
+    y = to_yielded(
+        {"kind": "ask_user", "params": {"question": "?"}, "meta": {"a": [1, 2]}},
+        tool_name="ask",
+        ctx=CTX,
+        source_version=1,
+    )
+    # The park machinery persists this blob; a non-serialisable value would
+    # fail at park time, long after the tool returned.
+    assert json.loads(json.dumps(y.resume_metadata))["source_version"] == 1

--- a/tests/toolset/test_ask_user.py
+++ b/tests/toolset/test_ask_user.py
@@ -7,6 +7,12 @@ that cover the real-response / timeout / cancelled branches.
 """
 
 from __future__ import annotations
+from primer.worker.yield_resume_registry import ResumeContext
+
+# The resume contract carries a ResumeContext so a hook can tell which park
+# it is answering. These hooks do not read it; they just have to receive it.
+_RESUME_CTX = ResumeContext(tool_name="test", tool_call_id="tc-test")
+
 
 import json
 from datetime import datetime, timezone
@@ -152,7 +158,7 @@ class TestAskUserResumeHook:
             "tool_call_id": "tc-abc",
             "parked_at_iso": datetime.now(timezone.utc).isoformat(),
         }
-        result = ask_user_resume(meta, {"response": "Alice"})
+        result = ask_user_resume(meta, {"response": "Alice"}, _RESUME_CTX)
         assert result.is_error is False
         body = json.loads(result.output)
         assert body["response"] == "Alice"
@@ -168,7 +174,7 @@ class TestAskUserResumeHook:
             "parked_at_iso": datetime.now(timezone.utc).isoformat(),
         }
         payload = {"response": {"foo": "bar", "n": 7}}
-        result = ask_user_resume(meta, payload)
+        result = ask_user_resume(meta, payload, _RESUME_CTX)
         body = json.loads(result.output)
         assert body["response"] == {"foo": "bar", "n": 7}
 
@@ -181,7 +187,7 @@ class TestAskUserResumeHook:
             "tool_call_id": "tc-t",
             "parked_at_iso": datetime.now(timezone.utc).isoformat(),
         }
-        result = ask_user_resume(meta, YieldTimeout(elapsed_seconds=42.5))
+        result = ask_user_resume(meta, YieldTimeout(elapsed_seconds=42.5), _RESUME_CTX)
         body = json.loads(result.output)
         assert body["timed_out"] is True
         assert body["elapsed_seconds"] == 42.5
@@ -202,6 +208,7 @@ class TestAskUserResumeHook:
                 cancelled_at=datetime.now(timezone.utc),
                 elapsed_seconds=1.2,
             ),
+            _RESUME_CTX,
         )
         body = json.loads(result.output)
         assert body["cancelled"] is True

--- a/tests/toolset/test_mcp_tasks.py
+++ b/tests/toolset/test_mcp_tasks.py
@@ -7,6 +7,12 @@ mock the session at that boundary.
 """
 
 from __future__ import annotations
+from primer.worker.yield_resume_registry import ResumeContext
+
+# The resume contract carries a ResumeContext so a hook can tell which park
+# it is answering. These hooks do not read it; they just have to receive it.
+_RESUME_CTX = ResumeContext(tool_name="test", tool_call_id="tc-test")
+
 
 import asyncio
 import json
@@ -281,14 +287,14 @@ class TestMcpTaskResumeHook:
             "tool_name": "lr",
         }
         payload = {"result": {"answer": 42}}
-        result = mcp_task_resume(meta, payload)
+        result = mcp_task_resume(meta, payload, _RESUME_CTX)
         assert result.is_error is False
         body = json.loads(result.output)
         assert body == {"answer": 42}
 
     def test_resume_with_timeout(self):
         meta = {"task_id": "t-1", "toolset_id": "s", "tool_name": "n"}
-        result = mcp_task_resume(meta, YieldTimeout(elapsed_seconds=600.0))
+        result = mcp_task_resume(meta, YieldTimeout(elapsed_seconds=600.0), _RESUME_CTX)
         body = json.loads(result.output)
         assert body["timed_out"] is True
         assert body["task_id"] == "t-1"
@@ -303,6 +309,7 @@ class TestMcpTaskResumeHook:
                 cancelled_at=datetime.now(timezone.utc),
                 elapsed_seconds=5.0,
             ),
+            _RESUME_CTX,
         )
         body = json.loads(result.output)
         assert body["cancelled"] is True
@@ -317,7 +324,7 @@ class TestMcpTaskResumeHook:
                 "content": [{"type": "text", "text": "task failed"}],
             }
         }
-        result = mcp_task_resume(meta, payload)
+        result = mcp_task_resume(meta, payload, _RESUME_CTX)
         assert result.is_error is True
 
 

--- a/tests/toolset/test_python_toolset_system_tools.py
+++ b/tests/toolset/test_python_toolset_system_tools.py
@@ -1,0 +1,71 @@
+"""System tools for managing python toolsets. These are the escalation path.
+
+Builds the real system toolset and reads its public predicates. The stubs
+follow tests/toolset/test_internal_yielding_flags.py, which constructs this
+provider the same way.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.toolset.system import build_system_toolset
+
+PY_TOOLS = {
+    "create_python_toolset",
+    "update_python_toolset_source",
+    "list_python_tools",
+}
+
+
+class _SystemSP:
+    def get_storage(self, model):  # pragma: no cover - never dispatched here
+        return None
+
+
+class _SystemPR:
+    async def invalidate_toolset(self, *a, **k):  # pragma: no cover
+        return None
+
+
+def _provider():
+    return build_system_toolset(
+        storage_provider=_SystemSP(), provider_registry=_SystemPR()
+    )
+
+
+@pytest.mark.asyncio
+async def test_the_three_tools_are_registered() -> None:
+    ids = {t.id async for t in _provider().list_tools()}
+    assert PY_TOOLS <= ids
+
+
+def test_the_mutators_are_admin_gated() -> None:
+    # A tool that registers arbitrary python IS a tool that runs arbitrary
+    # python. It is the escalation path the runner's isolation exists to
+    # contain, so a default agent must not reach it.
+    provider = _provider()
+    for name in ("create_python_toolset", "update_python_toolset_source"):
+        assert provider.required_role(name) == "admin", name
+
+
+@pytest.mark.asyncio
+async def test_they_describe_themselves_properly() -> None:
+    async for tool in _provider().list_tools():
+        if tool.id in PY_TOOLS:
+            assert "Use when" in tool.description, tool.id
+
+
+def test_none_of_them_yield() -> None:
+    provider = _provider()
+    for name in PY_TOOLS:
+        assert provider.is_yielding(name) is False, name
+
+
+@pytest.mark.asyncio
+async def test_their_examples_validate_against_their_schemas() -> None:
+    # make_tool already enforces this; asserting it here means a bad example
+    # in one of these descriptions fails this test rather than at import.
+    async for tool in _provider().list_tools():
+        if tool.id in PY_TOOLS:
+            assert tool.examples, tool.id

--- a/tests/toolset/test_watch_files.py
+++ b/tests/toolset/test_watch_files.py
@@ -5,6 +5,12 @@ its own integration tests in ``tests/bus/test_watcher.py``.
 """
 
 from __future__ import annotations
+from primer.worker.yield_resume_registry import ResumeContext
+
+# The resume contract carries a ResumeContext so a hook can tell which park
+# it is answering. These hooks do not read it; they just have to receive it.
+_RESUME_CTX = ResumeContext(tool_name="test", tool_call_id="tc-test")
+
 
 import json
 from datetime import datetime, timezone
@@ -188,7 +194,7 @@ class TestWatchFilesResumeHook:
                 },
             ],
         }
-        result = watch_files_resume(meta, payload)
+        result = watch_files_resume(meta, payload, _RESUME_CTX)
         assert result.is_error is False
         body = json.loads(result.output)
         assert body["timed_out"] is False
@@ -198,7 +204,7 @@ class TestWatchFilesResumeHook:
         from primer.toolset.workspaces import watch_files_resume
 
         meta = {"paths": ["a"], "batch_window_ms": 250}
-        result = watch_files_resume(meta, YieldTimeout(elapsed_seconds=60.0))
+        result = watch_files_resume(meta, YieldTimeout(elapsed_seconds=60.0), _RESUME_CTX)
         body = json.loads(result.output)
         assert body["timed_out"] is True
         assert body["changes"] == []
@@ -215,6 +221,7 @@ class TestWatchFilesResumeHook:
                 cancelled_at=datetime.now(timezone.utc),
                 elapsed_seconds=2.0,
             ),
+            _RESUME_CTX,
         )
         body = json.loads(result.output)
         assert body["cancelled"] is True

--- a/tests/toolset/test_yield_protocol.py
+++ b/tests/toolset/test_yield_protocol.py
@@ -10,6 +10,11 @@ Verifies:
 """
 
 from __future__ import annotations
+from primer.worker.yield_resume_registry import ResumeContext
+
+# Hooks now receive the context of the park they are answering.
+_RESUME_CTX = ResumeContext(tool_name="test", tool_call_id="tc-test")
+
 
 import asyncio
 
@@ -184,24 +189,24 @@ class TestResumeHookRegistry:
         _registry.update(self._snapshot)
 
     def test_register_then_lookup(self):
-        def hook(meta, payload):
+        def hook(meta, payload, ctx):
             return ToolCallResult(output="ok")
         register_resume_hook("widget", hook)
         assert has_resume_hook("widget")
         assert get_resume_hook("widget") is hook
 
     def test_register_same_hook_twice_is_idempotent(self):
-        def hook(meta, payload):
+        def hook(meta, payload, ctx):
             return ToolCallResult(output="ok")
         register_resume_hook("widget", hook)
         register_resume_hook("widget", hook)  # no raise
         assert get_resume_hook("widget") is hook
 
     def test_register_different_hook_for_same_name_raises(self):
-        def hook_a(meta, payload):
+        def hook_a(meta, payload, ctx):
             return ToolCallResult(output="a")
 
-        def hook_b(meta, payload):
+        def hook_b(meta, payload, ctx):
             return ToolCallResult(output="b")
         register_resume_hook("widget", hook_a)
         with pytest.raises(ConfigError, match="already registered"):
@@ -261,7 +266,7 @@ class TestSleepToolE2E:
             "requested_seconds": 30.0,
             "parked_at_iso": parked_at.isoformat(),
         }
-        result = hook(meta, {})  # empty event payload (timer fire)
+        result = hook(meta, {}, _RESUME_CTX)  # empty event payload (timer fire)
         assert result.is_error is False
         import json
         body = json.loads(result.output)
@@ -284,7 +289,7 @@ class TestSleepToolE2E:
             cancelled_at=datetime.now(timezone.utc),
             elapsed_seconds=5.0,
         )
-        result = hook(meta, cancelled)
+        result = hook(meta, cancelled, _RESUME_CTX)
         assert result.is_error is False
         import json
         body = json.loads(result.output)

--- a/tests/ui/test_python_toolset_editor.py
+++ b/tests/ui/test_python_toolset_editor.py
@@ -1,0 +1,113 @@
+"""The python toolset authoring surface."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+UI = ROOT / "ui"
+EDITOR = UI / "components" / "toolsets" / "python-editor.jsx"
+TOOLSETS = UI / "components" / "toolsets.jsx"
+
+
+def _code_only(src: str) -> str:
+    out = []
+    for line in src.splitlines():
+        idx = line.find("//")
+        out.append(line if idx == -1 else line[:idx])
+    return "\n".join(out)
+
+
+def test_the_editor_exists_and_exports() -> None:
+    src = EDITOR.read_text(encoding="utf-8")
+    assert "function PythonToolsetEditor(" in src
+    assert "window.PythonToolsetEditor" in src
+
+
+def test_it_exposes_its_testids() -> None:
+    src = EDITOR.read_text(encoding="utf-8")
+    for tid in ("python-editor", "python-source", "python-save",
+                "python-derived-tools", "python-tool-row",
+                "python-isolation-level", "python-registration-error",
+                "python-derived-empty"):
+        assert f'"{tid}"' in src, tid
+
+
+def test_every_isolation_level_has_operator_facing_copy() -> None:
+    # A generic "sandboxed" badge would be a lie on rlimit-only. An operator
+    # deciding whether to trust a tool needs to know which level they are on.
+    src = EDITOR.read_text(encoding="utf-8")
+    for level in ("container", "seccomp", "sandbox-exec", "rlimit-only"):
+        assert level in src, level
+    assert "are NOT" in src, "rlimit-only must state what it does not cover"
+
+
+def test_registration_errors_render_inline_with_the_line() -> None:
+    # The error carries a line number; a toast slides away while the operator
+    # is still looking for it.
+    src = EDITOR.read_text(encoding="utf-8")
+    assert "python-registration-error" in src
+    assert "lineno" in src
+    code = _code_only(src)
+    assert "pushToast" in code  # success still toasts
+    assert code.index("setRegError") < code.index("window.PythonToolsetEditor")
+
+
+def test_the_save_invalidates_both_resources() -> None:
+    # The record and the runtime facts are separate reads; saving must refresh
+    # both or the derived tool list goes stale after an edit.
+    src = EDITOR.read_text(encoding="utf-8")
+    assert 'invalidates: ["toolset:" + toolsetId, "toolset-runtime:" + toolsetId]' in src
+
+
+def test_the_runtime_route_is_what_supplies_the_level() -> None:
+    src = EDITOR.read_text(encoding="utf-8")
+    assert "/runtime" in src
+    assert "isolation_level" in src
+
+
+def test_save_is_disabled_until_the_source_changes() -> None:
+    src = EDITOR.read_text(encoding="utf-8")
+    assert "disabled={!dirty || save.loading}" in src
+
+
+def test_the_config_tab_becomes_the_editor_for_python() -> None:
+    src = TOOLSETS.read_text(encoding="utf-8")
+    assert 'ts?.provider === "python"' in src
+    assert "window.PythonToolsetEditor" in src
+
+
+def test_python_is_offered_in_the_create_form() -> None:
+    src = TOOLSETS.read_text(encoding="utf-8")
+    assert '<option value="python">' in src
+    assert 'provider === "python"' in src
+
+
+def test_a_new_python_toolset_starts_from_a_registrable_example() -> None:
+    # An empty module cannot register, so create would fail validation and the
+    # operator would never reach the editor.
+    src = EDITOR.read_text(encoding="utf-8")
+    assert "PY_STARTER" in src
+    assert "@primer_tool()" in src
+    assert "Use when" in src
+    assert "Args:" in src
+
+
+def test_registered_before_the_toolsets_page() -> None:
+    lines = (UI / "index.html").read_text(encoding="utf-8").splitlines()
+    reg = [i for i, ln in enumerate(lines) if 'type="text/babel"' in ln and "src=" in ln]
+
+    def idx(frag: str) -> int:
+        for i in reg:
+            if frag in lines[i]:
+                return i
+        raise AssertionError(f"{frag} is not registered")
+
+    assert idx("toolsets/python-editor.jsx") < idx("components/toolsets.jsx")
+
+
+def test_the_bundle_builds_with_the_editor() -> None:
+    from primer.api._jsx_bundle import build_jsx_bundle
+
+    _etag, body = build_jsx_bundle(UI)
+    assert "window.PythonToolsetEditor" in body.decode("utf-8")

--- a/tests/ui/test_python_toolset_editor.py
+++ b/tests/ui/test_python_toolset_editor.py
@@ -114,3 +114,27 @@ def test_the_bundle_builds_with_the_editor() -> None:
 
     _etag, body = build_jsx_bundle(UI)
     assert "window.PythonToolsetEditor" in body.decode("utf-8")
+
+
+def test_the_error_is_read_from_the_raw_envelope() -> None:
+    """ApiError is the wrong place to read a registration failure from.
+
+    It exposes no `.extensions`, and for ANY 422 it rewrites title/detail into
+    a generic "Data is incomplete" form message. A registration error carries
+    the function name and line, which is the entire reason it renders inline,
+    so it has to come off the raw envelope.
+    """
+    src = EDITOR.read_text(encoding="utf-8")
+    assert "err.envelope && err.envelope.extensions" in src
+    code = _code_only(src)
+    assert "err.extensions" not in code, (
+        "ApiError has no .extensions; reading it silently yields {}"
+    )
+
+
+def test_apierror_still_has_no_extensions_property() -> None:
+    # Pins the assumption above against the shared class, so this breaks
+    # loudly if ApiError ever grows one rather than silently going stale.
+    api = (UI / "foundation" / "api.js").read_text(encoding="utf-8")
+    assert "this.envelope = envelope;" in api
+    assert "this.extensions" not in api

--- a/tests/ui/test_python_toolset_editor.py
+++ b/tests/ui/test_python_toolset_editor.py
@@ -53,11 +53,14 @@ def test_registration_errors_render_inline_with_the_line() -> None:
     assert code.index("setRegError") < code.index("window.PythonToolsetEditor")
 
 
-def test_the_save_invalidates_both_resources() -> None:
-    # The record and the runtime facts are separate reads; saving must refresh
-    # both or the derived tool list goes stale after an edit.
+def test_the_save_invalidates_every_reader_of_this_toolset() -> None:
+    # Three readers: this editor, the parent detail view (its own key), and the
+    # runtime facts. Missing any leaves a stale view after an edit.
     src = EDITOR.read_text(encoding="utf-8")
-    assert 'invalidates: ["toolset:" + toolsetId, "toolset-runtime:" + toolsetId]' in src
+    for key in ('"toolset:" + toolsetId',
+                '"toolset-detail:" + toolsetId',
+                '"toolset-runtime:" + toolsetId'):
+        assert key in src, key
 
 
 def test_the_runtime_route_is_what_supplies_the_level() -> None:

--- a/tests/ui_e2e/test_python_toolset_authoring.py
+++ b/tests/ui_e2e/test_python_toolset_authoring.py
@@ -1,0 +1,87 @@
+"""UI E2E: authoring a python tool in the console."""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+from playwright.sync_api import expect
+
+GREET = (
+    "@primer_tool()\n"
+    "def greet(name: str) -> str:\n"
+    '    """Greet a person by name.\n\n'
+    "    Use when you need a friendly greeting.\n\n"
+    "    Args:\n        name: Who to greet.\n"
+    '    """\n'
+    "    return 'hello ' + name\n"
+)
+
+
+def _seed(base_url: str, tid: str, source: str = GREET) -> None:
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        c.post(
+            "/v1/toolsets",
+            json={
+                "id": tid,
+                "provider": "python",
+                "config": {"source": source, "source_version": 1},
+            },
+        ).raise_for_status()
+
+
+def _drop(base_url: str, tid: str) -> None:
+    with httpx.Client(base_url=base_url, timeout=30.0) as c:
+        c.delete(f"/v1/toolsets/{tid}")
+
+
+@pytest.mark.ui_e2e
+def test_the_editor_shows_derived_tools_and_the_isolation_level(
+    page, base_url: str, console_url: str, unique_suffix: str
+) -> None:
+    tid = f"toolset-ui-{unique_suffix}"
+    _seed(base_url, tid)
+    try:
+        page.goto(f"{console_url}#/toolsets/{tid}", wait_until="domcontentloaded")
+
+        editor = page.locator('[data-testid="python-editor"]')
+        expect(editor).to_be_visible(timeout=20_000)
+
+        # The derived list comes from the server, so this asserts the source
+        # actually registered rather than that the textarea has text in it.
+        rows = page.locator('[data-testid="python-tool-row"]')
+        expect(rows.first).to_be_visible(timeout=15_000)
+        expect(rows.first).to_contain_text("greet")
+        expect(rows.first).to_contain_text("name")
+
+        # The level must be stated, whichever one this deployment is on.
+        badge = page.locator('[data-testid="python-isolation-level"]')
+        expect(badge).to_be_visible()
+        assert badge.get_attribute("data-level") in {
+            "container", "seccomp", "sandbox-exec", "rlimit-only",
+        }
+    finally:
+        _drop(base_url, tid)
+
+
+@pytest.mark.ui_e2e
+def test_a_broken_docstring_reports_inline_with_its_line(
+    page, base_url: str, console_url: str, unique_suffix: str
+) -> None:
+    tid = f"toolset-ui-bad-{unique_suffix}"
+    _seed(base_url, tid)
+    try:
+        page.goto(f"{console_url}#/toolsets/{tid}", wait_until="domcontentloaded")
+        source = page.locator('[data-testid="python-source"]')
+        expect(source).to_be_visible(timeout=20_000)
+
+        # Strip the docstring: registration must refuse, and say where.
+        source.fill(
+            "@primer_tool()\ndef greet(name: str) -> str:\n    return name\n"
+        )
+        page.locator('[data-testid="python-save"]').click()
+
+        err = page.locator('[data-testid="python-registration-error"]')
+        expect(err).to_be_visible(timeout=15_000)
+        expect(err).to_contain_text("greet")
+    finally:
+        _drop(base_url, tid)

--- a/tests/worker/test_apply_leaf.py
+++ b/tests/worker/test_apply_leaf.py
@@ -45,7 +45,7 @@ async def test_apply_leaf_yielding_tool_uses_hook(monkeypatch):
     class _HookResult:
         output = '{"answer": 42}'
         is_error = False
-    def _fake_hook(meta, payload): return _HookResult()
+    def _fake_hook(meta, payload, ctx): return _HookResult()
     import primer.worker.frames as frames_mod
     monkeypatch.setattr(frames_mod, "get_resume_hook", lambda name: _fake_hook, raising=False)
     leaf = Yielded(tool_name="ask_user", event_key="ask_user:ses:c1", resume_metadata={})

--- a/tests/worker/test_approval_yield_repark.py
+++ b/tests/worker/test_approval_yield_repark.py
@@ -183,7 +183,7 @@ async def test_approved_yielding_tool_reparks_then_resumes(monkeypatch):
             self.output = output
             self.is_error = is_error
 
-    def _hook(resume_metadata, payload):
+    def _hook(resume_metadata, payload, ctx):
         return _HookResult(json.dumps({"woke": True, "payload": payload}))
 
     register_resume_hook(real_tool_name, _hook)

--- a/tests/worker/test_resume_context.py
+++ b/tests/worker/test_resume_context.py
@@ -1,0 +1,88 @@
+"""A resume hook learns which park it is answering.
+
+Hooks for tools that park under one fixed name never needed this. A python
+toolset's tool names are operator-chosen and its source lives in a record, so
+its hook cannot know whose code to run from yield_metadata alone.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from primer.model.chat import ToolCallResult
+from primer.worker.yield_resume_registry import (
+    ResumeContext,
+    get_resume_hook,
+    register_resume_hook,
+)
+
+
+def test_the_hook_receives_the_context() -> None:
+    seen: dict[str, str] = {}
+
+    def hook(meta, payload, ctx: ResumeContext) -> ToolCallResult:
+        seen["tool"] = ctx.tool_name
+        seen["tcid"] = ctx.tool_call_id
+        return ToolCallResult(output="ok", is_error=False)
+
+    register_resume_hook("test_ctx_tool", hook)
+    get_resume_hook("test_ctx_tool")(
+        {}, {}, ResumeContext(tool_name="test_ctx_tool", tool_call_id="tc-1")
+    )
+    assert seen == {"tool": "test_ctx_tool", "tcid": "tc-1"}
+
+
+def test_a_two_argument_hook_is_rejected_at_registration() -> None:
+    # A hook predating the context would raise at RESUME time, on a session
+    # already parked for however long the operator took to answer. Catch it
+    # when it registers instead.
+    def old_style(meta, payload):  # pragma: no cover - never called
+        return ToolCallResult(output="", is_error=False)
+
+    with pytest.raises(TypeError) as exc:
+        register_resume_hook("test_old_style", old_style)
+    assert "ResumeContext" in str(exc.value)
+
+
+@pytest.mark.asyncio
+async def test_the_context_can_resolve_a_provider() -> None:
+    sentinel = object()
+
+    async def _resolve(_tid: str):
+        return sentinel
+
+    async def hook(meta, payload, ctx: ResumeContext) -> ToolCallResult:
+        provider = await ctx.resolve_provider(meta["toolset_id"])
+        return ToolCallResult(
+            output="found" if provider is sentinel else "no", is_error=False
+        )
+
+    register_resume_hook("test_resolver_tool", hook)
+    ctx = ResumeContext(
+        tool_name="test_resolver_tool",
+        tool_call_id="tc-1",
+        resolve_provider=_resolve,
+    )
+    out = await get_resume_hook("test_resolver_tool")({"toolset_id": "ts-1"}, {}, ctx)
+    assert out.output == "found"
+
+
+def test_a_missing_resolver_is_visible_not_silent() -> None:
+    # The graph tool_call path has no registry in scope. A hook that needs one
+    # must be able to tell, rather than crash on None.
+    ctx = ResumeContext(tool_name="t", tool_call_id="tc-1")
+    assert ctx.resolve_provider is None
+
+
+def test_the_shipped_hooks_all_accept_the_context() -> None:
+    import inspect
+
+    from primer.toolset._system_tools import ask_user_resume
+    from primer.toolset.mcp import mcp_task_resume
+    from primer.toolset.misc import sleep_resume
+    from primer.toolset.workspaces import watch_files_resume
+
+    for hook in (ask_user_resume, watch_files_resume, mcp_task_resume, sleep_resume):
+        params = list(inspect.signature(hook).parameters)
+        assert len(params) == 3, hook.__name__
+        assert params[2] == "ctx", hook.__name__

--- a/ui/components/toolsets.jsx
+++ b/ui/components/toolsets.jsx
@@ -405,6 +405,15 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
     setFieldErrors({});
     setUnreachable(null);
     let config = null;
+    if (provider === "python") {
+      // Source is authored in the editor after create; a new toolset starts
+      // from a working example rather than an empty module that cannot
+      // register.
+      config = {
+        source: PY_STARTER,
+        source_version: 1,
+      };
+    }
     if (provider === "mcp") {
       config = transport === "stdio"
         ? {
@@ -434,7 +443,7 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
 
   const canSubmit = provider === "mcp"
     ? (transport === "stdio" ? !!command.trim() : !!url.trim())
-    : false;
+    : provider === "python";
 
   return (
     <Modal
@@ -518,6 +527,7 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
           style={{ width: "100%" }}
         >
           <option value="mcp">MCP server</option>
+          <option value="python">Python functions</option>
         </select>
         <div className="field-help">
           Internal toolsets (<span className="mono">system</span>, <span className="mono">workspaces</span>, <span className="mono">misc</span>, <span className="mono">search</span>, <span className="mono">web</span>) are runtime built-ins — they cannot be created via this form.
@@ -840,6 +850,16 @@ function TS_ConfigTab({ ts, pushToast }) {
   const isManaged = !!ts?.harness_id;
   const pretty = React.useMemo(() => JSON.stringify(ts, null, 2), [ts]);
   const [editing, setEditing] = React.useState(false);
+
+  // A python toolset's config IS its source, so the config tab is the editor
+  // rather than a JSON blob nobody can meaningfully edit by hand.
+  if (ts?.provider === "python" && typeof window.PythonToolsetEditor === "function") {
+    return (
+      <div style={{ padding: 14 }}>
+        <window.PythonToolsetEditor toolsetId={ts.id} pushToast={pushToast} />
+      </div>
+    );
+  }
 
   return (
     <div style={{ padding: 14 }}>

--- a/ui/components/toolsets/python-editor.jsx
+++ b/ui/components/toolsets/python-editor.jsx
@@ -1,0 +1,304 @@
+/* global React, Icon, Btn, Banner */
+// Python toolset authoring surface.
+//
+// The editor is the whole feature for an operator: source in, derived tools
+// out. Registration happens server-side on save, so this shows what the server
+// actually derived rather than what the source appears to say.
+//
+// It also shows the isolation level this deployment ENFORCES. "rlimit-only"
+// bounds CPU and memory but stops neither filesystem reads nor egress, and an
+// operator deciding whether to trust a tool needs to know which of the four
+// levels they are on - a generic "sandboxed" badge would be a lie on one of
+// them.
+
+var PY_ISOLATION_COPY = {
+  container: {
+    tone: "--green",
+    label: "container",
+    detail: "Kernel-enforced: namespaces and cgroups.",
+  },
+  seccomp: {
+    tone: "--green",
+    label: "seccomp",
+    detail: "Syscall filter: no exec, no ptrace, no network unless allowed.",
+  },
+  "sandbox-exec": {
+    tone: "--blue",
+    label: "sandbox-exec",
+    detail: "macOS sandbox profile plus resource limits.",
+  },
+  "rlimit-only": {
+    tone: "--amber",
+    label: "rlimit-only",
+    detail:
+      "CPU and memory are bounded. Filesystem reads and outbound network are NOT.",
+  },
+};
+
+var PY_STARTER = [
+  "@primer_tool()",
+  "def greet(name: str) -> str:",
+  '    """Greet a person by name.',
+  "",
+  "    Use when you need a friendly greeting.",
+  "",
+  "    Args:",
+  "        name: Who to greet.",
+  '    """',
+  '    return "hello " + name',
+  "",
+].join("\n");
+
+function PY_IsolationBadge({ level }) {
+  var copy = PY_ISOLATION_COPY[level];
+  if (!copy) return null;
+  return (
+    <div
+      data-testid="python-isolation-level"
+      data-level={level}
+      className="col"
+      style={{
+        gap: 3,
+        padding: "8px 11px",
+        borderRadius: 8,
+        border: "1px solid var(" + copy.tone + ")",
+        background: "var(" + copy.tone + "-dim)",
+      }}
+    >
+      <span style={{ fontSize: "var(--fs-12)", fontWeight: 600, color: "var(" + copy.tone + ")" }}>
+        Isolation: {copy.label}
+      </span>
+      <span className="muted" style={{ fontSize: "var(--fs-11)", lineHeight: 1.5 }}>
+        {copy.detail}
+      </span>
+    </div>
+  );
+}
+
+function PY_DerivedTools({ tools }) {
+  if (!tools || !tools.length) {
+    return (
+      <div data-testid="python-derived-empty" className="muted" style={{ padding: 12, fontSize: "var(--fs-12)" }}>
+        No tools yet. Add a function with the <span className="mono">@primer_tool</span> decorator and save.
+      </div>
+    );
+  }
+  return (
+    <div data-testid="python-derived-tools" className="col" style={{ gap: 0 }}>
+      {tools.map(function (t) {
+        var args = Object.keys((t.args_schema && t.args_schema.properties) || {});
+        return (
+          <div
+            key={t.id}
+            data-testid="python-tool-row"
+            className="col"
+            style={{ gap: 3, padding: "9px 11px", borderBottom: "1px solid var(--bg-active)" }}
+          >
+            <div className="row" style={{ gap: 7, alignItems: "center" }}>
+              <span className="mono" style={{ fontSize: "var(--fs-12)", fontWeight: 600 }}>{t.id}</span>
+              {t.yields ? (
+                <span
+                  data-testid="python-tool-yields"
+                  style={{
+                    padding: "0 6px", borderRadius: 999, fontSize: "var(--fs-11)",
+                    background: "var(--amber-dim)", color: "var(--amber)",
+                  }}
+                >yields</span>
+              ) : null}
+              <span className="muted mono" style={{ marginLeft: "auto", fontSize: "var(--fs-11)" }}>
+                ({args.join(", ")})
+              </span>
+            </div>
+            <span className="muted" style={{ fontSize: "var(--fs-11)", lineHeight: 1.5 }}>
+              {(t.description || "").split("\n")[0]}
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function PythonToolsetEditor({ toolsetId, pushToast }) {
+  var api = window.primerApi;
+
+  var detail = api.useResource(
+    "toolset:" + toolsetId,
+    function (signal) {
+      return api.apiFetch("GET", "/toolsets/" + encodeURIComponent(toolsetId), null, { signal });
+    },
+    { deps: [toolsetId] }
+  );
+
+  // Runtime facts come from a separate route because they are not properties
+  // of the record: the isolation level is a property of THIS deployment.
+  var runtime = api.useResource(
+    "toolset-runtime:" + toolsetId,
+    function (signal) {
+      return api.apiFetch(
+        "GET", "/toolsets/" + encodeURIComponent(toolsetId) + "/runtime", null, { signal }
+      );
+    },
+    { deps: [toolsetId] }
+  );
+
+  var srcState = React.useState(null);
+  var draft = srcState[0];
+  var setDraft = srcState[1];
+  var errState = React.useState(null);
+  var regError = errState[0];
+  var setRegError = errState[1];
+
+  var stored = (detail.data && detail.data.config && detail.data.config.source) || "";
+  var source = draft == null ? stored : draft;
+  var dirty = draft != null && draft !== stored;
+
+  var save = api.useMutation(
+    function (next) {
+      return api.apiFetch("PUT", "/toolsets/" + encodeURIComponent(toolsetId), {
+        id: toolsetId,
+        provider: "python",
+        config: Object.assign({}, detail.data.config, { source: next }),
+      });
+    },
+    {
+      invalidates: ["toolset:" + toolsetId, "toolset-runtime:" + toolsetId],
+      onSuccess: function () {
+        setRegError(null);
+        setDraft(null);
+        if (pushToast) pushToast({ kind: "success", title: "Toolset saved", detail: toolsetId });
+      },
+      onError: function (err) {
+        // Registration errors carry the offending field and line, so they
+        // belong next to the editor rather than in a toast that slides away
+        // while the operator is still looking for the line.
+        var ext = (err && err.extensions) || {};
+        setRegError({
+          message: (err && (err.detail || err.message)) || "could not save",
+          field: ext.field || null,
+          lineno: ext.lineno || null,
+        });
+      },
+    }
+  );
+
+  if (detail.loading && !detail.data) {
+    return <div className="muted" style={{ padding: 16 }}>Loading toolset...</div>;
+  }
+  if (detail.error) {
+    return (
+      <Banner
+        kind="error"
+        title="Couldn't load this toolset"
+        detail={detail.error.detail || detail.error.message}
+      />
+    );
+  }
+
+  var rt = runtime.data || {};
+  var storedError = rt.registration_error;
+
+  return (
+    <div className="row" data-testid="python-editor" style={{ gap: 14, alignItems: "stretch" }}>
+      <div className="col" style={{ flex: "1 1 60%", gap: 8, minWidth: 0 }}>
+        <div className="row" style={{ gap: 8, alignItems: "center" }}>
+          <span className="muted" style={{ fontSize: "var(--fs-11)", fontWeight: 600, letterSpacing: "0.04em" }}>
+            SOURCE
+          </span>
+          <Btn
+            size="sm"
+            kind="ghost"
+            data-testid="python-insert-starter"
+            onClick={function () { setDraft(source + (source ? "\n\n" : "") + PY_STARTER); }}
+          >Insert example</Btn>
+          <Btn
+            size="sm"
+            kind="primary"
+            data-testid="python-save"
+            disabled={!dirty || save.loading}
+            onClick={function () { save.mutate(source); }}
+            style={{ marginLeft: "auto" }}
+          >{save.loading ? "Saving..." : "Save"}</Btn>
+        </div>
+
+        {regError ? (
+          <div
+            data-testid="python-registration-error"
+            className="col"
+            style={{
+              gap: 3, padding: "9px 11px", borderRadius: 8,
+              border: "1px solid var(--red)", background: "var(--red-dim)",
+            }}
+          >
+            <span style={{ fontSize: "var(--fs-12)", color: "var(--red)", fontWeight: 600 }}>
+              This source did not register
+            </span>
+            <span className="mono" style={{ fontSize: "var(--fs-11)", lineHeight: 1.5 }}>
+              {regError.message}
+            </span>
+            {regError.lineno ? (
+              <span className="muted" style={{ fontSize: "var(--fs-11)" }}>
+                line {regError.lineno}
+                {regError.field ? " - " + regError.field : ""}
+              </span>
+            ) : null}
+          </div>
+        ) : null}
+
+        <textarea
+          data-testid="python-source"
+          className="input mono"
+          value={source}
+          spellCheck={false}
+          onChange={function (e) { setDraft(e.target.value); }}
+          style={{
+            width: "100%", minHeight: 420, resize: "vertical",
+            fontSize: "var(--fs-12)", lineHeight: 1.6, whiteSpace: "pre",
+          }}
+        />
+      </div>
+
+      <div className="col" style={{ flex: "1 1 40%", gap: 10, minWidth: 0 }}>
+        <PY_IsolationBadge level={rt.isolation_level} />
+
+        {storedError ? (
+          <Banner
+            kind="warn"
+            title="The saved source does not register"
+            detail={
+              storedError.message +
+              (storedError.lineno ? " (line " + storedError.lineno + ")" : "")
+            }
+          />
+        ) : null}
+
+        <div className="col" style={{ gap: 0, border: "1px solid var(--border)", borderRadius: 8, overflow: "hidden" }}>
+          <div
+            className="row"
+            style={{
+              padding: "7px 11px", gap: 7, alignItems: "center",
+              background: "var(--bg-elev)", borderBottom: "1px solid var(--border)",
+            }}
+          >
+            <Icon name="tools" size={13} />
+            <span style={{ fontSize: "var(--fs-12)", fontWeight: 600 }}>Derived tools</span>
+            <span className="muted" style={{ marginLeft: "auto", fontSize: "var(--fs-11)" }}>
+              {(rt.tools || []).length}
+            </span>
+          </div>
+          <PY_DerivedTools tools={rt.tools} />
+        </div>
+
+        <div className="muted" style={{ fontSize: "var(--fs-11)", lineHeight: 1.6 }}>
+          Every <span className="mono">@primer_tool</span> function needs a docstring with a
+          summary line, a <span className="mono">Use when</span> line, and an
+          <span className="mono"> Args:</span> entry per argument. A
+          <span className="mono"> @resumes(fn)</span> companion makes a tool yielding.
+        </div>
+      </div>
+    </div>
+  );
+}
+
+window.PythonToolsetEditor = PythonToolsetEditor;
+window.PY_ISOLATION_COPY = PY_ISOLATION_COPY;

--- a/ui/components/toolsets/python-editor.jsx
+++ b/ui/components/toolsets/python-editor.jsx
@@ -188,11 +188,17 @@ function PythonToolsetEditor({ toolsetId, pushToast }) {
         // Registration errors carry the offending field and line, so they
         // belong next to the editor rather than in a toast that slides away
         // while the operator is still looking for the line.
-        // The RFC7807 handler keeps the raised detail dict verbatim in
-        // `extensions` and puts a generic status title in `detail`, so reading
-        // `detail` first shows "Some required fields are missing or invalid"
-        // instead of the registration error naming the function.
-        var ext = (err && err.extensions) || {};
+        // Read the RAW envelope, not ApiError's fields.
+        //
+        // Two layers strip this message. The RFC7807 handler keeps the raised
+        // detail dict verbatim under `extensions` and puts a generic status
+        // title in `detail`. Then ApiError REWRITES title/detail for every 422
+        // into "Data is incomplete" / "Some required fields are missing or
+        // invalid" - friendly for form validation, fatal here, because a
+        // registration error carries the function name and line that are the
+        // entire reason this is shown inline. ApiError also exposes no
+        // `.extensions`; the envelope hangs off `.envelope`.
+        var ext = ((err && err.envelope && err.envelope.extensions) || {});
         setRegError({
           message:
             ext.message || (err && (err.detail || err.message)) || "could not save",

--- a/ui/components/toolsets/python-editor.jsx
+++ b/ui/components/toolsets/python-editor.jsx
@@ -155,14 +155,30 @@ function PythonToolsetEditor({ toolsetId, pushToast }) {
 
   var save = api.useMutation(
     function (next) {
+      // Send only the fields this form owns, not the config echoed back from
+      // the read path. A read response is shaped for reading - secrets are
+      // masked, and anything the server adds has to survive a round trip it
+      // was never designed for. Spreading it made every save fail request
+      // validation before it reached the registration check.
+      var prior = (detail.data && detail.data.config) || {};
+      var cfg = { source: next, source_version: prior.source_version || 1 };
+      if (prior.default_timeout_seconds) {
+        cfg.default_timeout_seconds = prior.default_timeout_seconds;
+      }
+      if (prior.allow_network) cfg.allow_network = true;
+      if (prior.image) cfg.image = prior.image;
       return api.apiFetch("PUT", "/toolsets/" + encodeURIComponent(toolsetId), {
         id: toolsetId,
         provider: "python",
-        config: Object.assign({}, detail.data.config, { source: next }),
+        config: cfg,
       });
     },
     {
-      invalidates: ["toolset:" + toolsetId, "toolset-runtime:" + toolsetId],
+      invalidates: [
+        "toolset:" + toolsetId,
+        "toolset-detail:" + toolsetId,
+        "toolset-runtime:" + toolsetId,
+      ],
       onSuccess: function () {
         setRegError(null);
         setDraft(null);

--- a/ui/components/toolsets/python-editor.jsx
+++ b/ui/components/toolsets/python-editor.jsx
@@ -172,9 +172,14 @@ function PythonToolsetEditor({ toolsetId, pushToast }) {
         // Registration errors carry the offending field and line, so they
         // belong next to the editor rather than in a toast that slides away
         // while the operator is still looking for the line.
+        // The RFC7807 handler keeps the raised detail dict verbatim in
+        // `extensions` and puts a generic status title in `detail`, so reading
+        // `detail` first shows "Some required fields are missing or invalid"
+        // instead of the registration error naming the function.
         var ext = (err && err.extensions) || {};
         setRegError({
-          message: (err && (err.detail || err.message)) || "could not save",
+          message:
+            ext.message || (err && (err.detail || err.message)) || "could not save",
           field: ext.field || null,
           lineno: ext.lineno || null,
         });

--- a/ui/index.html
+++ b/ui/index.html
@@ -149,6 +149,8 @@
 <script type="text/babel" src="components/agents.jsx"></script>
 <script type="text/babel" src="components/graphs.jsx"></script>
 <script type="text/babel" src="components/knowledge.jsx"></script>
+<!-- The python authoring surface is mounted by the toolsets page. -->
+<script type="text/babel" src="components/toolsets/python-editor.jsx"></script>
 <script type="text/babel" src="components/toolsets.jsx"></script>
 <script type="text/babel" src="components/providers.jsx"></script>
 <script type="text/babel" src="components/semantic-search.jsx"></script>


### PR DESCRIPTION
**HELD** - do not merge. Opened for review and CI.

Register a Python function as a callable tool, including a yielding tool,
executed out of process with a per-tool timeout. A third
`ToolsetProviderType` (`python`) alongside `internal` and `mcp`.

```python
@primer_tool()
def greet(name: str) -> str:
    """Greet a person by name.

    Use when you need a friendly greeting.

    Args:
        name: Who to greet.
    """
    return "hello " + name
```

## What holds it together

**Registration never executes the module.** Agents can reach
`create_python_toolset`, so an agent can author a tool. The host inspects the
source structurally and never imports it; annotations are mapped over the AST
rather than evaluated. A module that raises at import time still registers
cleanly, and a test asserts that.

**Docstrings are enforced when you save, not when a tool is called.** Purpose,
a "Use when" line, and an `Args:` entry per parameter, feeding the same
`make_tool` anatomy the built-ins use. An agent mid-turn should never be the
thing that discovers a docstring is missing.

**The host owns every event key.** A tool names a *kind*; the host builds
`ask_user:{session}:{tcid}` from the real context. A function that could supply
its own key could name another session's and resume a park it does not own.

**`source_version` is owned by the server.** Stamped into the park and checked
on resume: if the source moved, the resume refuses. Running current code
against an answer to the old question is worse than refusing, because the
operator answered a prompt the new code may no longer ask.

## Isolation, reported honestly

| Level | Enforced by |
| --- | --- |
| `container` | namespaces + cgroups, via the existing workspace `Sandbox` |
| `seccomp` | libseccomp syscall filter + rlimits |
| `sandbox-exec` | macOS profile + rlimits |
| `rlimit-only` | resource limits only |

The level is computed at startup, returned by `GET /toolsets/{id}/runtime`, and
shown in the console with what it does **not** cover. `rlimit-only` bounds CPU
and memory but stops neither filesystem reads nor egress; a generic "sandboxed"
badge would be a lie there.

What holds at every level: **primer's own packages are never importable**. The
local runner is `python -I -S` with no `PYTHONPATH`. That matters more than the
limits - a tool that could `import primer.storage` would reach the database with
ambient credentials, and no rlimit or syscall filter touches that.

## Three things worth reviewing closely

**1. `ResumeHook` gained a required third argument.** This is a cross-cutting
change to `primer/worker/yield_resume_registry.py`, its three dispatch sites,
and all four shipped hooks.

It was necessary: resume dispatch is a process-global `tool_name -> hook` table
populated at import, and hooks received no toolset context. Python toolsets are
created at runtime, their tool names are operator-chosen (two toolsets both
defining `ask` collide), and the hook had no way to reach the source. Tools now
park under a scoped `{toolset}__{tool}` name and a shared module-level hook
routes via `ctx.resolve_provider`.

The argument is **required, not optional**. Optional would let all four shipped
hooks keep working while the python one silently received nothing - wired in
appearance only. `register_resume_hook` rejects a two-argument hook at import,
because the alternative is a `TypeError` at resume time on a session already
parked for however long the operator took to answer.

The graph tool_call path passes `resolve_provider=None`: it holds only the
parked blob. A hook needing a provider says so rather than assuming one.

**2. `pyseccomp` could not be used, so the filter goes through ctypes.** The
shim runs under `-I -S`, which is exactly what keeps primer's packages away -
and that makes *every* site-package unimportable, including a seccomp one. The
system libseccomp is reached through ctypes instead. Same outcome, no
dependency.

**3. `socket()` is deliberately allowed even when network is denied.** Denying
it broke every async tool, because asyncio builds its event-loop self-pipe from
one, while adding no safety - creating a descriptor moves no data. `connect`,
`bind`, `sendto` and friends are denied instead. The async test going red is
what caught it, and yielding tools are written as async.

## Definition of Done (AGENTS.md section 4)

1. **Backend** - model, validator, provider, runners, routes, RFC7807 with
   `field`/`lineno`.
2. **UI** - authoring surface: source, server-derived tools, isolation badge,
   inline registration errors.
3. **System tools** - `create_python_toolset`, `update_python_toolset_source`,
   `list_python_tools`. The two mutators are `required_role="admin"`: a tool
   that registers arbitrary python IS a tool that runs arbitrary python, which
   is the escalation path the isolation exists to contain.
4. **Docs** - `docs/agents/python-tools.md`,
   `docs/dev/subsystems/python-runner-toolset.md`,
   `docs/dev/architecture/python-tool-isolation.md`.
5. **Unit tests** - 632 passing across the branch.
6. **E2E** - `tests/e2e/test_python_toolset.py` and
   `tests/ui_e2e/test_python_toolset_authoring.py`. **Not run locally** - the
   suite is CPU-exclusive per AGENTS.md section 5, so CI is the verdict.
7. **Regressions** - full sweep green; the four resume hooks and their tests
   were migrated rather than weakened.
8. **primectl** - `toolset create-python`, `update-python-source`,
   `list-python-tools`, reading source from `--source-file`.

## Known limits

- `requires_workspace` python tools (running inside a *workspace's* sandbox)
  are out of scope; tools run in their own sandbox so they work from chat too.
- `ctx.inform` is not available: it is a callable and cannot cross a process
  boundary.
- The toolset is one module; no multi-file toolsets, no dependency install.
