### PR TITLE
fix(ui): the Studio body collapsed instead of filling the shell [HELD]

### DIFF
--- a/tests/ui/test_studio_shell.py
+++ b/tests/ui/test_studio_shell.py
@@ -292,3 +292,58 @@ def test_url_reactivity_dedupes_against_active_tab() -> None:
     # No-op when the parsed tab is already active (prevents reopening a
     # user-closed tab unless the URL truly changes).
     assert "s.activeTabId === urlTab" in src
+
+
+# ---------------------------------------------------------------------------
+# Shell sizing contract
+#
+# .st-root's child count is variable: studioV2 inserts an AttentionBar
+# between the topbar and the body, phones swap the body for StudioMobile
+# plus a bottom tab bar. A row list sized for one of those shapes silently
+# collapses the body in the others -- which is exactly what shipped when
+# studioV2 became the default. These pin the sizing model that removes the
+# dependence on the count. The geometry itself is asserted in
+# tests/ui_e2e/test_studio.py.
+# ---------------------------------------------------------------------------
+
+
+def _st_root_block() -> str:
+    """The body of the `.st-root {...}` rule."""
+    css = STYLES.read_text(encoding="utf-8")
+    start = css.index(".st-root {")
+    return css[start:css.index("}", start)]
+
+
+def test_st_root_sizes_by_child_not_by_a_fixed_row_list() -> None:
+    block = _st_root_block()
+    assert "display: flex" in block
+    assert "flex-direction: column" in block
+    # A hardcoded row list is the bug: three children against a two-row
+    # template pushed .st-body into an implicit `auto` row.
+    assert "grid-template-rows" not in block
+
+
+def test_the_body_and_the_mobile_column_both_grow() -> None:
+    css = STYLES.read_text(encoding="utf-8")
+    body_start = css.index(".st-body {")
+    body = css[body_start:css.index("}", body_start)]
+    assert "flex: 1 1 auto" in body, "the body must absorb the leftover height"
+
+    # Phones render StudioMobile's .col instead of .st-body, so it needs the
+    # same treatment -- scoped to direct children so the generic .col
+    # utility is unaffected elsewhere.
+    assert ".st-root > .col {" in css
+    col_start = css.index(".st-root > .col {")
+    col = css[col_start:css.index("}", col_start)]
+    assert "flex: 1 1 auto" in col
+
+
+def test_the_topbar_keeps_its_height_and_may_shrink_horizontally() -> None:
+    css = STYLES.read_text(encoding="utf-8")
+    start = css.index(".st-topbar {")
+    block = css[start:css.index("}", start)]
+    # It used to inherit 44px from the grid row; as a flex item it must say so.
+    assert "flex: 0 0 var(--st-subhead-h, 44px)" in block
+    # min-width:auto floored the row at ~502px (workspace pill + five 44px
+    # touch targets), overflowing every phone viewport.
+    assert "min-width: 0" in block

--- a/tests/ui_e2e/test_studio.py
+++ b/tests/ui_e2e/test_studio.py
@@ -40,7 +40,12 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
-from tests.ui_e2e._studio_helpers import files_list, is_studio_v2, session_row
+from tests.ui_e2e._studio_helpers import (
+    files_list,
+    is_studio_v2,
+    open_studio,
+    session_row,
+)
 
 
 from tests._support.smk import smk  # noqa: E402
@@ -330,6 +335,88 @@ def test_studio_session_redirect_lands_with_tab_open(
         assert_no_console_errors(
             console_messages,
             ignore_patterns=STUDIO_CONSOLE_IGNORES,
+        )
+
+    finally:
+        _cleanup(base_url, ids)
+
+
+# ===========================================================================
+# Shell geometry - the children must tile .st-root with no dead space
+# ===========================================================================
+
+
+@pytest.mark.skipif(
+    os.environ.get("PRIMER_RUN_UI_E2E") != "1",
+    reason="Set PRIMER_RUN_UI_E2E=1 to run UI e2e tests",
+)
+def test_the_studio_body_fills_the_shell_with_no_dead_space(
+    page,
+    base_url: str,
+    console_url: str,
+    unique_suffix: str,
+) -> None:
+    """The Studio's rows must tile .st-root, and the body must own what the
+    topbar and attention bar leave.
+
+    Regression: .st-root was a grid whose ``grid-template-rows`` listed two
+    rows while studioV2 mounts three children (topbar, AttentionBar, body).
+    The body landed in an implicit ``auto`` row, collapsed to its content
+    height, and left ~550px of empty space above it -- the rail and the
+    center pane sat jammed against the bottom of the viewport.
+
+    Presence assertions cannot catch this: every element was mounted and
+    visible, just in the wrong place. So this measures geometry, and it is
+    written against the child *count* being irrelevant -- a fourth row
+    (phones add a bottom tab bar) must not reintroduce the bug.
+    """
+    ids = _seed_studio_ladder(base_url, unique_suffix)
+    wid = ids["workspace"]
+
+    try:
+        open_studio(page, console_url, wid)
+
+        geom = page.evaluate(
+            """
+            () => {
+              const root = document.querySelector('.st-root');
+              if (!root) return null;
+              const kids = [...root.children];
+              const rootH = root.getBoundingClientRect().height;
+              const sumKids = kids.reduce(
+                (a, c) => a + c.getBoundingClientRect().height, 0);
+              // .st-body on desktop; StudioMobile's .col on phones.
+              const fill = document.querySelector('.st-body')
+                        || document.querySelector('.st-root > .col');
+              return {
+                rootH: Math.round(rootH),
+                sumKids: Math.round(sumKids),
+                kidCount: kids.length,
+                fillH: fill ? Math.round(fill.getBoundingClientRect().height) : 0,
+                fillTop: fill
+                  ? Math.round(fill.getBoundingClientRect().top
+                               - root.getBoundingClientRect().top)
+                  : null,
+              };
+            }
+            """
+        )
+        assert geom is not None, "the Studio shell (.st-root) never mounted"
+
+        # 1. The children tile the shell. A few px of tolerance covers
+        #    sub-pixel rounding and the topbar's 1px bottom border.
+        dead = geom["rootH"] - geom["sumKids"]
+        assert dead <= 4, f"{dead}px of dead space inside .st-root: {geom}"
+
+        # 2. The body is the element that grows. Before the fix it was 313px
+        #    of a 952px shell (33%); after, 863px (91%).
+        assert geom["fillH"] > geom["rootH"] * 0.5, (
+            f"body is only {geom['fillH']}px of {geom['rootH']}px: {geom}"
+        )
+
+        # 3. It starts directly under the fixed rows, not pushed down.
+        assert geom["fillTop"] is not None and geom["fillTop"] <= 120, (
+            f"body starts {geom['fillTop']}px into the shell: {geom}"
         )
 
     finally:

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -130,9 +130,16 @@
    rather than the whole viewport. The .studio-page chrome reset below strips
    the empty page-header + page-body padding so this can size to 100%. Owns its
    own data-theme/-density. */
+/* Flex column, NOT a grid with a fixed row list. The child count varies:
+   studioV2 mounts an AttentionBar between the topbar and the body, and the
+   plain shell does not. A `grid-template-rows: 44px 1fr` sized for two
+   children silently pushed the third into an implicit `auto` row, which
+   collapsed .st-body to its content height and left ~550px of dead space
+   above it. Flex sizes by child, so adding a fourth row later cannot
+   reintroduce that class of bug. */
 .st-root {
-  display: grid;
-  grid-template-rows: var(--st-subhead-h, 44px) 1fr;
+  display: flex;
+  flex-direction: column;
   height: 100%;
   width: 100%;
   background: var(--bg);
@@ -151,8 +158,18 @@
 .app.studio-page .page-header { display: none; }
 .app.studio-page .page-body { padding: 0; height: 100%; min-height: 0; }
 
-/* Slim content sub-header (top row). */
+/* Phones swap .st-body for StudioMobile, whose content root is a plain .col
+   (with the bottom tab bar as a sibling .row.mobile-only). Scoped to direct
+   children so the generic .col utility is untouched everywhere else. */
+.st-root > .col {
+  flex: 1 1 auto;
+  min-height: 0;
+}
+
+/* Slim content sub-header (top row). Fixed height as a flex item -- it used to
+   inherit this from the .st-root grid row. */
 .st-topbar {
+  flex: 0 0 var(--st-subhead-h, 44px);
   display: flex;
   align-items: center;
   gap: 10px;
@@ -161,12 +178,20 @@
   border-bottom: 1px solid var(--border);
   position: relative;
   z-index: 30;
+  /* Without this the row is floored at min-content (~502px: the workspace pill
+     plus five 44px touch targets), so it overflowed every phone viewport. The
+     touch targets must keep their 44px (see tests/ui/test_touch_target_audit.py),
+     so the workspace pill is the element that gives. */
+  min-width: 0;
 }
 .st-ws-btn {
   position: relative;
   display: flex;
   align-items: center;
   gap: 8px;
+  /* Lets the workspace-id label actually use its ellipsis when the topbar is
+     narrower than the full id. */
+  min-width: 0;
   padding: 5px 10px;
   border: 1px solid var(--border);
   border-radius: 7px;
@@ -255,6 +280,9 @@
    --st-right-w inline on the grid element. At ≤639px the handles are
    display:none (desktop-only) and the mobile override re-declares 1fr. */
 .st-body {
+  /* Takes every row the topbar and the (optional) attention bar leave behind.
+     min-height:0 keeps the inner scrollers from inflating it past the shell. */
+  flex: 1 1 auto;
   display: grid;
   grid-template-columns: var(--st-left-w, 248px) 5px minmax(0, 1fr) 5px var(--st-right-w, 332px);
   min-height: 0;


### PR DESCRIPTION
**HELD** - do not merge without a maintainer's say-so.

Found by driving the deployed console with headless Chromium against the
live homelab instance (`app:6fa9fb9`), not by reading code.

## The bug

`.st-root` is the Studio shell. Its `grid-template-rows` listed two rows:

```css
grid-template-rows: var(--st-subhead-h, 44px) 1fr;
```

But its child count varies:

| shell | children |
|---|---|
| plain | topbar, body |
| studioV2 | topbar, **AttentionBar**, body |
| studioV2 on a phone | topbar, AttentionBar, **StudioMobile col**, **bottom tab bar** |

The AttentionBar took the `1fr`; `.st-body` fell into an *implicit* row,
which defaults to `auto`, so it shrank to its content height and got
pushed to the bottom of the viewport.

Measured on a 1600x1000 load:

```
rows: 44px | 594.672px | 313.328px
      topbar  attention   st-body
              (44px of    (needed
               content)    all of it)
```

**551px of dead black space** above the rail and the center pane. Phones
were worse: the mobile column got 146px of a 796px shell, 562px dead.

This shipped when `studioV2` became the default. With the tweak off there
are exactly two children and the row list is correct, so it was invisible
behind the flag.

## The fix

A flex column, sized by child rather than by a fixed row list - so adding
a fourth row later cannot reintroduce this class of bug. Verified against
the live shell in all three shapes:

| shape | dead space | fill height |
|---|---|---|
| desktop studioV2 (3 children) | 551px -> **0** | 313 -> **863** |
| desktop plain (2 children) | **0** | **907** |
| phone (4 children) | 562px -> **0** | 146 -> **707** |

The two-child row matters: patching the grid to `44px auto 1fr` fixes
studioV2 and silently breaks the plain shell, because `.st-body` would
then land on the `auto` row. Flex avoids having to be right about the
count.

## Second fix: topbar overflowed every phone

`.st-topbar` sat at 502px inside a 390px viewport. It is both a flex
container and a flex item, so `min-width: auto` floored it at min-content:

```
44 (left toggle) + 198 (workspace pill) + 44 + 44 + 44 + 44 = 418
+ 6 gaps x 10px = 60,  + padding 24                          = 502
```

The five 44px cells are deliberate touch targets
(`tests/ui/test_touch_target_audit.py`), so the workspace-id pill is the
element that gives. It already carried an ellipsis; nothing in its
ancestry permitted it to shrink. `min-width: 0` on the row and the pill:
502px -> 410px.

## Known residual, not addressed here

Below 410px the page still scrolls horizontally, from the **app shell** -
`HEADER.topbar` and `MAIN.main` are both floored at 410px. This predates
the Studio and reproduces identically on the dashboard, agents,
workspaces and toolsets pages. Out of scope; worth its own change.

## Why the existing suite missed it

The 135-test ui-e2e suite passed while this was live. Those tests assert
elements *exist* and are *visible* - both true here; the layout was just
wrong. Same blind spot that let the `ApiError` envelope bug through
earlier.

So this adds a **geometry** assertion (`tests/ui_e2e/test_studio.py`):
the children must tile `.st-root` within 4px, the body must hold >50% of
the shell, and it must start under the fixed rows. Written so the child
count is irrelevant. Plus three static contract tests in
`tests/ui/test_studio_shell.py` for fast CI feedback - notably that
`.st-root` must *not* carry a `grid-template-rows`.

## Testing

- `tests/ui/` - 1433 passed, 1 skipped (includes the bundle transpile)
- `tests/ui/test_studio_shell.py` + `test_touch_target_audit.py` - 28 passed
- ruff clean; no non-ASCII in added lines (verified by scanning the files,
  not the diff)
- the new e2e test collects; it needs the container, so CI runs it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
