### PR TITLE
fix(api): one wedged MCP toolset hung the whole /v1/tools catalogue [HELD]

### DIFF
--- a/primer/api/routers/providers.py
+++ b/primer/api/routers/providers.py
@@ -598,6 +598,58 @@ def _toolset_unreachable(
     )
 
 
+# Per-toolset bound for the /v1/tools catalogue.
+#
+# The create-time probe above can afford 8s: it is one toolset, on an explicit
+# operator action, and the operator is watching. The catalogue enumerates EVERY
+# toolset on page load, so the same bound would be paid per row.
+#
+# It only has to be generous enough for a healthy MCP server's connect +
+# handshake + tools/list, which is well under a second on a LAN.
+_CATALOGUE_PROBE_TIMEOUT_S = 5.0
+
+
+async def _catalogue_tools(
+    registry: Any, tid: str, principal: Any,
+) -> tuple[list[dict], str | None]:
+    """Drain one toolset's tools under a time bound.
+
+    Returns ``(tools, unavailable_reason)`` -- the reason is ``None`` when the
+    toolset answered.
+
+    The bound is the point. Catching exceptions is not enough to keep one bad
+    toolset from taking down the catalogue: an MCP server that accepts the TCP
+    connection and then never replies raises nothing at all, so an
+    ``except`` clause never runs and the request hangs forever. That is not
+    hypothetical -- it is what a Deployment whose pod is Running but whose
+    process is wedged looks like from the client side.
+    """
+    import asyncio
+
+    tools: list[dict] = []
+    try:
+        async with asyncio.timeout(_CATALOGUE_PROBE_TIMEOUT_S):
+            provider = await registry.get_toolset(tid)
+            async for tool in provider.list_tools(principal=principal):
+                tools.append({
+                    "id": tool.id,
+                    "scoped_id": f"{tid}__{tool.id}",
+                    "description": tool.description or "",
+                    "input_schema": tool.args_schema or {},
+                })
+    except Exception as exc:  # noqa: BLE001
+        # HTTP MCP runs in anyio task groups, so the useful error is a leaf of
+        # a BaseExceptionGroup; reporting the group renders an unreadable
+        # "unhandled errors in a TaskGroup (1 sub-exception)" in the console.
+        leaf = _informative_leaf(exc)
+        if isinstance(leaf, TimeoutError):
+            return [], (
+                f"did not respond within {_CATALOGUE_PROBE_TIMEOUT_S:g}s"
+            )
+        return [], f"{type(leaf).__name__}: {leaf}"
+    return tools, None
+
+
 def _informative_leaf(exc: BaseException) -> BaseException:
     """Unwrap anyio ``BaseExceptionGroup`` wrappers to the informative leaf.
 
@@ -1073,20 +1125,12 @@ async def list_all_tools(
             )
             out.append(entry)
             continue
-        try:
-            provider = await registry.get_toolset(tid)
-            async for tool in provider.list_tools(principal=principal):
-                entry["tools"].append({
-                    "id": tool.id,
-                    "scoped_id": f"{tid}__{tool.id}",
-                    "description": tool.description or "",
-                    "input_schema": tool.args_schema or {},
-                })
-        except Exception as exc:  # noqa: BLE001
+        tools, reason = await _catalogue_tools(registry, tid, principal)
+        if reason is None:
+            entry["tools"] = tools
+        else:
             entry["available"] = False
-            entry["unavailable_reason"] = (
-                f"{type(exc).__name__}: {exc}"
-            )
+            entry["unavailable_reason"] = reason
         out.append(entry)
 
     # 2. User-defined Toolset rows. Page through storage so the
@@ -1114,20 +1158,14 @@ async def list_all_tools(
                 "available": True,
                 "tools": [],
             }
-            try:
-                provider = await registry.get_toolset(row.id)
-                async for tool in provider.list_tools(principal=principal):
-                    entry["tools"].append({
-                        "id": tool.id,
-                        "scoped_id": f"{row.id}__{tool.id}",
-                        "description": tool.description or "",
-                        "input_schema": tool.args_schema or {},
-                    })
-            except Exception as exc:  # noqa: BLE001
+            tools, reason = await _catalogue_tools(
+                registry, row.id, principal,
+            )
+            if reason is None:
+                entry["tools"] = tools
+            else:
                 entry["available"] = False
-                entry["unavailable_reason"] = (
-                    f"{type(exc).__name__}: {exc}"
-                )
+                entry["unavailable_reason"] = reason
             out.append(entry)
         if len(page.items) < page_size:
             break

--- a/tests/api/test_tools_catalogue_bounded.py
+++ b/tests/api/test_tools_catalogue_bounded.py
@@ -1,0 +1,164 @@
+"""The /v1/tools catalogue must survive a toolset that never answers.
+
+The route's docstring already promised this: a broken toolset "is reported
+with ``available: false`` and the failure reason instead of bringing down
+the whole catalogue". That was implemented as a ``try/except`` around each
+toolset's ``list_tools`` -- which covers a toolset that *fails*, but not one
+that *hangs*.
+
+An MCP server whose process is wedged still accepts the TCP connection and
+then never replies. Nothing is raised, so the ``except`` never runs and the
+request blocks forever, taking the Toolsets and Tools pages with it. Seen in
+production: a Deployment reporting 1/1 Running whose endpoint answered
+neither POST nor GET.
+
+These pin the bound rather than the exception handling, because the bound is
+what was missing.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from primer.api.routers import providers as providers_mod
+
+
+class _Tool:
+    def __init__(self, tid: str) -> None:
+        self.id = tid
+        self.description = "does a thing"
+        self.args_schema = {"type": "object"}
+
+
+class _HealthyProvider:
+    async def list_tools(self, *, principal=None):  # noqa: ANN001
+        for t in ("alpha", "beta"):
+            yield _Tool(t)
+
+
+class _HangingProvider:
+    """Accepts the call and never yields -- a wedged MCP server."""
+
+    async def list_tools(self, *, principal=None):  # noqa: ANN001
+        await asyncio.sleep(3600)
+        yield _Tool("never")  # pragma: no cover
+
+
+class _RaisingProvider:
+    async def list_tools(self, *, principal=None):  # noqa: ANN001
+        raise ConnectionRefusedError("connection refused")
+        yield  # pragma: no cover - makes this an async generator
+
+
+class _GroupRaisingProvider:
+    """HTTP MCP runs in anyio task groups, so errors arrive wrapped."""
+
+    async def list_tools(self, *, principal=None):  # noqa: ANN001
+        raise BaseExceptionGroup(  # noqa: TRY003
+            "unhandled errors in a TaskGroup",
+            [ConnectionRefusedError("connection refused")],
+        )
+        yield  # pragma: no cover
+
+
+class _Registry:
+    def __init__(self, provider) -> None:  # noqa: ANN001
+        self._provider = provider
+
+    async def get_toolset(self, tid: str):  # noqa: ANN001, ARG002
+        return self._provider
+
+
+@pytest.fixture
+def fast_bound(monkeypatch) -> float:
+    """Shrink the production bound so the hang test stays quick."""
+    monkeypatch.setattr(providers_mod, "_CATALOGUE_PROBE_TIMEOUT_S", 0.25)
+    return 0.25
+
+
+@pytest.mark.asyncio
+async def test_a_healthy_toolset_returns_its_tools() -> None:
+    tools, reason = await providers_mod._catalogue_tools(
+        _Registry(_HealthyProvider()), "ts", None,
+    )
+    assert reason is None
+    assert [t["id"] for t in tools] == ["alpha", "beta"]
+    assert [t["scoped_id"] for t in tools] == ["ts__alpha", "ts__beta"]
+
+
+@pytest.mark.asyncio
+async def test_a_hanging_toolset_is_bounded_not_awaited_forever(
+    fast_bound: float,
+) -> None:
+    """The regression. Before the bound this never returned."""
+    # wait_for so a regression fails the test instead of hanging the suite.
+    tools, reason = await asyncio.wait_for(
+        providers_mod._catalogue_tools(
+            _Registry(_HangingProvider()), "wedged", None,
+        ),
+        timeout=10.0,
+    )
+    assert tools == []
+    assert reason is not None
+    assert "did not respond" in reason
+
+
+@pytest.mark.asyncio
+async def test_the_bound_is_reported_as_the_reason(fast_bound: float) -> None:
+    # The operator needs to know it timed out, not just that it is
+    # unavailable -- a timeout and a refused connection call for different
+    # fixes.
+    _tools, reason = await asyncio.wait_for(
+        providers_mod._catalogue_tools(
+            _Registry(_HangingProvider()), "wedged", None,
+        ),
+        timeout=10.0,
+    )
+    assert "0.25s" in reason
+
+
+@pytest.mark.asyncio
+async def test_a_failing_toolset_still_reports_its_error() -> None:
+    _tools, reason = await providers_mod._catalogue_tools(
+        _Registry(_RaisingProvider()), "refused", None,
+    )
+    assert reason is not None
+    assert "ConnectionRefusedError" in reason
+
+
+@pytest.mark.asyncio
+async def test_a_taskgroup_wrapped_error_is_unwrapped_to_its_leaf() -> None:
+    # Reporting the group gives the operator "ExceptionGroup: unhandled
+    # errors in a TaskGroup (1 sub-exception)", which names nothing useful.
+    _tools, reason = await providers_mod._catalogue_tools(
+        _Registry(_GroupRaisingProvider()), "wrapped", None,
+    )
+    assert reason is not None
+    assert "ConnectionRefusedError" in reason
+    assert "TaskGroup" not in reason
+
+
+@pytest.mark.asyncio
+async def test_one_wedged_toolset_does_not_stop_the_others(
+    fast_bound: float,
+) -> None:
+    """The whole point: the catalogue keeps going."""
+
+    class _Mixed:
+        async def get_toolset(self, tid: str):  # noqa: ANN001
+            return _HangingProvider() if tid == "wedged" else _HealthyProvider()
+
+    reg = _Mixed()
+    results = {}
+    for tid in ("good-1", "wedged", "good-2"):
+        results[tid] = await asyncio.wait_for(
+            providers_mod._catalogue_tools(reg, tid, None), timeout=10.0,
+        )
+
+    assert results["good-1"][1] is None
+    assert results["good-2"][1] is None
+    assert len(results["good-1"][0]) == 2
+    assert len(results["good-2"][0]) == 2
+    assert results["wedged"][1] is not None


### PR DESCRIPTION
**HELD** - do not merge without a maintainer's say-so.

Reported live: the Toolsets and Tools pages sat on "loading" forever.

## Diagnosis

```
GET /v1/toolsets           200   0.01s
GET /v1/toolsets/builtin   200   0.00s
GET /v1/tools              ReadTimeout after 30s
```

`/v1/tools` is the merged catalogue both pages consume. Per toolset:

```
'python'    200   0.00s   tools=1
'crawler'   200   0.02s   tools=7
'trao;'     HANG        (mcp/http -> http://trail-mcp.trail:3000/mcp)
```

The upstream MCP server was wedged - its pod reported `1/1 Running` for
22h, but a direct probe answered **neither POST nor GET**. That part is
the deployment's problem, not primer's.

## Primer's bug

The route already promised to survive this. Its own docstring:

> a broken toolset "is reported with `available: false` and the failure
> reason instead of bringing down the whole catalogue. The UI shows the
> rest of the picker so one broken MCP server doesn't block the operator"

and it wraps each toolset in `try/except Exception`. But that covers a
toolset that **fails**, not one that **hangs**. A wedged server completes
the TCP handshake and then never replies - nothing is raised, so the
`except` never runs and the request waits forever. The graceful-degradation
path was unreachable in exactly the case it was written for.

## Change

Bounds each toolset's enumeration with `asyncio.timeout`, turning a hang
into a `TimeoutError` that the existing handling already converts into
`available: false` + a reason. Both the built-in and user-toolset loops go
through one helper instead of two copies.

**5s**, not the create probe's 8s: that probe is one toolset on an explicit
operator action with someone watching; this one is paid per row on every
page load. It only needs to cover a healthy MCP connect + handshake +
`tools/list`, which is sub-second on a LAN.

Also unwraps `BaseExceptionGroup` before reporting. HTTP MCP runs inside
anyio task groups, so the raw reason rendered as `ExceptionGroup: unhandled
errors in a TaskGroup (1 sub-exception)` - naming nothing actionable.
`_informative_leaf` already existed for this in the create path; the
catalogue just wasn't using it.

## Tests

`tests/api/test_tools_catalogue_bounded.py` drives a provider that
**sleeps** rather than raises - precisely what the old `except` could not
catch:

- a hanging toolset returns instead of blocking (guarded by `wait_for`, so
  a regression fails the test rather than hanging CI)
- the timeout is reported distinctly from a refused connection (they call
  for different fixes)
- a task-group-wrapped error is unwrapped to its leaf
- one wedged toolset does not stop its neighbours

**Verified the bound is load-bearing**, not decoration: with it disabled
the hang case blocks past 3s; with it in force it returns
`did not respond within 0.25s`.

- 35 passed across the catalogue/toolset API tests; ruff clean; no
  non-ASCII in added lines

## Note

Enumeration is still sequential, so N unreachable toolsets cost up to N x 5s.
Bounded and no longer fatal, but running the probes concurrently would make
the catalogue cost max() instead of sum(). Left out to keep this change to
the actual defect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
