### PR TITLE
fix(trigger): stop a never-started session wedging its subscription

### DIFF
--- a/primer/trigger/subscribers/__init__.py
+++ b/primer/trigger/subscribers/__init__.py
@@ -15,11 +15,24 @@ import time by calling :func:`register`.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
 from typing import Any, Protocol
 
 from pydantic import BaseModel
 
+from primer.model.storage import Op, OffsetPage
 from primer.model.trigger import Subscription
+from primer.model.workspace_session import SessionStatus, WorkspaceSession
+from primer.storage.q import Q
+
+
+#: How long a session that has never run a turn may hold a ``parallelism="skip"``
+#: subscription closed. A session is created with ``auto_start=True`` and its first turn
+#: is claimed moments later; if the claim is lost (the worker died, the node OOM-killed it)
+#: the row stays non-terminal at ``turn_no == 0`` and nothing ever reaps it. Without a bound
+#: that one row wedges its subscription permanently - every later fire skips, silently, for
+#: as long as the row exists.
+SKIP_GATE_START_GRACE = timedelta(minutes=10)
 
 
 class SubscriptionDispatchResult(BaseModel):
@@ -114,11 +127,73 @@ def get_dispatcher(kind: str) -> Dispatcher:
     return DISPATCHERS[kind]
 
 
+def session_holds_skip_gate(
+    session: WorkspaceSession, *, now: datetime | None = None,
+) -> bool:
+    """Whether *session* should keep a ``parallelism="skip"`` subscription from firing.
+
+    Only sessions that are plausibly still doing work hold the gate:
+
+    * ``ENDED`` never holds it.
+    * A cancelled-requested session never holds it. Cancel is a flag the worker reads on
+      its next step, so a session that never started has nobody to read it; without this
+      an operator asking to cancel could not reopen the gate at all.
+    * ``turn_no >= 1`` always holds it, for as long as the turn runs. A started turn may
+      legitimately take hours (a graph build, a long exec), and firing a second session
+      beside it is worse than skipping - two runs writing the same workspace state can
+      clobber each other. Elapsed time is deliberately NOT consulted here.
+    * ``turn_no == 0`` holds it only within :data:`SKIP_GATE_START_GRACE`. The first turn
+      is claimed moments after creation, so a row still at turn 0 well past that lost its
+      claim and will never run.
+    """
+    if session.status == SessionStatus.ENDED:
+        return False
+    if session.cancel_requested:
+        return False
+    if session.turn_no > 0:
+        return True
+    ref = session.started_at or session.created_at
+    if ref is None:  # defensive: unset clock -> treat as live rather than fire twice
+        return True
+    if ref.tzinfo is None:
+        ref = ref.replace(tzinfo=timezone.utc)
+    return ((now or datetime.now(timezone.utc)) - ref) < SKIP_GATE_START_GRACE
+
+
+async def check_subscription_busy(
+    sub: Subscription, deps: DispatchDeps,
+) -> SubscriptionDispatchResult | None:
+    """Return a ``skipped`` result if a live session attributed to *sub* exists, else ``None``.
+
+    Shared by the agent_fresh and graph_fresh dispatchers so the busy-check semantics stay
+    identical; liveness is decided by :func:`session_holds_skip_gate`.
+    """
+    sessions = deps.storage_provider.get_storage(WorkspaceSession)
+    predicate = (
+        Q(WorkspaceSession)
+        .where_op("metadata.subscription_id", Op.EQ, sub.id)
+        .build()
+    )
+    page = await sessions.find(predicate, OffsetPage(offset=0, length=200))
+    for s in page.items:
+        if session_holds_skip_gate(s):
+            return SubscriptionDispatchResult(
+                ok=True,
+                skipped=True,
+                error_code="skipped_subscription_busy",
+                error_message=f"session {s.id!r} still in-flight",
+            )
+    return None
+
+
 __all__ = [
     "DISPATCHERS",
+    "SKIP_GATE_START_GRACE",
     "DispatchDeps",
     "Dispatcher",
     "SubscriptionDispatchResult",
+    "check_subscription_busy",
     "get_dispatcher",
     "register",
+    "session_holds_skip_gate",
 ]

--- a/primer/trigger/subscribers/agent_fresh_session.py
+++ b/primer/trigger/subscribers/agent_fresh_session.py
@@ -29,6 +29,7 @@ from primer.storage.q import Q
 from primer.trigger.subscribers import (
     DispatchDeps,
     SubscriptionDispatchResult,
+    check_subscription_busy,
     register,
 )
 from primer.workspace.session_factory import (
@@ -55,7 +56,7 @@ class AgentFreshSessionDispatcher:
         deps: DispatchDeps,
     ) -> SubscriptionDispatchResult:
         if sub.parallelism == "skip":
-            skip = await _check_subscription_busy(sub, deps)
+            skip = await check_subscription_busy(sub, deps)
             if skip is not None:
                 return skip
 
@@ -123,33 +124,6 @@ class AgentFreshSessionDispatcher:
                 error_message=str(exc),
             )
         return SubscriptionDispatchResult(ok=True, artefact_id=session.id)
-
-
-async def _check_subscription_busy(
-    sub: Subscription, deps: DispatchDeps,
-) -> SubscriptionDispatchResult | None:
-    """Return a ``skipped`` result if any non-terminal session attributed
-    to *sub* exists, otherwise ``None`` (fire normally).
-
-    Used by both the agent_fresh and graph_fresh dispatchers so the
-    busy-check semantics stay identical.
-    """
-    sessions = deps.storage_provider.get_storage(WorkspaceSession)
-    predicate = (
-        Q(WorkspaceSession)
-        .where_op("metadata.subscription_id", Op.EQ, sub.id)
-        .build()
-    )
-    page = await sessions.find(predicate, OffsetPage(offset=0, length=200))
-    for s in page.items:
-        if s.status != SessionStatus.ENDED:
-            return SubscriptionDispatchResult(
-                ok=True,
-                skipped=True,
-                error_code="skipped_subscription_busy",
-                error_message=f"session {s.id!r} still in-flight",
-            )
-    return None
 
 
 register("agent_fresh_session", AgentFreshSessionDispatcher())

--- a/primer/trigger/subscribers/graph_fresh_session.py
+++ b/primer/trigger/subscribers/graph_fresh_session.py
@@ -28,6 +28,7 @@ from primer.storage.q import Q
 from primer.trigger.subscribers import (
     DispatchDeps,
     SubscriptionDispatchResult,
+    check_subscription_busy,
     register,
 )
 from primer.workspace.session_factory import (
@@ -72,23 +73,9 @@ class GraphFreshSessionDispatcher:
             )
 
         if sub.parallelism == "skip":
-            sessions = deps.storage_provider.get_storage(WorkspaceSession)
-            predicate = (
-                Q(WorkspaceSession)
-                .where_op("metadata.subscription_id", Op.EQ, sub.id)
-                .build()
-            )
-            page = await sessions.find(
-                predicate, OffsetPage(offset=0, length=200),
-            )
-            for s in page.items:
-                if s.status != SessionStatus.ENDED:
-                    return SubscriptionDispatchResult(
-                        ok=True,
-                        skipped=True,
-                        error_code="skipped_subscription_busy",
-                        error_message=f"session {s.id!r} still in-flight",
-                    )
+            skip = await check_subscription_busy(sub, deps)
+            if skip is not None:
+                return skip
 
         # Use start_workspace_session (NOT create_session) so the on-disk
         # graph-holder slot is allocated via the workspace backend before

--- a/tests/trigger/test_subscribers_fresh_session.py
+++ b/tests/trigger/test_subscribers_fresh_session.py
@@ -276,3 +276,112 @@ async def test_graph_fresh_rejects_non_object_payload(
     )
     assert res.ok is False
     assert res.error_code == "graph_input_invalid"
+
+
+# ---------------------------------------------------------------------------
+# skip-gate liveness — a session that never ran a turn must not wedge its
+# subscription forever (observed: a `turn_no == 0` row held a cron trigger
+# closed for 14h; every fire skipped silently and the job simply stopped).
+# ---------------------------------------------------------------------------
+
+
+def _seed_session(sid, workspace_id, agent_id, **over):
+    from datetime import timedelta
+    base = dict(
+        id=sid,
+        workspace_id=workspace_id,
+        binding=AgentSessionBinding(agent_id=agent_id),
+        status=SessionStatus.RUNNING,
+        turn_status="idle",
+        metadata={"subscription_id": "sb-1"},
+        created_at=datetime.now(timezone.utc) - timedelta(hours=2),
+        turn_no=0,
+    )
+    base.update(over)
+    return WorkspaceSession(**base)
+
+
+def test_never_started_session_stops_holding_the_gate_after_grace(
+    seeded_workspace, seeded_agent,
+):
+    from primer.trigger.subscribers import session_holds_skip_gate
+    stuck = _seed_session("se-stuck", seeded_workspace.id, seeded_agent.id)
+    assert session_holds_skip_gate(stuck) is False
+
+
+def test_never_started_session_still_holds_the_gate_within_grace(
+    seeded_workspace, seeded_agent,
+):
+    """A freshly created session is mid-claim, not stuck - it must still block."""
+    from primer.trigger.subscribers import session_holds_skip_gate
+    fresh = _seed_session(
+        "se-fresh", seeded_workspace.id, seeded_agent.id,
+        created_at=datetime.now(timezone.utc),
+    )
+    assert session_holds_skip_gate(fresh) is True
+
+
+def test_long_running_turn_holds_the_gate_regardless_of_age(
+    seeded_workspace, seeded_agent,
+):
+    """The bound is on NEVER STARTING, never on duration.
+
+    A started turn may legitimately run for hours (a graph build, a long exec). Firing a
+    second session beside it would let two runs write the same workspace state.
+    """
+    from datetime import timedelta
+
+    from primer.trigger.subscribers import session_holds_skip_gate
+    working = _seed_session(
+        "se-working", seeded_workspace.id, seeded_agent.id,
+        turn_no=3, turn_status="running",
+        created_at=datetime.now(timezone.utc) - timedelta(days=1),
+    )
+    assert session_holds_skip_gate(working) is True
+
+
+def test_cancel_requested_releases_the_gate(seeded_workspace, seeded_agent):
+    """Cancel is a flag the worker reads on its next step; a session that never started
+    has nobody to read it, so cancel must reopen the gate by itself."""
+    from primer.trigger.subscribers import session_holds_skip_gate
+    cancelled = _seed_session(
+        "se-cancelled", seeded_workspace.id, seeded_agent.id,
+        turn_no=5, cancel_requested=True,
+    )
+    assert session_holds_skip_gate(cancelled) is False
+
+
+def test_ended_session_never_holds_the_gate(seeded_workspace, seeded_agent):
+    from primer.trigger.subscribers import session_holds_skip_gate
+    done = _seed_session(
+        "se-done", seeded_workspace.id, seeded_agent.id,
+        status=SessionStatus.ENDED, turn_no=2,
+    )
+    assert session_holds_skip_gate(done) is False
+
+
+@pytest.mark.asyncio
+async def test_graph_fresh_fires_past_a_stuck_never_started_session(
+    fake_storage_provider, fake_claim_engine, fake_scheduler,
+    fake_workspace_registry, seeded_workspace, seeded_graph,
+):
+    """End-to-end: the wedged-subscription bug. A stale turn_no==0 row must not skip."""
+    sessions = fake_storage_provider.get_storage(WorkspaceSession)
+    await sessions.create(
+        _seed_session("se-stuck", seeded_workspace.id, "ag-x")
+    )
+    deps = DispatchDeps(
+        storage_provider=fake_storage_provider,
+        claim_engine=fake_claim_engine,
+        scheduler=fake_scheduler,
+        workspace_registry=fake_workspace_registry,
+    )
+    res = await GraphFreshSessionDispatcher().dispatch(
+        _graph_sub(seeded_workspace.id, seeded_graph.id, parallelism="skip"),
+        rendered_payload="{}",
+        fire_context={"trigger_id": "tr-1"},
+        fire_id="fire-tr-1-102",
+        deps=deps,
+    )
+    assert res.ok and not res.skipped, res.error_message
+    assert res.artefact_id is not None


### PR DESCRIPTION
## The bug

A `parallelism="skip"` subscription declines to fire while **any** attributed session is `!= ENDED`. That check has no liveness component, so a session that never ran holds the gate closed **forever** — every later fire skips, silently, for as long as the row exists. `parallelism` defaults to `"skip"`, so every subscription is exposed.

## Seen in production

A scheduled trigger driving a long-running job stopped dead. The state:

```
session:  status=running   turn_no=0   turn_status=idle   (14 hours)
cancel:   HTTP 200, cancel_requested=True — never took effect
trigger:  cron */10, zero fires in 14h
API:      18h uptime, 0 restarts — healthy throughout
```

The session's first turn was never claimed — the workers were being OOM-killed at the moment it was created. Nothing reaps a session that never starts, and `cancel` only sets a flag the worker reads on its next step; with no turn running, nobody ever read it. So the row was unreapable, uncancellable, and blocking — and the only symptom was a job that quietly stopped, with no error recorded anywhere.

## The fix

The gate now asks whether a session is *plausibly still working*:

| State | Holds the gate? |
|---|---|
| `ENDED` | no |
| `cancel_requested` | no — cancel must reopen the gate itself, since a never-started session has nobody to observe the flag |
| `turn_no >= 1` | **yes, however long it runs** |
| `turn_no == 0`, older than `SKIP_GATE_START_GRACE` (10 min) | no — the claim was lost |
| `turn_no == 0`, within grace | yes — mid-claim, not stuck |

**Keying the bound on "never started" rather than elapsed time is the crux.** A started turn may legitimately run for hours (a graph build, a long exec), and firing a second session beside it lets two runs write the same workspace state and clobber each other. A time-based staleness rule would cause exactly that; `turn_no` distinguishes "nothing is running" from "something slow is running".

## Also

`graph_fresh_session` carried an inline copy of `agent_fresh_session`'s busy-check, so the two could drift. The check moves to the shared `subscribers` module and both call it.

## Testing

Six new tests in `tests/trigger/test_subscribers_fresh_session.py` covering each row of the table above, plus an end-to-end case asserting `graph_fresh_session` fires past a stale `turn_no == 0` row. Existing skip-gate tests still pass unchanged — they seed `created_at=now`, which is inside the grace window and correctly still blocks.

- `pytest tests/trigger` → **101 passed**
- `pytest tests/docs` → **294 passed, 1 skipped**
- `ruff check .` → clean

## Not covered here

Two follow-ups this deliberately leaves alone, both worth their own change: reaping never-started sessions (so the row doesn't linger at all), and making `cancel` on a `turn_no == 0` session end it directly rather than setting a flag with no reader. This PR stops the wedge; those remove the zombie.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
