### PR TITLE
docs: two README feature cards still sold the loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ A lot of what Primer ships - knowledge bases, channels, triggers, approvals - yo
 
 🔁 **Directed cyclic agent graphs**
 
-Wire small agents into a feedback loop with an evaluator at the end that grades the output and feeds it back - produce, critique, revise, until the loop **converges on a target** instead of hoping a one-shot prompt lands.
+Wire small agents into a topology that branches, fans out, and rejoins. Add an evaluator on a cycle back to the producer and the run **converges on a target** - produce, critique, revise - instead of hoping a one-shot prompt lands.
 
 </td>
     <td width="33%" valign="top">
@@ -53,7 +53,7 @@ Multiple agents and graphs run in one sandbox, reading and writing the same file
 
 ⏸️ **Yielding tools**
 
-An agent parks and **yields control** until an event fires - a file change, schedule, webhook, or human reply - so loops run in the background. One agent can wake the instant another writes a file.
+An agent parks and **yields control** until an event fires - a file change, schedule, webhook, or human reply - so runs continue in the background. One agent can wake the instant another writes a file.
 
 </td>
   </tr>


### PR DESCRIPTION
#195 rewrote the "Built for graph engineering" section but left the feature cards further up untouched. The sweep looked for the phrase *"loop engineering"* rather than for loop language generally, so copy that sold the loop without naming the practice survived. The same miss left **"Build the loop."** as the homepage hero (fixed in primerhq/primerhq.github.io#13).

## Changed

**Directed cyclic agent graphs** card - led with "wire small agents into a feedback loop", which sells the cycle as the product under a heading that says *graphs*. It now leads with the topology (branches, fans out, rejoins) and treats the evaluator cycle as the thing you add to make a run converge.

**Yielding tools** card - "so loops run in the background" becomes "so runs continue in the background". A parked run is not necessarily a loop.

## Not changed

Line 107, `A loop is one shape a graph can take: a cycle, usually two nodes and a condition.` That is the thesis stating itself, not a leftover.
