### PR TITLE
test(e2e): close the last status-only wait racing the two-write turn rest

### DIFF
--- a/tests/_support/runs.py
+++ b/tests/_support/runs.py
@@ -242,6 +242,12 @@ async def wait_completed(
     """Poll until an interactive agent session's turn cleanly finishes,
     however it now surfaces.
 
+    Never wait on ``status=="waiting"`` alone for this: the rest is TWO
+    writes (dispatch stamps status=WAITING, then on_release bumps
+    turn_no in a later update), so a status-only poll can stop inside
+    the gap and read a stale session_state (01a0590e, a CI-only flake
+    that hit three times before being traced).
+
     01a0518a: a clean stop on a plain interactive (non-autonomous) agent
     session rests it WAITING (session_state="parked") instead of ending
     it; a genuine failure/internal error still reaches ENDED as before

--- a/tests/e2e/test_cookbook_onboarding_assembly.py
+++ b/tests/e2e/test_cookbook_onboarding_assembly.py
@@ -53,7 +53,7 @@ from tests._support.runs import (
     make_local_workspace,
     make_scripted_agent,
     start_agent_session,
-    wait_for_status,
+    wait_completed,
     wait_terminal,
 )
 from tests._support.smk import smk
@@ -291,10 +291,43 @@ async def test_onboarding_assembly_composes_subgraphs(
         # instead of ENDING it - wait_terminal (status in {"ended"}) would
         # poll its full timeout_s and never see that value, which is
         # exactly the ~3min hang this test was filed for. Wait for the new
-        # terminal-like shape instead.
-        final = await wait_for_status(authed_client, sid, "waiting", timeout_s=180)
-        assert final.get("status") == "waiting", final
-        assert final.get("session_state") == "parked", final
+        # terminal-like shape instead - via wait_completed, NOT a raw
+        # wait_for_status(..., "waiting") poll (01a0590e, 3rd CI flake): the
+        # status=WAITING write (dispatch.py's _transition_session_status)
+        # and the turn_no bump that makes session_state read "parked"
+        # (claim/adapters/sessions.py on_release's separate, LATER
+        # self._storage.update()) are two distinct DB writes for the same
+        # logical "turn completed" event, so there is a real, if usually
+        # sub-millisecond, window where a poll can observe status="waiting"
+        # with turn_no still stale (session_state falls through to
+        # "waiting" instead of "parked" - see WorkspaceSession.session_state).
+        # A bare wait_for_status(..., "waiting") stops polling the INSTANT
+        # status flips, so it can return a snapshot from inside that window;
+        # under CI's more contended scheduling the window is wide enough to
+        # occasionally get polled (never seen locally, where both writes
+        # land back-to-back). wait_completed's own stop condition already
+        # requires session_state=="parked" (see tests/_support/runs.py), so
+        # it polls straight through this race instead of stopping short of it.
+        final = await wait_completed(authed_client, sid, timeout_s=180)
+
+        def _diag(row: dict) -> str:
+            return (
+                f"status={row.get('status')!r} "
+                f"session_state={row.get('session_state')!r} "
+                f"turn_no={row.get('turn_no')!r} "
+                f"parked_status={row.get('parked_status')!r}"
+            )
+
+        assert final.get("status") == "waiting", (
+            "coordinator session never rested after the assembly turn "
+            f"(composition may still be running, or ended some other way): "
+            f"{_diag(final)}"
+        )
+        assert final.get("session_state") == "parked", (
+            "session reached status=waiting but session_state never "
+            "converged to 'parked' within the timeout - see the turn_no-lag "
+            f"race noted above: {_diag(final)}"
+        )
 
         transcript = _session_transcript(tmp_path, wid, sid)
 

--- a/tests/ui_e2e/_shell_helpers.py
+++ b/tests/ui_e2e/_shell_helpers.py
@@ -206,13 +206,23 @@ def wait_for_overlay_url(page: Page, route: str, *,
 
 def open_legacy_route(page: Page, console_url: str, route: str,
                       *, tab: str | None = None, wid: str | None = None,
-                      timeout: int = 20_000):
+                      timeout: int = 45_000):
     """Open the overlay that succeeded a legacy console route.
 
     ``wid`` is optional because these surfaces are platform-wide, not
     workspace-scoped: with none given the console resolves the first
     workspace itself and the overlay still opens, since the URL grammar
-    parses the overlay independently of the workspace.
+    parses the overlay independently of the workspace. Every real
+    caller in this suite omits it, which means every call here is a
+    CHAIN exactly like open_doc's own (boot on whichever workspace the
+    console lands in first, then resolve the overlay) - so it gets the
+    same 45s budget open_doc's own comment already earned for that
+    reason, not a fresh guess. The overlay-flake hunt's cold-boot
+    specimens (test_knowledge_collection_journey and friends, GHA runs
+    33426311517 and earlier) all failed here specifically, at this
+    default's old 20s, with a fully-booted shell showing the wrong
+    (default Studio) view - the resolve-then-chain still in flight, not
+    a dead page.
     """
     target = overlay_target(route)
     if tab:

--- a/tests/ui_e2e/test_context_meter_journey.py
+++ b/tests/ui_e2e/test_context_meter_journey.py
@@ -74,14 +74,25 @@ def _seed(base_url: str, mock_base_url: str, suffix: str, tmp_path: Path, *, con
 def _wait_for_turn_to_settle(client: httpx.Client, sid: str, timeout_s: float = 20.0) -> dict:
     """Poll until the turn is no longer running - a simple completed
     turn resolves almost immediately server-side (no chunk delays in
-    the scripted rule), but the row still needs a moment to reflect it."""
+    the scripted rule), but the row still needs a moment to reflect it.
+
+    Overlay-flake hunt hardening: "not running" alone is ALSO true
+    before the worker has dispatched the turn at all
+    (poll_interval_seconds=1.0, scripts/e2e/bringup.sh's config) - a
+    check-too-early race that's invisible on an idle box (dispatch
+    beats the first 100ms poll) but real on a contended CI runner.
+    Require "running" to have been observed at least once first.
+    """
     deadline = time.monotonic() + timeout_s
     last: dict = {}
+    seen_running = False
     while time.monotonic() < deadline:
         r = client.get(f"/v1/sessions/{sid}")
         assert r.status_code == 200, r.text
         last = r.json()
-        if last.get("session_state") != "running":
+        if last.get("session_state") == "running":
+            seen_running = True
+        elif seen_running:
             return last
         time.sleep(0.1)
     raise AssertionError(f"turn never settled, last observed: {last}")

--- a/tests/ui_e2e/test_trace_sidebar_journey.py
+++ b/tests/ui_e2e/test_trace_sidebar_journey.py
@@ -67,13 +67,28 @@ def _seed(base_url: str, mock_base_url: str, suffix: str, tmp_path: Path) -> dic
 
 
 def _wait_for_turn_to_settle(client: httpx.Client, sid: str, timeout_s: float = 20.0) -> dict:
+    """Wait for the auto-started turn to finish, not just for a poll to
+    observe "not running" - those are the SAME reading before the
+    worker has dispatched the turn at all (poll_interval_seconds=1.0,
+    scripts/e2e/bringup.sh's config) and after it has finished, and a
+    check-too-early race here (returning on the pre-dispatch reading)
+    is invisible on an idle box - dispatch beats the first 100ms poll -
+    but real on a contended CI runner, where this returned before the
+    tool call even started and let the test open a still-mid-stream
+    session (the overlay-flake hunt's specimen on this file: two CI
+    failures, GHA run 33426311517, screenshot showed "forming a tool
+    call... STREAMING 10s" under an already-opened trace overlay).
+    """
     deadline = time.monotonic() + timeout_s
     last: dict = {}
+    seen_running = False
     while time.monotonic() < deadline:
         r = client.get(f"/v1/sessions/{sid}")
         assert r.status_code == 200, r.text
         last = r.json()
-        if last.get("session_state") != "running":
+        if last.get("session_state") == "running":
+            seen_running = True
+        elif seen_running:
             return last
         time.sleep(0.1)
     raise AssertionError(f"turn never settled, last observed: {last}")


### PR DESCRIPTION
Follow-up to #203 (landed on the branch minutes after the merge). Root-causes the 3-strike CI-only flake on the cookbook onboarding-assembly scenario: the test polled wait_for_status("waiting") and could stop inside the window between dispatch stamping status=WAITING and on_release bumping turn_no, reading a stale session_state. It now uses the race-safe wait_completed helper like the other park-shape e2e files, assertion failures print a concise state summary, and the helper's docstring documents the race. Test-only; verified live (single-test run, 7.6s pass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)