### PR TITLE
fix(ui): the console shell forced every page to scroll sideways on a phone [HELD]

### DIFF
--- a/tests/ui/test_shell_fits_narrow_viewports.py
+++ b/tests/ui/test_shell_fits_narrow_viewports.py
@@ -1,0 +1,52 @@
+"""The app shell's sizing contract for narrow viewports.
+
+`.topbar` and `.main` are both grid items of `.app`. A grid item defaults
+to `min-width: auto`, which floors it at its min-content width -- for the
+topbar that is ~410px, so on any phone the shell forced the whole document
+to scroll sideways. Every console page inherited it.
+
+Fast static guards so a revert fails in CI rather than only in the E2E
+workflow. The geometry itself is measured in
+tests/ui_e2e/test_mobile_no_horizontal_overflow.py.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+STYLES = Path(__file__).resolve().parents[2] / "ui" / "styles.css"
+
+
+def _rule(selector: str) -> str:
+    """The declaration block for `selector`, matched at the start of a line so
+    `.topbar` does not pick up `.topbar-right`."""
+    css = STYLES.read_text(encoding="utf-8")
+    needle = f"\n{selector} {{"
+    start = css.index(needle)
+    return css[start:css.index("}", start)]
+
+
+def test_the_topbar_may_shrink_below_its_min_content() -> None:
+    assert "min-width: 0" in _rule(".topbar")
+
+
+def test_the_scroll_region_may_shrink_below_its_min_content() -> None:
+    # Without this, wide page content widens .main itself rather than
+    # scrolling inside it, taking the document along.
+    assert "min-width: 0" in _rule(".main")
+    assert "overflow: auto" in _rule(".main")
+
+
+def test_the_status_cluster_and_its_children_may_shrink() -> None:
+    # Both levels are needed: the cluster is the widest item in the row, and
+    # its own children (the worker pill) are what must actually give.
+    assert "min-width: 0" in _rule(".topbar-right")
+    assert "min-width: 0" in _rule(".topbar-right > *")
+
+
+def test_the_worker_pill_clips_instead_of_wrapping() -> None:
+    # It can shrink now, so it needs to say what happens when it does.
+    block = _rule(".worker-pill")
+    assert "white-space: nowrap" in block
+    assert "text-overflow: ellipsis" in block
+    assert "overflow: hidden" in block

--- a/tests/ui_e2e/test_mobile_no_horizontal_overflow.py
+++ b/tests/ui_e2e/test_mobile_no_horizontal_overflow.py
@@ -1,0 +1,128 @@
+"""No console page may scroll the DOCUMENT sideways on a phone.
+
+Regression: `.topbar` and `.main` are grid items, so both defaulted to
+`min-width: auto`, which floors an item at its min-content width. The
+topbar's min-content is ~410px (brand + hamburger + the status cluster,
+whose worker pill alone was 182px and could not shrink), so on any
+viewport narrower than that the row forced the whole document wider than
+the screen. Every page was affected, not one -- it is shell chrome.
+
+The distinction this pins: chrome must fit the viewport. Content that
+genuinely needs more width is allowed to scroll, but inside `.main`
+(which already has `overflow: auto`), never by dragging the document.
+
+Measured rather than eyeballed: `documentElement.scrollWidth` against
+`clientWidth` is the whole assertion, and it is the one thing a
+presence-based test can never notice.
+"""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("playwright")
+from playwright.sync_api import Page  # noqa: E402
+
+
+from tests._support.smk import smk  # noqa: E402
+
+pytestmark = smk("SMK-UI-01", status="partial")
+
+
+# Two real device widths. 360 is the narrowest mainstream Android; 390 is the
+# modern iPhone. Both sat under the old 410px floor.
+PHONE_WIDTHS = [(390, 844), (360, 800)]
+
+# One per top-level nav section that renders the standard shell.
+ROUTES = ["#/", "#/agents", "#/workspaces", "#/toolsets", "#/chats"]
+
+
+def _overflow(page: Page) -> dict:
+    return page.evaluate(
+        """
+        () => {
+          const de = document.documentElement;
+          const widest = [];
+          document.querySelectorAll('*').forEach(e => {
+            const r = e.getBoundingClientRect();
+            if (r.width > de.clientWidth + 2) {
+              widest.push({
+                cls: (e.className || '').toString().slice(0, 40),
+                w: Math.round(r.width),
+              });
+            }
+          });
+          widest.sort((a, b) => b.w - a.w);
+          return {
+            clientWidth: de.clientWidth,
+            scrollWidth: de.scrollWidth,
+            // The shell itself must never be a culprit.
+            topbar: (() => {
+              const e = document.querySelector('.topbar');
+              return e ? Math.round(e.getBoundingClientRect().width) : null;
+            })(),
+            widest: widest.slice(0, 3),
+          };
+        }
+        """
+    )
+
+
+@pytest.mark.ui_e2e
+@pytest.mark.parametrize(("width", "height"), PHONE_WIDTHS)
+@pytest.mark.parametrize("route", ROUTES)
+def test_the_document_does_not_scroll_sideways_on_a_phone(
+    page: Page, console_url: str, route: str, width: int, height: int,
+) -> None:
+    page.set_viewport_size({"width": width, "height": height})
+    page.goto(f"{console_url}{route}")
+    page.wait_for_load_state("domcontentloaded")
+    # The shell mounts before data arrives; give the topbar's live pill a beat
+    # so we measure it populated rather than empty.
+    page.wait_for_timeout(1500)
+
+    m = _overflow(page)
+    assert m["scrollWidth"] <= m["clientWidth"] + 1, (
+        f"{route} at {width}px scrolls sideways "
+        f"({m['scrollWidth']} > {m['clientWidth']}): {m['widest']}"
+    )
+
+
+@pytest.mark.ui_e2e
+@pytest.mark.parametrize(("width", "height"), PHONE_WIDTHS)
+def test_the_topbar_fits_the_viewport(
+    page: Page, console_url: str, width: int, height: int,
+) -> None:
+    """The specific element that was floored. Asserted separately so a
+    regression here is not masked by a page whose content also overflows."""
+    page.set_viewport_size({"width": width, "height": height})
+    page.goto(f"{console_url}#/")
+    page.wait_for_load_state("domcontentloaded")
+    page.wait_for_timeout(1500)
+
+    m = _overflow(page)
+    assert m["topbar"] is not None, "the app topbar never mounted"
+    assert m["topbar"] <= m["clientWidth"] + 1, (
+        f"topbar is {m['topbar']}px in a {m['clientWidth']}px viewport"
+    )
+
+
+@pytest.mark.ui_e2e
+def test_the_worker_pill_stays_one_line_on_a_phone(page: Page, console_url: str) -> None:
+    """Letting the pill shrink is only half the fix -- unconstrained it wraps
+    'N/N workers - N in flight' mid-phrase and doubles its own height."""
+    page.set_viewport_size({"width": 390, "height": 844})
+    page.goto(f"{console_url}#/")
+    page.wait_for_load_state("domcontentloaded")
+    page.wait_for_timeout(1500)
+
+    pill = page.locator(".worker-pill")
+    if pill.count() == 0:  # pragma: no cover - health probe may be absent
+        pytest.skip("no worker pill rendered on this deployment")
+
+    box = pill.first.bounding_box()
+    assert box is not None
+    # One line of 11.5px monospace plus padding lands near 27px; wrapped it was
+    # 43px. 34 splits them without pinning the exact metrics.
+    assert box["height"] < 34, (
+        f"worker pill is {box['height']}px tall - it is wrapping"
+    )

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -761,6 +761,13 @@ input, textarea, select { font: inherit; color: inherit; }
   background: var(--bg-1);
   position: relative;
   z-index: 20;
+  /* As a grid item this defaults to min-width:auto, which floors the row at
+     its min-content (~410px: brand + hamburger + the status cluster). That is
+     wider than a 390px phone, so the row forced the whole DOCUMENT to scroll
+     sideways on every console page. Chrome must fit the viewport; content that
+     genuinely needs more room scrolls inside .main, which already has
+     overflow:auto for exactly that. */
+  min-width: 0;
 }
 
 .topbar-brand {
@@ -824,6 +831,13 @@ input, textarea, select { font: inherit; color: inherit; }
   align-items: center;
   gap: 8px;
   margin-left: auto;
+  /* The status cluster is the widest thing in the row (~254px). Both levels
+     need releasing: the cluster so it may shrink, and its children so the
+     worker pill's text is what gives rather than the row overflowing. */
+  min-width: 0;
+}
+.topbar-right > * {
+  min-width: 0;
 }
 
 .worker-pill {
@@ -839,6 +853,12 @@ input, textarea, select { font: inherit; color: inherit; }
   color: var(--text-2);
   cursor: pointer;
   transition: border-color 0.15s;
+  /* Now that the pill can shrink, it must clip rather than wrap: "3/3 workers
+     - 0 in flight" breaking mid-phrase doubles the topbar's height on a phone.
+     The worker count leads, so an ellipsis drops the least important half. */
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
 }
 .worker-pill:hover { border-color: var(--border-strong); }
 .worker-pill .dot {
@@ -986,6 +1006,10 @@ input, textarea, select { font: inherit; color: inherit; }
   overflow: auto;
   background: var(--bg);
   position: relative;
+  /* Same min-width:auto floor as .topbar. Without this, a page whose content
+     is wider than the viewport widens .main itself instead of scrolling within
+     it, taking the document with it. */
+  min-width: 0;
 }
 
 .page-header {


### PR DESCRIPTION
**HELD** - do not merge without a maintainer's say-so.

This is the residual flagged in #173: the app shell was floored at 410px, so
below that the document scrolled sideways. Unlike #173 this predates the
Studio entirely.

## Cause

`.topbar` and `.main` are both grid items of `.app`. A grid item defaults to
`min-width: auto`, which floors it at its **min-content** width. The
topbar's min-content is ~410px:

```
44 (hamburger) + 56 (brand) + 254 (status cluster) + gaps/padding = 410
```

and the cluster's worker pill was 182px of that, unshrinkable. So on a 390px
phone the row forced the document to 410px. `.app` itself was correctly
390px - only its two children overflowed it.

Because it is shell chrome, it was not one page. Measured at 410px on
**dashboard, agents, workspaces, toolsets and chats.**

## Change

Four rules, all shell-level:

- `.topbar { min-width: 0 }` - the bulk of it (410 -> 390)
- `.main { min-width: 0 }` - otherwise wide content widens the scroll region instead of scrolling inside it
- `.topbar-right { min-width: 0 }` **and** `.topbar-right > * { min-width: 0 }` - both levels are needed, or the pill still refuses to give
- `.worker-pill` gets `nowrap` + `ellipsis` - once it *can* shrink it must clip, or it breaks `N/N workers - N in flight` mid-phrase and stands 43px tall in a 48px row

The principle: chrome fits the viewport; content that needs more width
scrolls inside `.main`, which already had `overflow: auto` for exactly that.

## Measured on the live console

Five pages x two real device widths, plus a desktop regression check:

| viewport | before | after | worker pill |
|---|---|---|---|
| 390x844 | 410 (all 5) | **390** (all 5) | 182x43 -> 170x27 |
| 360x800 | 410 (all 5) | **360** (all 5) | 182x43 -> 146x27 |
| 1600x1000 | 1600 | **1600, unchanged** | 215x27 -> 215x27 |

Desktop is untouched - at 1600px there is slack, so releasing a minimum
changes nothing. The pill's 43px -> 27px is the wrap disappearing; it had
been silently two lines.

## Tests

`tests/ui_e2e/test_mobile_no_horizontal_overflow.py` (13 cases) asserts
`documentElement.scrollWidth <= clientWidth` across those five routes at
both widths, plus the topbar specifically (so a page whose *content*
overflows cannot mask a shell regression), plus that the pill stays one
line. On failure it names the widest offending elements.

`tests/ui/test_shell_fits_narrow_viewports.py` gives fast static guards.
**Verified to bite:** with the CSS reverted all 4 fail; restored, all 4
pass.

- `tests/ui/` - 1434 passed, 1 skipped
- new e2e file collects 13 tests; ruff clean; no non-ASCII in added lines

## Deliberately not fixed

The dashboard's gauge/quick-actions row hardcodes
`gridTemplateColumns: "1.4fr 1fr"` at
[dashboard.jsx:159](../blob/main/ui/components/dashboard.jsx#L159) with no
responsive branch, so it clips on a phone. That is page content, not shell.
It now scrolls within `.main` rather than moving the document, which is the
correct containment - but the row still wants a mobile stack. Other pages
may have similar hardcoded grids; worth a sweep of its own rather than
widening this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
