### PR TITLE
fix(health): API pod serves real worker-pool capacity, dashboard stops rendering ?

### DIFF
--- a/primer/api/routers/health.py
+++ b/primer/api/routers/health.py
@@ -67,8 +67,11 @@ class WorkerPoolHealth(BaseModel):
     capacity: int | None = Field(
         default=None,
         description=(
-            "Configured per-worker concurrency. Null when the process "
-            "is API-only."
+            "This process's own worker-pool concurrency, or (when this "
+            "process has no local pool attached) the durable scheduler "
+            "registry's summed capacity across live workers. Null only "
+            "when neither source is available (no local pool and no "
+            "scheduler)."
         ),
     )
     metrics: dict[str, Any] = Field(
@@ -130,6 +133,21 @@ async def health(request: Request) -> HealthStatus:
             pool_metrics = {}
         pool_in_flight = pool_metrics.get("primer_worker_in_flight")
         pool_capacity = pool_metrics.get("primer_worker_capacity")
+
+    if pool_capacity is None and scheduler is not None:
+        # This process has no local worker pool attached (API-only, per
+        # the field docstring) — worker pods own the pool in this
+        # topology, so the in-process metrics snapshot above can never
+        # answer capacity here. Fall back to the durable scheduler
+        # registry, summing live (non-dead) workers' capacity, the same
+        # aggregate the Workers page computes client-side. in_flight has
+        # no durable equivalent (per-worker live load is process-local
+        # and never persisted) so it is left null rather than guessed.
+        try:
+            workers = await scheduler.list_workers()
+            pool_capacity = sum(w.capacity for w in workers if w.status != "dead")
+        except Exception:
+            pool_capacity = None
 
     return HealthStatus(
         version=APP_VERSION,

--- a/tests/api/test_health.py
+++ b/tests/api/test_health.py
@@ -62,14 +62,60 @@ async def test_health_surfaces_scheduler_degraded(app, client) -> None:
 async def test_health_surfaces_worker_pool_in_flight_capacity(client) -> None:
     """/v1/health includes worker_pool.in_flight + worker_pool.capacity.
 
-    The test app does not run a real WorkerPool (worker_pool=None), so
-    in_flight + capacity should both be null but the keys must exist.
+    The test app does not run a real WorkerPool (worker_pool=None) and
+    has no workers registered with the scheduler, so in_flight stays
+    null (no durable equivalent) and capacity falls back to the durable
+    registry's sum — 0 for an empty registry, not null.
     """
     response = await client.get("/v1/health")
     body = response.json()
     assert "worker_pool" in body
     assert body["worker_pool"]["in_flight"] is None
-    assert body["worker_pool"]["capacity"] is None
+    assert body["worker_pool"]["capacity"] == 0
+
+
+@pytest.mark.asyncio
+async def test_health_worker_pool_capacity_falls_back_to_scheduler_registry(
+    app, client,
+) -> None:
+    """01a063c3: an API-only process (no local WorkerPool) must not
+    report capacity=null just because worker pods, not this pod, own
+    the pool — that rendered as the dashboard's literal 'of ? capacity'.
+    Capacity instead sums the durable scheduler registry's live
+    (non-dead) workers, excluding a dead one."""
+    await app.state.scheduler.register_worker(
+        worker_id="w1", host="h1", pid=1, capacity=3,
+    )
+    await app.state.scheduler.register_worker(
+        worker_id="w2", host="h2", pid=2, capacity=4,
+    )
+    await app.state.scheduler.register_worker(
+        worker_id="w3", host="h3", pid=3, capacity=99,
+    )
+    app.state.scheduler.mark_worker_dead_for_test("w3")
+
+    response = await client.get("/v1/health")
+    body = response.json()
+    assert body["worker_pool"]["in_flight"] is None
+    assert body["worker_pool"]["capacity"] == 7
+
+
+@pytest.mark.asyncio
+async def test_health_worker_pool_capacity_null_without_scheduler(app, client) -> None:
+    """No local pool and no scheduler at all: capacity has nothing to
+    fall back to, so it stays null (the UI renders its own clean
+    fallback for that case, not this endpoint's job to fake a number)."""
+    real_scheduler = app.state.scheduler
+    app.state.scheduler = None
+    try:
+        response = await client.get("/v1/health")
+        body = response.json()
+        assert body["worker_pool"]["in_flight"] is None
+        assert body["worker_pool"]["capacity"] is None
+        # scheduler.alive also reflects the missing scheduler.
+        assert body["scheduler"]["alive"] is False
+    finally:
+        app.state.scheduler = real_scheduler
 
 
 @pytest.mark.asyncio

--- a/tests/ui/test_console_system.py
+++ b/tests/ui/test_console_system.py
@@ -83,6 +83,18 @@ def test_health_cards_match_notes_not_the_old_scheduler_dump():
     assert "status=running" in SYS, "sessions-active reads GET /sessions?status=running"
 
 
+def test_worker_pool_capacity_falls_back_to_a_clean_label_not_a_bare_question_mark():
+    # 01a063c3: a null worker_pool.capacity (this API process has no
+    # local pool attached) used to render the card subtitle as the
+    # literal "of ? capacity" - a raw unresolved-placeholder character,
+    # not a clean fallback. The backend now sums the durable scheduler
+    # registry's live workers when its own pool is absent (health.py),
+    # but the UI must still degrade cleanly for the case neither source
+    # can answer (no scheduler either).
+    assert 'wp.capacity == null ? "?"' not in SYS
+    assert 'wp.capacity == null ? "n/a" : wp.capacity' in SYS
+
+
 def test_worker_rows_carry_turns_and_uptime():
     # notes section 4: "worker rows show ... turns + uptime". Turns come
     # from grouping /workers/stats by worker id (workers.jsx's own lane

--- a/ui/components/console/nv-system.jsx
+++ b/ui/components/console/nv-system.jsx
@@ -101,7 +101,7 @@ function NV_HealthCards() {
     },
     {
       k: "worker pool", v: String(wp.in_flight == null ? "…" : wp.in_flight),
-      sub: "of " + (wp.capacity == null ? "?" : wp.capacity) + " capacity",
+      sub: "of " + (wp.capacity == null ? "n/a" : wp.capacity) + " capacity",
       tone: "var(--blue)",
     },
     {


### PR DESCRIPTION
Found during the uiv2 reconciliation screenshot sweep: the system dashboard's WORKER POOL stat rendered a literal `... of ? capacity` on the k3s topology, because /v1/health only consulted the in-process pool (None on an API-only pod). Capacity now falls back to the durable scheduler registry summed over live workers - consistent with the Workers page's own client-side aggregate; in_flight stays honestly null (per-worker live load is never persisted). UI renders n/a in the residual no-scheduler case. Tests: live-worker summing incl. dead-worker exclusion, no-scheduler null, and a scoped source regression pin on the n/a fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)