### PR TITLE
fix(session): stop the stuck-session sweeper reaping live first turns

### DIFF
--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -468,6 +468,10 @@ def _make_lifespan(config: AppConfig):
             from primer.bus.scheduler_tasks import StuckSessionSweeper
             stuck_session_sweeper = StuckSessionSweeper(
                 session_storage=storage_provider.get_storage(_WorkspaceSession),
+                # Without the engine the sweeper cannot tell a session whose first turn
+                # is still running from one that never started, and defaults to reaping
+                # neither. Passing it is what keeps the sweeper both safe and useful.
+                claim_engine=claim_engine,
             )
             stuck_session_sweeper.start(coordinator.leader_elector)
 

--- a/primer/bus/scheduler_tasks.py
+++ b/primer/bus/scheduler_tasks.py
@@ -37,6 +37,7 @@ from primer.int.coordinator import (
     ROLE_TIMEOUT_SWEEPER,
     ROLE_TIMER_SCHEDULER,
 )
+from primer.int.claim import ClaimKind
 from primer.int.event_bus import EventBus
 from primer.int.storage import Storage
 from primer.model.storage import FieldRef, OffsetPage, Op, Predicate, Value
@@ -44,6 +45,7 @@ from primer.model.workspace_session import SessionStatus
 from primer.worker.yield_runtime import make_timeout_payload
 
 if TYPE_CHECKING:
+    from primer.int.claim import ClaimEngine
     from primer.int.coordinator import LeaderElector
 
 
@@ -268,9 +270,20 @@ class StuckSessionSweeper(_BackgroundTask):
     silently halts its trigger - observed in production as a cron job that stopped for 14h
     with no error recorded anywhere.
 
-    Sessions that HAVE started (``turn_no >= 1``) are never touched however long they run: a
-    turn may legitimately take hours, and ending it from underneath the worker would be far
-    worse than leaving it alone.
+    Sessions that HAVE started are never touched however long they run: a turn may
+    legitimately take hours, and ending it from underneath the worker would be far worse
+    than leaving it alone.
+
+    Establishing "has started" needs the claim engine, and getting this wrong is what the
+    ``claim_engine`` argument exists to prevent. ``turn_no`` alone cannot answer it: the
+    counter is bumped on RELEASE, so a first turn that has been running for hours still
+    reads 0 and looks identical to one that was never claimed. Gating on ``turn_no == 0``
+    plus a 10-minute age therefore reaped live sessions — observed on a daily rating job
+    whose turns run ~3.5h: the row was flipped to ENDED at the 10-minute mark while its
+    worker computed happily for another three hours, which both lied about session state
+    and released the ``parallelism="skip"`` gate, letting the next cron tick start a
+    second concurrent run. A live lease (heartbeated by the worker, expiring within one
+    TTL of its death) is the signal that actually distinguishes the two cases.
     """
 
     role = ROLE_STUCK_SESSION_SWEEPER
@@ -279,11 +292,13 @@ class StuckSessionSweeper(_BackgroundTask):
         self,
         *,
         session_storage: Storage,
+        claim_engine: "ClaimEngine | None" = None,
         poll_seconds: float = DEFAULT_SWEEPER_POLL_SECONDS,
         grace_seconds: float = STUCK_SESSION_GRACE_SECONDS,
     ) -> None:
         super().__init__(name="stuck-session-sweeper")
         self._storage = session_storage
+        self._claim_engine = claim_engine
         self._poll = poll_seconds
         self._grace = grace_seconds
 
@@ -307,6 +322,13 @@ class StuckSessionSweeper(_BackgroundTask):
             # which case the turn is now running and must not be ended.
             if fresh is None or not _never_started(fresh, self._grace):
                 continue
+            # The decisive check, and the last one before a destructive write: a live
+            # lease means a worker is mid-turn on this session right now. Done per
+            # candidate rather than as a bulk filter because the candidate list is
+            # already narrow (turn_no == 0 past the grace) and the read must be as
+            # close to the write as possible.
+            if await self._has_live_lease(fresh.id):
+                continue
             await self._storage.update(fresh.model_copy(update={
                 "status": SessionStatus.ENDED,
                 "ended_reason": "failed",
@@ -319,6 +341,23 @@ class StuckSessionSweeper(_BackgroundTask):
                 fresh.id, fresh.created_at,
             )
         return reaped
+
+    async def _has_live_lease(self, session_id: str) -> bool:
+        """Whether a worker is mid-turn on *session_id*.
+
+        Errs toward "yes" on both no-engine and error paths. Skipping a genuinely stuck
+        session costs one more poll interval; ending a live one destroys a running job.
+        """
+        if self._claim_engine is None:
+            return True
+        try:
+            return await self._claim_engine.has_live_lease(ClaimKind.SESSION, session_id)
+        except Exception as exc:  # noqa: BLE001 - an unreadable lease must not authorise a reap
+            logger.warning(
+                "stuck-session-sweeper: lease lookup failed for %s, leaving it alone: %s",
+                session_id, exc,
+            )
+            return True
 
     async def _find_stuck(self) -> list:
         """Every never-started session, paged. Pages rather than taking one capped slice:

--- a/primer/claim/in_memory.py
+++ b/primer/claim/in_memory.py
@@ -66,6 +66,12 @@ class InMemoryClaimEngine(ClaimEngine):
     async def delete_lease(self, kind: ClaimKind, entity_id: str) -> None:
         self._leases.pop((kind, entity_id), None)
 
+    async def has_live_lease(self, kind: ClaimKind, entity_id: str) -> bool:
+        row = self._leases.get((kind, entity_id))
+        if row is None or row.claimed_by is None or row.expires_at is None:
+            return False
+        return row.expires_at > datetime.now(UTC)
+
     async def claim_due(self, worker_id: str, *, max_count: int) -> list[Lease]:
         _tracer = _tracing.get_tracer("primer.claim")
         with _tracer.start_as_current_span("claim.due") as _span:

--- a/primer/claim/postgres.py
+++ b/primer/claim/postgres.py
@@ -190,6 +190,26 @@ class PostgresClaimEngine(ClaimEngine):
             )
 
     # ------------------------------------------------------------------
+    # has_live_lease
+    # ------------------------------------------------------------------
+
+    async def has_live_lease(self, kind: ClaimKind, entity_id: str) -> bool:
+        """Whether a worker holds an unexpired lease on (kind, entity_id) right now.
+
+        ``expires_at`` is pushed forward by every heartbeat, so this stays true for as
+        long as the worker is alive and false within one lease TTL of it dying — which
+        is exactly the line the stuck-session sweeper needs to draw.
+        """
+        async with self._storage.pool.acquire() as conn:
+            row = await conn.fetchrow(
+                f"SELECT 1 FROM {self._table} "
+                f"WHERE kind = $1 AND entity_id = $2 "
+                f"AND claimed_by IS NOT NULL AND expires_at > now()",
+                kind.value, entity_id,
+            )
+        return row is not None
+
+    # ------------------------------------------------------------------
     # claim_due
     # ------------------------------------------------------------------
 

--- a/primer/int/claim.py
+++ b/primer/int/claim.py
@@ -112,3 +112,18 @@ class ClaimEngine(ABC):
 
     @abstractmethod
     async def delete_lease(self, kind: ClaimKind, entity_id: str) -> None: ...
+
+    async def has_live_lease(self, kind: ClaimKind, entity_id: str) -> bool:
+        """Whether a worker currently holds an unexpired lease on (kind, entity_id).
+
+        This is the only honest "a turn is running right now" signal in the system.
+        ``sessions.turn_no`` is not one: it is bumped on RELEASE, so a first turn that
+        has been executing for hours still reads 0, indistinguishable from a turn that
+        was never claimed.
+
+        Concrete, not abstract, and the default is ``True`` on purpose. The sole caller
+        is :class:`~primer.bus.scheduler_tasks.StuckSessionSweeper`, whose failure mode
+        is ending a session out from under a live worker. An engine that cannot answer
+        must therefore make the sweeper do nothing rather than make it reap.
+        """
+        return True

--- a/tests/bus/test_stuck_session_sweeper.py
+++ b/tests/bus/test_stuck_session_sweeper.py
@@ -5,6 +5,11 @@ waiting), and cancel just sets a flag a worker reads on its next step. A session
 started has no worker, so it stays non-terminal forever — and a `parallelism="skip"`
 subscription will not fire while any attributed session is non-terminal, so one stuck row
 silently halts its trigger.
+
+The sweeper's whole difficulty is telling "never started" from "started and still going",
+because `turn_no` cannot: it is bumped on RELEASE, so a first turn running for hours still
+reads 0. Only a live claim lease separates the two, which is why every test here supplies a
+claim engine — a sweeper without one is deliberately inert.
 """
 
 from __future__ import annotations
@@ -14,11 +19,35 @@ from datetime import datetime, timedelta, timezone
 import pytest
 
 from primer.bus.scheduler_tasks import StuckSessionSweeper
+from primer.int.claim import ClaimKind
 from primer.model.workspace_session import (
     GraphSessionBinding,
     SessionStatus,
     WorkspaceSession,
 )
+
+
+class _FakeClaimEngine:
+    """Just the one method the sweeper calls, over a set of leased session ids."""
+
+    def __init__(self, leased: set[str] | None = None, *, raises: bool = False) -> None:
+        self.leased = leased or set()
+        self.raises = raises
+        self.calls: list[tuple[ClaimKind, str]] = []
+
+    async def has_live_lease(self, kind: ClaimKind, entity_id: str) -> bool:
+        self.calls.append((kind, entity_id))
+        if self.raises:
+            raise RuntimeError("lease table unreachable")
+        return entity_id in self.leased
+
+
+def _sweeper(storage, *, leased=None, raises=False, **kw):
+    return StuckSessionSweeper(
+        session_storage=storage,
+        claim_engine=_FakeClaimEngine(leased, raises=raises),
+        **kw,
+    )
 
 
 def _session(sid, *, age_seconds=3600, turn_no=0, status=SessionStatus.RUNNING, **over):
@@ -40,7 +69,7 @@ async def test_ends_a_session_whose_first_turn_never_ran(fake_storage_provider):
     storage = fake_storage_provider.get_storage(WorkspaceSession)
     await storage.create(_session("se-stuck"))
 
-    reaped = await StuckSessionSweeper(session_storage=storage)._tick()
+    reaped = await _sweeper(storage)._tick()
 
     assert reaped == 1
     row = await storage.get("se-stuck")
@@ -48,6 +77,62 @@ async def test_ends_a_session_whose_first_turn_never_ran(fake_storage_provider):
     assert row.ended_reason == "failed"
     assert row.ended_detail == "never_started"
     assert row.ended_at is not None
+
+
+@pytest.mark.asyncio
+async def test_leaves_a_first_turn_that_is_still_running(fake_storage_provider):
+    """The regression that motivated the lease check.
+
+    turn_no is bumped on release, so a session whose FIRST turn is mid-flight still reads
+    turn_no == 0 — indistinguishable by that field alone from one that was never claimed.
+    In production this reaped a daily rating job at the 10-minute mark while its worker
+    went on computing for another three hours: the row claimed ENDED, and the released
+    `parallelism="skip"` gate let the next tick start a second concurrent run.
+    """
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(_session("se-inflight", age_seconds=12_600, turn_no=0))
+
+    sweeper = _sweeper(storage, leased={"se-inflight"})
+    reaped = await sweeper._tick()
+
+    assert reaped == 0
+    row = await storage.get("se-inflight")
+    assert row.status == SessionStatus.RUNNING
+    assert row.ended_reason is None
+
+
+@pytest.mark.asyncio
+async def test_reaps_once_the_lease_expires(fake_storage_provider):
+    """A worker that dies stops heartbeating, so its lease lapses and the row is reapable.
+
+    This is the other half of the lease check: it must not turn the sweeper off for the
+    abandoned sessions it exists to clean up.
+    """
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(_session("se-abandoned", age_seconds=12_600, turn_no=0))
+
+    assert await _sweeper(storage, leased={"se-abandoned"})._tick() == 0
+    assert await _sweeper(storage, leased=set())._tick() == 1
+    assert (await storage.get("se-abandoned")).ended_detail == "never_started"
+
+
+@pytest.mark.asyncio
+async def test_an_unreadable_lease_never_authorises_a_reap(fake_storage_provider):
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(_session("se-unknown"))
+
+    assert await _sweeper(storage, raises=True)._tick() == 0
+    assert (await storage.get("se-unknown")).status == SessionStatus.RUNNING
+
+
+@pytest.mark.asyncio
+async def test_without_a_claim_engine_the_sweeper_is_inert(fake_storage_provider):
+    """No engine means no way to prove a session is idle, so it reaps nothing."""
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(_session("se-stuck"))
+
+    assert await StuckSessionSweeper(session_storage=storage)._tick() == 0
+    assert (await storage.get("se-stuck")).status == SessionStatus.RUNNING
 
 
 @pytest.mark.asyncio
@@ -62,7 +147,7 @@ async def test_leaves_a_running_turn_alone_however_long_it_runs(fake_storage_pro
         _session("se-working", age_seconds=86_400, turn_no=4, turn_status="running")
     )
 
-    reaped = await StuckSessionSweeper(session_storage=storage)._tick()
+    reaped = await _sweeper(storage)._tick()
 
     assert reaped == 0
     assert (await storage.get("se-working")).status == SessionStatus.RUNNING
@@ -74,7 +159,7 @@ async def test_leaves_a_freshly_created_session_alone(fake_storage_provider):
     storage = fake_storage_provider.get_storage(WorkspaceSession)
     await storage.create(_session("se-fresh", age_seconds=5))
 
-    reaped = await StuckSessionSweeper(session_storage=storage)._tick()
+    reaped = await _sweeper(storage)._tick()
 
     assert reaped == 0
     assert (await storage.get("se-fresh")).status == SessionStatus.RUNNING
@@ -87,8 +172,19 @@ async def test_ignores_already_ended_sessions(fake_storage_provider):
         _session("se-done", status=SessionStatus.ENDED, ended_reason="completed")
     )
 
-    assert await StuckSessionSweeper(session_storage=storage)._tick() == 0
+    assert await _sweeper(storage)._tick() == 0
     assert (await storage.get("se-done")).ended_reason == "completed"
+
+
+@pytest.mark.asyncio
+async def test_the_lease_is_checked_for_sessions_not_some_other_kind(fake_storage_provider):
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    await storage.create(_session("se-stuck"))
+
+    engine = _FakeClaimEngine()
+    await StuckSessionSweeper(session_storage=storage, claim_engine=engine)._tick()
+
+    assert engine.calls == [(ClaimKind.SESSION, "se-stuck")]
 
 
 @pytest.mark.asyncio
@@ -96,9 +192,5 @@ async def test_grace_is_configurable(fake_storage_provider):
     storage = fake_storage_provider.get_storage(WorkspaceSession)
     await storage.create(_session("se-recent", age_seconds=30))
 
-    assert await StuckSessionSweeper(
-        session_storage=storage, grace_seconds=3600,
-    )._tick() == 0
-    assert await StuckSessionSweeper(
-        session_storage=storage, grace_seconds=10,
-    )._tick() == 1
+    assert await _sweeper(storage, grace_seconds=3600)._tick() == 0
+    assert await _sweeper(storage, grace_seconds=10)._tick() == 1


### PR DESCRIPTION
## The bug

`turn_no` is bumped on **release**, so a session whose *first* turn is still running reads `turn_no == 0` — by that field alone, indistinguishable from one whose claim was lost. `StuckSessionSweeper` gated on exactly that plus a 10-minute age, so it ended live sessions out from under their workers.

This is a regression from #188, which introduced the sweeper.

## How it showed up

A daily rating job whose turns run ~3.5h. The row was flipped to `ENDED` at the 10-minute mark while its worker went on computing for another three hours, then completed normally and wrote `turn_no=1` / `ended_reason=completed` over the top. The only surviving trace is the stale detail left behind — 21 rows in six days:

```
ended_detail  | ended_reason | count
never_started | completed    |    21   <- reaped while alive, then finished anyway
never_started | failed       |     1   <- the genuine case the sweeper is for
```

Two real consequences:
- session state lied for hours — `ENDED` on a session actively doing work
- the prematurely released `parallelism="skip"` gate let the next cron tick start a **second concurrent run** of a job meant to be serialised

## The fix

Gate on a live claim lease. It is the only signal that actually separates the two cases: heartbeated for as long as the turn runs, and lapsing within one TTL of a worker's death — so genuinely abandoned sessions are still reaped, which is the whole point of the sweeper.

`ClaimEngine.has_live_lease` is concrete rather than abstract and defaults to `True`, as does every error path in the sweeper. The asymmetry is deliberate: skipping a stuck session costs one poll interval, ending a live one destroys a running job. A sweeper with no engine is inert.

## Tests

`tests/bus/test_stuck_session_sweeper.py` — the regression case (`turn_no == 0`, 3.5h old, lease live → not reaped) plus its converse (lease lapsed → reaped), an unreadable lease, the no-engine case, and that the lookup uses `ClaimKind.SESSION`.

```
tests/bus tests/claim tests/trigger tests/session
364 passed, 22 skipped, 1 xfailed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)