### PR TITLE
fix(session): reap sessions whose first turn never ran

### DIFF
--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -386,6 +386,7 @@ def _make_lifespan(config: AppConfig):
         yield_listener = None
         timer_scheduler = None
         timeout_sweeper = None
+        stuck_session_sweeper = None
         chat_sweeper = None
         harness_sweeper = None
         watcher_manager = None
@@ -455,6 +456,15 @@ def _make_lifespan(config: AppConfig):
                 session_storage=storage_provider.get_storage(_WorkspaceSession),
             )
             timeout_sweeper.start(coordinator.leader_elector)
+
+            # Ends sessions whose first turn never ran. Without this a lost claim leaves a
+            # non-terminal row forever, and a `parallelism="skip"` subscription will not fire
+            # while one exists — so a single stuck session silently halts its trigger.
+            from primer.bus.scheduler_tasks import StuckSessionSweeper
+            stuck_session_sweeper = StuckSessionSweeper(
+                session_storage=storage_provider.get_storage(_WorkspaceSession),
+            )
+            stuck_session_sweeper.start(coordinator.leader_elector)
 
             from primer.bus.scheduler_tasks import ChatSweeper, HarnessSweeper
             chat_sweeper = ChatSweeper(
@@ -893,6 +903,7 @@ def _make_lifespan(config: AppConfig):
                 (harness_sweeper, "harness_sweeper"),
                 (chat_sweeper, "chat_sweeper"),
                 (timeout_sweeper, "timeout_sweeper"),
+                (stuck_session_sweeper, "stuck_session_sweeper"),
                 (timer_scheduler, "timer_scheduler"),
                 (yield_listener, "yield_listener"),
             ):

--- a/primer/bus/scheduler_tasks.py
+++ b/primer/bus/scheduler_tasks.py
@@ -33,12 +33,14 @@ from typing import TYPE_CHECKING
 from primer.int.coordinator import (
     ROLE_CHAT_SWEEPER,
     ROLE_HARNESS_SWEEPER,
+    ROLE_STUCK_SESSION_SWEEPER,
     ROLE_TIMEOUT_SWEEPER,
     ROLE_TIMER_SCHEDULER,
 )
 from primer.int.event_bus import EventBus
 from primer.int.storage import Storage
 from primer.model.storage import FieldRef, OffsetPage, Op, Predicate, Value
+from primer.model.workspace_session import SessionStatus
 from primer.worker.yield_runtime import make_timeout_payload
 
 if TYPE_CHECKING:
@@ -242,6 +244,116 @@ class TimeoutSweeper(_BackgroundTask):
         payload = make_timeout_payload()
         for event_key in keys:
             await self._bus.publish(event_key, payload=payload)
+
+
+#: A session's first turn is claimed moments after the row is created. One that is still at
+#: turn 0 well past this never got claimed - the worker died, the node OOM-killed it, the
+#: claim was lost - and it will sit non-terminal forever, because every other terminal path
+#: runs INSIDE a turn that never started.
+STUCK_SESSION_GRACE_SECONDS = 600.0
+
+#: OffsetPage caps a single page at 200 rows.
+_MAX_PAGE = 200
+
+
+class StuckSessionSweeper(_BackgroundTask):
+    """Ends sessions that were created but whose first turn never ran.
+
+    Nothing else reaps these. ``TimeoutSweeper`` only handles parks (a turn that started and
+    is waiting), and ``cancel`` merely sets a flag the worker reads on its next step - with no
+    turn running there is nobody to read it, so a stuck row cannot even be cancelled.
+
+    Left alone, one such row is not merely litter: a ``parallelism="skip"`` subscription
+    declines to fire while any attributed session is non-terminal, so a single stuck session
+    silently halts its trigger - observed in production as a cron job that stopped for 14h
+    with no error recorded anywhere.
+
+    Sessions that HAVE started (``turn_no >= 1``) are never touched however long they run: a
+    turn may legitimately take hours, and ending it from underneath the worker would be far
+    worse than leaving it alone.
+    """
+
+    role = ROLE_STUCK_SESSION_SWEEPER
+
+    def __init__(
+        self,
+        *,
+        session_storage: Storage,
+        poll_seconds: float = DEFAULT_SWEEPER_POLL_SECONDS,
+        grace_seconds: float = STUCK_SESSION_GRACE_SECONDS,
+    ) -> None:
+        super().__init__(name="stuck-session-sweeper")
+        self._storage = session_storage
+        self._poll = poll_seconds
+        self._grace = grace_seconds
+
+    async def _run(self) -> None:
+        while not self._stopping:
+            try:
+                await self._tick()
+            except Exception as exc:  # noqa: BLE001 - a sweeper must never die on one bad row
+                logger.exception("stuck-session-sweeper: tick failed: %s", exc)
+            try:
+                await asyncio.sleep(self._poll)
+            except asyncio.CancelledError:
+                break
+
+    async def _tick(self) -> int:
+        """End every never-started session past the grace period. Returns how many."""
+        reaped = 0
+        for row in await self._find_stuck():
+            fresh = await self._storage.get(row.id)
+            # Re-read before writing: the claim may have landed while we were looking, in
+            # which case the turn is now running and must not be ended.
+            if fresh is None or not _never_started(fresh, self._grace):
+                continue
+            await self._storage.update(fresh.model_copy(update={
+                "status": SessionStatus.ENDED,
+                "ended_reason": "failed",
+                "ended_detail": "never_started",
+                "ended_at": datetime.now(timezone.utc),
+            }))
+            reaped += 1
+            logger.warning(
+                "stuck-session-sweeper: ended %s - created %s, first turn never ran",
+                fresh.id, fresh.created_at,
+            )
+        return reaped
+
+    async def _find_stuck(self) -> list:
+        """Every never-started session, paged. Pages rather than taking one capped slice:
+        a backlog can exceed a page, and a silent truncation would leave the tail stuck
+        exactly as before while looking like the sweeper had run."""
+        predicate = Predicate(
+            left=FieldRef(name="turn_no"),
+            op=Op.EQ,
+            right=Value(value=0),
+        )
+        out: list = []
+        offset, page_size = 0, _MAX_PAGE
+        while True:
+            page = await self._storage.find(
+                predicate, OffsetPage(offset=offset, length=page_size),
+            )
+            out.extend(s for s in page.items if _never_started(s, self._grace))
+            if len(page.items) < page_size:
+                return out
+            offset += page_size
+
+
+def _never_started(session, grace_seconds: float) -> bool:
+    """Whether *session* is non-terminal and its first turn never ran, past the grace."""
+    if session.status == SessionStatus.ENDED:
+        return False
+    if session.turn_no > 0:
+        return False
+    ref = session.started_at or session.created_at
+    if ref is None:
+        return False
+    if ref.tzinfo is None:
+        ref = ref.replace(tzinfo=timezone.utc)
+    age = (datetime.now(timezone.utc) - ref).total_seconds()
+    return age >= grace_seconds
 
 
 class ChatSweeper(_BackgroundTask):

--- a/primer/int/coordinator.py
+++ b/primer/int/coordinator.py
@@ -49,6 +49,7 @@ ROLE_HARNESS_SWEEPER = "harness-sweeper"
 ROLE_WATCHER_MANAGER = "watcher-manager"
 ROLE_MCP_BRIDGE = "mcp-bridge"
 ROLE_COORDINATOR_SWEEPER = "coordinator-sweeper"
+ROLE_STUCK_SESSION_SWEEPER = "stuck-session-sweeper"
 
 
 class RateLimiterLease(AbstractAsyncContextManager["RateLimiterLease"]):
@@ -183,6 +184,7 @@ __all__ = [
     "ROLE_COORDINATOR_SWEEPER",
     "ROLE_HARNESS_SWEEPER",
     "ROLE_MCP_BRIDGE",
+    "ROLE_STUCK_SESSION_SWEEPER",
     "ROLE_TIMEOUT_SWEEPER",
     "ROLE_TIMER_SCHEDULER",
     "ROLE_WATCHER_MANAGER",

--- a/tests/bus/test_stuck_session_sweeper.py
+++ b/tests/bus/test_stuck_session_sweeper.py
@@ -1,0 +1,104 @@
+"""StuckSessionSweeper — ends sessions whose first turn never ran.
+
+Nothing else reaps these: TimeoutSweeper only handles parks (a turn that started and is
+waiting), and cancel just sets a flag a worker reads on its next step. A session that never
+started has no worker, so it stays non-terminal forever — and a `parallelism="skip"`
+subscription will not fire while any attributed session is non-terminal, so one stuck row
+silently halts its trigger.
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+
+import pytest
+
+from primer.bus.scheduler_tasks import StuckSessionSweeper
+from primer.model.workspace_session import (
+    GraphSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+
+
+def _session(sid, *, age_seconds=3600, turn_no=0, status=SessionStatus.RUNNING, **over):
+    base = dict(
+        id=sid,
+        workspace_id="ws-1",
+        binding=GraphSessionBinding(graph_id="g-1"),
+        status=status,
+        turn_status="idle",
+        turn_no=turn_no,
+        created_at=datetime.now(timezone.utc) - timedelta(seconds=age_seconds),
+    )
+    base.update(over)
+    return WorkspaceSession(**base)
+
+
+@pytest.mark.asyncio
+async def test_ends_a_session_whose_first_turn_never_ran(fake_storage_provider):
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(_session("se-stuck"))
+
+    reaped = await StuckSessionSweeper(session_storage=storage)._tick()
+
+    assert reaped == 1
+    row = await storage.get("se-stuck")
+    assert row.status == SessionStatus.ENDED
+    assert row.ended_reason == "failed"
+    assert row.ended_detail == "never_started"
+    assert row.ended_at is not None
+
+
+@pytest.mark.asyncio
+async def test_leaves_a_running_turn_alone_however_long_it_runs(fake_storage_provider):
+    """The bound is on NEVER STARTING, never on duration.
+
+    A started turn may legitimately take hours (a graph build, a long exec). Ending it from
+    under the worker would be far worse than leaving it.
+    """
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(
+        _session("se-working", age_seconds=86_400, turn_no=4, turn_status="running")
+    )
+
+    reaped = await StuckSessionSweeper(session_storage=storage)._tick()
+
+    assert reaped == 0
+    assert (await storage.get("se-working")).status == SessionStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_leaves_a_freshly_created_session_alone(fake_storage_provider):
+    """Inside the grace window the claim is simply still in flight."""
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(_session("se-fresh", age_seconds=5))
+
+    reaped = await StuckSessionSweeper(session_storage=storage)._tick()
+
+    assert reaped == 0
+    assert (await storage.get("se-fresh")).status == SessionStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_ignores_already_ended_sessions(fake_storage_provider):
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(
+        _session("se-done", status=SessionStatus.ENDED, ended_reason="completed")
+    )
+
+    assert await StuckSessionSweeper(session_storage=storage)._tick() == 0
+    assert (await storage.get("se-done")).ended_reason == "completed"
+
+
+@pytest.mark.asyncio
+async def test_grace_is_configurable(fake_storage_provider):
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(_session("se-recent", age_seconds=30))
+
+    assert await StuckSessionSweeper(
+        session_storage=storage, grace_seconds=3600,
+    )._tick() == 0
+    assert await StuckSessionSweeper(
+        session_storage=storage, grace_seconds=10,
+    )._tick() == 1


### PR DESCRIPTION
Follow-up to #185, which bounds the symptom. This removes the cause.

## The problem

A session's first turn is claimed moments after the row is created. When that claim is lost — the worker died, the node OOM-killed it mid-dispatch — the row stays non-terminal at `turn_no 0` **forever**:

- `TimeoutSweeper` only handles *parks* (a turn that started and is waiting)
- `cancel` sets a flag the worker reads on its next step; with no turn running, nobody reads it — so the row **cannot even be cancelled**

Every other terminal path runs *inside* a turn that never started.

That's not just litter. A `parallelism="skip"` subscription declines to fire while any attributed session is non-terminal, so **one stuck row silently halts its trigger**. Observed in production:

```
session:  status=running   turn_no=0   turn_status=idle   (14 hours)
cancel:   HTTP 200, cancel_requested=True — never took effect
trigger:  cron */10, zero fires in 14h
API:      18h uptime, 0 restarts — healthy throughout
```

The job behind it simply stopped, with no error recorded anywhere.

## The fix

`StuckSessionSweeper` ends those rows (`ended_reason="failed"`, `ended_detail="never_started"`), on the same leader-elected background-task harness as the existing sweepers, wired into the lifespan next to them and stopped with them.

**Sessions that have started are never touched, however long they run.** The bound is on *never starting*, not on duration — a turn may legitimately take hours (a graph build, a long exec), and ending one from under its worker would be far worse than leaving it. `turn_no` distinguishes "nothing is running" from "something slow is running"; elapsed time cannot.

Two details worth review:

- **Re-read before write.** The tick re-fetches each row immediately before ending it, so a claim that lands while the sweeper is looking isn't ended from underneath.
- **Pages, not one capped slice.** `OffsetPage` caps at 200; truncating would leave the tail stuck exactly as before while *looking* like the sweeper had run.

## Testing

`tests/bus/test_stuck_session_sweeper.py` — 5 tests: reaps a never-started session with the right terminal fields; leaves a 24-hour-old **running** turn alone; leaves a freshly created session alone (claim still in flight); ignores already-ended rows; honours a configurable grace.

- `pytest tests/bus tests/trigger tests/int` → **185 passed**
- `pytest tests/docs` → **294 passed, 1 skipped**
- `ruff check .` → clean

## Relationship to #185

#185 makes the skip-gate ignore a stuck session after 10 minutes, so a trigger recovers even if a zombie exists. This ends the zombie so it stops existing. They're independent — either alone prevents the 14-hour stall — but together the gate recovers quickly *and* the row doesn't linger.

Still not covered: `cancel` on a `turn_no == 0` session remains a flag with no reader. It's now bounded (the sweeper ends the row within the grace) but making cancel end it directly would be the complete fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
