### PR TITLE
feat(storage): migration runner and ModelProfile foundation

### DIFF
--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -98,13 +98,18 @@ def _make_lifespan(config: AppConfig):
         storage_provider = _app_facade._build_storage_provider(config)
         await storage_provider.initialize()
         await storage_provider.get_content_store().ensure_schema()
-        # One-time, idempotent, resumable migration of legacy document bodies
-        # (Document.meta['content']/['text']) + paths into the content store.
-        # Cheap on re-runs: documents already migrated are skipped, and a fresh
-        # install with no legacy rows is a no-op.
-        from primer.knowledge.migration import migrate_document_content
+        # Ordered data migrations. Runs BEFORE auto-bootstrap so a migration
+        # never has to reason about whether a reserved row exists yet: it
+        # only ever transforms rows that were already there. A fresh install
+        # baselines straight to LATEST_VERSION instead of running the chain
+        # against an empty database.
+        from primer.storage.migrations import run_migrations
 
-        await migrate_document_content(storage_provider)
+        _state = await storage_provider.get_system_state()
+        await run_migrations(
+            storage_provider,
+            is_fresh_install=_state.bootstrap_completed_at is None,
+        )
 
         from primer.model.provider import SecretProviderConfig
         from primer.secret.factory import SecretProviderFactory

--- a/primer/int/storage_provider.py
+++ b/primer/int/storage_provider.py
@@ -105,6 +105,18 @@ class StorageProvider(ABC):
         """
 
     @abstractmethod
+    async def set_schema_version(
+        self, version: int, *, migrated_at: datetime | None = None,
+    ) -> None:
+        """Stamp ``schema_version`` and ``last_migration_at`` on the singleton.
+
+        ``schema_version = N`` means migrations 1..N have been applied.
+        ``migrated_at`` defaults to now. Called by the migration runner
+        after each migration commits, so a crash mid-chain resumes from
+        the last completed version rather than re-running the whole set.
+        """
+
+    @abstractmethod
     async def set_session_secret(self, secret: str) -> None:
         """Persist the cookie-signing HMAC secret on the singleton row.
 

--- a/primer/model/model_profile.py
+++ b/primer/model/model_profile.py
@@ -1,0 +1,120 @@
+"""A named (provider, model) pair plus its API-level configuration.
+
+One model may be registered many times under a single provider with
+different configuration, and the profile id is what an
+:class:`~primer.model.agent.Agent` references. That is the whole point of
+the entity: before it existed, ``LLMProvider.models[]`` was keyed by the
+provider-side wire name, so the same model could not be registered twice
+with, say, reasoning on and reasoning off.
+
+This entity replaces ``LLMProvider.models[]`` as the sole registry of what
+a provider can serve; ``context_length`` moved here from the former
+``LLMModel``.
+"""
+
+from __future__ import annotations
+
+from enum import Enum
+from typing import Any, ClassVar
+
+from pydantic import BaseModel, Field, PositiveInt
+
+from primer.model.common import Describeable
+
+
+class ReasoningLevel(str, Enum):
+    """Vendor-neutral reasoning effort, mapped per adapter.
+
+    No two vendors expose the same scale, so each adapter maps these onto
+    the closest wire value it has and documents the approximation. This is
+    the same normalisation the codebase already does for stop reasons: the
+    universal vocabulary is the contract, and the translation lives at the
+    SDK boundary.
+
+    ``OFF`` means "suppress reasoning wherever the vendor allows it". Some
+    vendors have no true off switch (the OpenAI Responses API's floor is
+    ``minimal``), so ``OFF`` is a request rather than a guarantee.
+    """
+
+    OFF = "off"
+    MINIMAL = "minimal"
+    LOW = "low"
+    MEDIUM = "medium"
+    HIGH = "high"
+
+
+class ModelProfileConfig(BaseModel):
+    """API-level tunables applied to every call made under a profile.
+
+    Deliberately does NOT carry ``temperature`` or ``max_output_tokens``:
+    those live on :class:`~primer.model.agent.Agent`, and duplicating them
+    here would create a precedence question with no defensible answer. This
+    block is scoped to model-BEHAVIOUR tunables only.
+
+    An empty config is inert: a profile carrying it behaves exactly as a
+    bare ``(provider, model)`` pair did before profiles existed.
+    """
+
+    reasoning: ReasoningLevel | None = Field(
+        default=None,
+        description=(
+            "Reasoning effort for this profile. None defers to the vendor "
+            "default. Mapped per adapter onto the vendor's own wire shape."
+        ),
+    )
+    extended: dict[str, Any] = Field(
+        default_factory=dict,
+        description=(
+            "Provider-specific knobs forwarded verbatim to "
+            "``LLM.stream(extended=...)``. Adapters whitelist the keys they "
+            "understand and DEBUG-log the remainder, so an unrecognised key "
+            "is inert rather than an error. Use this for anything not worth "
+            "normalising across vendors."
+        ),
+    )
+
+
+class ModelProfile(Describeable):
+    """One registered configuration of one model on one provider."""
+
+    _id_prefix: ClassVar[str] = "model-profile"
+
+    provider_id: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Identifier of the :class:`~primer.model.provider.LLMProvider` "
+            "this profile draws from."
+        ),
+    )
+    model_name: str = Field(
+        ...,
+        min_length=1,
+        description=(
+            "Provider-side wire name (e.g. 'gpt-4o-mini', 'qwen'). Several "
+            "profiles on one provider may share a model_name; they are "
+            "distinguished by their id and config."
+        ),
+    )
+    context_length: PositiveInt = Field(
+        ...,
+        description=(
+            "Maximum tokens the model accepts in a request. Consumed by "
+            "compaction to decide when to summarise."
+        ),
+    )
+    config: ModelProfileConfig = Field(
+        default_factory=ModelProfileConfig,
+        description="API-level tunables applied to every call under this profile.",
+    )
+    harness_id: str | None = Field(
+        default=None,
+        description=(
+            "Set when this row is managed by a harness; direct CRUD is then "
+            "rejected with 409 and the row changes only by re-running the "
+            "harness."
+        ),
+    )
+
+
+__all__ = ["ModelProfile", "ModelProfileConfig", "ReasoningLevel"]

--- a/primer/model_profile/__init__.py
+++ b/primer/model_profile/__init__.py
@@ -1,0 +1,11 @@
+"""Model-profile resolution.
+
+A profile names one (provider, model) pair plus its API-level config; the
+model itself lives in :mod:`primer.model.model_profile`. This package holds
+the resolution logic that turns a profile id into the concrete facts a turn
+needs.
+"""
+
+from primer.model_profile.resolver import ResolvedModel, resolve_model
+
+__all__ = ["ResolvedModel", "resolve_model"]

--- a/primer/model_profile/resolver.py
+++ b/primer/model_profile/resolver.py
@@ -1,0 +1,68 @@
+"""Resolve a model profile to the concrete facts a call needs.
+
+The single seam every executor-build path goes through. It replaces the
+former "``get_llm(provider_id)``, then scan ``provider.models`` for a
+matching name" lookup that was duplicated across five call sites.
+
+Takes ids rather than an :class:`~primer.model.agent.Agent` so the
+precedence rule lives in exactly one place and the resolver stays
+independent of the agent model's shape.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from primer.int.storage_provider import StorageProvider
+from primer.model.except_ import NotFoundError
+from primer.model.model_profile import ModelProfile, ModelProfileConfig
+
+
+@dataclass(frozen=True)
+class ResolvedModel:
+    """Everything a turn needs to make a call, flattened from a profile.
+
+    Frozen because it is threaded through executor construction and read
+    at several layers; a mutable carrier here would make it unclear which
+    layer owned the values.
+    """
+
+    profile_id: str
+    provider_id: str
+    model_name: str
+    context_length: int
+    config: ModelProfileConfig
+
+
+async def resolve_model(
+    storage_provider: StorageProvider,
+    *,
+    default_profile_id: str,
+    override_profile_id: str | None = None,
+) -> ResolvedModel:
+    """Resolve the profile a turn should run under.
+
+    ``override_profile_id`` wins when set; otherwise the agent's own
+    default applies. An override naming a profile that does not exist is
+    an error rather than a silent fallback to the default: the caller
+    asked for a specific model and quietly running a different one would
+    be worse than failing.
+
+    Raises :class:`~primer.model.except_.NotFoundError` when the resolved
+    profile is absent, which the REST layer renders as 404 and the
+    executor-build path surfaces as a failed turn.
+    """
+    profile_id = override_profile_id or default_profile_id
+    row = await storage_provider.get_storage(ModelProfile).get(profile_id)
+    if row is None:
+        raise NotFoundError(f"ModelProfile {profile_id!r} does not exist")
+    return ResolvedModel(
+        profile_id=row.id,
+        provider_id=row.provider_id,
+        model_name=row.model_name,
+        context_length=row.context_length,
+        config=row.config,
+    )
+
+
+__all__ = ["ResolvedModel", "resolve_model"]

--- a/primer/storage/migrations/__init__.py
+++ b/primer/storage/migrations/__init__.py
@@ -1,0 +1,117 @@
+"""Ordered, idempotent, backend-agnostic data migrations.
+
+Primer's entity storage is schemaless JSONB with per-model tables created
+lazily on first handle use, so there is no DDL to version. What does need
+versioning is the SHAPE of the data inside those tables: renaming a field,
+splitting one entity into two, moving a value from one row to another.
+
+Three properties make this safe without a heavyweight migration framework:
+
+* **Backend-agnostic.** Migrations operate through ``Storage[T]`` handles,
+  never raw SQL, so Postgres and SQLite behave identically with no
+  duplicated statements. The cost is paged reads plus per-row updates,
+  which is irrelevant at the scale of providers, agents, and collections.
+* **Idempotent.** Every migration is get-then-create, so a process death
+  mid-run re-runs harmlessly on the next boot.
+* **Forward-only.** ``schema_version`` is stamped after each migration
+  commits, so a crash resumes from the last completed version. Downgrades
+  are not attempted; see :func:`run_migrations`.
+
+``SystemState.schema_version = N`` means migrations 1..N have been applied.
+The field defaults to ``1``, which correctly describes every install that
+predates this module (see :mod:`~primer.storage.migrations.m001_document_content`).
+
+To add a migration: create ``mNNN_<slug>.py`` exposing a class satisfying
+:class:`Migration`, then append an instance to :data:`MIGRATIONS`. The
+contract test in ``tests/storage/test_migrations.py`` pins that versions
+stay contiguous and unique.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Protocol, runtime_checkable
+
+from primer.int.storage_provider import StorageProvider
+from primer.storage.migrations.m001_document_content import M001DocumentContent
+
+logger = logging.getLogger(__name__)
+
+
+@runtime_checkable
+class Migration(Protocol):
+    """One versioned, idempotent transformation of stored data."""
+
+    version: int
+    description: str
+
+    async def apply(self, sp: StorageProvider) -> None:
+        """Transform stored rows. Must be safe to run more than once."""
+        ...
+
+
+#: Ordered registry. Index position is not significant; ``version`` is.
+MIGRATIONS: tuple[Migration, ...] = (M001DocumentContent(),)
+
+#: Highest version this build knows how to apply.
+LATEST_VERSION: int = len(MIGRATIONS)
+
+
+async def run_migrations(
+    sp: StorageProvider, *, is_fresh_install: bool,
+) -> int:
+    """Apply every migration newer than the stored ``schema_version``.
+
+    A fresh install has no rows to transform, so it baselines straight to
+    :data:`LATEST_VERSION` rather than running the chain against an empty
+    database. ``is_fresh_install`` is decided by the caller from
+    ``bootstrap_completed_at IS NULL``.
+
+    When the database reports a version NEWER than this build understands,
+    the runner logs a warning and returns without touching anything. Primer
+    has no down-migration story, and guessing at one would be worse than
+    refusing: the operator is running old code against a newer database and
+    needs to know that, not have it silently half-handled.
+
+    Returns the resulting schema version.
+    """
+    state = await sp.get_system_state()
+    current = state.schema_version or 0
+
+    if is_fresh_install:
+        await sp.set_schema_version(LATEST_VERSION, migrated_at=datetime.now(UTC))
+        logger.info(
+            "fresh install; baselined schema version",
+            extra={"schema_version": LATEST_VERSION},
+        )
+        return LATEST_VERSION
+
+    if current > LATEST_VERSION:
+        logger.warning(
+            "database schema version is newer than this build; "
+            "refusing to downgrade",
+            extra={"db_version": current, "build_version": LATEST_VERSION},
+        )
+        return current
+
+    for migration in MIGRATIONS:
+        if migration.version <= current:
+            continue
+        logger.info(
+            "applying migration",
+            extra={
+                "version": migration.version,
+                "description": migration.description,
+            },
+        )
+        await migration.apply(sp)
+        await sp.set_schema_version(
+            migration.version, migrated_at=datetime.now(UTC),
+        )
+        current = migration.version
+
+    return current
+
+
+__all__ = ["LATEST_VERSION", "MIGRATIONS", "Migration", "run_migrations"]

--- a/primer/storage/migrations/__init__.py
+++ b/primer/storage/migrations/__init__.py
@@ -35,6 +35,7 @@ from typing import Protocol, runtime_checkable
 
 from primer.int.storage_provider import StorageProvider
 from primer.storage.migrations.m001_document_content import M001DocumentContent
+from primer.storage.migrations.m002_model_profiles import M002ModelProfiles
 
 logger = logging.getLogger(__name__)
 
@@ -52,7 +53,10 @@ class Migration(Protocol):
 
 
 #: Ordered registry. Index position is not significant; ``version`` is.
-MIGRATIONS: tuple[Migration, ...] = (M001DocumentContent(),)
+MIGRATIONS: tuple[Migration, ...] = (
+    M001DocumentContent(),
+    M002ModelProfiles(),
+)
 
 #: Highest version this build knows how to apply.
 LATEST_VERSION: int = len(MIGRATIONS)

--- a/primer/storage/migrations/m001_document_content.py
+++ b/primer/storage/migrations/m001_document_content.py
@@ -1,0 +1,29 @@
+"""Migration 1: move legacy document bodies into the content store.
+
+Wraps :func:`primer.knowledge.migration.migrate_document_content`, which
+already ran ad-hoc from the API lifespan before the migration runner
+existed. Because ``SystemState.schema_version`` defaults to ``1``, every
+install that predates the runner is treated as having this migration
+applied, which is accurate: the ad-hoc call was unconditional on every
+boot. The wrapper exists so the chain starts at 1 and so a future
+install that somehow sits below 1 still gets it; the underlying function
+is idempotent either way.
+"""
+
+from __future__ import annotations
+
+from primer.int.storage_provider import StorageProvider
+from primer.knowledge.migration import migrate_document_content
+
+
+class M001DocumentContent:
+    """Backfill document paths and copy legacy bodies into the content store."""
+
+    version = 1
+    description = "migrate legacy document bodies into the content store"
+
+    async def apply(self, sp: StorageProvider) -> None:
+        await migrate_document_content(sp)
+
+
+__all__ = ["M001DocumentContent"]

--- a/primer/storage/migrations/m002_model_profiles.py
+++ b/primer/storage/migrations/m002_model_profiles.py
@@ -1,0 +1,172 @@
+"""Migration 2: replace ``LLMProvider.models[]`` with ``ModelProfile`` rows.
+
+Three steps, each idempotent:
+
+1. Synthesise one :class:`~primer.model.model_profile.ModelProfile` per
+   legacy ``models[]`` entry.
+2. Rewrite every ``Agent.model`` from ``{provider_id, model_name}`` to
+   ``{profile_id}``.
+3. Strip ``models[]`` from the provider rows.
+
+**Why this module redefines LLMProvider and Agent.** A migration reads rows
+written by the OLD schema, but it runs inside a build where the models have
+already changed: ``LLMProvider.models`` no longer exists and
+``AgentModel.profile_id`` is required. Loading those rows through the live
+models would silently drop ``models[]`` in one case and fail validation in
+the other.
+
+The storage layer derives a table name from ``model_class.__name__.lower()``,
+so a class named ``LLMProvider`` declared here addresses the same
+``llmprovider`` table. Both views set ``extra="allow"`` so every field this
+migration does not care about survives the read-modify-write untouched.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from primer.int.storage_provider import StorageProvider
+from primer.model.common import Identifiable
+from primer.model.model_profile import ModelProfile
+from primer.model.storage import OffsetPage
+
+logger = logging.getLogger(__name__)
+
+_PAGE = 200
+_UNSAFE = re.compile(r"[^a-z0-9-]+")
+
+
+def synth_profile_id(provider_id: str, model_name: str) -> str:
+    """Deterministic id for a migrated profile: ``<provider>--<model-slug>``.
+
+    Deterministic so re-running the migration converges on the same ids
+    rather than duplicating profiles, and so step 2 can compute the id an
+    agent should point at without a lookup table.
+    """
+    slug = _UNSAFE.sub("-", model_name.lower()).strip("-")
+    return f"{provider_id}--{slug}"
+
+
+class LLMProvider(Identifiable):  # noqa: N801 - name selects the storage table
+    """Migration-local view of a provider row, retaining ``models[]``."""
+
+    model_config = ConfigDict(extra="allow")
+
+    models: list[dict[str, Any]] | None = Field(default=None)
+
+
+class Agent(Identifiable):  # noqa: N801 - name selects the storage table
+    """Migration-local view of an agent row, with an untyped model block."""
+
+    model_config = ConfigDict(extra="allow", protected_namespaces=())
+
+    model: dict[str, Any] = Field(default_factory=dict)
+
+
+async def _iter_rows(storage, model_cls):
+    """Page through every row of one table."""
+    offset = 0
+    while True:
+        page = await storage.list(OffsetPage(offset=offset, length=_PAGE))
+        if not page.items:
+            return
+        for row in page.items:
+            yield row
+        if len(page.items) < _PAGE:
+            return
+        offset += _PAGE
+
+
+class M002ModelProfiles:
+    """Cut LLM model identity over from names to profile ids."""
+
+    version = 2
+    description = "replace LLMProvider.models[] with ModelProfile rows"
+
+    async def apply(self, sp: StorageProvider) -> None:
+        await self._synthesise_profiles(sp)
+        await self._rewrite_agents(sp)
+        await self._strip_models(sp)
+
+    # -- step 1 ----------------------------------------------------------
+    async def _synthesise_profiles(self, sp: StorageProvider) -> None:
+        providers = sp.get_storage(LLMProvider)
+        profiles = sp.get_storage(ModelProfile)
+        created = 0
+        async for row in _iter_rows(providers, LLMProvider):
+            for entry in row.models or []:
+                name = entry.get("name")
+                if not name:
+                    continue
+                profile_id = synth_profile_id(row.id, name)
+                if await profiles.get(profile_id) is not None:
+                    continue
+                await profiles.create(
+                    ModelProfile(
+                        id=profile_id,
+                        description=(
+                            f"Migrated from provider {row.id!r} model {name!r}."
+                        ),
+                        provider_id=row.id,
+                        model_name=name,
+                        context_length=entry.get("context_length") or 8192,
+                    )
+                )
+                created += 1
+        if created:
+            logger.info("synthesised model profiles", extra={"count": created})
+
+    # -- step 2 ----------------------------------------------------------
+    async def _rewrite_agents(self, sp: StorageProvider) -> None:
+        agents = sp.get_storage(Agent)
+        profiles = sp.get_storage(ModelProfile)
+        rewritten = 0
+        async for row in _iter_rows(agents, Agent):
+            block = row.model or {}
+            if block.get("profile_id"):
+                continue  # already migrated
+            provider_id = block.get("provider_id")
+            model_name = block.get("model_name")
+            if not provider_id or not model_name:
+                logger.warning(
+                    "agent has no resolvable model block; leaving untouched",
+                    extra={"agent_id": row.id},
+                )
+                continue
+            profile_id = synth_profile_id(provider_id, model_name)
+            if await profiles.get(profile_id) is None:
+                # The provider row is gone, so no profile was synthesised.
+                # The agent was already broken; do not invent a target.
+                logger.warning(
+                    "agent references a model with no matching provider; "
+                    "leaving untouched",
+                    extra={
+                        "agent_id": row.id,
+                        "provider_id": provider_id,
+                        "model_name": model_name,
+                    },
+                )
+                continue
+            await agents.update(row.model_copy(update={"model": {"profile_id": profile_id}}))
+            rewritten += 1
+        if rewritten:
+            logger.info("rewrote agent model bindings", extra={"count": rewritten})
+
+    # -- step 3 ----------------------------------------------------------
+    async def _strip_models(self, sp: StorageProvider) -> None:
+        providers = sp.get_storage(LLMProvider)
+        stripped = 0
+        async for row in _iter_rows(providers, LLMProvider):
+            if row.models is None:
+                continue
+            await providers.update(row.model_copy(update={"models": None}))
+            stripped += 1
+        if stripped:
+            logger.info("stripped legacy models[]", extra={"count": stripped})
+
+
+__all__ = ["M002ModelProfiles", "synth_profile_id"]

--- a/primer/storage/postgres.py
+++ b/primer/storage/postgres.py
@@ -51,7 +51,7 @@ import json
 import logging
 import re
 from contextlib import asynccontextmanager
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, TypeVar
 
 import asyncpg
@@ -387,6 +387,18 @@ class PostgresStorageProvider(StorageProvider):
         )
         async with self.pool.acquire() as conn:
             await conn.execute(sql, ts, "singleton")
+
+    async def set_schema_version(
+        self, version: int, *, migrated_at: datetime | None = None,
+    ) -> None:
+        """Stamp ``schema_version`` and ``last_migration_at``."""
+        ts = migrated_at or datetime.now(UTC)
+        sql = (
+            f'UPDATE {self.system_state_table} '
+            f'SET schema_version = $1, last_migration_at = $2 WHERE id = $3'
+        )
+        async with self.pool.acquire() as conn:
+            await conn.execute(sql, version, ts, "singleton")
 
     async def set_session_secret(self, secret: str) -> None:
         """Persist the cookie-signing HMAC secret on the singleton row."""

--- a/primer/storage/sqlite.py
+++ b/primer/storage/sqlite.py
@@ -441,6 +441,18 @@ class SqliteStorageProvider(StorageProvider):
         await self.connection.execute(sql, (ts_str, "singleton"))
         await self.connection.commit()
 
+    async def set_schema_version(
+        self, version: int, *, migrated_at: datetime | None = None,
+    ) -> None:
+        """Stamp ``schema_version`` and ``last_migration_at``."""
+        ts = (migrated_at or datetime.now(timezone.utc)).isoformat()
+        sql = (
+            "UPDATE system_state SET schema_version = ?, last_migration_at = ? "
+            "WHERE id = ?"
+        )
+        await self.connection.execute(sql, (version, ts, "singleton"))
+        await self.connection.commit()
+
     async def set_session_secret(self, secret: str) -> None:
         """Persist the cookie-signing HMAC secret on the singleton row.
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,7 +8,7 @@ use it without duplication.
 from __future__ import annotations
 
 from collections.abc import AsyncIterator
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any, Generic, TypeVar
 
 import pytest
@@ -324,6 +324,8 @@ class _FakeStorageProvider:
         self._stores: dict[type, _InMemoryStorage[Any]] = {}
         self._content_store = _FakeContentStore()
         self._bootstrap_completed_at: datetime | None = None
+        self._schema_version: int = 1
+        self._last_migration_at: datetime | None = None
 
     def get_storage(self, model_class: type[_T]) -> _InMemoryStorage[_T]:
         return self._stores.setdefault(model_class, _InMemoryStorage(model_class))
@@ -344,6 +346,8 @@ class _FakeStorageProvider:
         from primer.model.system_state import SystemState
         return SystemState(
             bootstrap_completed_at=self._bootstrap_completed_at,
+            schema_version=self._schema_version,
+            last_migration_at=self._last_migration_at,
             session_secret=getattr(self, "_session_secret", None),
             sso_jit_enabled=getattr(self, "_sso_jit_enabled", False),
             sso_default_access=getattr(self, "_sso_default_access", None),
@@ -351,6 +355,12 @@ class _FakeStorageProvider:
 
     async def set_bootstrap_completed(self, ts: datetime) -> None:
         self._bootstrap_completed_at = ts
+
+    async def set_schema_version(
+        self, version: int, *, migrated_at: datetime | None = None,
+    ) -> None:
+        self._schema_version = version
+        self._last_migration_at = migrated_at or datetime.now(UTC)
 
     async def set_session_secret(self, secret: str) -> None:
         self._session_secret = secret

--- a/tests/model/test_model_profile.py
+++ b/tests/model/test_model_profile.py
@@ -1,0 +1,113 @@
+"""Tests for the ModelProfile entity and its config block."""
+
+from __future__ import annotations
+
+import pytest
+from pydantic import ValidationError
+
+from primer.model.model_profile import (
+    ModelProfile,
+    ModelProfileConfig,
+    ReasoningLevel,
+)
+
+
+def _profile(**overrides: object) -> ModelProfile:
+    payload: dict[str, object] = {
+        "id": "gx10-qwen-fast",
+        "description": "Qwen with reasoning suppressed for cheap turns.",
+        "provider_id": "gx10",
+        "model_name": "qwen",
+        "context_length": 262144,
+    }
+    payload.update(overrides)
+    return ModelProfile(**payload)  # type: ignore[arg-type]
+
+
+class TestReasoningLevel:
+    def test_values(self) -> None:
+        assert [level.value for level in ReasoningLevel] == [
+            "off", "minimal", "low", "medium", "high",
+        ]
+
+    def test_is_str_enum_so_it_serialises_as_its_value(self) -> None:
+        assert ReasoningLevel.OFF == "off"
+
+
+class TestModelProfileConfig:
+    def test_defaults_are_inert(self) -> None:
+        """A profile with no config must behave exactly like today."""
+        cfg = ModelProfileConfig()
+        assert cfg.reasoning is None
+        assert cfg.extended == {}
+
+    def test_extended_accepts_arbitrary_json(self) -> None:
+        cfg = ModelProfileConfig(
+            extended={"chat_template_kwargs": {"enable_thinking": False}}
+        )
+        assert cfg.extended["chat_template_kwargs"]["enable_thinking"] is False
+
+    def test_reasoning_rejects_unknown_level(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelProfileConfig(reasoning="ludicrous")  # type: ignore[arg-type]
+
+    def test_extended_default_is_not_shared_between_instances(self) -> None:
+        a = ModelProfileConfig()
+        b = ModelProfileConfig()
+        a.extended["k"] = "v"
+        assert b.extended == {}
+
+
+class TestModelProfile:
+    def test_minimal_profile(self) -> None:
+        p = _profile()
+        assert p.config.reasoning is None
+        assert p.config.extended == {}
+        assert p.harness_id is None
+
+    def test_id_prefix(self) -> None:
+        assert ModelProfile._id_prefix == "model-profile"
+
+    def test_context_length_must_be_positive(self) -> None:
+        with pytest.raises(ValidationError):
+            _profile(context_length=0)
+
+    def test_provider_id_must_be_non_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            _profile(provider_id="")
+
+    def test_model_name_must_be_non_empty(self) -> None:
+        with pytest.raises(ValidationError):
+            _profile(model_name="")
+
+    def test_description_is_required(self) -> None:
+        with pytest.raises(ValidationError):
+            ModelProfile(  # type: ignore[call-arg]
+                id="p", provider_id="g", model_name="m", context_length=1,
+            )
+
+    def test_two_profiles_may_share_a_model_on_one_provider(self) -> None:
+        """The whole point: same (provider, model), different config."""
+        fast = _profile(
+            id="gx10-qwen-fast",
+            config=ModelProfileConfig(reasoning=ReasoningLevel.OFF),
+        )
+        think = _profile(
+            id="gx10-qwen-think",
+            config=ModelProfileConfig(reasoning=ReasoningLevel.HIGH),
+        )
+        assert fast.provider_id == think.provider_id
+        assert fast.model_name == think.model_name
+        assert fast.id != think.id
+        assert fast.config.reasoning is ReasoningLevel.OFF
+        assert think.config.reasoning is ReasoningLevel.HIGH
+
+    def test_round_trips_through_json(self) -> None:
+        p = _profile(
+            config=ModelProfileConfig(
+                reasoning=ReasoningLevel.MEDIUM,
+                extended={"seed": 7},
+            )
+        )
+        restored = ModelProfile.model_validate(p.model_dump(mode="json"))
+        assert restored == p

--- a/tests/model_profile/test_resolver.py
+++ b/tests/model_profile/test_resolver.py
@@ -1,0 +1,117 @@
+"""Tests for model-profile resolution and override precedence."""
+
+from __future__ import annotations
+
+import dataclasses
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from primer.int.storage_provider import StorageProvider
+from primer.model.except_ import NotFoundError
+from primer.model.model_profile import (
+    ModelProfile,
+    ModelProfileConfig,
+    ReasoningLevel,
+)
+from primer.model.provider import SqliteConfig
+from primer.model_profile import ResolvedModel, resolve_model
+from primer.storage.sqlite import SqliteStorageProvider
+
+
+@pytest_asyncio.fixture
+async def sp(tmp_path: Path) -> AsyncIterator[StorageProvider]:
+    provider = SqliteStorageProvider(
+        SqliteConfig(path=str(tmp_path / "profiles.sqlite"))
+    )
+    await provider.initialize()
+    store = provider.get_storage(ModelProfile)
+    await store.create(
+        ModelProfile(
+            id="gx10-qwen-fast",
+            description="Qwen, reasoning suppressed.",
+            provider_id="gx10",
+            model_name="qwen",
+            context_length=262144,
+            config=ModelProfileConfig(reasoning=ReasoningLevel.OFF),
+        )
+    )
+    await store.create(
+        ModelProfile(
+            id="gx10-qwen-think",
+            description="Qwen, full reasoning.",
+            provider_id="gx10",
+            model_name="qwen",
+            context_length=262144,
+            config=ModelProfileConfig(reasoning=ReasoningLevel.HIGH),
+        )
+    )
+    try:
+        yield provider
+    finally:
+        await provider.aclose()
+
+
+class TestResolveModel:
+    async def test_uses_default_when_no_override(self, sp: StorageProvider) -> None:
+        r = await resolve_model(sp, default_profile_id="gx10-qwen-fast")
+        assert r.profile_id == "gx10-qwen-fast"
+        assert r.provider_id == "gx10"
+        assert r.model_name == "qwen"
+        assert r.context_length == 262144
+        assert r.config.reasoning is ReasoningLevel.OFF
+
+    async def test_override_wins(self, sp: StorageProvider) -> None:
+        r = await resolve_model(
+            sp,
+            default_profile_id="gx10-qwen-fast",
+            override_profile_id="gx10-qwen-think",
+        )
+        assert r.profile_id == "gx10-qwen-think"
+        assert r.config.reasoning is ReasoningLevel.HIGH
+
+    async def test_none_override_falls_back_to_default(
+        self, sp: StorageProvider
+    ) -> None:
+        r = await resolve_model(
+            sp, default_profile_id="gx10-qwen-fast", override_profile_id=None,
+        )
+        assert r.profile_id == "gx10-qwen-fast"
+
+    async def test_two_profiles_resolve_to_the_same_model(
+        self, sp: StorageProvider
+    ) -> None:
+        """The feature this entity exists for."""
+        fast = await resolve_model(sp, default_profile_id="gx10-qwen-fast")
+        think = await resolve_model(sp, default_profile_id="gx10-qwen-think")
+        assert fast.provider_id == think.provider_id == "gx10"
+        assert fast.model_name == think.model_name == "qwen"
+        assert fast.config.reasoning is not think.config.reasoning
+
+    async def test_missing_default_raises_not_found(
+        self, sp: StorageProvider
+    ) -> None:
+        with pytest.raises(NotFoundError, match="nope"):
+            await resolve_model(sp, default_profile_id="nope")
+
+    async def test_missing_override_raises_rather_than_falling_back(
+        self, sp: StorageProvider
+    ) -> None:
+        """A bad override must fail loudly, not silently run the default."""
+        with pytest.raises(NotFoundError, match="ghost"):
+            await resolve_model(
+                sp,
+                default_profile_id="gx10-qwen-fast",
+                override_profile_id="ghost",
+            )
+
+    async def test_resolved_model_is_frozen(self, sp: StorageProvider) -> None:
+        r = await resolve_model(sp, default_profile_id="gx10-qwen-fast")
+        with pytest.raises(dataclasses.FrozenInstanceError):
+            r.model_name = "other"  # type: ignore[misc]
+
+    async def test_returns_resolved_model_type(self, sp: StorageProvider) -> None:
+        r = await resolve_model(sp, default_profile_id="gx10-qwen-fast")
+        assert isinstance(r, ResolvedModel)

--- a/tests/storage/test_m002_model_profiles.py
+++ b/tests/storage/test_m002_model_profiles.py
@@ -1,0 +1,194 @@
+"""Tests for the models[] -> ModelProfile cutover migration."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from primer.int.storage_provider import StorageProvider
+from primer.model.model_profile import ModelProfile
+from primer.model.provider import SqliteConfig
+from primer.model.storage import OffsetPage
+from primer.storage.migrations.m002_model_profiles import (
+    Agent as LegacyAgent,
+    LLMProvider as LegacyProvider,
+    M002ModelProfiles,
+    synth_profile_id,
+)
+from primer.storage.sqlite import SqliteStorageProvider
+
+
+@pytest_asyncio.fixture
+async def sp(tmp_path: Path) -> AsyncIterator[StorageProvider]:
+    provider = SqliteStorageProvider(SqliteConfig(path=str(tmp_path / "m002.sqlite")))
+    await provider.initialize()
+    try:
+        yield provider
+    finally:
+        await provider.aclose()
+
+
+async def _seed_provider(sp: StorageProvider, **extra: object) -> None:
+    await sp.get_storage(LegacyProvider).create(
+        LegacyProvider(
+            id="gx10",
+            models=[
+                {"name": "qwen", "context_length": 262144},
+                {"name": "Qwen/Qwen3-32B", "context_length": 32768},
+            ],
+            **extra,  # type: ignore[arg-type]
+        )
+    )
+
+
+async def _seed_agent(sp: StorageProvider, model: dict[str, object]) -> None:
+    await sp.get_storage(LegacyAgent).create(
+        LegacyAgent(id="reviewer", model=model, description="A reviewer.")  # type: ignore[call-arg]
+    )
+
+
+async def _all_profiles(sp: StorageProvider) -> list[ModelProfile]:
+    page = await sp.get_storage(ModelProfile).list(OffsetPage(offset=0, length=200))
+    return list(page.items)
+
+
+class TestSynthProfileId:
+    def test_simple(self) -> None:
+        assert synth_profile_id("gx10", "qwen") == "gx10--qwen"
+
+    def test_sanitises_slashes_and_case(self) -> None:
+        assert synth_profile_id("gx10", "Qwen/Qwen3-32B") == "gx10--qwen-qwen3-32b"
+
+    def test_strips_leading_and_trailing_separators(self) -> None:
+        assert synth_profile_id("p", "/weird/") == "p--weird"
+
+    def test_is_deterministic(self) -> None:
+        assert synth_profile_id("a", "b") == synth_profile_id("a", "b")
+
+
+class TestSynthesiseProfiles:
+    async def test_creates_one_profile_per_model_entry(
+        self, sp: StorageProvider
+    ) -> None:
+        await _seed_provider(sp)
+        await M002ModelProfiles().apply(sp)
+
+        profiles = await _all_profiles(sp)
+        assert {p.id for p in profiles} == {"gx10--qwen", "gx10--qwen-qwen3-32b"}
+
+    async def test_carries_context_length_across(self, sp: StorageProvider) -> None:
+        await _seed_provider(sp)
+        await M002ModelProfiles().apply(sp)
+
+        qwen = next(p for p in await _all_profiles(sp) if p.id == "gx10--qwen")
+        assert qwen.context_length == 262144
+        assert qwen.provider_id == "gx10"
+        assert qwen.model_name == "qwen"
+
+    async def test_migrated_profile_config_is_inert(
+        self, sp: StorageProvider
+    ) -> None:
+        """A migrated profile must behave exactly as the old row did."""
+        await _seed_provider(sp)
+        await M002ModelProfiles().apply(sp)
+
+        qwen = next(p for p in await _all_profiles(sp) if p.id == "gx10--qwen")
+        assert qwen.config.reasoning is None
+        assert qwen.config.extended == {}
+
+
+class TestRewriteAgents:
+    async def test_rewrites_model_block_to_profile_id(
+        self, sp: StorageProvider
+    ) -> None:
+        await _seed_provider(sp)
+        await _seed_agent(sp, {"provider_id": "gx10", "model_name": "qwen"})
+
+        await M002ModelProfiles().apply(sp)
+
+        row = await sp.get_storage(LegacyAgent).get("reviewer")
+        assert row is not None
+        assert row.model == {"profile_id": "gx10--qwen"}
+
+    async def test_preserves_other_agent_fields(self, sp: StorageProvider) -> None:
+        await _seed_provider(sp)
+        await _seed_agent(sp, {"provider_id": "gx10", "model_name": "qwen"})
+
+        await M002ModelProfiles().apply(sp)
+
+        row = await sp.get_storage(LegacyAgent).get("reviewer")
+        assert row is not None
+        assert (row.model_extra or {}).get("description") == "A reviewer."
+
+    async def test_already_migrated_agent_is_left_alone(
+        self, sp: StorageProvider
+    ) -> None:
+        await _seed_provider(sp)
+        await _seed_agent(sp, {"profile_id": "hand-picked"})
+
+        await M002ModelProfiles().apply(sp)
+
+        row = await sp.get_storage(LegacyAgent).get("reviewer")
+        assert row is not None
+        assert row.model == {"profile_id": "hand-picked"}
+
+    async def test_orphan_agent_is_logged_not_rewritten(
+        self, sp: StorageProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """An agent naming a provider that no longer exists was already broken."""
+        await _seed_agent(sp, {"provider_id": "ghost", "model_name": "qwen"})
+
+        with caplog.at_level(logging.WARNING):
+            await M002ModelProfiles().apply(sp)
+
+        row = await sp.get_storage(LegacyAgent).get("reviewer")
+        assert row is not None
+        assert row.model == {"provider_id": "ghost", "model_name": "qwen"}
+        assert any(
+            "no matching provider" in r.getMessage() for r in caplog.records
+        )
+
+
+class TestStripModels:
+    async def test_removes_models_from_provider(self, sp: StorageProvider) -> None:
+        await _seed_provider(sp)
+        await M002ModelProfiles().apply(sp)
+
+        row = await sp.get_storage(LegacyProvider).get("gx10")
+        assert row is not None
+        assert row.models is None
+
+    async def test_preserves_other_provider_fields(
+        self, sp: StorageProvider
+    ) -> None:
+        await _seed_provider(sp, provider="openresponses")
+        await M002ModelProfiles().apply(sp)
+
+        row = await sp.get_storage(LegacyProvider).get("gx10")
+        assert row is not None
+        assert (row.model_extra or {}).get("provider") == "openresponses"
+
+
+class TestIdempotency:
+    async def test_second_run_is_a_noop(self, sp: StorageProvider) -> None:
+        await _seed_provider(sp)
+        await _seed_agent(sp, {"provider_id": "gx10", "model_name": "qwen"})
+
+        await M002ModelProfiles().apply(sp)
+        first = {p.id for p in await _all_profiles(sp)}
+        agent_first = (await sp.get_storage(LegacyAgent).get("reviewer")).model
+
+        await M002ModelProfiles().apply(sp)
+        second = {p.id for p in await _all_profiles(sp)}
+        agent_second = (await sp.get_storage(LegacyAgent).get("reviewer")).model
+
+        assert first == second
+        assert agent_first == agent_second
+
+    async def test_empty_database_is_a_noop(self, sp: StorageProvider) -> None:
+        await M002ModelProfiles().apply(sp)
+        assert await _all_profiles(sp) == []

--- a/tests/storage/test_migrations.py
+++ b/tests/storage/test_migrations.py
@@ -1,0 +1,203 @@
+"""Tests for the ordered data-migration runner.
+
+The runner operates through ``Storage[T]`` handles rather than raw SQL, so
+these tests exercise it against the SQLite backend and the behaviour holds
+for Postgres by construction.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import AsyncIterator
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+from primer.int.storage_provider import StorageProvider
+from primer.model.provider import SqliteConfig
+from primer.storage.migrations import (
+    LATEST_VERSION,
+    MIGRATIONS,
+    run_migrations,
+)
+from primer.storage.sqlite import SqliteStorageProvider
+
+# asyncio_mode = "auto" in pyproject.toml, so async tests need no marker.
+
+
+@pytest_asyncio.fixture
+async def sp(tmp_path: Path) -> AsyncIterator[StorageProvider]:
+    provider = SqliteStorageProvider(
+        SqliteConfig(path=str(tmp_path / "migrations.sqlite"))
+    )
+    await provider.initialize()
+    try:
+        yield provider
+    finally:
+        await provider.aclose()
+
+
+# ---------------------------------------------------------------------------
+# Registry invariants
+# ---------------------------------------------------------------------------
+
+
+class TestRegistry:
+    def test_versions_are_contiguous_from_one(self) -> None:
+        versions = [m.version for m in MIGRATIONS]
+        assert versions == list(range(1, len(MIGRATIONS) + 1))
+
+    def test_versions_are_unique(self) -> None:
+        versions = [m.version for m in MIGRATIONS]
+        assert len(set(versions)) == len(versions)
+
+    def test_latest_version_matches_registry(self) -> None:
+        assert LATEST_VERSION == len(MIGRATIONS)
+
+    def test_every_migration_has_a_description(self) -> None:
+        assert all(m.description.strip() for m in MIGRATIONS)
+
+
+# ---------------------------------------------------------------------------
+# Runner behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestRunMigrations:
+    async def test_fresh_install_baselines_without_applying(
+        self, sp: StorageProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A fresh install has nothing to transform, so it baselines."""
+        applied: list[int] = []
+        for migration in MIGRATIONS:
+            monkeypatch.setattr(
+                migration,
+                "apply",
+                _recording_apply(migration.version, applied),
+                raising=False,
+            )
+
+        result = await run_migrations(sp, is_fresh_install=True)
+
+        assert result == LATEST_VERSION
+        assert applied == []
+        state = await sp.get_system_state()
+        assert state.schema_version == LATEST_VERSION
+        assert state.last_migration_at is not None
+
+    async def test_existing_install_converges_on_latest(
+        self, sp: StorageProvider
+    ) -> None:
+        result = await run_migrations(sp, is_fresh_install=False)
+
+        assert result == LATEST_VERSION
+        state = await sp.get_system_state()
+        assert state.schema_version == LATEST_VERSION
+
+    async def test_pending_migration_runs_and_stamps(
+        self, sp: StorageProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """A migration above the stored version runs and advances it.
+
+        Driven with a synthetic registry rather than the real one so the
+        test keeps meaning as migrations are added: with schema_version
+        defaulting to 1, whether any SHIPPED migration is pending depends
+        on how many exist.
+        """
+        applied: list[int] = []
+        fake = _FakeMigration(version=2, sink=applied)
+        monkeypatch.setattr(
+            "primer.storage.migrations.MIGRATIONS", (fake,),
+        )
+        monkeypatch.setattr("primer.storage.migrations.LATEST_VERSION", 2)
+
+        result = await run_migrations(sp, is_fresh_install=False)
+
+        assert applied == [2]
+        assert result == 2
+        state = await sp.get_system_state()
+        assert state.schema_version == 2
+        assert state.last_migration_at is not None
+
+    async def test_already_applied_migrations_are_skipped(
+        self, sp: StorageProvider, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """schema_version = N means migrations 1..N have already run."""
+        await sp.set_schema_version(LATEST_VERSION)
+        applied: list[int] = []
+        for migration in MIGRATIONS:
+            monkeypatch.setattr(
+                migration,
+                "apply",
+                _recording_apply(migration.version, applied),
+                raising=False,
+            )
+
+        await run_migrations(sp, is_fresh_install=False)
+
+        assert applied == []
+
+    async def test_double_apply_is_idempotent(self, sp: StorageProvider) -> None:
+        await run_migrations(sp, is_fresh_install=False)
+        first = await sp.get_system_state()
+        await run_migrations(sp, is_fresh_install=False)
+        second = await sp.get_system_state()
+
+        assert second.schema_version == first.schema_version == LATEST_VERSION
+
+    async def test_future_version_warns_and_does_not_downgrade(
+        self, sp: StorageProvider, caplog: pytest.LogCaptureFixture
+    ) -> None:
+        """Older code against a newer DB must refuse rather than guess."""
+        future = LATEST_VERSION + 5
+        await sp.set_schema_version(future)
+
+        with caplog.at_level(logging.WARNING):
+            result = await run_migrations(sp, is_fresh_install=False)
+
+        assert result == future
+        state = await sp.get_system_state()
+        assert state.schema_version == future
+        assert any(
+            "newer than this build" in record.getMessage()
+            for record in caplog.records
+        )
+
+
+# ---------------------------------------------------------------------------
+# set_schema_version storage contract
+# ---------------------------------------------------------------------------
+
+
+class TestSetSchemaVersion:
+    async def test_stamps_version_and_timestamp(self, sp: StorageProvider) -> None:
+        await sp.set_schema_version(7)
+        state = await sp.get_system_state()
+        assert state.schema_version == 7
+        assert state.last_migration_at is not None
+
+    async def test_overwrites_previous_value(self, sp: StorageProvider) -> None:
+        await sp.set_schema_version(3)
+        await sp.set_schema_version(4)
+        state = await sp.get_system_state()
+        assert state.schema_version == 4
+
+
+def _recording_apply(version: int, sink: list[int]):
+    async def _apply(_sp: StorageProvider) -> None:
+        sink.append(version)
+
+    return _apply
+
+
+class _FakeMigration:
+    """Stand-in migration so runner tests do not depend on the real chain."""
+
+    def __init__(self, *, version: int, sink: list[int]) -> None:
+        self.version = version
+        self.description = f"fake migration {version}"
+        self._sink = sink
+
+    async def apply(self, _sp: StorageProvider) -> None:
+        self._sink.append(self.version)


### PR DESCRIPTION
## What this changes

Foundation for model profiles: a model can be registered many times under one
provider with different configuration, so a reasoning and a non-reasoning
variant of the same model can coexist. This PR lands the **additive half**; the
cutover that removes `LLMProvider.models[]` is deliberately not here (see
Scope below).

### 1. A migration runner

Primer's entity storage is schemaless JSONB with per-model tables created
lazily, so there is no DDL to version. What does need versioning is the shape
of the data inside those tables. This adds a forward-only runner using the
`system_state.schema_version` / `last_migration_at` columns that already
existed unused for exactly this purpose.

- **Backend-agnostic:** migrations go through `Storage[T]` handles, never raw
  SQL, so Postgres and SQLite behave identically with no duplicated statements.
- **Idempotent:** every migration is get-then-create, so a process death
  mid-run re-runs harmlessly.
- **Forward-only:** `schema_version` is stamped after each migration commits,
  so a crash resumes from the last completed version. A database newer than the
  running build logs a warning and is left alone rather than having a
  down-migration guessed at.

`schema_version = N` means migrations 1..N have been applied. The field already
defaulted to 1, which correctly describes every install predating this module:
m001 wraps `migrate_document_content`, whose ad-hoc lifespan call was
unconditional on every boot. The runner replaces that call and is placed before
auto-bootstrap, so a migration never has to reason about whether a reserved row
exists yet.

**Alembic was considered and rejected.** It is built on SQLAlchemy, which this
codebase deliberately does not use, and there is no DDL for it to version;
revisions would contain only hand-written JSONB data rewrites.

### 2. `ModelProfile` entity and resolver

A profile names one `(provider, model)` pair plus its API-level config. The
profile id is what an Agent will reference, which is what makes the same model
registerable twice under one provider.

`ModelProfileConfig` carries a vendor-neutral `reasoning` level plus an open
`extended` passthrough. The reasoning level is normalised the way stop reasons
already are: the universal vocabulary is the contract, each adapter translates
at the SDK boundary. `extended` flows into the `LLM.stream(extended=...)`
escape hatch that adapters already honour but nothing persisted ever populated.

Deliberately **not** on the config: `temperature` and `max_output_tokens`.
Those live on `Agent`, and duplicating them would create a precedence question
with no defensible answer.

`resolve_model()` takes default and override profile ids rather than an `Agent`,
so precedence lives in one place. A bad override raises rather than falling
back to the default: quietly running a different model than the caller asked
for is worse than failing.

### 3. m002 cutover migration

Synthesises one profile per legacy `models[]` entry, rewrites `Agent.model` to
`{profile_id}`, strips `models[]`. It declares its own `LLMProvider` / `Agent`
view classes because a migration reads rows written by the OLD schema from
inside a build where the models have already changed; the storage layer derives
table names from the lowercased class name, so a view class named `LLMProvider`
addresses the same table, and `extra="allow"` keeps untouched fields intact.

## Scope

**This PR is additive and inert.** Nothing consumes `ModelProfile` yet, and
m002 is registered but is a no-op on any install whose agents already carry
`profile_id`. The cutover (removing `LLMProvider.models[]` and
`LLM.list_models()`, switching `AgentModel`, repointing the five resolution
sites) is pushed separately on `wip/model-profiles-cutover` and is **red**:
97 failing. It is split out because it is one large diff and because the
remaining work there is a genuine fixture change across ~100 test files, not a
mechanical rewrite: making resolution storage-backed means every test that
builds an agent and runs a turn now needs a `ModelProfile` row seeded.

## Checklist

- [x] Conventional commit messages
- [x] Tests added for the changed behavior (51 new)
- [x] Narrowed unit sweep passes locally (8149 passed, 0 failed)
- [x] No em-dash characters introduced
- [x] No secrets, tokens, or internal-only references added
- [ ] Docs: dev docs NOT yet updated. `docs/dev/architecture/storage.md` states
      "there is no Alembic step to add" and that per-model tables defer to first
      handle use, which is still true, but it should gain a migration-runner
      section. Deferred to the cutover PR so the docs describe the finished
      shape rather than an intermediate one.

## Notes for reviewers

**A vLLM finding that changes the follow-up design.** Probing a live vLLM
server (`Qwen/Qwen3.6-35B-A3B-FP8`) showed its **Responses API cannot suppress
reasoning at all**: `chat_template_kwargs`, `extra_body.chat_template_kwargs`,
top-level `enable_thinking`, and native `reasoning.effort` are each accepted
silently with reasoning still present. On Chat Completions,
`chat_template_kwargs: {enable_thinking: false}` works cleanly. So the
per-adapter reasoning mapping must warn rather than pretend on
`openresponses` + vLLM, and an operator wanting reasoning control against vLLM
needs the `openchat` provider type.

**`schema_version` becomes load-bearing.** Running older code against a
migrated database is now genuinely unsafe rather than merely untested. The
runner warns and refuses rather than attempting a downgrade.

**Pre-existing, unrelated:** `tests/primectl/` fails to collect on a fresh
checkout (`ModuleNotFoundError: primectl.commands`). `primectl` is a
`[tool.uv.workspace]` member but not a dependency of `primer-ai`, so the
`uv sync --all-extras` that AGENTS.md and CI prescribe does not install it;
`--all-packages` does. Flagged in PR #190 as well.
