### PR TITLE
fix(api): /runtime never reported which tools yield

### DIFF
--- a/primer/api/routers/providers.py
+++ b/primer/api/routers/providers.py
@@ -1281,7 +1281,15 @@ async def toolset_runtime(
     than a generic "sandboxed" badge.
     """
     provider = await registry.get_toolset(toolset_id)
-    tools = [t.model_dump(mode="json") async for t in provider.list_tools()]
+    # `yields` is not part of Tool's serialisation, but it is the single most
+    # important thing to know about a python tool at a glance: a yielding tool
+    # parks the run rather than returning. The console renders a badge from it,
+    # so add it explicitly rather than leaving the badge unreachable.
+    tools = []
+    async for t in provider.list_tools():
+        entry = t.model_dump(mode="json")
+        entry["yields"] = bool(getattr(t, "yields", False))
+        tools.append(entry)
     error = getattr(provider, "registration_error", None)
     return {
         "toolset_id": toolset_id,

--- a/tests/api/test_python_toolset_routes.py
+++ b/tests/api/test_python_toolset_routes.py
@@ -165,3 +165,46 @@ async def test_a_round_tripped_config_can_be_put_back(client) -> None:
         "id": "toolset-rt2", "provider": "python", "config": config,
     })
     assert r.status_code == 200, r.text
+
+
+@pytest.mark.asyncio
+async def test_runtime_reports_which_tools_yield(client) -> None:
+    """The console's saved-tools panel renders a `yields` badge from this
+    route, so the field has to be here.
+
+    Tool.model_dump() emits id, toolset_id, description and schema only --
+    `yields` is not part of the serialisation. Without it the badge was
+    unreachable: a genuinely yielding tool came back with the key absent, the
+    JSX read `t.yields` as undefined, and the badge never rendered. Found by
+    checking the route's real output while documenting it.
+    """
+    src = (
+        "@primer_tool()\n"
+        "def plain(a: str) -> str:\n"
+        '    """Do it.\n\n    Use when you must.\n\n    Args:\n        a: A.\n    """\n'
+        "    return a\n"
+        "\n\n@primer_tool()\n"
+        "async def ask(question: str, ctx) -> str:\n"
+        '    """Ask the operator.\n\n    Use when a human must decide.\n\n'
+        "    Args:\n        question: What to ask.\n"
+        '    """\n'
+        "    return ask_user(question)\n"
+        "\n\n@resumes(ask)\n"
+        "def _ask_resume(payload: dict, meta: dict) -> str:\n"
+        '    """Return the answer.\n\n    Use when resuming.\n\n'
+        "    Args:\n        payload: P.\n        meta: M.\n"
+        '    """\n'
+        "    return payload['response']\n"
+    )
+    r = await client.post(
+        "/v1/toolsets",
+        json={"id": "rt-yields", "provider": "python",
+              "config": {"source": src, "source_version": 1}},
+    )
+    assert r.status_code == 201, r.text
+
+    body = (await client.get("/v1/toolsets/rt-yields/runtime")).json()
+    by_id = {t["id"]: t for t in body["tools"]}
+    assert "yields" in by_id["ask"], "the badge reads this key"
+    assert by_id["ask"]["yields"] is True
+    assert by_id["plain"]["yields"] is False


### PR DESCRIPTION
The console's **Saved and callable** panel renders a `yields` badge from `GET /v1/toolsets/{id}/runtime`. That route never sent the field.

`Tool.model_dump()` emits `id`, `toolset_id`, `description` and `schema` only — `yields` is not part of the serialisation. So the key was absent, the JSX read `t.yields` as `undefined`, and the badge never rendered for a genuinely yielding tool.

The **draft outline showed it correctly all along**, because that is fed by `/validate`, whose payload is built by hand. So the two panels disagreed about the same tool depending only on whether it had been saved.

## How it was found

While documenting the route for the docs catch-up. I had written that `/runtime` reports `yields` per tool, then — per the plan's own instruction to check against the code rather than against neighbouring prose — queried a running server with a yielding tool. It does not.

Documentation work found a product bug that no test covered, which is the argument for writing reference docs from the running system rather than from the source you remember writing.

## Verification

The regression test is **confirmed to fail without the fix** (stashed the change, watched it go red, restored it). 19 tests pass across the python toolset route suites; ruff clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)