### PR TITLE
chore: point the PR docs checklist at the repo docs actually live in

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,9 @@ Closes #
 - [ ] Conventional commit messages (`feat:` / `fix:` / `docs:` / `test:` / `chore:` / `refactor:` / `perf:`)
 - [ ] Tests added or updated for the changed behavior
 - [ ] Narrowed unit sweep passes locally
-- [ ] Docs updated (user docs under `primer/user_docs/`, dev docs under `docs/dev/`); doc hygiene passes
+- [ ] Docs updated, or explicitly N/A. **User-facing docs live in the
+      separate `primerhq/primerhq.github.io` repo** (`docs_source/`), not in
+      this one; dev docs are under `docs/dev/`. Doc hygiene passes
 - [ ] No em-dash characters introduced
 - [ ] No secrets, tokens, or internal-only references added
 


### PR DESCRIPTION
The docs checklist item asked contributors to update `primer/user_docs/` — **a directory that no longer exists in this repo.** User-facing docs moved to `primerhq/primerhq.github.io`.

So the item was unactionable. A contributor could tick it truthfully having changed nothing, because there was nothing at that path to change.

That is the mechanism behind the drift a docs audit just found: the published corpus went a month without an update while three feature areas shipped (python toolsets, the Studio revamp, the graph builder), and `toolsets/overview` ended up telling readers there are *two* kinds of toolset when there are three.

Points at the right repo, and allows an explicit N/A so the answer is a decision rather than a shrug.

Companion changes in the docs repo (primerhq.github.io#10) make its CI actually run the lint and tests, which it currently does not.

🤖 Generated with [Claude Code](https://claude.com/claude-code)