### PR TITLE
exec: optional `check` so a failing command fails the tool call

### DIFF
--- a/primer/workspace/local/tools/exec_.py
+++ b/primer/workspace/local/tools/exec_.py
@@ -50,6 +50,16 @@ class ExecArgs(BaseModel):
             "raises BadRequestError."
         ),
     )
+    check: bool = Field(
+        default=False,
+        description=(
+            "Fail the tool call when the command exits non-zero. Default False "
+            "keeps the historical behaviour, where a failing command returns "
+            "normally and its exit code is visible only in the output text - so "
+            "a graph node wrapping it reports success no matter what happened "
+            "inside. Set True for any step whose failure should stop the graph."
+        ),
+    )
     description: str = Field(
         ...,
         min_length=1,
@@ -221,6 +231,8 @@ class Exec(WorkspaceTool):
         out_text = stdout.decode("utf-8", errors="replace")
         err_text = stderr.decode("utf-8", errors="replace")
         body = f"{rc}\n{out_text}\n{err_text}"
+        if args.check and rc != 0:
+            raise BadRequestError(nonzero_exit_message(args.command, rc, out_text, err_text))
         return ToolResult(
             output=body,
             metadata={
@@ -277,4 +289,16 @@ def _curated_subprocess_env() -> dict[str, str]:
     return {k: v for k, v in os.environ.items() if k in _ENV_PASSTHROUGH}
 
 
-__all__ = ["Exec", "ExecArgs"]
+def nonzero_exit_message(command: str, rc: int, stdout: str, stderr: str) -> str:
+    """A failure message carrying the tail of the output, not just the code.
+
+    The exit code alone sends the reader back to the raw output to find out what
+    happened; including the tail means the node's error field says it directly.
+    stderr first because that is where a traceback lands.
+    """
+    tail = (stderr.strip() or stdout.strip())[-800:]
+    suffix = f"\n{tail}" if tail else ""
+    return f"command exited {rc}: {command!r}{suffix}"
+
+
+__all__ = ["Exec", "ExecArgs", "nonzero_exit_message"]

--- a/primer/workspace/sandbox/tools/exec_.py
+++ b/primer/workspace/sandbox/tools/exec_.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 from primer.int.sandbox import Sandbox
 from primer.model.chat import ToolExample
 from primer.model.except_ import BadRequestError
-from primer.workspace.local.tools.exec_ import ExecArgs
+from primer.workspace.local.tools.exec_ import ExecArgs, nonzero_exit_message
 from primer.workspace.sandbox.tools._common import resolve_sandbox_path
 from primer.workspace.tool import ToolCallContext, ToolResult, WorkspaceTool
 
@@ -89,6 +89,17 @@ class SandboxExec(WorkspaceTool):
                 f"{args.command!r}"
             ) from exc
         body = f"{result.exit_code}\n{result.stdout}\n{result.stderr}"
+        # Without `check`, a command that fails still produces a SUCCESSFUL tool
+        # call, so the graph node wrapping it records status=completed, error=None.
+        # A run whose script raised is then indistinguishable from one that
+        # succeeded, and the only trace is an exit code buried at the head of the
+        # output text.
+        if args.check and result.exit_code != 0:
+            raise BadRequestError(
+                nonzero_exit_message(
+                    args.command, result.exit_code, result.stdout, result.stderr
+                )
+            )
         return ToolResult(
             output=body,
             metadata={

--- a/tests/workspace/test_exec_check.py
+++ b/tests/workspace/test_exec_check.py
@@ -1,0 +1,112 @@
+"""`exec` can fail the tool call when the command fails.
+
+Without `check`, a command that exits non-zero still produces a SUCCESSFUL tool
+call. A graph node wrapping it therefore records ``status=completed`` and
+``error=None``, so a run whose script raised is indistinguishable from one that
+succeeded -- the only trace is an exit code at the head of the output text. That
+misdirection is expensive: a scoring graph reported every node "completed" across
+three separate failed runs while writing nothing.
+
+Default stays False. Plenty of commands use a non-zero exit as information
+(``grep`` finding nothing, ``diff`` reporting a difference), so failing by
+default would break them; the flag is opt-in for steps whose failure should stop
+the graph.
+"""
+import sys
+
+import pytest
+
+from primer.model.except_ import BadRequestError
+from primer.workspace.local.tools.exec_ import ExecArgs, nonzero_exit_message
+
+FAIL = f'"{sys.executable}" -c "import sys; sys.stderr.write(\'boom\\n\'); sys.exit(3)"'
+OK = f'"{sys.executable}" -c "print(\'fine\')"'
+
+
+def test_check_defaults_to_false():
+    """The historical contract: a failing command is not a failing tool call."""
+    assert ExecArgs(command="ls", description="d").check is False
+
+
+def test_check_is_settable():
+    assert ExecArgs(command="ls", description="d", check=True).check is True
+
+
+def test_message_leads_with_the_exit_code_and_carries_the_tail():
+    """The exit code alone sends the reader back to the raw output.
+
+    Including the tail means the node's `error` field states the cause directly,
+    which is the whole point -- the traceback existed all along, just not
+    anywhere the run status was visible.
+    """
+    msg = nonzero_exit_message("python x.py", 1, "some stdout",
+                               "Traceback (most recent call last):\nRuntimeError: boom")
+    assert "exited 1" in msg
+    assert "python x.py" in msg
+    assert "RuntimeError: boom" in msg
+
+
+def test_message_prefers_stderr_but_falls_back_to_stdout():
+    assert "on stdout" in nonzero_exit_message("c", 2, "on stdout", "")
+    assert "on stderr" in nonzero_exit_message("c", 2, "on stdout", "on stderr")
+
+
+def test_message_is_bounded():
+    """A runaway log must not become the node's error field verbatim."""
+    msg = nonzero_exit_message("c", 1, "", "x" * 10_000)
+    assert len(msg) < 1_200
+
+
+@pytest.mark.asyncio
+async def test_local_exec_raises_on_nonzero_when_checked(tmp_path):
+    from primer.workspace.local.tools.exec_ import Exec
+
+    tool = Exec(tmp_path)
+    with pytest.raises(BadRequestError) as ei:
+        await tool.execute(
+            ExecArgs(command=FAIL, description="fails", check=True, workdir="."),
+            _ctx(),
+        )
+    assert "exited 3" in str(ei.value)
+    assert "boom" in str(ei.value), "the cause must reach the error message"
+
+
+@pytest.mark.asyncio
+async def test_local_exec_is_unchanged_without_check(tmp_path):
+    """The default path must keep returning normally, exit code in the output."""
+    from primer.workspace.local.tools.exec_ import Exec
+
+    tool = Exec(tmp_path)
+    result = await tool.execute(
+        ExecArgs(command=FAIL, description="fails", workdir="."), _ctx()
+    )
+    assert result.metadata["exit_code"] == 3
+    assert result.output.startswith("3\n")
+
+
+@pytest.mark.asyncio
+async def test_check_does_not_disturb_a_successful_command(tmp_path):
+    from primer.workspace.local.tools.exec_ import Exec
+
+    tool = Exec(tmp_path)
+    result = await tool.execute(
+        ExecArgs(command=OK, description="ok", check=True, workdir="."), _ctx()
+    )
+    assert result.metadata["exit_code"] == 0
+    assert "fine" in result.output
+
+
+def _ctx():
+    """A context with only the fields `exec` actually reads.
+
+    ToolCallContext requires a live AgentSession, which these tests have no use
+    for; model_construct skips validation so the test stays about `check`.
+    """
+    import asyncio
+
+    from primer.workspace.tool import ToolCallContext
+
+    return ToolCallContext.model_construct(
+        workspace_id="ws-1", session_id="s-1", agent_id="a-1", call_id="c-1",
+        abort=asyncio.Event(), session=None,
+    )


### PR DESCRIPTION
## The problem

A command that exits non-zero currently produces a **successful** tool call. The graph node wrapping it records `status=completed`, `error=None` — so a run whose script raised is indistinguishable from one that succeeded. The only trace is an exit code at the head of the output text.

This is not theoretical. A scoring graph reported every node `completed` across **three separate failed runs while writing nothing**:

```
graph_transition  run  →  status: "completed"
assistant_token   →  "RuntimeError: run did not write a file: {'error': ...}"
```

The traceback was in `/v1/sessions/{id}/messages` the whole time, but `node_states` — the obvious place to look — reported the run as fine. Three wrong diagnoses came out of that before the raw output was read directly.

## The change

`ExecArgs` gains `check: bool = False`. When set, a non-zero exit raises instead of returning a successful `ToolResult`, so the existing error plumbing carries it into the node's status and `error` field.

**Default is `False`, so nothing changes for existing callers.** Plenty of commands use a non-zero exit as information — `grep` finding nothing, `diff` reporting a difference — which is why failing by default would be wrong. This is opt-in for steps whose failure should stop the graph.

The message leads with the exit code and carries the tail of stderr (falling back to stdout), bounded so a runaway log can't become the node's `error` field verbatim. The exit code alone would just send the reader back to the raw output, which is the problem being fixed.

Applied to both the local and sandbox exec tools, sharing one message helper.

## An alternative worth considering

`check=True` as the *default* is arguably more correct — a failing step failing its node is what most graph authors expect. I chose the conservative route because it would break any existing graph that relies on tolerating non-zero. Happy to flip it if you'd rather.

## Testing

8 new tests covering the flag, the message format and bounds, and the real subprocess paths for both checked and unchecked behaviour.

Full suite verified in **per-directory capped chunks**: **8,598 passed, 2 failed**. Both failures are pre-existing flaky inotify tests in `tests/bus`, and they fail *more* without this change (3 vs 2) — timing sensitivity, not a regression. `tests/workspace`, where this lives, is 738/738.

> Chunking was necessary because the suite accumulates memory as it runs — a single xdist worker reached **3.04 GB** by 39% of the run. With the committed `addopts = "-n auto"` that is 16 growing workers, which reliably exhausts a 28 GB machine. Worth a separate look; the `INTERNALERROR> KeyError: <WorkerController gwN>` some of us see is a worker being OOM-killed, and it takes the failure summary with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)