### PR TITLE
fix: collision-safe tool-call identity across dispatch, resume, and transcript

### DIFF
--- a/primer/agent/tool_manager.py
+++ b/primer/agent/tool_manager.py
@@ -566,6 +566,15 @@ class ToolExecutionManager:
                 )
                 if verdict.required:
                     from primer.agent.approval import effective_approvers
+                    # Lazy import: primer.graph (this contextvar's home
+                    # package) imports primer.agent.tool_manager
+                    # transitively at package-init time (base.py ->
+                    # _agent_node.py -> here), so a module-level import
+                    # the other direction would be circular. See the
+                    # module docstring on primer.graph._node_identity.
+                    from primer.graph._node_identity import (
+                        current_graph_node_id,
+                    )
 
                     approvers = effective_approvers(policy, verdict)
                     session_or_chat = (
@@ -580,12 +589,25 @@ class ToolExecutionManager:
                                 "policy_id": policy.id,
                             },
                         )
+                    # 01a0518f: fold the ambient graph node instance id
+                    # (set only while a graph node's turn is in flight -
+                    # see primer.graph._node_identity) into the event_key
+                    # so concurrent fan-out siblings of the SAME node
+                    # stop sharing one key when their raw provider
+                    # tool_call_id collides. None (every non-graph path,
+                    # e.g. a plain agent session or chat) keeps the
+                    # existing shape byte-identical.
+                    node_scope = current_graph_node_id()
+                    event_key = (
+                        f"tool_approval:{session_or_chat}:{node_scope}:"
+                        f"{call.id}"
+                        if node_scope is not None
+                        else f"tool_approval:{session_or_chat}:{call.id}"
+                    )
                     raise YieldToWorker(
                         Yielded(
                             tool_name="_approval",
-                            event_key=(
-                                f"tool_approval:{session_or_chat}:{call.id}"
-                            ),
+                            event_key=event_key,
                             timeout=policy.timeout_seconds,
                             resume_metadata={
                                 "policy_id": policy.id,

--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -169,6 +169,10 @@ def _make_lifespan(config: AppConfig):
 
         channel_inbox = ChannelInbox(
             event_bus=getattr(app.state, "event_bus", None),
+            # 01a0518f: lets handle_response look up a park's OWN stored
+            # event_key instead of reconstructing it - required now that
+            # a graph park's key can be node-qualified.
+            storage_provider=storage_provider,
         )
         channel_registry = ChannelRegistry(
             channel_storage=storage_provider.get_storage(Channel),

--- a/primer/api/routers/yields.py
+++ b/primer/api/routers/yields.py
@@ -121,13 +121,24 @@ def _graph_ask_user_dispatch(
     checkpoint = blob.get("graph_checkpoint")
     if not checkpoint:
         return None
-    for entry in checkpoint.get("pending_dispatch") or []:
-        if entry.get("kind") != "ask_user":
-            continue
-        if tool_call_id is not None and entry.get("tool_call_id") != tool_call_id:
-            continue
-        return entry
-    return None
+    matches = [
+        entry
+        for entry in checkpoint.get("pending_dispatch") or []
+        if entry.get("kind") == "ask_user"
+        and (tool_call_id is None or entry.get("tool_call_id") == tool_call_id)
+    ]
+    if len(matches) > 1:
+        # 01a0518f: two concurrent fan-out siblings can share a raw
+        # provider tool_call_id; the REST wire contract has no other
+        # field to disambiguate. First-match is the same ambiguity this
+        # endpoint already had - logged so a real collision is visible
+        # rather than silently resolving an arbitrary sibling.
+        logger.warning(
+            "_graph_ask_user_dispatch: %d pending entries share "
+            "tool_call_id=%r; resolving the first",
+            len(matches), tool_call_id,
+        )
+    return matches[0] if matches else None
 
 
 async def _durable_wake(

--- a/primer/channel/inbox.py
+++ b/primer/channel/inbox.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from primer.channel.adapter import ResponseEnvelope
 from primer.model.except_ import BadRequestError
@@ -11,33 +11,166 @@ from primer.model.except_ import BadRequestError
 
 if TYPE_CHECKING:
     from primer.int.event_bus import EventBus
+    from primer.int.storage_provider import StorageProvider
 
 
 logger = logging.getLogger(__name__)
+
+# env.kind -> the pending-entry tool_name(s) that answer it. A "tool_approval"
+# reply can resolve either an agent-side/internal approval gate (tool_name
+# "_approval") or a legacy park predating the tool_name field (None).
+_KIND_TOOL_NAMES: dict[str, frozenset[str | None]] = {
+    "ask_user": frozenset({"ask_user"}),
+    "tool_approval": frozenset({"_approval", None}),
+}
+
+
+def _single_park_tool_call_id(blob: dict[str, Any], yielded: dict[str, Any]) -> str | None:
+    """Where a single (non-graph) park's tool_call_id lives.
+
+    Mirrors ``primer.api.routers.yields._tool_call_id_for``: the worker
+    writes it at the top level of ``parked_state`` (M3+); older parks may
+    have only had it inside ``yielded.resume_metadata``.
+    """
+    tcid = blob.get("tool_call_id")
+    if tcid:
+        return tcid
+    metadata = yielded.get("resume_metadata") or {}
+    return metadata.get("tool_call_id")
+
+
+def _matching_event_keys(row: Any, env: ResponseEnvelope) -> list[str]:
+    """Every pending entry on ``row`` that ``env`` could be answering.
+
+    01a0518f: the row's OWN stored ``event_key`` is the source of truth -
+    a graph park's event_key is node-qualified since the contextvar-based
+    approval-gate fix, which a bare ``f"{kind}:{session_id}:{tcid}"``
+    reconstruction can no longer reproduce. Searches every surface a
+    pending item can live on: the single-park blob
+    (``parked_state['yielded']``) and, for a graph park, the checkpoint's
+    ``pending_agent_yields`` + ``pending_dispatch`` (mirrors
+    ``primer.worker.yield_runtime.merge_pending_dispatch``'s combined
+    view). Returns event_keys in no particular priority order; the caller
+    logs + picks the first on an actual collision (two fan-out siblings
+    sharing a raw tool_call_id are still ambiguous from a channel reply
+    alone - the wire format has no other field to disambiguate, same as
+    the REST respond routes).
+    """
+    wanted_names = _KIND_TOOL_NAMES.get(env.kind, frozenset())
+    blob = getattr(row, "parked_state", None) or {}
+    keys: list[str] = []
+
+    yielded = blob.get("yielded") or {}
+    if (
+        yielded.get("tool_name") in wanted_names
+        and _single_park_tool_call_id(blob, yielded) == env.tool_call_id
+        and yielded.get("event_key")
+    ):
+        keys.append(yielded["event_key"])
+
+    checkpoint = blob.get("graph_checkpoint") or {}
+    for entry in checkpoint.get("pending_agent_yields") or []:
+        if (
+            entry.get("tool_name") in wanted_names
+            and entry.get("tool_call_id") == env.tool_call_id
+            and entry.get("event_key")
+        ):
+            keys.append(entry["event_key"])
+    for entry in checkpoint.get("pending_dispatch") or []:
+        if (
+            entry.get("kind") in wanted_names
+            and entry.get("tool_call_id") == env.tool_call_id
+        ):
+            # pending_dispatch entries (primer.graph._checkpoint's
+            # _toolcall_dispatch_entry) don't carry their own event_key -
+            # the graph-native ToolCall node's park key is always the
+            # unscoped tool_approval:<session_id>:<tool_call_id> shape
+            # (its tool_call_id is a fresh uuid4, never provider-raw, so
+            # it was never collision-prone - see primer.graph.
+            # workspace_executor._dispatch_toolcall). Reconstruct exactly
+            # that shape, not the generic fallback (which would use
+            # env.kind's literal string, "tool_approval", correctly here
+            # since _approval is the only kind pending_dispatch models).
+            keys.append(f"tool_approval:{env.session_id}:{env.tool_call_id}")
+    return keys
 
 
 class ChannelInbox:
     """Single fan-in point for every adapter's inbound responses."""
 
-    def __init__(self, *, event_bus: "EventBus") -> None:
+    def __init__(
+        self,
+        *,
+        event_bus: "EventBus",
+        storage_provider: "StorageProvider | None" = None,
+    ) -> None:
         self._event_bus = event_bus
+        # Optional (01a0518f): enables the stored-event_key LOOKUP path
+        # below instead of reconstructing it. None (e.g. a lightweight
+        # test app) degrades to the pre-existing reconstruct-only
+        # behaviour - never a hard dependency.
+        self._storage_provider = storage_provider
 
     async def handle_response(self, env: ResponseEnvelope) -> None:
-        if env.kind == "ask_user":
-            event_key = f"ask_user:{env.session_id}:{env.tool_call_id}"
-            payload: dict = {"response": env.response}
-        elif env.kind == "tool_approval":
-            event_key = f"tool_approval:{env.session_id}:{env.tool_call_id}"
-            payload = {"decision": env.decision, "reason": env.reason}
-        else:
+        if env.kind not in ("ask_user", "tool_approval"):
             raise BadRequestError(
                 f"unknown ResponseEnvelope kind {env.kind!r}"
             )
+        event_key = await self._resolve_event_key(env)
+        payload: dict = (
+            {"response": env.response} if env.kind == "ask_user"
+            else {"decision": env.decision, "reason": env.reason}
+        )
         logger.info(
-            "channel inbox publishing %s for session=%s tool_call=%s",
-            env.kind, env.session_id, env.tool_call_id,
+            "channel inbox publishing %s for session=%s tool_call=%s "
+            "event_key=%s",
+            env.kind, env.session_id, env.tool_call_id, event_key,
         )
         await self._event_bus.publish(event_key, payload)
+
+    async def _resolve_event_key(self, env: ResponseEnvelope) -> str:
+        """The event_key to publish for ``env``.
+
+        01a0518f: LOOKS UP the session's own stored pending-entry
+        event_key (see :func:`_matching_event_keys`) instead of
+        reconstructing ``f"{kind}:{session_id}:{tool_call_id}"`` - a
+        graph park's key is node-qualified now, which the bare
+        reconstruction can't reproduce. Falls back to the reconstructed
+        (pre-fix) shape whenever the lookup can't help: no
+        storage_provider wired, the lookup itself fails, ``env.session_id``
+        doesn't resolve to a WorkspaceSession row at all (e.g. a chat
+        surface response, which never uses a node-qualified key), or no
+        pending entry matches - every one of those is exactly today's
+        behaviour, so this is purely additive.
+        """
+        fallback = f"{env.kind}:{env.session_id}:{env.tool_call_id}"
+        if self._storage_provider is None:
+            return fallback
+        try:
+            from primer.model.workspace_session import WorkspaceSession
+
+            row = await self._storage_provider.get_storage(
+                WorkspaceSession,
+            ).get(env.session_id)
+        except Exception:  # noqa: BLE001 -- advisory; never block delivery
+            logger.exception(
+                "channel inbox: session lookup failed for %s; falling "
+                "back to a reconstructed event_key", env.session_id,
+            )
+            return fallback
+        if row is None:
+            return fallback
+        matches = _matching_event_keys(row, env)
+        if not matches:
+            return fallback
+        if len(matches) > 1:
+            logger.warning(
+                "channel inbox: %d pending entries match "
+                "tool_call_id=%r kind=%r on session %s; resolving the "
+                "first",
+                len(matches), env.tool_call_id, env.kind, env.session_id,
+            )
+        return matches[0]
 
 
 __all__ = ["ChannelInbox"]

--- a/primer/graph/_agent_node.py
+++ b/primer/graph/_agent_node.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING, Any
 from primer.agent.loop import run_agent_turn
 from primer.agent.prompt_render import render_system_prompt_or_raw
 from primer.agent.tool_manager import ToolExecutionManager
+from primer.graph._node_identity import current_graph_node_id
 from primer.graph._node_refs import _NodeDone, _PendingAgentYield
 from primer.graph.template import render_input_template
 from primer.model.chat import Message, StreamEvent, TextPart
@@ -181,8 +182,18 @@ class _AgentNodeMixin:
                 principal=self._principal,
                 messages_out=produced_messages,
             ):
+                # 01a0518f: current_graph_node_id() is the fan-out-
+                # instance-qualified id (_stream_node sets it before
+                # calling in), so concurrent siblings of this SAME agent
+                # node tag their streamed events distinctly instead of
+                # colliding on the shared base node.id - see
+                # primer.graph._node_identity. Falls back to node.id when
+                # unset (byte-identical to before that call path).
                 await queue.put(
-                    self._wrap_event(event, node.id, context.iteration)
+                    self._wrap_event(
+                        event, current_graph_node_id() or node.id,
+                        context.iteration,
+                    )
                 )
         except YieldToWorker as yld:
             # A yielding tool (ask_user) or an approval gate fired. The

--- a/primer/graph/_checkpoint.py
+++ b/primer/graph/_checkpoint.py
@@ -216,11 +216,13 @@ class _CheckpointMixin:
         if _is_value_yield_toolcall(p):
             return {
                 "kind": p.tool_name,
+                "node_id": p.node_id,
                 "tool_call_id": p.tool_call_id,
                 "resume_metadata": dict(p.resume_metadata or {}),
             }
         return {
             "kind": "_approval",
+            "node_id": p.node_id,
             "tool_call_id": p.tool_call_id,
             "resume_metadata": {
                 "original_call": {

--- a/primer/graph/_node_dispatch.py
+++ b/primer/graph/_node_dispatch.py
@@ -30,6 +30,11 @@ import asyncio
 import json
 from typing import Any
 
+from primer.graph._node_identity import (
+    current_graph_node_id,
+    reset_current_graph_node_id,
+    set_current_graph_node_id,
+)
 from primer.graph._node_refs import (
     _FanoutDrainState,
     _FanoutInstance,
@@ -388,13 +393,33 @@ class _NodeDispatchMixin:
                         graph_input=gi, initial_messages=[]
                     )
             elif isinstance(node, _GraphNodeRef):
-                output = await self._stream_subgraph_node(
-                    node, context, queue, extra_scope=extra_scope
-                )
+                # 01a0518f: publish the fan-out-instance-qualified id
+                # (this function's own node_id - "worker[0]" etc., already
+                # resolved above) for the duration of this node's turn, so
+                # _wrap_event tags forwarded sub-events with it instead of
+                # the shared base node.id (which concurrent siblings would
+                # otherwise collide on) - see primer.graph._node_identity.
+                token = set_current_graph_node_id(node_id)
+                try:
+                    output = await self._stream_subgraph_node(
+                        node, context, queue, extra_scope=extra_scope
+                    )
+                finally:
+                    reset_current_graph_node_id(token)
             elif isinstance(node, _AgentNodeRef):
-                output = await self._stream_agent_node(
-                    node, context, queue, extra_scope=extra_scope
-                )
+                # Same as above: the approval gate's event_key
+                # (primer.agent.tool_manager) and _wrap_event's tagging
+                # both read this so concurrent fan-out siblings of THIS
+                # node stop colliding on the shared base node.id / a
+                # provider-synthesized tool_call_id that legitimately
+                # repeats across them.
+                token = set_current_graph_node_id(node_id)
+                try:
+                    output = await self._stream_agent_node(
+                        node, context, queue, extra_scope=extra_scope
+                    )
+                finally:
+                    reset_current_graph_node_id(token)
             else:  # pragma: no cover -- discriminated union exhausted
                 raise ConfigError(
                     f"unknown node kind: {type(node).__name__}"
@@ -518,8 +543,18 @@ class _NodeDispatchMixin:
                 # under the child's node ids.
                 await queue.put(sub_event)  # type: ignore[arg-type]
                 continue
+            # 01a0518f: current_graph_node_id() is the fan-out-instance-
+            # qualified id (_stream_node sets it before calling in), so
+            # concurrent siblings of this SAME subgraph node forward
+            # their sub-events under distinct tags instead of colliding
+            # on the shared base node.id. Falls back to node.id when
+            # unset (a direct/non-fan-out call, or a call path that
+            # predates this contextvar - byte-identical to before).
             await queue.put(
-                self._wrap_event(sub_event, node.id, context.iteration)
+                self._wrap_event(
+                    sub_event, current_graph_node_id() or node.id,
+                    context.iteration,
+                )
             )
             ev_type = getattr(sub_event, "type", None)
             if ev_type == "text-delta":

--- a/primer/graph/_node_identity.py
+++ b/primer/graph/_node_identity.py
@@ -1,0 +1,57 @@
+"""Ambient fan-out-instance-qualified node identity for the current task.
+
+01a0518f: a graph node's dispatch (tool call approval gate, streamed
+event tagging) happens many call-frames below the superstep loop that
+actually knows WHICH fan-out instance is running (``"worker[0]"`` vs the
+shared graph-definition id ``"worker"``) - threading that id as an
+explicit parameter through every intermediate signature (``run_agent_turn``
+-> the agent loop -> ``ToolExecutionManager.execute``, a resolver contract
+several unrelated builders/test fakes also implement) would be a much
+wider, riskier change than the actual bug warrants. A contextvar is the
+established pattern in this codebase for exactly this shape of problem -
+see :mod:`primer.session.delegation`'s ``_SINK`` (a turn-scoped recorder)
+and :mod:`primer.agent.invoke`'s ``_DEPTH`` (nested-invocation depth) -
+and it composes correctly with the same concurrency shape fan-out uses:
+``asyncio.create_task`` copies the current context per task, so concurrent
+sibling tasks never see each other's ``.set()`` calls.
+
+Set once per node-turn (:func:`primer.graph._node_dispatch._BaseGraphExecutor._stream_node`
+for the live/streaming path, and the graph executor's own resume loop for
+the resume path), read by anything that needs to distinguish concurrent
+fan-out siblings sharing a raw provider tool_call_id: the approval gate's
+event_key (primer.agent.tool_manager), and the streamed-event node
+tagging (``_wrap_event``, primer.graph._agent_node /
+primer.graph._node_dispatch). ``None`` (the default, and every non-graph
+call path) means "no ambient graph node identity" - every reader folds
+that in as "use the base id / today's behaviour", so this is purely
+additive.
+"""
+
+from __future__ import annotations
+
+import contextvars
+
+_NODE_ID: contextvars.ContextVar[str | None] = contextvars.ContextVar(
+    "primer_graph_node_instance_id", default=None,
+)
+
+
+def set_current_graph_node_id(node_id: str | None) -> contextvars.Token:
+    """Publish the fan-out-instance-qualified node id for the current task."""
+    return _NODE_ID.set(node_id)
+
+
+def reset_current_graph_node_id(token: contextvars.Token) -> None:
+    _NODE_ID.reset(token)
+
+
+def current_graph_node_id() -> str | None:
+    """The ambient graph node instance id, if one is active on this task."""
+    return _NODE_ID.get()
+
+
+__all__ = [
+    "current_graph_node_id",
+    "reset_current_graph_node_id",
+    "set_current_graph_node_id",
+]

--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -136,6 +136,10 @@ from primer.graph._node_refs import (  # noqa: E402
 )
 from primer.graph._checkpoint import _CheckpointMixin  # noqa: E402
 from primer.graph._agent_node import _AgentNodeMixin  # noqa: E402
+from primer.graph._node_identity import (  # noqa: E402
+    reset_current_graph_node_id,
+    set_current_graph_node_id,
+)
 from primer.graph._routing import _RoutingMixin  # noqa: E402
 # ``_SubgraphFailed`` is raised by ``_NodeDispatchMixin._stream_subgraph_node``;
 # it lives alongside that mixin and is re-exported here so existing references
@@ -646,51 +650,61 @@ class _BaseGraphExecutor(
         # Resume the selected agent-node yields: continue each node's turn
         # with the human's answer / decision injected as the tool result.
         for ay in ay_pending:
+            # 01a0518f: publish ay.node_id (already fan-out-instance-
+            # qualified, e.g. "worker[0]") for the duration of this
+            # node's resume - a resumed turn's own tool calls can hit
+            # the approval gate again, and its event_key needs the same
+            # disambiguation a fresh dispatch gets. See
+            # primer.graph._node_identity.
+            token = set_current_graph_node_id(ay.node_id)
             try:
-                out = await self._resume_agent_node(
-                    ay, agent_tool_result if agent_tool_result is not None
-                    else Message(role="tool", parts=[
-                        ToolResultPart(id=ay.tool_call_id, output="")]),
-                )
-            except Exception as exc:  # noqa: BLE001 -- map to node failure
-                fail_out = NodeOutput(
-                    text="", parsed=None, history=[],
-                    iteration=context.iteration, error=str(exc),
-                    ended_detail="tool_execution_failed",
-                )
-                context.nodes[ay.node_id] = fail_out
+                try:
+                    out = await self._resume_agent_node(
+                        ay, agent_tool_result if agent_tool_result is not None
+                        else Message(role="tool", parts=[
+                            ToolResultPart(id=ay.tool_call_id, output="")]),
+                    )
+                except Exception as exc:  # noqa: BLE001 -- map to node failure
+                    fail_out = NodeOutput(
+                        text="", parsed=None, history=[],
+                        iteration=context.iteration, error=str(exc),
+                        ended_detail="tool_execution_failed",
+                    )
+                    context.nodes[ay.node_id] = fail_out
+                    node_states[ay.node_id] = NodeRuntimeState(
+                        status=NodeRuntimeStatus.FAILED,
+                        last_run_iteration=context.iteration,
+                        last_run_at=datetime.now(timezone.utc),
+                        error=str(exc),
+                    )
+                    yield _GraphErrorEvent(  # type: ignore[misc]
+                        code="tool_execution_failed", message=str(exc),
+                        node_id=ay.node_id,
+                    )
+                    # Balanced exit for this resumed agent-yield node (parked →
+                    # resumed → failed). The superstep loop deferred this node's
+                    # exit on park; emit it here with status="failed".
+                    yield _GraphTransitionEvent(  # type: ignore[misc]
+                        node_id=ay.node_id,
+                        node_kind=self._node_kind_for(ay.node_id),
+                        phase="exit",
+                        status="failed",
+                    )
+                    await self._save_state(
+                        iteration=context.iteration, node_states=node_states,
+                        status=SessionStatus.ENDED, ended_reason="failed",
+                        ended_detail="tool_execution_failed",
+                    )
+                    return
+                context.nodes[ay.node_id] = out
                 node_states[ay.node_id] = NodeRuntimeState(
-                    status=NodeRuntimeStatus.FAILED,
+                    status=NodeRuntimeStatus.ENDED,
                     last_run_iteration=context.iteration,
                     last_run_at=datetime.now(timezone.utc),
-                    error=str(exc),
                 )
-                yield _GraphErrorEvent(  # type: ignore[misc]
-                    code="tool_execution_failed", message=str(exc),
-                    node_id=ay.node_id,
-                )
-                # Balanced exit for this resumed agent-yield node (parked →
-                # resumed → failed). The superstep loop deferred this node's
-                # exit on park; emit it here with status="failed".
-                yield _GraphTransitionEvent(  # type: ignore[misc]
-                    node_id=ay.node_id,
-                    node_kind=self._node_kind_for(ay.node_id),
-                    phase="exit",
-                    status="failed",
-                )
-                await self._save_state(
-                    iteration=context.iteration, node_states=node_states,
-                    status=SessionStatus.ENDED, ended_reason="failed",
-                    ended_detail="tool_execution_failed",
-                )
-                return
-            context.nodes[ay.node_id] = out
-            node_states[ay.node_id] = NodeRuntimeState(
-                status=NodeRuntimeStatus.ENDED,
-                last_run_iteration=context.iteration,
-                last_run_at=datetime.now(timezone.utc),
-            )
-            completed_ids.append(ay.node_id)
+                completed_ids.append(ay.node_id)
+            finally:
+                reset_current_graph_node_id(token)
 
         # graph_transition EXIT for each resumed node that finished this
         # cycle. The superstep loop SKIPS the exit emit when a node parks

--- a/primer/session/external_tools.py
+++ b/primer/session/external_tools.py
@@ -25,7 +25,16 @@ CANCEL_REASON_SUPERSEDED = "superseded by new user message"
 
 def _pending_targets(session: Any) -> dict[str, str]:
     """Map tool_call_id -> event_key for every external call parked on
-    this session (single-agent park OR graph checkpoint entries)."""
+    this session (single-agent park OR graph checkpoint entries).
+
+    01a0518f: two concurrent fan-out siblings can share a raw provider
+    tool_call_id; this dict collapses to whichever entry is written last,
+    same as ``apply_tool_results``'s own ``rows``/``targets`` matching
+    below (the ``ExternalToolResultIn`` wire contract has no other field
+    to disambiguate - a full fix needs the delivered external id scoped
+    and mapped back to the raw id server-side, tracked as a follow-up).
+    Logged here so a real collision is visible instead of silent.
+    """
     out: dict[str, str] = {}
     if getattr(session, "parked_status", None) not in ("parked", "resumable"):
         return out
@@ -47,6 +56,12 @@ def _pending_targets(session: Any) -> dict[str, str]:
         tcid = entry.get("tool_call_id")
         if not tcid:
             continue
+        if tcid in out:
+            logger.warning(
+                "_pending_targets: tool_call_id=%r already pending on "
+                "session %s; a later entry overwrites the earlier one",
+                tcid, session.id,
+            )
         out[tcid] = entry.get("parked_event_key") or (
             f"external_tool:{session.id}:{tcid}"
         )
@@ -56,6 +71,12 @@ def _pending_targets(session: Any) -> dict[str, str]:
         tcid = entry.get("tool_call_id")
         if not tcid:
             continue
+        if tcid in out:
+            logger.warning(
+                "_pending_targets: tool_call_id=%r already pending on "
+                "session %s; a later entry overwrites the earlier one",
+                tcid, session.id,
+            )
         out[tcid] = entry.get("event_key") or (
             f"external_tool:{session.id}:{tcid}"
         )
@@ -74,7 +95,17 @@ async def _rows_by_tcid(
     if chat_id is not None:
         q = q.where("chat_id", chat_id)
     page = await call_storage.find(q.build(), OffsetPage(offset=0, length=200))
-    return {r.tool_call_id: r for r in page.items}
+    rows: dict[str, ExternalToolCall] = {}
+    for r in page.items:
+        if r.tool_call_id in rows:
+            # 01a0518f: same wire-contract limit as _pending_targets above.
+            logger.warning(
+                "_rows_by_tcid: tool_call_id=%r already resolved to row "
+                "%r; row %r overwrites it",
+                r.tool_call_id, rows[r.tool_call_id].id, r.id,
+            )
+        rows[r.tool_call_id] = r
+    return rows
 
 
 async def apply_tool_results(

--- a/primer/session/persistence.py
+++ b/primer/session/persistence.py
@@ -245,6 +245,25 @@ class _CoalesceState:
     # leaves a dangling entry, but it's bounded to this _CoalesceState's
     # lifetime (one run) — not worth cleanup machinery.
     tool_names: dict[tuple[str | None, str], str] = field(default_factory=dict)
+    # 01a0518f: per-node monotonic counter, incremented once per
+    # ToolCallStart, feeding the scoped tool-call id below. node_id alone
+    # disambiguates SIBLINGS sharing a raw id within the same tool-round,
+    # but not two DIFFERENT tool-rounds on the SAME node (loop.py issues a
+    # fresh llm.stream() per round, and each adapter's id counter resets
+    # every stream call — see persistence.py's module comment / the
+    # tool_names note above) — the seq closes that gap too.
+    tool_call_seq: dict[str | None, int] = field(default_factory=dict)
+    # Raw provider id -> scoped id ("<node>:tool:<turn_no>:<seq>", mirrors
+    # part_id()'s node:kind:turn_no convention with a seq appended since,
+    # unlike text/reasoning, more than one tool call can happen per node
+    # per turn). Minted at ToolCallStart (before ToolCallDelta needs it),
+    # read (not popped) through ToolCallEnd, and popped at the matching
+    # _ExecutorToolResult — the one guaranteed-last consumer, since
+    # loop.py's tool-rounds are strictly sequential (every round's
+    # _ExecutorToolResult events land before the NEXT round's
+    # ToolCallStart can reuse the same raw id). Keyed by (node_id, raw_id)
+    # like tool_names above, for the identical reason.
+    scoped_call_ids: dict[tuple[str | None, str], str] = field(default_factory=dict)
 
 
 class _DeltaSink(Protocol):
@@ -430,17 +449,30 @@ def translate_stream_event(
         # Keyed by (node_id, id): synthesized ids can collide across
         # concurrent fan-out siblings, so node_id disambiguates.
         state.tool_names[(node_id, event.id)] = event.name
+        # 01a0518f: mint the scoped id NOW (not at End) - ToolCallDelta,
+        # which arrives between Start and End, needs the same id the
+        # durable TOOL_CALL record will carry, for live-arguments
+        # reconciliation to work. See _CoalesceState.scoped_call_ids.
+        seq = state.tool_call_seq.get(node_id, 0) + 1
+        state.tool_call_seq[node_id] = seq
+        state.scoped_call_ids[(node_id, event.id)] = (
+            f"{node_id or 'x'}:{KIND_TOOL}:{turn_no}:{seq}"
+        )
         return None
 
     if isinstance(event, ToolCallDelta):
         # Like TextDelta this coalesces into the single TOOL_CALL record
         # (produced on ToolCallEnd), so it produces no durable record of its
         # own - but it feeds the delta sink so a client can render the
-        # arguments as they stream. The part_id is the tool call id, not a
-        # node-scoped id, because the paired TOOL_CALL record carries the same
-        # id and the client reconciles the live arguments to it by that id.
+        # arguments as they stream. The part_id is the SCOPED tool-call id
+        # (01a0518f - was the raw id verbatim), because the paired TOOL_CALL
+        # record carries the same scoped id and the client reconciles the
+        # live arguments to it by that id. Falls back to the raw id if
+        # ToolCallStart's mint is missing (defensive; every real adapter
+        # emits Start before Delta).
         if delta_sink is not None:
-            delta_sink.on_delta(event.id, KIND_TOOL, event.arguments_delta)
+            scoped_id = state.scoped_call_ids.get((node_id, event.id), event.id)
+            delta_sink.on_delta(scoped_id, KIND_TOOL, event.arguments_delta)
         return None
 
     if isinstance(event, ToolCallEnd):
@@ -475,25 +507,47 @@ def translate_stream_event(
                 )
             )
             state.text_buffers[node_id] = ""
+        # 01a0518f: the durable TOOL_CALL id is the SCOPED id minted at
+        # ToolCallStart (was the raw provider id verbatim, which
+        # restarts at the same value every llm.stream() call and can
+        # collide across tool-rounds and concurrent fan-out siblings -
+        # see _CoalesceState.scoped_call_ids). Read, not popped: the
+        # LATER _ExecutorToolResult event for this same call still needs
+        # to resolve back to it.
+        scoped_id = state.scoped_call_ids.get((node_id, event.id), event.id)
         records.append(
             SessionMessageRecord(
                 seq=1,
                 kind=SessionMessageKind.TOOL_CALL,
                 payload={
-                    "id": event.id,
+                    "id": scoped_id,
                     "name": state.tool_names.pop((node_id, event.id), None),
                     "arguments": event.arguments,
+                    # 01a0518f: the raw provider id, preserved alongside
+                    # the scoped "id" above. primer.session.delegation's
+                    # DelegationRecorder stamps a delegated record's
+                    # payload["delegate_tool_call_id"] with the raw id
+                    # (it never sees this _CoalesceState's scoped-id
+                    # minting - a genuinely separate _CoalesceState
+                    # instance for the subagent's own content), so
+                    # primer.session.timeline's delegation-nesting lookup
+                    # needs the raw id to find its parent, not the scoped
+                    # one. Every OTHER consumer keys off "id"/"call_id"
+                    # (the scoped id) as usual - this field exists solely
+                    # for that one cross-_CoalesceState-boundary lookup.
+                    "raw_id": event.id,
                 },
                 node_id=node_id,
                 created_at=now,
             )
         )
         # The text/reasoning parts end here; the tool-input part ends here too
-        # (its part_id is the tool call id). A part with no deltas is a no-op.
+        # (its part_id is the SCOPED tool call id, matching what ToolCallDelta
+        # opened it under above). A part with no deltas is a no-op.
         if delta_sink is not None:
             delta_sink.close(part_id(node_id, KIND_TEXT, turn_no))
             delta_sink.close(part_id(node_id, KIND_REASONING, turn_no))
-            delta_sink.close(event.id)
+            delta_sink.close(scoped_id)
         if len(records) == 1:
             return records[0]
         return records
@@ -519,11 +573,23 @@ def translate_stream_event(
     if isinstance(event, ExtendedEvent) and isinstance(
         event.extended, _ExecutorToolResult
     ):
+        # 01a0518f: resolve back to the SAME scoped id the paired
+        # TOOL_CALL record carries (was the raw provider id verbatim) -
+        # this is the LAST consumer of the mapping entry, so pop it
+        # (loop.py's tool-rounds are strictly sequential: every round's
+        # results land before the next round's ToolCallStart could reuse
+        # the same raw id, so popping here can't race a later Start for
+        # the same key). Falls back to the raw id if the mapping is
+        # somehow missing (defensive; every real dispatch pairs a
+        # ToolCallEnd with exactly one later result).
+        scoped_call_id = state.scoped_call_ids.pop(
+            (node_id, event.extended.call_id), event.extended.call_id,
+        )
         return SessionMessageRecord(
             seq=1,
             kind=SessionMessageKind.TOOL_RESULT,
             payload={
-                "call_id": event.extended.call_id,
+                "call_id": scoped_call_id,
                 "output": event.extended.output,
                 "error": event.extended.error,
                 # UX reconcile wave 5: a workspace tool's own extra data
@@ -542,11 +608,22 @@ def translate_stream_event(
     if isinstance(event, ExtendedEvent) and isinstance(
         event.extended, _ClientAction
     ):
+        # 01a0518f: resolve to the SAME scoped id the paired TOOL_CALL
+        # record carries (was the raw id verbatim) - a client-delivered
+        # tool's streaming ToolCallEnd has already run by the time
+        # _dispatch_tool_calls builds this event (loop.py dispatches
+        # AFTER the assistant message is fully built), so the mapping is
+        # already populated. Read, not popped: the notifying contract
+        # still emits a TOOL_RESULT after this delivery frame (loop.py's
+        # own comment: "tool_call -> client_action -> tool_result"),
+        # which is the actual last consumer.
         return SessionMessageRecord(
             seq=1,
             kind=SessionMessageKind.CLIENT_ACTION,
             payload={
-                "call_id": event.extended.call_id,
+                "call_id": state.scoped_call_ids.get(
+                    (node_id, event.extended.call_id), event.extended.call_id,
+                ),
                 "name": event.extended.name,
                 "arguments": dict(event.extended.arguments or {}),
             },

--- a/primer/session/timeline.py
+++ b/primer/session/timeline.py
@@ -274,17 +274,26 @@ def _attach(
     payload: dict[str, Any],
     roots: list[dict[str, Any]],
     nodes: dict[str, dict[str, Any]],
-    calls: dict[str, dict[str, Any]],
+    calls: dict[tuple[str | None, str], dict[str, Any]],
+    calls_by_raw_id: dict[str, dict[str, Any]],
 ) -> None:
     """Place one child entry: delegation wins, then node, else the root.
 
     Delegated records (C1: an inline subagent run appends to the PARENT
     log) carry the delegating tool_call_id, so they nest under that call
-    rather than sitting beside it.
+    rather than sitting beside it. That id is always the RAW provider id
+    (primer.session.delegation's DelegationRecorder stamps it from a
+    completely separate _CoalesceState that never sees the delegating
+    call's scoped-id minting - see persistence.py's ToolCallEnd handler),
+    so this looks it up in ``calls_by_raw_id`` (raw id -> entry, no node
+    scoping - the delegating call and the delegated records don't
+    reliably share a node_id either, see _tree()'s docstring), NOT
+    ``calls`` (node+scoped-id -> entry, for TOOL_RESULT/CLIENT_ACTION
+    pairing).
     """
     delegate = payload.get("delegate_tool_call_id")
-    if payload.get("delegated") and delegate in calls:
-        calls[delegate]["children"].append(entry)
+    if payload.get("delegated") and delegate in calls_by_raw_id:
+        calls_by_raw_id[delegate]["children"].append(entry)
         return
     node = nodes.get(rec.get("node_id"))
     if node is not None:
@@ -300,10 +309,24 @@ def _tree(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
     the tool_call that delegated it, a node-attributed record nests under
     its graph node, everything else is a root child. tool_result rows are
     never children of their own: they close the tool_call they answer.
+
+    ``calls`` is keyed by ``(node_id, tool_call_id)``, not tool_call_id
+    alone (01a0518f defense-in-depth): the write side now mints a
+    node+turn+seq-scoped id for every NEW record (primer.session.
+    persistence's _CoalesceState.scoped_call_ids), so a live collision
+    shouldn't reach here at all - but a record persisted before that fix
+    landed still carries the bare provider id, and two such records from
+    concurrent fan-out siblings sharing one raw id would otherwise
+    overwrite each other's ``calls`` entry / mispair a TOOL_RESULT to the
+    wrong sibling's TOOL_CALL. ``calls_by_raw_id`` is a SEPARATE, bare
+    (no node scoping) raw-id -> entry map used only by the delegation
+    lookup in :func:`_attach` - see its docstring for why that lookup
+    can't use the scoped/node-keyed ``calls`` map.
     """
     roots: list[dict[str, Any]] = []
     nodes: dict[str, dict[str, Any]] = {}
-    calls: dict[str, dict[str, Any]] = {}
+    calls: dict[tuple[str | None, str], dict[str, Any]] = {}
+    calls_by_raw_id: dict[str, dict[str, Any]] = {}
     for rec in records:
         kind = rec.get("kind")
         payload = rec.get("payload") or {}
@@ -364,9 +387,15 @@ def _tree(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
                 "children": [],
             }
             if payload.get("id"):
-                calls[payload["id"]] = entry
+                calls[(rec.get("node_id"), payload["id"])] = entry
+                # A record predating the raw_id field (01a0518f) has no
+                # separate raw id at all - payload["id"] WAS the raw id
+                # at write time, so falling back to it here is correct,
+                # not just defensive.
+                raw_id = payload.get("raw_id") or payload["id"]
+                calls_by_raw_id[raw_id] = entry
         elif kind == _TOOL_RESULT:
-            parent = calls.get(payload.get("call_id"))
+            parent = calls.get((rec.get("node_id"), payload.get("call_id")))
             if parent is not None:
                 parent["status"] = "error" if payload.get("error") else "ok"
                 parent["duration_ms"] = _delta_ms(
@@ -378,7 +407,7 @@ def _tree(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
             # Task 13's leaf rule, preserved through this rewrite: the S3
             # delivery record belongs to the call it delivered, so it is
             # never routed through _attach.
-            parent = calls.get(payload.get("call_id"))
+            parent = calls.get((rec.get("node_id"), payload.get("call_id")))
             if parent is not None:
                 parent["children"].append({
                     "kind": "client_action",
@@ -390,7 +419,7 @@ def _tree(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
             continue
         else:
             continue
-        _attach(entry, rec, payload, roots, nodes, calls)
+        _attach(entry, rec, payload, roots, nodes, calls, calls_by_raw_id)
     return roots
 
 

--- a/primer/session/yields.py
+++ b/primer/session/yields.py
@@ -44,6 +44,40 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _dispatch_key_for(event_key: str, *, session_id: str) -> str:
+    """The ``resume_event_payloads`` accumulation key for ``event_key``.
+
+    Every event_key producer emits the fixed shape
+    ``"<kind>:<session_id>:<tail>"`` (``kind`` a hardcoded, colon-free
+    literal like ``"tool_approval"``/``"ask_user"``; see
+    primer/agent/tool_manager.py, primer/graph/_node_dispatch.py,
+    primer/toolset/_system_crud.py, primer/channel/inbox.py). ``tail`` is
+    a bare ``tool_call_id`` for a non-graph park, or (01a0518f)
+    ``"<node_id>:<tool_call_id>"`` once a graph-checkpoint capture site
+    scopes it - two concurrent fan-out siblings can legitimately share a
+    raw provider tool_call_id, so accumulating multi-event replies by the
+    bare tail alone silently overwrote one sibling's reply with the
+    other's.
+
+    Strips the ``"<kind>:<session_id>:"`` prefix POSITIONALLY: ``kind`` is
+    recovered with ONE bounded split (safe - it's always a colon-free
+    literal), then the prefix is built from that ``kind`` plus the CALLER'S
+    OWN KNOWN ``session_id`` (never re-derived by counting colons in the
+    string), and stripped with an exact ``startswith``/slice. This is
+    immune to a session_id or a future kind ever containing a colon -
+    unlike splitting the whole string positionally, which would shift
+    every character after it into the wrong field. Falls back to the full
+    event_key when the expected prefix isn't found (defensive; every known
+    producer emits this exact shape) - degrading to today's behaviour
+    rather than raising.
+    """
+    kind = event_key.split(":", 1)[0]
+    prefix = f"{kind}:{session_id}:"
+    if event_key.startswith(prefix):
+        return event_key[len(prefix):]
+    return event_key
+
+
 async def durably_mark_session_resumable(
     session: WorkspaceSession,
     *,
@@ -65,8 +99,11 @@ async def durably_mark_session_resumable(
     * Stamp the singular ``resume_event_payload`` / ``resume_event_key`` (the
       single-event resume path + a "last fired" hint).
     * For a MULTI-event park (``parked_event_keys`` set) also accumulate
-      ``resume_event_payloads[fired_tcid]`` so a second concurrent reply is
-      preserved rather than overwritten.
+      ``resume_event_payloads[dispatch_key]`` (see :func:`_dispatch_key_for`
+      - 01a0518f: the event_key's tail past the fixed ``kind:session_id:``
+      prefix, node-qualified for a graph park) so a second concurrent reply
+      is preserved rather than overwritten - including two fan-out siblings
+      that happen to share a raw provider tool_call_id.
     * ``storage.update_unless`` the flipped row, guarded on ``status`` -
       see below.
     * Re-arm the claim lease via ``engine.mark_resumable`` (park dropped it)
@@ -95,9 +132,9 @@ async def durably_mark_session_resumable(
     Idempotency (the listener may also process the NOTIFY): a single-event
     park only advances from ``parked``, so a second flip is a no-op; a
     multi-event park may advance from ``resumable`` and re-accumulates the
-    same ``fired_tcid`` with identical data. Returns True when the row was
-    advanced/accumulated, False when the guard rejected it (including the
-    ENDED race above, resolved at write time rather than read time).
+    same ``dispatch_key`` with identical data. Returns True when the row
+    was advanced/accumulated, False when the guard rejected it (including
+    the ENDED race above, resolved at write time rather than read time).
     """
     is_multi = bool(session.parked_event_keys)
     allowed = ("parked", "resumable") if is_multi else ("parked",)
@@ -114,9 +151,9 @@ async def durably_mark_session_resumable(
     state["resume_event_payload"] = dict(payload or {})
     state["resume_event_key"] = event_key
     if is_multi:
-        fired_tcid = event_key.rsplit(":", 1)[-1]
+        dispatch_key = _dispatch_key_for(event_key, session_id=session.id)
         payloads = dict(state.get("resume_event_payloads") or {})
-        payloads[fired_tcid] = {
+        payloads[dispatch_key] = {
             "payload": dict(payload or {}),
             "event_key": event_key,
         }

--- a/primer/toolset/_system_crud.py
+++ b/primer/toolset/_system_crud.py
@@ -757,6 +757,14 @@ def _call_tool_tool(
                     provider_registry=registry,
                 )
                 if verdict.required:
+                    # Lazy import: avoids a circular import with
+                    # primer.graph (which imports primer.agent.tool_manager,
+                    # a sibling of this dispatch path, at package-init
+                    # time). See primer.graph._node_identity's docstring.
+                    from primer.graph._node_identity import (
+                        current_graph_node_id,
+                    )
+
                     session_or_chat = (
                         ctx.session_id or ctx.chat_id or "unknown"
                     )
@@ -767,13 +775,21 @@ def _call_tool_tool(
                     # own name (``call_tool``), and the worker resume path
                     # keys the approval re-dispatch on ``_approval``. This is
                     # exactly how the agent loop parks for approval.
+                    # 01a0518f: fold in the ambient graph node instance id
+                    # the same way tool_manager.py's approval gate does -
+                    # see that call site's comment for the full rationale.
+                    node_scope = current_graph_node_id()
+                    event_key = (
+                        f"tool_approval:{session_or_chat}:{node_scope}:"
+                        f"{ctx.tool_call_id}"
+                        if node_scope is not None
+                        else f"tool_approval:{session_or_chat}:"
+                        f"{ctx.tool_call_id}"
+                    )
                     raise YieldToWorker(
                         Yielded(
                             tool_name="_approval",
-                            event_key=(
-                                f"tool_approval:{session_or_chat}:"
-                                f"{ctx.tool_call_id}"
-                            ),
+                            event_key=event_key,
                             timeout=policy.timeout_seconds,
                             resume_metadata={
                                 "policy_id": policy.id,

--- a/primer/worker/graph_resume_coordinator.py
+++ b/primer/worker/graph_resume_coordinator.py
@@ -62,19 +62,36 @@ async def write_approval_record_for_graph(
     # form the shared builder expects. A tcid that matches neither (or no
     # tcid at all -> legacy drain) is skipped.
     resume_metadata: dict | None = None
-    entry = next(
-        (e for e in (checkpoint.get("pending_agent_yields") or [])
-         if e.get("tool_call_id") == tcid),
-        None,
-    )
+    ay_matches = [
+        e for e in (checkpoint.get("pending_agent_yields") or [])
+        if e.get("tool_call_id") == tcid
+    ]
+    if len(ay_matches) > 1:
+        # 01a0518f: two concurrent fan-out siblings can share a raw
+        # provider tool_call_id; the resume payload only ever carries
+        # tool_call_id, so first-match is the same ambiguity the resume
+        # path already has - logged so a real collision is visible.
+        logger.warning(
+            "write_approval_record_for_graph: %d pending_agent_yields "
+            "share tool_call_id=%r on session %s; resolving the first",
+            len(ay_matches), tcid, session.id,
+        )
+    entry = ay_matches[0] if ay_matches else None
     if entry is not None and entry.get("tool_name") == "_approval":
         resume_metadata = entry.get("resume_metadata") or {}
     else:
-        disp = next(
-            (d for d in (checkpoint.get("pending_dispatch") or [])
-             if d.get("tool_call_id") == tcid),
-            None,
-        )
+        disp_matches = [
+            d for d in (checkpoint.get("pending_dispatch") or [])
+            if d.get("tool_call_id") == tcid
+        ]
+        if len(disp_matches) > 1:
+            logger.warning(
+                "write_approval_record_for_graph: %d pending_dispatch "
+                "entries share tool_call_id=%r on session %s; resolving "
+                "the first",
+                len(disp_matches), tcid, session.id,
+            )
+        disp = disp_matches[0] if disp_matches else None
         if disp is not None:
             resume_metadata = disp.get("resume_metadata") or {}
     if resume_metadata is None:
@@ -136,18 +153,29 @@ async def resume_graph_engine(pool: "WorkerPool", session, parked):
     executor = getattr(executor_or_driver, "_executor", executor_or_driver)
 
     # Replies to drain this cycle. A multi-event park accumulates every
-    # reply that arrived into ``resume_event_payloads`` (tcid -> reply);
-    # we drain them ALL so a concurrent second reply isn't lost. A
-    # single-event park / timeout / cancel uses the singular path
-    # (classified payload, resumed_tcid from the fired key, or None for
-    # the legacy drain-all).
+    # reply that arrived into ``resume_event_payloads`` (dispatch_key ->
+    # reply, see primer.session.yields._dispatch_key_for - 01a0518f: the
+    # dict key is node-qualified for a graph park so two fan-out siblings
+    # sharing a raw tool_call_id don't overwrite each other's reply); we
+    # drain them ALL so a concurrent second reply isn't lost. Every entry
+    # still carries its own full ``event_key`` verbatim regardless of the
+    # dict key's shape, so the bare tool_call_id downstream matching
+    # (graph_value_yield_toolcall etc., which key checkpoint entries by
+    # tool_call_id, not the compound dispatch key) is recovered from
+    # THAT, the same rsplit-last-segment extraction used everywhere else
+    # on this path - never from the dict key itself. A single-event park
+    # / timeout / cancel uses the singular path (classified payload,
+    # resumed_tcid from the fired key, or None for the legacy drain-all).
     raw_state = session.parked_state or {}
     payloads_map = raw_state.get("resume_event_payloads")
     ck = parked.graph_checkpoint
     if payloads_map:
         replies = [
-            (tcid, (entry or {}).get("payload") or {})
-            for tcid, entry in payloads_map.items()
+            (
+                (entry or {}).get("event_key", "").rsplit(":", 1)[-1] or None,
+                (entry or {}).get("payload") or {},
+            )
+            for entry in payloads_map.values()
         ]
     else:
         resume_event_key = raw_state.get("resume_event_key")
@@ -227,11 +255,18 @@ def graph_value_yield_toolcall(pool: "WorkerPool", checkpoint, tcid) -> bool:
     """
     from primer.graph._node_refs import _PendingToolCall, _is_value_yield_toolcall
 
-    raw = next(
-        (e for e in (checkpoint.get("pending_toolcalls") or [])
-         if e.get("tool_call_id") == tcid),
-        None,
-    )
+    matches = [
+        e for e in (checkpoint.get("pending_toolcalls") or [])
+        if e.get("tool_call_id") == tcid
+    ]
+    if len(matches) > 1:
+        # 01a0518f: see write_approval_record_for_graph's comment above.
+        logger.warning(
+            "graph_value_yield_toolcall: %d pending_toolcalls share "
+            "tool_call_id=%r; resolving the first",
+            len(matches), tcid,
+        )
+    raw = matches[0] if matches else None
     if raw is None:
         return False
     entry = _PendingToolCall(
@@ -254,11 +289,18 @@ def graph_nested_agent_yield(pool: "WorkerPool", checkpoint, tcid):
     continuation walk (:meth:`_resume_graph_continuation`) rather than the
     flat ask_user / approval path.
     """
-    ay = next(
-        (e for e in (checkpoint.get("pending_agent_yields") or [])
-         if e.get("tool_call_id") == tcid),
-        None,
-    )
+    matches = [
+        e for e in (checkpoint.get("pending_agent_yields") or [])
+        if e.get("tool_call_id") == tcid
+    ]
+    if len(matches) > 1:
+        # 01a0518f: see write_approval_record_for_graph's comment above.
+        logger.warning(
+            "graph_nested_agent_yield: %d pending_agent_yields share "
+            "tool_call_id=%r; resolving the first",
+            len(matches), tcid,
+        )
+    ay = matches[0] if matches else None
     if ay is None or not ay.get("frames"):
         return None
     return ay
@@ -374,11 +416,18 @@ async def graph_agent_tool_result(pool: "WorkerPool", checkpoint, tcid, payload)
     the fired tcid is not a hook-backed agent yield."""
     from primer.model.chat import Message, ToolResultPart
 
-    ay = next(
-        (e for e in (checkpoint.get("pending_agent_yields") or [])
-         if e.get("tool_call_id") == tcid),
-        None,
-    )
+    matches = [
+        e for e in (checkpoint.get("pending_agent_yields") or [])
+        if e.get("tool_call_id") == tcid
+    ]
+    if len(matches) > 1:
+        # 01a0518f: see write_approval_record_for_graph's comment above.
+        logger.warning(
+            "graph_agent_tool_result: %d pending_agent_yields share "
+            "tool_call_id=%r; resolving the first",
+            len(matches), tcid,
+        )
+    ay = matches[0] if matches else None
     if ay is None or ay.get("tool_name") in (None, "_approval"):
         return None
     try:

--- a/primer/worker/yield_runtime.py
+++ b/primer/worker/yield_runtime.py
@@ -688,12 +688,17 @@ def merge_pending_dispatch(checkpoint: dict[str, Any]) -> list[dict[str, Any]]:
 
     Backward compatible: a pre-slim checkpoint that still carries agent-yield
     entries inside ``pending_dispatch`` produces a duplicate here, but the
-    channel dispatcher dedups by ``tool_call_id`` so the prompt is sent once.
+    channel dispatcher dedups by ``(node_id, tool_call_id)`` so the prompt is
+    sent once. Each entry carries ``node_id`` (01a0518f: two concurrent
+    fan-out siblings can legitimately share a raw provider tool_call_id -
+    deduping by tool_call_id alone silently dropped one sibling's channel
+    prompt entirely, not just risked cross-wired resume).
     """
     stored = list(checkpoint.get("pending_dispatch") or [])
     derived = [
         {
             "kind": ay.get("tool_name", ""),
+            "node_id": ay.get("node_id"),
             "tool_call_id": ay.get("tool_call_id"),
             "resume_metadata": dict(ay.get("resume_metadata") or {}),
         }
@@ -708,19 +713,30 @@ async def _dispatch_to_channels_multi(
     workspace_id: str,
     session_id: str,
     pending: list[dict[str, Any]],
-    already_sent: set[str],
+    already_sent: set[tuple[str | None, str]],
     workspace_name: str | None = None,
     session_label: str | None = None,
     session=None,
-) -> set[str]:
+) -> set[tuple[str | None, str]]:
     """Send one channel prompt per pending human-interaction node.
 
     For a multi-event graph park (several agent/tool_call nodes yielding
     in one superstep), each pending node gets its own message. ``pending``
-    items are ``{"kind": "ask_user"|"_approval", "tool_call_id",
+    items are ``{"kind": "ask_user"|"_approval", "node_id", "tool_call_id",
     "resume_metadata"}``. Returns the union of ``already_sent`` and the
-    tool_call_ids dispatched this call, so a re-park does not re-send a
-    message for a node already prompted. Never raises.
+    ``(node_id, tool_call_id)`` pairs dispatched this call, so a re-park
+    does not re-send a message for a node already prompted. Never raises.
+
+    Deduped by ``(node_id, tool_call_id)``, NOT ``tool_call_id`` alone
+    (01a0518f): two concurrent fan-out siblings can legitimately share a
+    raw provider tool_call_id, and a tool_call_id-only dedup silently
+    dropped one sibling's channel prompt entirely - a genuinely different
+    (and worse) failure than the cross-wired-resume bug this fix's
+    sibling changes address, since the operator never even sees a
+    request to respond to. ``node_id`` is ``None`` for entries built
+    before this fix (an in-flight checkpoint at deploy time); dedup then
+    degrades to the old tool_call_id-only behaviour for exactly those
+    entries, same as today.
     """
     import logging
     if dispatcher is None:
@@ -728,7 +744,10 @@ async def _dispatch_to_channels_multi(
     sent = set(already_sent)
     for p in pending:
         tcid = p.get("tool_call_id")
-        if not tcid or tcid in sent:
+        if not tcid:
+            continue
+        key = (p.get("node_id"), tcid)
+        if key in sent:
             continue
         envelope = _build_prompt_envelope(
             kind=p.get("kind", ""),
@@ -743,7 +762,7 @@ async def _dispatch_to_channels_multi(
             continue
         try:
             await dispatcher.dispatch_prompt(envelope=envelope, session=session)
-            sent.add(tcid)
+            sent.add(key)
         except Exception:
             logging.getLogger(__name__).exception(
                 "_dispatch_to_channels_multi failed for %s/%s",

--- a/tests/agent/test_tool_manager_approval_gate.py
+++ b/tests/agent/test_tool_manager_approval_gate.py
@@ -149,3 +149,103 @@ async def test_approval_event_key_is_session_scoped(
     expected = f"tool_approval:{sess.session_id}:c1"
     assert ek == expected, f"event key {ek!r} != {expected!r}"
     assert "unknown" not in ek  # regression guard: the old bug produced this
+
+
+def _tm_bound_to(sess, provider) -> ToolExecutionManager:
+    tm = ToolExecutionManager(
+        toolset_providers={"_test": provider},  # type: ignore[arg-type]
+        workspace_session=sess,  # type: ignore[arg-type]
+    )
+    tm._approval_resolver = _PoliciesOnlyResolver(
+        [
+            ToolApprovalPolicy(
+                id="p", toolset_id="_test", tool_name="echo",
+                approval=RequiredApprovalConfig(),
+            ),
+        ]
+    )
+    return tm
+
+
+@pytest.mark.asyncio
+async def test_approval_event_key_folds_in_the_ambient_graph_node_id(
+    tool_manager_with_test_tools,
+):
+    """01a0518f: when a graph node's turn is in flight (the ambient
+    contextvar set by _stream_node/base.py's resume loop), the approval
+    gate's event_key must include that node id - not just the session id
+    - so concurrent fan-out siblings of the SAME node don't share a key."""
+    from primer.graph._node_identity import (
+        reset_current_graph_node_id,
+        set_current_graph_node_id,
+    )
+    from primer.model.chat import ToolCallPart
+
+    sess = _FakeAgentSession()
+    provider = tool_manager_with_test_tools._toolsets["_test"]
+    tm = _tm_bound_to(sess, provider)
+
+    token = set_current_graph_node_id("worker[0]")
+    try:
+        with pytest.raises(YieldToWorker) as ei:
+            await tm.execute(
+                ToolCallPart(id="c1", name=_SCOPED_NAME, arguments={"x": 1}),
+            )
+    finally:
+        reset_current_graph_node_id(token)
+
+    ek = ei.value.yielded.event_key
+    expected = f"tool_approval:{sess.session_id}:worker[0]:c1"
+    assert ek == expected, f"event key {ek!r} != {expected!r}"
+    # The stored/round-tripped tool_call_id (fed back to the LLM on
+    # resume) must stay the RAW id, untouched by the node-scoping.
+    assert ei.value.tool_call_id == "c1"
+    assert ei.value.yielded.resume_metadata["original_call"]["id"] == "c1"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_fanout_siblings_sharing_a_raw_id_get_distinct_event_keys(
+    tool_manager_with_test_tools,
+):
+    """01a0518f: THE regression this task exists for. Two concurrent
+    fan-out sibling node instances can legitimately mint the identical
+    raw provider tool_call_id ("call_0" restarts every LLM stream call -
+    see primer/session/persistence.py's own comment on this). Without
+    node-scoping, both siblings' approval gates would produce the exact
+    same event_key, so resolving either one's decision would ALSO
+    (mis-)resolve the other's pending park - the wrong-sibling-resolved
+    correctness bug flagged in the task filing. Simulates two concurrent
+    dispatches (sequential here, but each under its own ambient node id,
+    exactly as two real asyncio.create_task siblings would each see via
+    the contextvar's per-task copy-on-create semantics) and asserts the
+    resulting event_keys never collide."""
+    from primer.graph._node_identity import (
+        reset_current_graph_node_id,
+        set_current_graph_node_id,
+    )
+    from primer.model.chat import ToolCallPart
+
+    sess = _FakeAgentSession()
+    provider = tool_manager_with_test_tools._toolsets["_test"]
+
+    keys: dict[str, str] = {}
+    for node_id in ("worker[0]", "worker[1]"):
+        tm = _tm_bound_to(sess, provider)
+        token = set_current_graph_node_id(node_id)
+        try:
+            with pytest.raises(YieldToWorker) as ei:
+                await tm.execute(
+                    ToolCallPart(
+                        id="call_0", name=_SCOPED_NAME, arguments={"x": 1},
+                    ),
+                )
+        finally:
+            reset_current_graph_node_id(token)
+        keys[node_id] = ei.value.yielded.event_key
+
+    assert keys["worker[0]"] != keys["worker[1]"], (
+        f"fan-out siblings sharing raw tool_call_id 'call_0' produced the "
+        f"same event_key: {keys}"
+    )
+    assert keys["worker[0]"] == f"tool_approval:{sess.session_id}:worker[0]:call_0"
+    assert keys["worker[1]"] == f"tool_approval:{sess.session_id}:worker[1]:call_0"

--- a/tests/bus/test_listener_multi_event.py
+++ b/tests/bus/test_listener_multi_event.py
@@ -118,3 +118,79 @@ async def test_single_event_does_not_accumulate(tmp_path):
     assert got.parked_status == "resumable"
     assert "resume_event_payloads" not in got.parked_state
     assert got.parked_state["resume_event_payload"] == {"response": "x"}
+
+
+async def test_colliding_fanout_siblings_both_land_and_route(tmp_path):
+    """01a0518f: two concurrent fan-out siblings can legitimately share a
+    raw provider tool_call_id ("call_0"). Their node-qualified event_keys
+    ("<kind>:<session_id>:<node_id>:<tool_call_id>") still differ, and the
+    resume_event_payloads dict must key on the FULL disambiguated tail
+    (_dispatch_key_for) - not the bare tool_call_id - or the second
+    sibling's reply silently overwrites the first's."""
+    storage, engine, listener = await _build(tmp_path)
+    keys = ["ask_user:s1:worker[0]:call_0", "ask_user:s1:worker[1]:call_0"]
+    await storage.create(_multi(keys, keys[0]))
+    await listener._handle_event(_Event(keys[0], {"response": "region 0"}))
+    await listener._handle_event(_Event(keys[1], {"response": "region 1"}))
+    got = await storage.get("s1")
+    payloads = got.parked_state.get("resume_event_payloads")
+    assert set(payloads.keys()) == {"worker[0]:call_0", "worker[1]:call_0"}
+    assert payloads["worker[0]:call_0"]["payload"] == {"response": "region 0"}
+    assert payloads["worker[1]:call_0"]["payload"] == {"response": "region 1"}
+
+
+async def test_mixed_legacy_and_scoped_keys_do_not_cross_route(tmp_path):
+    """01a0518f: a multi-event park whose keys are a MIX of the legacy
+    bare-tool_call_id shape (a pending item that predates the scoping fix,
+    or a non-graph park) and the new node-qualified shape must accumulate
+    both under their own distinct dispatch keys, with neither clobbering
+    or being mistaken for the other."""
+    storage, engine, listener = await _build(tmp_path)
+    keys = ["ask_user:s1:tc-legacy", "ask_user:s1:worker[0]:call_0"]
+    await storage.create(_multi(keys, keys[0]))
+    await listener._handle_event(_Event(keys[0], {"response": "legacy"}))
+    await listener._handle_event(_Event(keys[1], {"response": "scoped"}))
+    got = await storage.get("s1")
+    payloads = got.parked_state.get("resume_event_payloads")
+    assert set(payloads.keys()) == {"tc-legacy", "worker[0]:call_0"}
+    assert payloads["tc-legacy"]["payload"] == {"response": "legacy"}
+    assert payloads["worker[0]:call_0"]["payload"] == {"response": "scoped"}
+
+
+async def test_dispatch_key_identical_via_rest_handler_and_bus_listener(tmp_path):
+    """01a0518f: the durable flip is one shared function
+    (durably_mark_session_resumable) - assert directly that calling it
+    (the REST handlers' own path) and driving the same event through the
+    bus listener produce byte-identical resume_event_payloads keying for
+    a plain (non-graph, non-scoped) event_key, proving the two delivery
+    paths cannot diverge on this. Same storage/db throughout (two
+    identically-shaped rows, one per path) - a second SqliteStorageProvider
+    leaked its background connection thread past the test's event loop
+    closing in an earlier version of this test."""
+    from primer.session.yields import durably_mark_session_resumable
+
+    storage, _engine, listener = await _build(tmp_path)
+
+    sess_a = _multi(["ask_user:sA:tc1", "ask_user:sA:tc2"], "ask_user:sA:tc1")
+    sess_a.id = "sA"
+    await storage.create(sess_a)
+    await listener._handle_event(_Event("ask_user:sA:tc1", {"response": "x"}))
+    via_listener = (await storage.get("sA")).parked_state["resume_event_payloads"]
+
+    sess_b = _multi(["ask_user:sB:tc1", "ask_user:sB:tc2"], "ask_user:sB:tc1")
+    sess_b.id = "sB"
+    await storage.create(sess_b)
+    await durably_mark_session_resumable(
+        sess_b, event_key="ask_user:sB:tc1", payload={"response": "x"},
+        session_storage=storage, engine=None,
+    )
+    via_rest = (await storage.get("sB")).parked_state["resume_event_payloads"]
+
+    # Same dispatch-key shape and payload from both delivery paths; only
+    # the per-session event_key text differs (sA vs sB), as expected.
+    assert set(via_listener) == set(via_rest) == {"tc1"}
+    assert via_listener["tc1"]["payload"] == via_rest["tc1"]["payload"] == {
+        "response": "x",
+    }
+    assert via_listener["tc1"]["event_key"] == "ask_user:sA:tc1"
+    assert via_rest["tc1"]["event_key"] == "ask_user:sB:tc1"

--- a/tests/channel/test_inbox.py
+++ b/tests/channel/test_inbox.py
@@ -8,6 +8,8 @@ then consume the next event from the iterator and assert event_key + payload.
 from __future__ import annotations
 
 import asyncio
+import logging
+from datetime import datetime, timezone
 
 import pytest
 
@@ -15,6 +17,11 @@ from primer.bus.in_memory import InMemoryEventBus
 from primer.channel.adapter import ResponseEnvelope
 from primer.channel.inbox import ChannelInbox
 from primer.model.except_ import BadRequestError
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
 
 
 @pytest.mark.asyncio
@@ -87,5 +94,233 @@ async def test_unknown_kind_rejected():
                     response=None, decision=None, reason=None,
                 ),
             )
+    finally:
+        await bus.aclose()
+
+
+# ===========================================================================
+# 01a0518f: storage_provider-backed lookup (replaces reconstruction)
+# ===========================================================================
+
+
+def _session(sid: str, *, parked_state: dict) -> WorkspaceSession:
+    now = datetime.now(timezone.utc)
+    return WorkspaceSession(
+        id=sid,
+        workspace_id="ws-1",
+        binding=AgentSessionBinding(kind="agent", agent_id="agt"),
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        parked_status="parked",
+        parked_at=now,
+        parked_state=parked_state,
+    )
+
+
+async def _handle_and_capture(inbox: ChannelInbox, env: ResponseEnvelope, bus):
+    sub = bus.subscribe()
+    try:
+        await inbox.handle_response(env)
+        return await asyncio.wait_for(anext(sub), timeout=1.0)
+    finally:
+        await sub.aclose()
+
+
+@pytest.mark.asyncio
+async def test_lookup_finds_the_stored_key_for_a_plain_single_park():
+    """A non-graph park's looked-up key matches what reconstruction would
+    have produced anyway - the lookup path is a superset, not a behaviour
+    change, for the case that already worked."""
+    from tests.conftest import _FakeStorageProvider
+
+    sp = _FakeStorageProvider()
+    await sp.get_storage(WorkspaceSession).create(_session(
+        "s-1",
+        parked_state={
+            "tool_call_id": "tc-1",
+            "yielded": {
+                "tool_name": "ask_user",
+                "event_key": "ask_user:s-1:tc-1",
+            },
+        },
+    ))
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    try:
+        inbox = ChannelInbox(event_bus=bus, storage_provider=sp)
+        event = await _handle_and_capture(
+            inbox,
+            ResponseEnvelope(
+                kind="ask_user", workspace_id="ws-1", session_id="s-1",
+                tool_call_id="tc-1", response="42", decision=None, reason=None,
+            ),
+            bus,
+        )
+        assert event.event_key == "ask_user:s-1:tc-1"
+    finally:
+        await bus.aclose()
+
+
+@pytest.mark.asyncio
+async def test_lookup_finds_a_node_qualified_graph_event_key():
+    """01a0518f: THE regression this fix closes. A graph agent-node's
+    approval park now stores a node-qualified event_key
+    (tool_approval:<session>:<node>:<tcid>) - reconstruction from the
+    channel reply alone (which only ever carries session_id + tool_call_id)
+    can no longer reproduce it. The lookup must find and use the row's
+    OWN stored key instead."""
+    from tests.conftest import _FakeStorageProvider
+
+    sp = _FakeStorageProvider()
+    qualified_key = "tool_approval:s-2:worker[0]:call_0"
+    await sp.get_storage(WorkspaceSession).create(_session(
+        "s-2",
+        parked_state={
+            "yielded": {"tool_name": "_approval", "event_key": "irrelevant"},
+            "graph_checkpoint": {
+                "pending_agent_yields": [
+                    {
+                        "node_id": "worker[0]",
+                        "tool_call_id": "call_0",
+                        "event_key": qualified_key,
+                        "tool_name": "_approval",
+                    },
+                ],
+            },
+        },
+    ))
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    try:
+        inbox = ChannelInbox(event_bus=bus, storage_provider=sp)
+        event = await _handle_and_capture(
+            inbox,
+            ResponseEnvelope(
+                kind="tool_approval", workspace_id="ws-1", session_id="s-2",
+                tool_call_id="call_0", response=None,
+                decision="approved", reason=None,
+            ),
+            bus,
+        )
+        # NOT the reconstructed "tool_approval:s-2:call_0" - the actual
+        # node-qualified key the park stored.
+        assert event.event_key == qualified_key
+    finally:
+        await bus.aclose()
+
+
+@pytest.mark.asyncio
+async def test_lookup_falls_back_when_session_not_found():
+    """A storage_provider is wired but env.session_id resolves to nothing
+    (e.g. a chat-surface response, or a stale/duplicate webhook) - falls
+    back to the reconstructed key exactly like the pre-fix behaviour."""
+    from tests.conftest import _FakeStorageProvider
+
+    sp = _FakeStorageProvider()
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    try:
+        inbox = ChannelInbox(event_bus=bus, storage_provider=sp)
+        event = await _handle_and_capture(
+            inbox,
+            ResponseEnvelope(
+                kind="ask_user", workspace_id="ws-1", session_id="chat-1",
+                tool_call_id="tc-9", response="hi", decision=None, reason=None,
+            ),
+            bus,
+        )
+        assert event.event_key == "ask_user:chat-1:tc-9"
+    finally:
+        await bus.aclose()
+
+
+@pytest.mark.asyncio
+async def test_lookup_falls_back_when_no_pending_entry_matches():
+    """The session exists and is parked, but on a DIFFERENT tool_call_id
+    than the reply names - falls back rather than raising or misrouting."""
+    from tests.conftest import _FakeStorageProvider
+
+    sp = _FakeStorageProvider()
+    await sp.get_storage(WorkspaceSession).create(_session(
+        "s-3",
+        parked_state={
+            "tool_call_id": "tc-other",
+            "yielded": {
+                "tool_name": "ask_user",
+                "event_key": "ask_user:s-3:tc-other",
+            },
+        },
+    ))
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    try:
+        inbox = ChannelInbox(event_bus=bus, storage_provider=sp)
+        event = await _handle_and_capture(
+            inbox,
+            ResponseEnvelope(
+                kind="ask_user", workspace_id="ws-1", session_id="s-3",
+                tool_call_id="tc-mismatched", response="hi",
+                decision=None, reason=None,
+            ),
+            bus,
+        )
+        assert event.event_key == "ask_user:s-3:tc-mismatched"
+    finally:
+        await bus.aclose()
+
+
+@pytest.mark.asyncio
+async def test_lookup_warns_and_resolves_the_first_on_a_genuine_collision(
+    caplog,
+):
+    """01a0518f: two fan-out siblings sharing a raw provider tool_call_id
+    still can't be told apart from a channel reply alone (the wire format
+    has no other field to disambiguate - same ambiguity the REST respond
+    routes already accept). Must not raise or drop the reply - resolves
+    the first match and logs a warning so the collision is visible."""
+    from tests.conftest import _FakeStorageProvider
+
+    sp = _FakeStorageProvider()
+    await sp.get_storage(WorkspaceSession).create(_session(
+        "s-4",
+        parked_state={
+            "yielded": {"tool_name": "_approval", "event_key": "irrelevant"},
+            "graph_checkpoint": {
+                "pending_agent_yields": [
+                    {
+                        "node_id": "worker[0]", "tool_call_id": "call_0",
+                        "event_key": "tool_approval:s-4:worker[0]:call_0",
+                        "tool_name": "_approval",
+                    },
+                    {
+                        "node_id": "worker[1]", "tool_call_id": "call_0",
+                        "event_key": "tool_approval:s-4:worker[1]:call_0",
+                        "tool_name": "_approval",
+                    },
+                ],
+            },
+        },
+    ))
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    try:
+        inbox = ChannelInbox(event_bus=bus, storage_provider=sp)
+        with caplog.at_level(logging.WARNING, logger="primer.channel.inbox"):
+            event = await _handle_and_capture(
+                inbox,
+                ResponseEnvelope(
+                    kind="tool_approval", workspace_id="ws-1",
+                    session_id="s-4", tool_call_id="call_0", response=None,
+                    decision="approved", reason=None,
+                ),
+                bus,
+            )
+        assert event.event_key in (
+            "tool_approval:s-4:worker[0]:call_0",
+            "tool_approval:s-4:worker[1]:call_0",
+        )
+        assert any(
+            "2 pending entries match" in r.message for r in caplog.records
+        )
     finally:
         await bus.aclose()

--- a/tests/graph/test_spec_b_end_to_end.py
+++ b/tests/graph/test_spec_b_end_to_end.py
@@ -301,17 +301,23 @@ async def test_spec_b_end_to_end_graph_runs_to_completion() -> None:
             if inner_node_id is not None:
                 graph_node_event_ids.append(inner_node_id)
 
-    # Worker events are tagged with the synthesized instance id
-    # (``worker[i]``) OR the base target id (``worker``) depending on
-    # the executor's stamping path; tolerate both. Pin that we saw at
-    # least one worker-tagged event per instance.
-    worker_event_count = sum(
-        1
-        for nid in graph_node_event_ids
+    # 01a0518f: worker events are now ALWAYS tagged with the synthesized,
+    # fan-out-instance-qualified id ("worker[i]") - _wrap_event no longer
+    # collapses concurrent siblings onto the shared base target id
+    # ("worker"), which used to make their streamed text/reasoning/
+    # tool_names collide into the same primer.session.persistence
+    # _CoalesceState bucket (a real data-loss bug, not just cosmetic
+    # attribution - two siblings' text could interleave/clobber each
+    # other in the persisted transcript). Assert each of the 3 fan-out
+    # instances gets its OWN distinct tag, proving isolation rather than
+    # merely "some worker-ish tag exists at least 3 times".
+    worker_event_ids = {
+        nid for nid in graph_node_event_ids
         if nid == "worker" or nid.startswith("worker[")
-    )
-    assert worker_event_count >= 3, (
-        f"expected at least 3 worker-tagged events, got {graph_node_event_ids!r}"
+    }
+    assert worker_event_ids == {"worker[0]", "worker[1]", "worker[2]"}, (
+        f"expected each fan-out instance tagged distinctly, got "
+        f"{sorted(worker_event_ids)} from {graph_node_event_ids!r}"
     )
 
     # ToolCall nodes don't emit a wrapped child stream-event in this

--- a/tests/session/test_persistence.py
+++ b/tests/session/test_persistence.py
@@ -266,11 +266,18 @@ def test_translate_tool_call_carries_name_from_start() -> None:
     )
     assert isinstance(rec, SessionMessageRecord)
     assert rec.kind == SessionMessageKind.TOOL_CALL
-    assert rec.payload.get("id") == "tc9"
+    # 01a0518f: the durable id is the SCOPED id minted at ToolCallStart,
+    # not the raw provider id verbatim - it restarts at the same value
+    # every llm.stream() call, so bare "tc9" can legitimately collide
+    # across tool-rounds and concurrent fan-out siblings.
+    assert rec.payload.get("id") == "x:tool:0:1"
     assert rec.payload.get("name") == "fs__write"
     assert rec.payload.get("arguments") == {"path": "x"}
     # Consumed on End — the map doesn't accumulate dead keys.
     assert (None, "tc9") not in state.tool_names
+    # The scoped-id mapping itself is NOT consumed on End - the later
+    # _ExecutorToolResult event for this same call still needs it.
+    assert state.scoped_call_ids[(None, "tc9")] == "x:tool:0:1"
 
 
 def test_translate_tool_call_end_without_start_has_null_name() -> None:
@@ -286,6 +293,133 @@ def test_translate_tool_call_end_without_start_has_null_name() -> None:
     assert isinstance(rec, SessionMessageRecord)
     assert rec.kind == SessionMessageKind.TOOL_CALL
     assert rec.payload.get("name") is None
+
+
+class _FakeDeltaSink:
+    def __init__(self):
+        self.deltas: list[tuple[str, str, str]] = []
+        self.closed: list[str] = []
+
+    def on_delta(self, pid, kind, delta):
+        self.deltas.append((pid, kind, delta))
+
+    def close(self, pid):
+        self.closed.append(pid)
+
+
+def test_tool_call_round_trip_shares_one_scoped_id_across_call_delta_and_result() -> None:
+    """01a0518f: ToolCallStart mints the scoped id; ToolCallDelta's live
+    delta_sink calls, the durable TOOL_CALL record, and the LATER
+    TOOL_RESULT record must all carry that SAME scoped id - not the raw
+    provider id verbatim - so live-argument reconciliation and the
+    TOOL_CALL/TOOL_RESULT pairing both still work with the new id shape."""
+    from primer.model.chat import (
+        ExtendedEvent,
+        ToolCallDelta,
+        ToolCallEnd,
+        ToolCallStart,
+        _ExecutorToolResult,
+    )
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+    sink = _FakeDeltaSink()
+
+    assert translate_stream_event(
+        ToolCallStart(id="call_0", name="fs__write", index=0), state,
+        delta_sink=sink,
+    ) is None
+    assert translate_stream_event(
+        ToolCallDelta(id="call_0", arguments_delta='{"path"', index=0), state,
+        delta_sink=sink,
+    ) is None
+
+    call_rec = translate_stream_event(
+        ToolCallEnd(id="call_0", arguments={"path": "x"}, index=0), state,
+        delta_sink=sink,
+    )
+    scoped_id = call_rec.payload["id"]
+    assert scoped_id != "call_0"  # not the raw id verbatim
+
+    result_rec = translate_stream_event(
+        ExtendedEvent(extended=_ExecutorToolResult(
+            call_id="call_0", output="done", error=False,
+        )),
+        state,
+    )
+    assert result_rec.payload["call_id"] == scoped_id, (
+        "TOOL_CALL and TOOL_RESULT must carry the identical scoped id"
+    )
+    # Live delta_sink calls used the scoped id throughout, not the raw one.
+    assert sink.deltas == [(scoped_id, "tool", '{"path"')]
+    assert scoped_id in sink.closed
+    # The mapping is popped once the result consumes it - not left dangling.
+    assert (None, "call_0") not in state.scoped_call_ids
+
+
+def test_two_tool_rounds_on_the_same_node_get_distinct_scoped_ids_for_the_same_raw_id() -> None:
+    """01a0518f: THE bug this fix exists for. The LLM adapter's id
+    counter restarts on every llm.stream() call (persistence.py's own
+    module comment), so a SECOND tool-calling round on the SAME graph
+    node can legitimately reuse "call_0" for an entirely different tool
+    call. The two TOOL_CALL records must not collide."""
+    from primer.model.chat import ToolCallEnd, ToolCallStart
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+    node = "worker"
+
+    translate_stream_event(
+        ToolCallStart(id="call_0", name="fs__read", index=0), state,
+        node_id=node,
+    )
+    round1 = translate_stream_event(
+        ToolCallEnd(id="call_0", arguments={"path": "a"}, index=0), state,
+        node_id=node,
+    )
+
+    translate_stream_event(
+        ToolCallStart(id="call_0", name="fs__write", index=0), state,
+        node_id=node,
+    )
+    round2 = translate_stream_event(
+        ToolCallEnd(id="call_0", arguments={"path": "b"}, index=0), state,
+        node_id=node,
+    )
+
+    assert round1.payload["id"] != round2.payload["id"], (
+        f"two distinct tool-rounds sharing raw id 'call_0' collided: "
+        f"{round1.payload['id']!r}"
+    )
+
+
+def test_concurrent_fanout_siblings_get_distinct_scoped_ids_for_the_same_raw_id() -> None:
+    """01a0518f: two concurrent fan-out sibling nodes each restart their
+    OWN LLM stream call's id counter independently, so they can also
+    legitimately share a raw id within the SAME turn/round."""
+    from primer.model.chat import ToolCallEnd, ToolCallStart
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+
+    translate_stream_event(
+        ToolCallStart(id="call_0", name="fs__read", index=0), state,
+        node_id="worker[0]",
+    )
+    sibling0 = translate_stream_event(
+        ToolCallEnd(id="call_0", arguments={}, index=0), state,
+        node_id="worker[0]",
+    )
+    translate_stream_event(
+        ToolCallStart(id="call_0", name="fs__read", index=0), state,
+        node_id="worker[1]",
+    )
+    sibling1 = translate_stream_event(
+        ToolCallEnd(id="call_0", arguments={}, index=0), state,
+        node_id="worker[1]",
+    )
+
+    assert sibling0.payload["id"] != sibling1.payload["id"]
 
 
 def test_translate_executor_tool_result() -> None:

--- a/tests/session/test_timeline_builder.py
+++ b/tests/session/test_timeline_builder.py
@@ -138,6 +138,52 @@ def test_tool_result_output_is_capped_and_flagged_when_oversized():
     assert result["error"] is False
 
 
+def _node_rec(seq, kind, ts, node_id, **payload):
+    """Like _rec, but sets the RECORD-level node_id field (as a graph
+    fan-out sibling's persisted records genuinely do), not just the
+    payload - _tree() reads rec["node_id"], not payload["node_id"], for
+    everything except _GRAPH_TRANSITION."""
+    return json.dumps({
+        "seq": seq, "kind": kind, "payload": payload, "created_at": ts,
+        "node_id": node_id,
+    })
+
+
+def test_fanout_siblings_sharing_a_raw_tool_call_id_do_not_overwrite_each_other():
+    """01a0518f: THE regression this task exists for, reproduced at the
+    timeline level. Two concurrent fan-out sibling nodes can legitimately
+    mint the identical raw provider tool_call_id ("call_0" restarts every
+    llm.stream() call - persistence.py's own module comment). Before the
+    fix, _tree()'s `calls` dict was keyed by the bare id alone: the
+    second sibling's TOOL_CALL record would silently overwrite the
+    first's entry in that dict, and BOTH tool_result records would then
+    pair to whichever entry happened to still be there - one sibling's
+    real result, or neither. With scoped ids (persistence.py) plus the
+    node-keyed `calls` dict (timeline.py) as defense-in-depth, each
+    sibling gets its own entry and its own correctly-paired result."""
+    lines = [
+        _node_rec(1, "tool_call", T0, "worker[0]", id="call_0", name="fs__read", arguments={}),
+        _node_rec(2, "tool_call", T0, "worker[1]", id="call_0", name="fs__read", arguments={}),
+        _node_rec(3, "tool_result", T1, "worker[0]", call_id="call_0", output="from sibling 0", error=False),
+        _node_rec(4, "tool_result", T1, "worker[1]", call_id="call_0", output="from sibling 1", error=True),
+        _rec(5, "done", T2, stop_reason="stop"),
+    ]
+    tl = build_turn_timeline(message_lines=lines, turn_log_lines=[], turn_no=0)
+
+    tool_calls = [c for c in tl["children"] if c["kind"] == "tool_call"]
+    assert len(tool_calls) == 2, (
+        f"expected 2 distinct tool_call entries (one per sibling), got "
+        f"{len(tool_calls)}: {tool_calls}"
+    )
+    by_node = {c["node_id"]: c for c in tool_calls}
+    assert set(by_node) == {"worker[0]", "worker[1]"}
+    # Each sibling's result pairs to ITS OWN call, not the other's.
+    assert by_node["worker[0]"]["status"] == "ok"
+    assert by_node["worker[0]"]["result"]["output"] == "from sibling 0"
+    assert by_node["worker[1]"]["status"] == "error"
+    assert by_node["worker[1]"]["result"]["output"] == "from sibling 1"
+
+
 def test_client_action_is_a_leaf_under_the_call_it_delivered():
     """S3 writes one delivery record per notifying call into this log."""
     lines = [

--- a/tests/tap/test_delta.py
+++ b/tests/tap/test_delta.py
@@ -241,21 +241,29 @@ def test_translate_feeds_sink_and_stamps_part_id() -> None:
     if not isinstance(records, list):
         records = [records]
 
+    # 01a0518f: the tool part_id is the SCOPED id minted at ToolCallStart
+    # ("x:tool:0:1" - node "x"/None, kind "tool", turn 0, seq 1), not the
+    # raw provider id "c1" verbatim - it restarts at the same value every
+    # llm.stream() call and can collide across tool-rounds / concurrent
+    # fan-out siblings.
+    scoped_tool_id = "x:tool:0:1"
+
     # The live path saw every content delta.
     assert ("x:text:0", "text", "hi") in sink.delta_calls
     assert ("x:reasoning:0", "reasoning", "think") in sink.delta_calls
-    assert ("c1", "tool", '{"q":') in sink.delta_calls
+    assert (scoped_tool_id, "tool", '{"q":') in sink.delta_calls
     # The parts are closed at the durable record.
     assert "x:text:0" in sink.close_calls
     assert "x:reasoning:0" in sink.close_calls
-    assert "c1" in sink.close_calls
+    assert scoped_tool_id in sink.close_calls
 
     # The durable records carry the matching part_id.
     by_kind = {r.kind: r for r in records}
     assert by_kind[SessionMessageKind.ASSISTANT_TOKEN].payload["part_id"] == "x:text:0"
     assert by_kind[SessionMessageKind.REASONING].payload["part_id"] == "x:reasoning:0"
-    # The tool input part reconciles to the TOOL_CALL record by its id.
-    assert by_kind[SessionMessageKind.TOOL_CALL].payload["id"] == "c1"
+    # The tool input part reconciles to the TOOL_CALL record by its
+    # (now scoped) id - live and durable still agree.
+    assert by_kind[SessionMessageKind.TOOL_CALL].payload["id"] == scoped_tool_id
 
 
 def test_translate_without_sink_is_unchanged() -> None:

--- a/tests/ui/test_session_detail_node_inspector.py
+++ b/tests/ui/test_session_detail_node_inspector.py
@@ -68,3 +68,24 @@ def test_bundle_transpiles_with_inspector() -> None:
     etag, body = build_jsx_bundle(UI)
     assert etag and body
     assert "SD_NodeInspector" in body.decode("utf-8")
+
+
+def test_inspector_matches_fanout_instance_ids_not_just_the_base_id() -> None:
+    """01a0518f: a fan-out node's live/history records carry the
+    synthesized instance id ("worker[0]") the node's own node_id never
+    equals ("worker") - an exact-equality match showed nothing for a
+    fan-out node (worse than the old merged-collided view). The inspector
+    must accept both the exact base id and any "<base>[" instance."""
+    src = DETAIL
+    assert "matchesNode" in src
+    assert 'id === nodeId' in src
+    assert 'startsWith(`${nodeId}[`)' in src
+    # Every place that used to compare directly against nodeId now routes
+    # through the matcher instead of a bare equality/inequality check.
+    assert "if (!matchesNode(fnode)) return;" in src
+    assert "matchesNode(it.node_id || p.node_id || it.end_node_id || p.end_node_id)" in src
+    # Regression guard: the old exact-only checks are gone, not just
+    # supplemented (a stray leftover would silently win via short-circuit
+    # if both existed).
+    assert "if (fnode !== nodeId) return;" not in src
+    assert "=== nodeId;" not in src

--- a/tests/worker/test_pending_dispatch_merge.py
+++ b/tests/worker/test_pending_dispatch_merge.py
@@ -82,3 +82,35 @@ def test_old_blob_with_agent_yields_in_dispatch_does_not_duplicate_after_dedup()
 
 def test_empty_checkpoint_yields_empty_list():
     assert merge_pending_dispatch({}) == []
+
+
+def test_derived_agent_yield_entries_carry_node_id():
+    """01a0518f: node_id must survive into the merged dispatch entry so
+    the channel dedup can key on (node_id, tool_call_id) instead of
+    tool_call_id alone - two fan-out siblings can share a raw id."""
+    checkpoint = {
+        "pending_agent_yields": [
+            {
+                "node_id": "worker[0]",
+                "tool_call_id": "call_0",
+                "event_key": "ask_user:s:call_0",
+                "tool_name": "ask_user",
+                "resume_metadata": {"prompt": "region 0?"},
+                "llm_messages": [],
+                "iteration": 0,
+            },
+            {
+                "node_id": "worker[1]",
+                "tool_call_id": "call_0",
+                "event_key": "ask_user:s:call_0",
+                "tool_name": "ask_user",
+                "resume_metadata": {"prompt": "region 1?"},
+                "llm_messages": [],
+                "iteration": 0,
+            },
+        ],
+    }
+    merged = merge_pending_dispatch(checkpoint)
+    assert {(p["node_id"], p["tool_call_id"]) for p in merged} == {
+        ("worker[0]", "call_0"), ("worker[1]", "call_0"),
+    }

--- a/tests/worker/test_post_park_channel_dispatch.py
+++ b/tests/worker/test_post_park_channel_dispatch.py
@@ -116,9 +116,9 @@ async def test_dispatch_multi_event_sends_one_message_per_pending_node():
 
     d = _Disp()
     pending = [
-        {"kind": "ask_user", "tool_call_id": "tc1",
+        {"kind": "ask_user", "node_id": "n1", "tool_call_id": "tc1",
          "resume_metadata": {"prompt": "color?"}},
-        {"kind": "_approval", "tool_call_id": "tc2",
+        {"kind": "_approval", "node_id": "n2", "tool_call_id": "tc2",
          "resume_metadata": {"original_call": {"id": "tc2", "name": "workspace__write",
                                                "arguments": {"path": "a.txt"}}}},
     ]
@@ -130,7 +130,37 @@ async def test_dispatch_multi_event_sends_one_message_per_pending_node():
     appr = next(e for e in d.calls if e.kind == "tool_approval")
     assert appr.tool_name == "workspace__write"
     assert appr.tool_args == {"path": "a.txt"}
-    assert sent == {"tc1", "tc2"}
+    assert sent == {("n1", "tc1"), ("n2", "tc2")}
+
+
+@pytest.mark.asyncio
+async def test_dispatch_multi_event_sends_both_fanout_siblings_sharing_a_raw_id():
+    """01a0518f: two concurrent fan-out siblings can legitimately share a
+    raw provider tool_call_id. Deduping by tool_call_id alone silently
+    dropped one sibling's channel prompt entirely - dedup must be keyed
+    by (node_id, tool_call_id), not tool_call_id alone."""
+    from primer.worker.yield_runtime import _dispatch_to_channels_multi
+
+    class _Disp:
+        def __init__(self): self.calls = []
+        async def dispatch_prompt(self, *, envelope, session=None):
+            self.calls.append(envelope); return [{"ok": True}]
+
+    d = _Disp()
+    pending = [
+        {"kind": "ask_user", "node_id": "worker[0]", "tool_call_id": "call_0",
+         "resume_metadata": {"prompt": "region 0?"}},
+        {"kind": "ask_user", "node_id": "worker[1]", "tool_call_id": "call_0",
+         "resume_metadata": {"prompt": "region 1?"}},
+    ]
+    sent = await _dispatch_to_channels_multi(
+        dispatcher=d, workspace_id="w1", session_id="s1",
+        pending=pending, already_sent=set())
+    assert len(d.calls) == 2, (
+        "both fan-out siblings must get their own channel prompt even "
+        "though they share the raw tool_call_id"
+    )
+    assert sent == {("worker[0]", "call_0"), ("worker[1]", "call_0")}
 
 
 @pytest.mark.asyncio
@@ -143,9 +173,10 @@ async def test_dispatch_multi_event_skips_already_sent():
             self.calls.append(envelope); return [{"ok": True}]
 
     d = _Disp()
-    pending = [{"kind": "ask_user", "tool_call_id": "tc1", "resume_metadata": {"prompt": "q"}}]
+    pending = [{"kind": "ask_user", "node_id": "n1", "tool_call_id": "tc1",
+                "resume_metadata": {"prompt": "q"}}]
     sent = await _dispatch_to_channels_multi(
         dispatcher=d, workspace_id="w1", session_id="s1",
-        pending=pending, already_sent={"tc1"})
+        pending=pending, already_sent={("n1", "tc1")})
     assert d.calls == []  # already sent -> no re-send
-    assert sent == {"tc1"}
+    assert sent == {("n1", "tc1")}

--- a/ui/components/session-detail.jsx
+++ b/ui/components/session-detail.jsx
@@ -620,12 +620,22 @@ function SD_NodeInspector({ gid, rid, wid, session, node, graph, pushToast, hide
     if (!wid || !rid || !nodeId) return undefined;
     let alive = true;
     let es;
+    // 01a0518f: a fan-out node's live records carry the synthesized
+    // instance id ("worker[0]"), never the shared base id ("worker")
+    // node.node_id resolves to - so an exact-equality selector/filter
+    // matched nothing for a fan-out node (worse than the OLD merged-
+    // collided view, which at least showed something). Match either the
+    // exact base id (a non-fan-out node) or any "<base>[" instance.
+    const matchesNode = (id) => id === nodeId || (typeof id === "string" && id.startsWith(`${nodeId}[`));
     const openTap = () => {
       if (!alive) return;
-      // Build a selector: sessions:id==rid AND events:node_id==nodeId.
+      // Build a selector: sessions:id==rid. Node attribution is filtered
+      // client-side (matchesNode, below) rather than server-side here -
+      // the tap selector's "=" operator can't express "this id OR any of
+      // its fan-out instances" - so this panel trades a slightly wider
+      // server-side stream for correct fan-out attribution.
       const selector = {
         sessions: { kind: "predicate", left: { kind: "field", name: "id" }, op: "=", right: { kind: "value", value: rid } },
-        events: { kind: "predicate", left: { kind: "field", name: "node_id" }, op: "=", right: { kind: "value", value: nodeId } },
       };
       const highWater = _niCursorRef.current || 0;
       const cursorToken = highWater > 0 ? _slsEncodeCursor(rid, highWater) : null;
@@ -640,10 +650,11 @@ function SD_NodeInspector({ gid, rid, wid, session, node, graph, pushToast, hide
         if (!tev || typeof tev !== "object" || typeof tev.seq !== "number") return;
         const payload = tev.payload && typeof tev.payload === "object" ? tev.payload : {};
         const frame = { ...payload, kind: tev.class, seq: tev.seq, payload, ts: tev.ts };
-        // Defensive node filter: the server-side selector already gates this
-        // but we double-check so a selector mismatch can't pollute frames.
+        // Node filter: the server-side selector no longer gates by node_id
+        // (see openTap's comment), so this is the sole node attribution
+        // check for live frames now, not just a defensive double-check.
         const fnode = frame.node_id || frame.end_node_id;
-        if (fnode !== nodeId) return;
+        if (!matchesNode(fnode)) return;
         setFrames((prev) => prev.some((p) => p.seq === frame.seq) ? prev : [...prev, frame].sort((a, b) => (a.seq || 0) - (b.seq || 0)));
       };
     };
@@ -660,10 +671,11 @@ function SD_NodeInspector({ gid, rid, wid, session, node, graph, pushToast, hide
           let maxSeq = 0;
           for (const it of items) { if (typeof it.seq === "number" && it.seq > maxSeq) maxSeq = it.seq; }
           _niCursorRef.current = maxSeq;
-          // Keep only frames attributed to this node for display.
+          // Keep only frames attributed to this node (or one of its
+          // fan-out instances) for display.
           const nodeItems = items.filter((it) => {
             const p = it.payload && typeof it.payload === "object" ? it.payload : {};
-            return (it.node_id || p.node_id || it.end_node_id || p.end_node_id) === nodeId;
+            return matchesNode(it.node_id || p.node_id || it.end_node_id || p.end_node_id);
           });
           if (nodeItems.length) {
             setFrames((prev) => {


### PR DESCRIPTION
Raw provider tool-call ids (call_0, ...) restart on every llm.stream() call, so a single multi-round turn or concurrent fan-out siblings can mint the same id for unrelated calls. This PR closes every collision surface found in the 01a0518f investigation, in six reviewed commits:

- **bdff4324** - channel dispatch dedup by (node_id, tool_call_id): a colliding sibling's approval prompt was silently never sent; pure-lookup resume scans now warn on multi-match instead of silently resolving the wrong sibling.
- **b59bf60d** - resume reply accumulation keyed past the raw id: a second operator's reply silently overwrote the first at the shared durable park->resumable primitive. Transition guards/lease repair untouched.
- **12869ea1** - instance-qualified node identity contextvar: fan-out siblings get distinct approval event_keys and distinct event tagging (closes a real coalescing-buffer data-loss bug; the spec-b e2e assertion is strengthened to the exact instance set).
- **1f67ab8e** - the node inspector matches fan-out instances (and works for them for the first time).
- **ca521828** - the channel inbox resolves stored approval keys by lookup instead of reconstruction (required once graph keys are node-qualified; every previously-working case byte-identical via fallback).
- **94fc2460** - durable/live transcript ids are scoped (node:tool:turn_no:seq); raw id preserved solely for delegation nesting; timeline pairs by (node, id) as defense-in-depth.

Raw provider ids still round-trip untouched everywhere the LLM history requires byte-match (parked state, ToolResultPart, resume injection).

**Flagged, deliberately not fixed here**: the external-tools wire contract can only name tool_call_id (a true sibling collision remains ambiguous for external callers - needs a delivered-id design); tool_approval's REST route only exposes the first pending item's blob; three adjacent pre-existing fan-out base-id bugs are filed as board task 01a05935.

🤖 Generated with [Claude Code](https://claude.com/claude-code)