### PR TITLE
fix(console): gate the model profile delete confirm on its own state

### DIFF
--- a/tests/ui/test_modal_open_prop.py
+++ b/tests/ui/test_modal_open_prop.py
@@ -1,0 +1,67 @@
+"""``Modal`` has no ``open`` prop, so no call site may pretend it does.
+
+``Modal`` (components/shared.jsx) renders whenever it is mounted; visibility
+is the caller's job, spelled ``{cond && <Modal ...>}`` on every page that has
+a confirm dialog. Passing ``open={cond}`` instead looks right and type-checks
+nowhere, so the prop is silently dropped and the dialog renders permanently.
+
+That shipped on the model profiles page: the delete confirm appeared on page
+load with a blank id (no row was selected, so ``confirmDelete?.id`` was
+undefined) and Cancel could not dismiss it, because closing only reset state
+the modal never consulted.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+UI = Path(__file__).resolve().parents[2] / "ui"
+
+
+def test_modal_signature_has_no_open_prop() -> None:
+    """Pin the premise. If Modal ever gains `open`, this test must be revisited."""
+    src = (UI / "components" / "shared.jsx").read_text(encoding="utf-8")
+    sig = re.search(r"const Modal = \(\{([^}]*)\}\)", src)
+    assert sig, "Modal signature not found in shared.jsx; update this test"
+    props = {p.strip() for p in sig.group(1).split(",")}
+    assert "open" not in props, (
+        "Modal now accepts `open`; either it gates itself (drop this test) or "
+        "the callers below are no longer wrong"
+    )
+
+
+def _modal_call_sites_passing_open() -> list[str]:
+    """Every `<Modal ... open=...>` opening tag, as `path:line`."""
+    hits = []
+    for path in sorted(UI.rglob("*.jsx")):
+        lines = path.read_text(encoding="utf-8").splitlines()
+        for i, line in enumerate(lines):
+            if not re.search(r"<Modal\b", line):
+                continue
+            # Props are one per line; the opening tag ends on a bare ">".
+            for j in range(i, min(i + 40, len(lines))):
+                stripped = lines[j].strip()
+                if j > i and stripped in (">", "/>"):
+                    break
+                if re.match(r"^open=", stripped):
+                    hits.append(f"{path.relative_to(UI)}:{j + 1}")
+                    break
+    return hits
+
+
+def test_no_caller_passes_open_to_modal() -> None:
+    offenders = _modal_call_sites_passing_open()
+    assert not offenders, (
+        "Modal ignores `open`, so these dialogs render unconditionally. Gate "
+        f"them with {{cond && <Modal ...>}} instead: {offenders}"
+    )
+
+
+def test_model_profiles_delete_confirm_is_gated() -> None:
+    """The dialog that regressed, pinned directly."""
+    src = (UI / "components" / "model-profiles.jsx").read_text(encoding="utf-8")
+    assert "{confirmDelete && (" in src
+    # Inside the guard the row is present, so no optional chaining is needed;
+    # `confirmDelete?.id` was what rendered the tell-tale blank "Delete ?".
+    assert "confirmDelete?.id" not in src

--- a/ui/components/model-profiles.jsx
+++ b/ui/components/model-profiles.jsx
@@ -98,7 +98,6 @@ function MP_ProfileModal({ open, onClose, onSaved, existing, providers, prefill 
   const errFor = (name) => fieldErrors[`body.${name}`];
   return (
     <Modal
-      open={open}
       onClose={onClose}
       title={isEdit ? `Edit ${existing.id}` : "New model profile"}
       footer={
@@ -332,25 +331,28 @@ function ModelProfilesPage() {
         onSaved={() => list.refetch()}
       />
 
-      <Modal
-        open={confirmDelete != null}
-        onClose={() => setConfirmDelete(null)}
-        title="Delete model profile"
-        footer={
-          <>
-            <Btn onClick={() => setConfirmDelete(null)}>Cancel</Btn>
-            <Btn variant="danger" onClick={doDelete} disabled={del.loading}>
-              Delete
-            </Btn>
-          </>
-        }
-      >
-        <p>
-          Delete <code>{confirmDelete?.id}</code>? Any agent that names this
-          profile will fail to start until it is repointed.
-        </p>
-        {deleteErr && <div className="field-help warn">{deleteErr}</div>}
-      </Modal>
+      {/* Modal has no `open` prop: it renders whenever it is mounted, so the
+          caller gates it. Every other page's confirm does the same. */}
+      {confirmDelete && (
+        <Modal
+          onClose={() => setConfirmDelete(null)}
+          title="Delete model profile"
+          footer={
+            <>
+              <Btn onClick={() => setConfirmDelete(null)}>Cancel</Btn>
+              <Btn variant="danger" onClick={doDelete} disabled={del.loading}>
+                Delete
+              </Btn>
+            </>
+          }
+        >
+          <p>
+            Delete <code>{confirmDelete.id}</code>? Any agent that names this
+            profile will fail to start until it is repointed.
+          </p>
+          {deleteErr && <div className="field-help warn">{deleteErr}</div>}
+        </Modal>
+      )}
     </>
   );
 }


### PR DESCRIPTION
## What

The delete confirm on **Model profiles** rendered permanently: it appeared on page load rather than on **Delete**, read `Delete ?` with a blank id, and **Cancel** could not dismiss it.

## Root cause

`Modal` (`components/shared.jsx`) takes no `open` prop. It renders whenever it is mounted, and visibility is the caller's job, spelled `{cond && <Modal ...>}` on every other page with a confirm dialog (agents, channels, chats, graphs, providers, toolsets).

The model profiles delete confirm passed `open={confirmDelete != null}` instead. React dropped the unknown prop silently, so:

- the modal was mounted unconditionally, hence visible on load
- `confirmDelete?.id` was `undefined` because no row had been chosen, hence the blank `Delete ?`
- `Cancel` set `confirmDelete` to `null`, which nothing consulted, hence it never closed

All three symptoms are the one defect.

## Change

- Gate the confirm with `{confirmDelete && (<Modal ...>)}`, matching every sibling page, and drop the now-unnecessary optional chaining.
- Drop the same dead `open` prop from `MP_ProfileModal`'s `Modal`. It was harmless there only because that component already early-returns on `!open`, and it is what made the broken call site look correct by precedent.
- Add `tests/ui/test_modal_open_prop.py`: `Modal`'s signature must not accept `open`, and no call site may pass it.

## Verification

- The new guard fails against the pre-fix code, naming both call sites (`model-profiles.jsx:101`, `model-profiles.jsx:336`), and passes after.
- `tests/ui`: 1599 passed, 1 skipped.