### PR TITLE
fix(ci): the release workflow never created a GitHub Release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -131,11 +131,18 @@ jobs:
         uses: python-semantic-release/python-semantic-release@v10.6.1
         with:
           github_token: ${{ steps.app-token.outputs.token }}
-          # The first release spans ~1785 commits; the auto-generated
-          # notes exceed the GitHub release-body size limit (125k chars, 422).
-          # Skip the VCS release object here; the tag still pushes and PyPI +
-          # GHCR still publish.
-          vcs_release: "false"
+          # vcs_release was disabled for v0.1.0: that release spanned ~1785
+          # commits and its auto-generated notes blew past GitHub's 125k
+          # release-body limit (422). Every release since inherited the
+          # workaround and shipped without a GitHub Release object, so the
+          # Releases page stopped at v0.5.0 while PyPI and GHCR moved on.
+          #
+          # The constraint does not survive a normal release. v0.6.0 was 59
+          # commits and its hand-written notes were 4.7k chars, under 4% of
+          # the limit. Re-enabled; if a release ever does approach the cap,
+          # the fix is to summarise that release's notes, not to stop
+          # publishing them.
+          vcs_release: "true"
 
   publish-pypi:
     needs: release


### PR DESCRIPTION
`vcs_release` has been `"false"` since v0.1.0. The comment explains why:

> The first release spans ~1785 commits; the auto-generated notes exceed the GitHub release-body size limit (125k chars, 422).

Correct at the time. But **every release since inherited it**: v0.2.0 through v0.6.0 all tagged, published to PyPI and GHCR, and left the Releases page showing **v0.5.0 as latest**. Anyone watching Releases missed five versions, including the largest feature drop the project has had.

## The constraint does not survive a normal release

| | commits | notes size | % of limit |
|---|---|---|---|
| v0.1.0 | ~1785 | >125k | **422'd** |
| v0.6.0 | 59 | 4.7k | **3.8%** |

The workaround outlived its problem by five releases. If a release ever does approach the cap, the fix is to summarise that release's notes — not to stop publishing them.

v0.6.0's release object was backfilled by hand; this stops the next one needing that.

## Separately: CHANGELOG.md has no per-version structure

Found while checking this, **not fixed here** and not a blocker.

`CHANGELOG.md` (884K) contains only one version heading, `## v0.1.0`. It is not missing content — `v0.6.0` appears 60 times in the body — but every commit since the beginning is filed under that single heading. The release log shows why: commits are being added to release `'unknown'`.

Verified empirically: running `semantic-release changelog` at 10.6.1 against current main regenerates the file **byte-identical**, so this is not drift that a re-run repairs.

Releases themselves are unaffected — versioning, PyPI, GHCR and the release notes all derive from the release history, which categorises commits correctly (the v0.6.0 run sorted all 59 into the right buckets). Worth its own investigation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)