### PR TITLE
fix(ui): a new python toolset no longer ships a tool nobody wrote [HELD]

### DIFF
--- a/tests/ui/test_python_toolset_editor.py
+++ b/tests/ui/test_python_toolset_editor.py
@@ -86,14 +86,37 @@ def test_python_is_offered_in_the_create_form() -> None:
     assert 'provider === "python"' in src
 
 
-def test_a_new_python_toolset_starts_from_a_registrable_example() -> None:
-    # An empty module cannot register, so create would fail validation and the
-    # operator would never reach the editor.
+def test_a_new_python_toolset_starts_empty() -> None:
+    # This used to seed PY_STARTER on create, justified as "an empty module
+    # cannot register". That was simply false: register_module("") returns []
+    # and PythonConfig(source="") validates. The seed's only real effect was
+    # that every new toolset shipped a live, agent-callable `greet` tool the
+    # operator never wrote.
+    src = TOOLSETS.read_text(encoding="utf-8")
+    start = src.index('if (provider === "python")')
+    block = src[start:src.index("}", start)]
+    assert 'source: ""' in block, "create must not seed a source"
+    assert "PY_STARTER" not in block
+
+
+def test_the_starter_template_is_still_available_on_demand() -> None:
+    # Removing the seed must not remove the template -- it moves to the
+    # editor's explicit "Insert example" action.
     src = EDITOR.read_text(encoding="utf-8")
     assert "PY_STARTER" in src
     assert "@primer_tool()" in src
     assert "Use when" in src
     assert "Args:" in src
+    assert 'data-testid="python-insert-starter"' in src
+
+
+def test_the_empty_state_is_reachable() -> None:
+    # The editor has always had a "no tools yet" branch, but seeding on create
+    # made it dead code through the UI: every new toolset arrived with greet
+    # already registered.
+    src = EDITOR.read_text(encoding="utf-8")
+    assert 'data-testid="python-derived-empty"' in src
+    assert "No tools yet" in src
 
 
 def test_registered_before_the_toolsets_page() -> None:

--- a/ui/components/toolsets.jsx
+++ b/ui/components/toolsets.jsx
@@ -406,11 +406,14 @@ function TS_NewToolsetModal({ onClose, onCreate, pushToast, existing }) {
     setUnreachable(null);
     let config = null;
     if (provider === "python") {
-      // Source is authored in the editor after create; a new toolset starts
-      // from a working example rather than an empty module that cannot
-      // register.
+      // Empty, deliberately. An empty module registers fine -- it just yields
+      // zero tools -- so seeding a starter here only meant every new toolset
+      // shipped a `greet` tool the operator never wrote, live and callable by
+      // any agent bound to it, indistinguishable from an intentional one. The
+      // editor's "Insert example" button is where the template belongs; that
+      // way nothing is callable until someone writes it.
       config = {
-        source: PY_STARTER,
+        source: "",
         source_version: 1,
       };
     }


### PR DESCRIPTION
**HELD** - do not merge without a maintainer's say-so.

Found by inspecting a real deployment: the homelab instance had a python
toolset with `source_version=1` (never edited) whose only tool was
`greet`, which nobody had written.

```
toolset: python   source_version=1   isolation=seccomp
LIVE TOOLS: ['greet']
```

## What was happening

The New-toolset modal seeded the source when provider is `python`:

```js
config = { source: PY_STARTER, source_version: 1 };
```

So every python toolset created from the console arrived with a `greet`
tool that is immediately **live and callable by any agent bound to the
toolset**, with nothing in the catalogue distinguishing it from a tool the
operator meant to create.

## The justification was wrong

The comment read "a new toolset starts from a working example rather than
an empty module that cannot register." An empty module registers fine:

```
register_module("")                        -> []
PythonConfig(source="", source_version=1)  -> valid
_validate_python_toolset(<empty source>)   -> no 422
```

Zero tools, no error. The seed bought nothing.

It also made the editor's own empty state dead code through the UI -
`python-derived-empty` ("No tools yet. Add a function with the
`@primer_tool` decorator and save") could never render for a
console-created toolset, because greet was always already registered.

## Change

Create sends `source: ""`. The template moves nowhere - it was already
behind the editor's explicit **"Insert example"** button
(`python-insert-starter`), which is where scaffolding belongs. Nothing is
callable until someone writes it.

No API or model change; the route already accepted an empty source.

## Tests

The old `test_a_new_python_toolset_starts_from_a_registrable_example`
pinned the seed *and* repeated the false rationale in its comment. Replaced
with three:

- `test_a_new_python_toolset_starts_empty` - create sends no source
- `test_the_starter_template_is_still_available_on_demand` - the template
  and its Insert-example trigger survive
- `test_the_empty_state_is_reachable` - the empty branch exists

The e2e authoring suite is unaffected: it seeds through the API with its
own source rather than the UI create flow.

- `tests/ui/` + `tests/api/test_python_toolset_routes.py` - 1442 passed, 1 skipped
- ruff clean; no non-ASCII in added lines (verified by scanning files, not the diff)

## Note on existing toolsets

This only changes what *new* toolsets start with. Your existing `python`
toolset still holds the seeded greet source - clear the editor and save if
you want it gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
