### PR TITLE
feat(console): providers page and create overlay match the designer's version

### DIFF
--- a/tests/ui/test_provider_catalog.py
+++ b/tests/ui/test_provider_catalog.py
@@ -30,25 +30,28 @@ def test_the_catalog_exports_itself_on_window() -> None:
 def test_every_spec_class_is_on_the_rail() -> None:
     """M11b: eleven classes, Web Fetch and Artifact Storage included.
 
-    RETARGET (platform wave P1a item 5): the "Vector Stores" label became
-    "Semantic Search" - the vision doc's own reference screenshots 4/6
-    name this family chip "Semantic search", and unifying it onto the
-    Providers page (rather than a standalone route) is exactly what this
-    wave's item 5 asks for.
+    RETARGET (01a063ab, ratified uiv2 designer mockup): chip labels and
+    order were reconciled to the mockup's exact wording - compact
+    lowercase-style labels without the old title-case/hyphenation
+    ("Cross-Encoder" -> "Cross encoding", "Semantic Search" ->
+    "Semantic search", "Speech-to-Text" -> "ASR", "Text-to-Speech" ->
+    "TTS", "Web Search"/"Web Fetch"/"Artifact Storage" -> lowercase
+    "search"/"fetch"/"storage", "Workspaces" -> singular "Workspace").
+    "Channels" and "LLM"/"Embedding" were already an exact match.
     """
     src = _read("components/provider-catalog.jsx")
     for label in (
         "LLM",
         "Embedding",
-        "Cross-Encoder",
-        "Semantic Search",
-        "Speech-to-Text",
-        "Text-to-Speech",
-        "Web Search",
-        "Web Fetch",
-        "Artifact Storage",
-        "Workspaces",
+        "TTS",
+        "ASR",
+        "Semantic search",
+        "Cross encoding",
+        "Workspace",
+        "Web search",
+        "Web fetch",
         "Channels",
+        "Artifact storage",
     ):
         assert f'label: "{label}"' in src, f"family chips missing {label}"
 

--- a/tests/ui/test_provider_catalog_actions.py
+++ b/tests/ui/test_provider_catalog_actions.py
@@ -18,6 +18,10 @@ def _src() -> str:
     return (UI / "components" / "provider-catalog.jsx").read_text(encoding="utf-8")
 
 
+def _form_src() -> str:
+    return (UI / "components" / "provider-form.jsx").read_text(encoding="utf-8")
+
+
 def test_rows_offer_delete() -> None:
     """RETARGET (platform wave P1a item 3): the reference card anatomy
     puts Delete directly on each card's own footer rather than beside a
@@ -40,15 +44,24 @@ def test_delete_asks_first() -> None:
 
 
 def test_invalidate_is_offered_only_where_the_endpoint_exists() -> None:
+    """01a063ab: the Invalidate action itself relocated into the edit
+    overlay (PC_InvalidateAction in provider-form.jsx) - the card footer
+    stays mockup-pure (Open/Delete only) per the lead's ruling, so the
+    capability moved rather than being dropped. Which classes offer it
+    (invalidate: true on PROVIDER_CLASSES) is unchanged and still lives
+    on the catalog."""
     src = _src()
-    assert "/invalidate" in src
     marked = re.findall(r'key:\s*"(\w+)"[^}]*invalidate:\s*true', src)
     assert marked == ["llm", "embedding", "cross_encoder"], marked
+    assert "/invalidate" in _form_src()
 
 
 def test_the_backend_reason_is_shown_inline_not_swallowed() -> None:
     src = _src()
-    assert "err.status" in src or "error.status" in src
+    # RETARGET (01a063ab): the delete catch variable was renamed from the
+    # generic `err` (which would have shadowed the sibling error-message
+    # state variable of the same name) to `deleteErr`.
+    assert "deleteErr.status" in src
     assert "detail" in src
     assert 'data-testid={`provider-card-error-${row.id}`}' in src
 

--- a/tests/ui/test_provider_catalog_discover_gate.py
+++ b/tests/ui/test_provider_catalog_discover_gate.py
@@ -81,8 +81,12 @@ def test_discoverable_prop_is_fully_removed_not_left_dangling() -> None:
     always undefined at PC_InstanceCard regardless. Confirm it's gone
     everywhere rather than left as a red herring."""
     src = _src()
-    assert "PC_InstanceCard({ klass, row, onOpen, onChanged })" in src
-    assert "PC_InstanceGrid({ klass, onSelect, onRegisterRefetch })" in src
+    # 01a063ab added profileCount/filterQuery/onCountChange for the
+    # designer reconciliation (default-for-N-profiles fact, card filter) -
+    # additive real props, not a reintroduction of the dead `discoverable`
+    # prop this test guards against.
+    assert "PC_InstanceCard({ klass, row, onOpen, onChanged, profileCount })" in src
+    assert "PC_InstanceGrid({ klass, onSelect, onRegisterRefetch, filterQuery, onCountChange })" in src
     assert "discoverable={discoverable}" not in src
 
 

--- a/tests/ui/test_provider_catalog_ia_restructure.py
+++ b/tests/ui/test_provider_catalog_ia_restructure.py
@@ -1,8 +1,14 @@
-"""Providers IA restructure (01a04d6a, user directive supersedes the
-mockup where they conflict): ONE page, all types together with a type
-filter, Register-by-type, card-click opens the SAME overlay in edit
-mode, form spacing fixed. Static source checks, same technique as
-tests/ui/test_provider_catalog.py.
+"""Providers IA restructure. Originally 01a04d6a (user directive
+supersedes the mockup where they conflict); superseded in turn by
+01a063ab where the ratified uiv2 designer mockup itself was named
+authoritative - LLM is now the default class (not the merged All view)
+and Register lists a class's kinds via PC_RegisterDropdown, not
+PC_RegisterAll. The merged All view and PC_RegisterAll survive as a
+restorable fallback (unreachable from the header once a class is
+selected, kept for symmetry - see PC_ALL_TYPE_CHIPS/PC_AllInstancesGrid
+below). Card-click-opens-the-same-overlay-in-edit-mode and form-spacing
+fixes are unaffected by the mockup and remain as originally landed.
+Static source checks, same technique as tests/ui/test_provider_catalog.py.
 """
 
 from __future__ import annotations
@@ -30,13 +36,19 @@ def _platform() -> str:
 # ---------------------------------------------------------------------------
 
 
-def test_all_is_the_default_class_and_the_first_type_chip() -> None:
+def test_llm_is_the_default_class_and_all_survives_as_a_restorable_fallback() -> None:
+    """01a063ab: the ratified mockup drops the "All" chip and its
+    per-type section headings, defaulting to LLM instead. PC_ALL_TYPE_CHIPS
+    and PC_AllInstancesGrid are kept intact (unreferenced from the header
+    once a class is selected) so the merged view can be restored without
+    reconstructing it from scratch."""
     src = _catalog()
-    assert 'React.useState(initialClass || "all")' in src, (
-        "the catalog must default to the merged All view, not the first "
-        "real class"
+    assert 'React.useState(initialClass || "llm")' in src, (
+        "the catalog must default to the LLM class per the ratified mockup"
     )
-    assert 'const PC_ALL_TYPE_CHIPS = [{ key: "all", label: "All" }, ...PROVIDER_CLASSES];' in src
+    assert 'const PC_ALL_TYPE_CHIPS = [{ key: "all", label: "All" }, ...PROVIDER_CLASSES];' in src, (
+        "the merged All view's chip list must survive for restorability"
+    )
 
 
 def test_all_instances_grid_merges_only_crud_classes() -> None:
@@ -85,9 +97,28 @@ def test_register_all_lists_every_type_with_no_fetch() -> None:
     assert "function PC_RegisterDropdown" in src
 
 
-def test_register_all_is_the_top_level_control_not_gated_on_a_class() -> None:
+def test_register_dropdown_is_primary_and_register_all_is_the_no_class_fallback() -> None:
+    """01a063ab: with a class always selected by default (LLM), the live
+    top-level control is PC_RegisterDropdown (lists that class's KINDS,
+    not types) - PC_RegisterAll only surfaces if isAll is ever reached
+    again, which is why its exact call survives verbatim as the fallback
+    branch rather than being deleted."""
     src = _catalog()
+    assert "<PC_RegisterDropdown klass={klass} onPick={(kind) => openCreateWithKind(klass, kind)} />" in src
     assert "<PC_RegisterAll onPick={openCreate} />" in src
+
+
+def test_register_dropdown_shows_the_served_kind_label() -> None:
+    """01a063ab: retired from test_provider_form_fields.py's old
+    test_the_type_picker_shows_the_served_label - the in-form kind
+    picker it pinned is gone; the served-label behavior lives in
+    PC_RegisterDropdown now, annotated per kind (discoverable ->
+    "probes models live", aggregated variant -> "gated / special")."""
+    src = _catalog()
+    dropdown = src[src.index("function PC_RegisterDropdown"):]
+    dropdown = dropdown[:dropdown.index("\nfunction ", 1)]
+    assert "typeMap[k]" in dropdown
+    assert "{meta.label || k}" in dropdown
 
 
 def test_picking_a_panel_type_switches_the_filter_not_a_form() -> None:
@@ -145,14 +176,15 @@ def test_form_receives_the_editing_flag() -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_id_field_and_kind_select_are_disabled_while_editing() -> None:
+def test_id_field_is_disabled_while_editing() -> None:
+    """01a063ab: the in-form kind <select> is gone entirely (kind always
+    arrives preselected from the Register dropdown), so only the id/Name
+    PC_Field is left to gate - exactly one `disabled={editing}` JSX prop
+    now exists (a second, unrelated `disabled` guards Save on `busy`, not
+    `editing`, so this counts the literal prop, not the word)."""
     src = _form()
-    # Both the id PC_Field and the provider <select> must be gated - not
-    # just one of the two - so exactly two `disabled={editing}` JSX
-    # props exist (a third, unrelated `disabled` guards Save on `busy`,
-    # not `editing`, so this counts the literal prop, not the word).
-    assert src.count("disabled={editing}") == 2
-    id_block = src[src.index('field={PC_normalizeField({ key: "id"'):]
+    assert src.count("disabled={editing}") == 1
+    id_block = src[src.index('key: "id", label: "Name"'):]
     id_block = id_block[:id_block.index("/>")]
     assert "disabled={editing}" in id_block
 
@@ -229,9 +261,13 @@ def test_form_opens_in_a_wider_modal() -> None:
 
 
 def test_fields_and_probe_panel_are_a_real_css_grid() -> None:
+    """01a063ab: the right column now also hosts PC_InvalidateAction for
+    classes with no probe panel (e.g. cross_encoder), so the grid gates
+    on showRightColumn (showProbePanel || showInvalidate), not
+    showProbePanel alone."""
     src = _form()
     assert 'display: "grid"' in src
-    assert 'gridTemplateColumns: showProbePanel ? "minmax(0, 1fr) 240px" : "minmax(0, 1fr)"' in src
+    assert 'gridTemplateColumns: showRightColumn ? "minmax(0, 1fr) 240px" : "minmax(0, 1fr)"' in src
     # The old flex tug-of-war (flex: 1 fields vs. a fixed-width sibling
     # in the same flex row) must be gone, not just supplemented.
     assert 'className="row" style={{ gap: 20, alignItems: "flex-start" }}' not in src

--- a/tests/ui/test_provider_catalog_p4.py
+++ b/tests/ui/test_provider_catalog_p4.py
@@ -61,15 +61,29 @@ def test_reachable_and_unreachable_are_derived_from_last_probe_ok() -> None:
 
 
 def test_card_shows_last_probed_and_error_fact_rows() -> None:
+    """RETARGET (01a063ab): facts became a `{key, value}` array feeding a
+    real two-column CSS grid (the designer mockup's aligned key-value
+    card) - "last probed" (a verb-phrase label) became the noun-phrase
+    "last probe" to match its siblings' key style ("models", "default
+    for", "key", "error"). Same information, consistent column heading."""
     card = _card_src()
-    assert "last probed" in card
+    assert '"last probe"' in card
     assert "row.last_error" in card
-    assert 'data-testid={`provider-card-probe-error-${row.id}`}' in card
+    # The testid is now assigned per-fact via a ternary (only the "error"
+    # fact row carries it), not a literal per-field JSX attribute.
+    assert '`provider-card-probe-error-${row.id}` : undefined' in card
 
 
 def test_error_row_only_renders_when_actually_unreachable() -> None:
+    """RETARGET (01a063ab): the fact set is now built by an if(!unreachable)
+    / else branch (reachable and unreachable rows show different fact
+    sets entirely, matching the mockup's own two examples) rather than a
+    single flat list each fact self-guards within - the error fact is
+    still only ever pushed from inside the `unreachable` branch."""
     card = _card_src()
-    assert "unreachable && row.last_error" in card
+    else_branch = card[card.index("} else {"):card.index("\n  }\n\n  return (")]
+    assert "if (row.last_error) {" in else_branch
+    assert 'facts.push({ key: "error"' in else_branch
 
 
 # ---- PC_ProfilesPanel: real card wiring + the fixed modal invocation ------

--- a/tests/ui/test_provider_form_fields.py
+++ b/tests/ui/test_provider_form_fields.py
@@ -73,7 +73,8 @@ def test_no_provider_field_table_survives_in_the_console() -> None:
         )
 
 
-def test_the_type_picker_shows_the_served_label() -> None:
-    src = _src()
-    assert "shapeOf(" in src or "typeMap[k]" in src
-    assert ".label" in src
+## test_the_type_picker_shows_the_served_label retired (01a063ab): the
+## in-form kind picker is gone - kind always arrives preselected from
+## PC_RegisterDropdown now. The served-label behavior it pinned moved
+## with it; see test_register_dropdown_shows_the_served_kind_label in
+## test_provider_catalog_ia_restructure.py.

--- a/tests/ui_e2e/test_backfill_sister_2.py
+++ b/tests/ui_e2e/test_backfill_sister_2.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 import httpx
 from playwright.sync_api import expect
 from tests.ui_e2e._shell_helpers import open_legacy_route
+from tests.ui_e2e._studio_helpers import open_provider_catalog
 
 
 # ---------------------------------------------------------------------------
@@ -113,11 +114,18 @@ def test_u0098_embedding_provider_invalidate_toasts_and_preserves_row(
     page, base_url, console_url, unique_suffix,
 ) -> None:
     """U0098 — Sister of U0091 (LLM provider Invalidate). Seed an
-    embedding provider; navigate to ``#/providers/embedding/<id>``;
-    click "Invalidate" → POST /v1/embedding_providers/{id}/invalidate
-    fires → ``kind=info`` toast "Cache dropped" appears per
-    providers.jsx:593; the row remains GET-able via API
-    (invalidate drops the cached adapter, not the row).
+    embedding provider, open its card's edit overlay, click
+    "Invalidate model cache" → POST /v1/embedding_providers/{id}/invalidate
+    fires → ``kind=success`` toast "Cache dropped" appears per
+    PC_InvalidateAction (provider-form.jsx); the row remains GET-able
+    via API (invalidate drops the cached adapter, not the row).
+
+    RETARGET (01a063ab, designer reconciliation): same relocation as
+    U0091 - Invalidate moved off the card footer into the edit overlay
+    (PC_InvalidateAction), so this reaches it via the card's Open
+    button rather than a direct instance-id route (which only ever set
+    instanceId for the model-profiles panel, not an auto-opened edit
+    form, on this class either before or after this change).
     """
     pid = f"emb-u98-{unique_suffix}"
     with httpx.Client(base_url=base_url, timeout=30.0) as c:
@@ -136,16 +144,14 @@ def test_u0098_embedding_provider_invalidate_toasts_and_preserves_row(
         assert r.status_code == 201, r.text
     cleanup_urls = [f"/v1/embedding_providers/{pid}"]
     try:
-        open_legacy_route(page, console_url, f"providers/embedding/{pid}")
+        open_provider_catalog(page, console_url, cls="embedding")
+        page.click(f'[data-testid="provider-card-open-{pid}"]')
+        form = page.get_by_test_id("provider-form-embedding_providers")
+        form.wait_for(state="visible", timeout=15_000)
 
-        inv = page.get_by_role(
-            "button", name="Invalidate", exact=True,
-        ).first
-        # Embedding provider detail page can take a while to fully
-        # render (detail + models fetches must both settle before the
-        # Header switches from loading-branch to success-branch with
-        # the Invalidate button). Bump the wait vs U0091's LLM
-        # variant.
+        inv = form.get_by_test_id("provider-form-invalidate-action")
+        # Bumped wait vs U0091's LLM variant, same margin as before this
+        # retarget, to give the form's own fetches a beat to settle.
         inv.wait_for(state="visible", timeout=20_000)
         inv.click()
 

--- a/tests/ui_e2e/test_empty_states_and_lifecycle.py
+++ b/tests/ui_e2e/test_empty_states_and_lifecycle.py
@@ -135,21 +135,20 @@ def test_u0047_provider_list_reflects_new_row_after_modal_create(
     """
     provider_id = f"llm-u0047-{unique_suffix}"
     try:
-        # RETARGET (IA restructure 01a04d6a): "Register provider" now
-        # names the TYPE ("llm") up front rather than the kind directly -
-        # the form's own kind dropdown is STILL re-picked below to
-        # Anthropic regardless of which kind the type pick defaulted the
-        # form to. The round trip out to a detail page and back is still
-        # gone, and the list still has to show the new row in place, just
-        # now behind Register -> type -> (re-pick kind) -> Save.
+        # RETARGET (01a063ab, designer reconciliation): Register now
+        # lists the active class's KINDS directly (PC_RegisterDropdown) -
+        # picking "anthropic" there opens the form with kind already
+        # preselected, no in-form re-pick left to do. The round trip out
+        # to a detail page and back is still gone, and the list still has
+        # to show the new row in place, just now behind Register -> kind
+        # -> Save.
         open_legacy_route(page, console_url, "providers/llm")
-        page.get_by_test_id("provider-register-all-toggle").click()
-        page.get_by_test_id("provider-register-type-llm").click()
+        page.get_by_test_id("provider-register-toggle").click()
+        page.get_by_test_id("provider-register-kind-anthropic").click()
         form = page.get_by_test_id("provider-form-llm_providers")
         form.wait_for(state="visible", timeout=15_000)
 
-        form.locator("input").first.fill(provider_id)
-        form.locator("select").first.select_option(label="Anthropic")
+        form.locator('[data-field="id"] input').fill(provider_id)
         api_key_input = form.locator("input[type=password]").first
         if api_key_input.count():
             api_key_input.fill("sk-test-placeholder")

--- a/tests/ui_e2e/test_provider_catalog_journey.py
+++ b/tests/ui_e2e/test_provider_catalog_journey.py
@@ -41,22 +41,20 @@ def test_the_speech_classes_expose_the_active_defaults_panel(page, console_url) 
 
 
 def test_the_llm_class_offers_the_shared_form(page, console_url) -> None:
-    # RETARGET (IA restructure 01a04d6a): "Register provider" now names
-    # the TYPE up front (11 classes, independent of whichever chip is
-    # active) rather than the kind - the kind select moved INSIDE the
-    # form, unchanged in spirit from the P1a note this replaces ("names
-    # the kind first" is no longer true at the top level, but the form
-    # still opens with one, defaulted, and still lets it be re-picked).
-    # Re-selecting anthropic explicitly keeps this test's actual
-    # invariant (an LLM-class form renders, with the Test button) robust
-    # to whatever kind happens to be _types' own default first entry.
+    # RETARGET (01a063ab, designer reconciliation): Register now lists
+    # the active class's KINDS directly (PC_RegisterDropdown), each
+    # annotated from the served _types data - picking "anthropic" opens
+    # the form with that kind already preselected, no in-form re-pick
+    # left. Anthropic is a discoverable kind (providers.py), so its form
+    # shows the Live-model-probe panel's own Test connect button
+    # (provider-probe-test) - the generic footer Test button
+    # (provider-form-test) only survives for classes with no probe panel.
     open_provider_catalog(page, console_url, cls="llm")
-    page.click('[data-testid="provider-register-all-toggle"]')
-    page.click('[data-testid="provider-register-type-llm"]')
+    page.click('[data-testid="provider-register-toggle"]')
+    page.click('[data-testid="provider-register-kind-anthropic"]')
     form = page.get_by_test_id("provider-form-llm_providers")
     form.wait_for(state="visible", timeout=15_000)
-    form.locator("#pf-provider").select_option(value="anthropic")
-    page.wait_for_selector('[data-testid="provider-form-test"]')
+    page.wait_for_selector('[data-testid="provider-probe-test"]')
 
 
 def test_the_catalog_is_reachable_from_the_sidebar(page, console_url) -> None:
@@ -64,18 +62,16 @@ def test_the_catalog_is_reachable_from_the_sidebar(page, console_url) -> None:
 
 
 def test_a_provider_row_can_be_created_and_deleted(page, console_url) -> None:
-    # RETARGET (IA restructure 01a04d6a): Register provider now names the
-    # TYPE ("stt"), not the kind directly - the kind ("openai") is
-    # re-picked inside the form, same mechanic as every other retargeted
-    # test in this pass. The card grid's own per-row footer button still
-    # replaces the old select-row-then-use-the-side-panel delete.
+    # RETARGET (01a063ab, designer reconciliation): Register now lists
+    # the active class's KINDS directly (PC_RegisterDropdown) - picking
+    # "openai" opens the form with that kind already preselected, no
+    # in-form re-pick left. The card grid's own per-row footer button
+    # still replaces the old select-row-then-use-the-side-panel delete.
     open_provider_catalog(page, console_url, cls="stt")
-    page.click('[data-testid="provider-register-all-toggle"]')
-    page.click('[data-testid="provider-register-type-stt"]')
+    page.click('[data-testid="provider-register-toggle"]')
+    page.click('[data-testid="provider-register-kind-openai"]')
     form_locator = page.get_by_test_id("provider-form-stt_providers")
     form_locator.wait_for(state="visible", timeout=15_000)
-    form_locator.locator("#pf-provider").select_option(value="openai")
-    page.wait_for_selector('[data-testid="provider-form-stt_providers"]')
     form = '[data-testid="provider-form-stt_providers"]'
     page.fill(f'{form} [data-field="id"] input', "journey-stt")
     # default_model is required on SpeechToTextProvider, so Save stays
@@ -87,5 +83,28 @@ def test_a_provider_row_can_be_created_and_deleted(page, console_url) -> None:
     page.fill(f'{form} [data-field="url"] input', "https://api.openai.com/v1")
     page.click('[data-testid="provider-form-save"]')
     page.wait_for_selector("text=journey-stt")
+
+    # Coverage (01a063ab): Open is now a text link on the card footer,
+    # not a button - reopening the SAME form/edit overlay confirms it
+    # still hands back the full row (editing=true), then Cancel returns
+    # to the grid without mutating anything.
+    page.click('[data-testid="provider-card-open-journey-stt"]')
+    form_locator.wait_for(state="visible", timeout=15_000)
+    page.click('[data-testid="provider-form-cancel"]')
+    form_locator.wait_for(state="hidden", timeout=15_000)
+
+    # Coverage (01a063ab): the header Filter input narrows the visible
+    # cards by name/kind, client-side, without touching the "N entities"
+    # count (that count reflects the class's real total, not the
+    # filtered subset - PC_InstanceGrid's own documented behavior).
+    count_before = page.get_by_test_id("provider-entity-count").inner_text()
+    page.fill('[data-testid="provider-filter"]', "no-such-provider-xyz")
+    page.wait_for_selector('[data-testid="provider-filter-empty-stt"]')
+    assert page.get_by_test_id("provider-card-journey-stt").count() == 0
+    assert page.get_by_test_id("provider-entity-count").inner_text() == count_before
+    page.fill('[data-testid="provider-filter"]', "journey-stt")
+    page.wait_for_selector('[data-testid="provider-card-journey-stt"]')
+    page.fill('[data-testid="provider-filter"]', "")
+
     page.click('[data-testid="provider-card-delete-journey-stt"]')
     page.click('[data-testid="provider-card-delete-confirm-journey-stt"]')

--- a/tests/ui_e2e/test_providers_create_anomaly_helpers.py
+++ b/tests/ui_e2e/test_providers_create_anomaly_helpers.py
@@ -39,16 +39,15 @@ def test_u0010_embedding_provider_modal_shows_t0025_static_models_helper(
     phrasing and the (T0025) tag are present so a future copy-edit can't
     silently drop the anomaly reference.
     """
-    # RETARGET (IA restructure 01a04d6a): "Register provider" now names
-    # the TYPE ("embedding"), not the kind directly - the kind ("openai")
-    # is re-picked inside the form, same mechanic every retargeted test
-    # in this file uses.
+    # RETARGET (01a063ab, designer reconciliation): Register now lists
+    # the active class's KINDS directly (PC_RegisterDropdown) - kind
+    # arrives preselected, there is no more in-form kind picker to
+    # re-pick it from.
     open_legacy_route(page, console_url, "providers/embedding")
-    page.get_by_test_id("provider-register-all-toggle").click()
-    page.get_by_test_id("provider-register-type-embedding").click()
+    page.get_by_test_id("provider-register-toggle").click()
+    page.get_by_test_id("provider-register-kind-openai").click()
     form = page.get_by_test_id("provider-form-embedding_providers")
     form.wait_for(state="visible", timeout=15_000)
-    form.locator("#pf-provider").select_option(value="openai")
     # The form root renders before /\_types resolves, so wait for the
     # field the helper hangs off before reading the text: a bare
     # inner_text() here reads an empty shell and reports the copy as
@@ -73,51 +72,17 @@ def test_u0010_embedding_provider_modal_shows_t0025_static_models_helper(
     )
 
 
-def test_u0011_llm_provider_modal_shows_t0379_cross_validation_warning(
-    page,
-    console_url: str,
-) -> None:
-    """U0011 — Opening the New LLM provider modal renders the documented
-    T0379 cross-validation warning ("Provider ↔ config alignment is NOT
-    cross-validated server-side (T0379) — make sure the vendor name
-    matches the config shape") somewhere in the modal body.
-
-    Sister of U0010. The T0379 warning lives alongside the provider
-    dropdown in PROVIDER_FIELDS so operators see it before submitting
-    a misaligned provider×config combo. Like U0010, no backend
-    precondition needed — text is unconditional UI copy.
-
-    Defence: if a future copy-edit drops the T0379 reference, this
-    test catches it before the anomaly drift propagates to operators.
-    """
-    # RETARGET (IA restructure 01a04d6a): same mechanic as U0010 above -
-    # Register provider names the TYPE, the kind is picked inside the
-    # form. The T0379 copy itself is unconditional create-mode text
-    # (provider-form.jsx's PC_ProviderForm), untouched by the restructure
-    # beyond moving alongside a new editing-mode variant - this assertion
-    # still targets the same string.
-    open_legacy_route(page, console_url, "providers/llm")
-    page.get_by_test_id("provider-register-all-toggle").click()
-    page.get_by_test_id("provider-register-type-llm").click()
-    form = page.get_by_test_id("provider-form-llm_providers")
-    form.wait_for(state="visible", timeout=15_000)
-    form.locator("#pf-provider").select_option(value="anthropic")
-
-    modal_text = form.inner_text()
-    assert "Provider" in modal_text and "config" in modal_text, (
-        "Expected T0379 cross-validation warning copy mentioning "
-        "'Provider ↔ config' alignment in the New LLM provider modal.\n"
-        f"Modal text was:\n{modal_text}"
-    )
-    assert "cross-validated" in modal_text or "cross-validation" in modal_text, (
-        "Expected T0379 helper text mentioning 'cross-validated' / "
-        "'cross-validation' in the modal body — copy drift?\n"
-        f"Modal text was:\n{modal_text}"
-    )
-    assert "T0379" in modal_text, (
-        "T0379 anomaly tag missing from the modal body — copy edit "
-        "dropped the anomaly reference?\nModal text was:\n" + modal_text
-    )
+## test_u0011_llm_provider_modal_shows_t0379_cross_validation_warning
+## retired (01a063ab, designer reconciliation): the T0379 warning existed
+## to flag a mismatch between a manually re-picked kind and the fields
+## shown for it. That mismatch class is now structurally impossible -
+## kind always arrives preselected from PC_RegisterDropdown (create) or
+## is the row's own real value (edit), with no in-form control left to
+## re-pick it from - so provider-form.jsx dropped both the kind <select>
+## and the warning it explained (see the "Designer reconciliation"
+## comment above PC_ProviderForm's `fields` block). Flagged in the PR
+## body per the task's own instruction; not replaced, since there is no
+## remaining surface for this anomaly to occupy.
 
 
 def test_provider_create_disabled_until_model_name_filled(
@@ -134,19 +99,18 @@ def test_provider_create_disabled_until_model_name_filled(
     ``body.models.0.name: Field required``. The fix requires every
     non-optional model field to be non-empty before enabling Create.
 
-    RETARGET (IA restructure 01a04d6a): "Register provider" now names
-    the TYPE ("embedding") up front instead of the kind directly - the
-    kind ("openai") is re-picked inside the form (same testids, same
-    gate logic once it renders).
+    RETARGET (01a063ab, designer reconciliation): Register now lists the
+    active class's KINDS directly (PC_RegisterDropdown) - kind arrives
+    preselected, so this opens straight on the openai embedding form
+    (same testids, same gate logic once it renders).
     """
     from playwright.sync_api import expect
 
     open_legacy_route(page, console_url, "providers/embedding")
-    page.get_by_test_id("provider-register-all-toggle").click()
-    page.get_by_test_id("provider-register-type-embedding").click()
+    page.get_by_test_id("provider-register-toggle").click()
+    page.get_by_test_id("provider-register-kind-openai").click()
     form = page.get_by_test_id("provider-form-embedding_providers")
     form.wait_for(state="visible", timeout=15_000)
-    form.locator("#pf-provider").select_option(value="openai")
 
     save_btn = form.get_by_test_id("provider-form-save")
     model_list = form.get_by_test_id("provider-form-model-list")

--- a/tests/ui_e2e/test_workspace_destroy_graph_provider.py
+++ b/tests/ui_e2e/test_workspace_destroy_graph_provider.py
@@ -23,6 +23,7 @@ from playwright.sync_api import expect
 
 from tests.ui_e2e._studio_helpers import (
     files_list,
+    open_provider_catalog,
     open_studio,
     open_workspace_settings,
     sessions_list,
@@ -36,7 +37,6 @@ from tests.ui_e2e._studio_helpers import (
 
 from tests._support.smk import smk  # noqa: E402
 from tests._support.model_profiles import agent_model, seed_llm_provider_with
-from tests.ui_e2e._shell_helpers import open_legacy_route
 pytestmark = smk("SMK-UI-06", status="partial")
 
 
@@ -246,22 +246,34 @@ def test_u0078_workspace_destroy_modal_cancel_does_not_delete(
 def test_u0091_llm_provider_invalidate_toasts_and_preserves_row(
     page, base_url, console_url, unique_suffix,
 ) -> None:
-    """U0091 — On LLM provider detail page, the Invalidate button
-    triggers POST /v1/llm_providers/{id}/invalidate. Success path
-    shows a toast (per providers.jsx: kind="info", title="Cache
-    dropped") and the row is still GET-able afterward (invalidate
-    drops the cached adapter, not the row).
+    """U0091 — Invalidate triggers POST /v1/llm_providers/{id}/invalidate.
+    Success path shows a toast (kind="info", title="Cache dropped") and
+    the row is still GET-able afterward (invalidate drops the cached
+    adapter, not the row).
+
+    RETARGET (01a063ab, designer reconciliation): Invalidate moved off
+    the card footer (mockup-pure Open/Delete only) into the edit
+    overlay, adjacent to the Live-model-probe panel
+    (PC_InvalidateAction, provider-form.jsx) - a deliberate
+    capability-preserving addition beyond the mockup, per the lead's
+    ruling. The direct ``providers/llm/{id}`` route only ever set
+    instanceId (used for the model-profiles panel on a crud class, not
+    an auto-opened edit form - confirmed unchanged on origin/main, a
+    pre-existing gap from the 01a04d6a IA restructure, not something
+    this task introduced), so it never actually reached an Invalidate
+    surface either before or after this change. Reaching it via the
+    card's own Open button is both the fix and the more realistic path.
     """
     pid = f"llm-91-{unique_suffix}"
     _seed_llm_provider(base_url, pid)
     cleanup_urls = [f"/v1/llm_providers/{pid}"]
     try:
-        open_legacy_route(page, console_url, f"providers/llm/{pid}")
+        open_provider_catalog(page, console_url, cls="llm")
+        page.click(f'[data-testid="provider-card-open-{pid}"]')
+        form = page.get_by_test_id("provider-form-llm_providers")
+        form.wait_for(state="visible", timeout=15_000)
 
-        # Wait for the Invalidate button.
-        inv = page.get_by_role(
-            "button", name="Invalidate", exact=True,
-        ).first
+        inv = form.get_by_test_id("provider-form-invalidate-action")
         inv.wait_for(state="visible", timeout=10_000)
         inv.click()
 

--- a/ui/components/provider-catalog.jsx
+++ b/ui/components/provider-catalog.jsx
@@ -38,29 +38,36 @@
 // third file to patch for this pass.
 // ============================================================================
 
+// Designer reconciliation (uiv2 "Primer Console.dc.html", implementer-
+// notes.md 3.2): order and labels now match the mockup's chip row
+// exactly (LLM, Embedding, TTS, ASR, Semantic search, Cross encoding,
+// Workspace, Web search, Web fetch, Channels, Artifact storage) - this
+// array is the single source both the chip row and the Register
+// dropdown draw from, so reordering it here reorders both. Keys are
+// untouched (backend-facing, unrelated to display order/labels).
 const PROVIDER_CLASSES = [
   { key: "llm", label: "LLM", plural: "llm_providers", form: "crud", profiles: true, invalidate: true },
   { key: "embedding", label: "Embedding", plural: "embedding_providers", form: "crud", invalidate: true },
-  { key: "cross_encoder", label: "Cross-Encoder", plural: "cross_encoder_providers", form: "crud", invalidate: true },
-  { key: "ssp", label: "Semantic Search", plural: "ssp", form: "panel",
+  { key: "tts", label: "TTS", plural: "tts_providers", form: "crud" },
+  { key: "stt", label: "ASR", plural: "stt_providers", form: "crud" },
+  { key: "ssp", label: "Semantic search", plural: "ssp", form: "panel",
     panel: () => window.SSPListPage,
     // Without a detail the catalog selected a store and then showed the
     // list again, so a vector store's own page was unreachable. It takes
     // its id as `sspId`, hence detailProp.
     detail: () => window.SSPDetail, detailProp: "sspId" },
-  { key: "stt", label: "Speech-to-Text", plural: "stt_providers", form: "crud" },
-  { key: "tts", label: "Text-to-Speech", plural: "tts_providers", form: "crud" },
-  { key: "web_search", label: "Web Search", plural: "web_search_providers", form: "crud" },
-  { key: "web_fetch", label: "Web Fetch", plural: "web_fetch_providers", form: "crud" },
-  { key: "artifact_storage", label: "Artifact Storage", plural: "artifact_storage_providers", form: "crud" },
-  { key: "workspace", label: "Workspaces", plural: "workspace_providers", form: "panel",
+  { key: "cross_encoder", label: "Cross encoding", plural: "cross_encoder_providers", form: "crud", invalidate: true },
+  { key: "workspace", label: "Workspace", plural: "workspace_providers", form: "panel",
     panel: () => window.WorkspaceProvidersPage,
     detail: () => window.WorkspaceProviderDetail },
+  { key: "web_search", label: "Web search", plural: "web_search_providers", form: "crud" },
+  { key: "web_fetch", label: "Web fetch", plural: "web_fetch_providers", form: "crud" },
   { key: "channel", label: "Channels", plural: "channel_providers", form: "panel",
     panel: () => window.ChannelProvidersPage,
     // A panel class can still have a detail view; without one the
     // catalog can select an instance and then show the list again.
     detail: () => window.ChannelProviderDetail },
+  { key: "artifact_storage", label: "Artifact storage", plural: "artifact_storage_providers", form: "crud" },
 ];
 
 // IA restructure 01a04d6a: "All" is a synthetic, non-fetchable pseudo-
@@ -70,23 +77,6 @@ const PROVIDER_CLASSES = [
 // real backend-class registry every other lookup (Register dropdown,
 // per-card labels, plural/form lookups) keys off unmodified.
 const PC_ALL_TYPE_CHIPS = [{ key: "all", label: "All" }, ...PROVIDER_CLASSES];
-
-// One glyph per provider class, same 12x12 stroke language as the
-// platform nav (ui-ux pass 2026-08-26: the rail was bare text links).
-const PC_CLASS_ICONS = {
-  all: "M2.5 2.5h3.5v3.5H2.5Z M8 2.5h3.5v3.5H8Z M2.5 8h3.5v3.5H2.5Z M8 8h3.5v3.5H8Z",
-  llm: "M2 4.5 7 2l5 2.5-5 2.5Z M2 7l5 2.5L12 7 M2 9.5 7 12l5-2.5",
-  embedding: "M2 10h2.2V6.5H2Z M5.4 10h2.2V3H5.4Z M8.8 10H11V5H8.8Z M2 12h9",
-  cross_encoder: "M2 3.5h6.5 M5.5 7h6.5 M2 10.5h6.5 M10 2l2 1.5-2 1.5 M4 5.5 2 7l2 1.5 M10 9l2 1.5-2 1.5",
-  ssp: "M2 3.5a5 1.8 0 0 0 10 0 5 1.8 0 0 0-10 0Z M2 3.5v7a5 1.8 0 0 0 10 0v-7 M2 7a5 1.8 0 0 0 10 0",
-  stt: "M5 1.5h4v5.5a2 2 0 0 1-4 0Z M2.8 6a4.2 4.2 0 0 0 8.4 0 M7 10.2V13",
-  tts: "M2 5h2.3L8 2.2v9.6L4.3 9H2Z M9.8 4.6a3.4 3.4 0 0 1 0 4.8",
-  web_search: "M5.8 1.5a4.3 4.3 0 1 0 0 8.6 4.3 4.3 0 0 0 0-8.6Z M9 9l3.5 3.5",
-  web_fetch: "M7 1.5a5.5 5.5 0 1 0 0 11 5.5 5.5 0 0 0 0-11Z M1.5 7h11 M7 1.5c2.2 2.6 2.2 8.4 0 11",
-  artifact: "M2 4.5 7 2l5 2.5v5L7 12 2 9.5Z M2 4.5 7 7l5-2.5 M7 7v5",
-  workspaces: "M1.5 3.5h4l1 1.5h6V11h-11Z",
-  channel: "M2 2.5h10v7H6L3 12V9.5H2Z",
-};
 
 // Platform wave P1a item 1: the family rail becomes a CHIPS row (reuses the
 // app's own .chip-group/.chip pattern, already proven elsewhere - e.g. the
@@ -99,6 +89,11 @@ const PC_CLASS_ICONS = {
 // "All" entry prepended by the caller (PC_ALL_TYPE_CHIPS below); this
 // component itself stays a plain, presentational chip row with no
 // opinion about what "All" means.
+// Designer reconciliation: compact rounded PILLS, no icons - a single
+// row of .pc-chips overrides (styles.css) rather than the app's default
+// segmented-control .chip-group look, since the two read as visually
+// distinct families (a bordered container of tightly-packed tabs vs.
+// individually-outlined, gapped pills).
 function PC_TypeFilter({ classes, selected, onSelect }) {
   return (
     <div className="chip-group pc-chips" role="tablist"
@@ -119,12 +114,7 @@ function PC_TypeFilter({ classes, selected, onSelect }) {
             }
           }}
         >
-          <svg width="12" height="12" viewBox="0 0 14 14" fill="none"
-            stroke="currentColor" strokeWidth="1.2" strokeLinejoin="round"
-            aria-hidden="true">
-            <path d={PC_CLASS_ICONS[cls.key] || PC_CLASS_ICONS.llm} />
-          </svg>
-          <span>{cls.label}</span>
+          {cls.label}
         </span>
       ))}
     </div>
@@ -237,29 +227,30 @@ function PC_RegisterAll({ onPick }) {
 function PC_ReachabilityBadge({ lastProbeAt, lastProbeOk }) {
   if (lastProbeAt == null) return null;
   const ok = !!lastProbeOk;
-  const color = ok ? "var(--green)" : "var(--red)";
+  // Designer reconciliation: plain colored TEXT, no pill background/dot.
   return (
-    <span className="pill" data-testid="provider-card-reachability"
-      style={{ color, borderColor: "var(--border)", background: "var(--bg-2)" }}>
-      <span className="dot" style={{ background: color }}></span>
+    <span className={`pc-card-status ${ok ? "ok" : "down"}`}
+      data-testid="provider-card-reachability">
       {ok ? "reachable" : "unreachable"}
     </span>
   );
 }
 
-// The three actions a card's footer offers: Open (address the instance),
-// Invalidate (only where the endpoint exists - the model-family registry
-// caches an adapter per row id, api/registries/provider_registry.py; the
-// sibling registries drop their entry on the CRUD hook and need no button),
-// Delete (confirm-gated). Reference anatomy is Open+Delete only; Invalidate
-// is real, tested, currently-shipped functionality for three classes, kept
-// as a third small action rather than silently dropped to match a mockup
-// that likely never modeled cache invalidation at all.
-function PC_InstanceCard({ klass, row, onOpen, onChanged }) {
+// Designer reconciliation: the card footer is mockup-pure now - Open (a
+// text link) and Delete (muted text) only. Invalidate is real, tested,
+// currently-shipped functionality (the model-family registry caches an
+// adapter per row id, api/registries/provider_registry.py; the sibling
+// registries drop their entry on the CRUD hook and need no button) - it
+// did NOT get dropped, it moved into the provider edit overlay next to
+// the Live-model-probe panel (that panel's own Test connect probes the
+// DRAFT config, never the stored cache, so this stays a genuinely
+// distinct action - see PC_ProbePanel's own comment). A capability-
+// preserving addition beyond the mockup, per lead ruling.
+function PC_InstanceCard({ klass, row, onOpen, onChanged, profileCount }) {
   const { apiFetch, useResource } = window.primerApi;
   const [confirmDelete, setConfirmDelete] = React.useState(false);
   const [err, setErr] = React.useState("");
-  const [busy, setBusy] = React.useState("");
+  const [busy, setBusy] = React.useState(false);
   const encoded = encodeURIComponent(row.id);
 
   // Wave P1a item 3 / CI fix: "models N probed live". Two real gates,
@@ -287,32 +278,63 @@ function PC_InstanceCard({ klass, row, onOpen, onChanged }) {
     ? discovered.data.models.length
     : null;
 
-  const run = async (what, method, path) => {
+  const remove = async () => {
     setErr("");
-    setBusy(what);
+    setBusy(true);
     try {
-      await apiFetch(method, path);
+      await apiFetch("DELETE", `/${klass.plural}/${encoded}`);
       setConfirmDelete(false);
-      const toast = window.primerApi && window.primerApi.toastPush;
-      if (what === "invalidate" && typeof toast === "function") {
-        toast({ kind: "success", title: "Cache dropped", detail: row.id });
-      }
-      if (onChanged) onChanged(what);
-    } catch (err) {
+      if (onChanged) onChanged("delete");
+    } catch (deleteErr) {
       // 403 means a reserved row; the backend detail says which and why
       // (routers/providers.py:116-135). Show it where the click was
       // rather than hiding the button behind a copied id list.
-      const detail = err && err.detail ? err.detail : null;
-      const message =
-        (detail && (detail.message || detail)) || (err && err.title) || String(err);
-      setErr(err && err.status ? `${err.status}: ${message}` : String(message));
+      const detail = deleteErr && deleteErr.detail ? deleteErr.detail : null;
+      const message = (detail && (detail.message || detail))
+        || (deleteErr && deleteErr.title) || String(deleteErr);
+      setErr(deleteErr && deleteErr.status ? `${deleteErr.status}: ${message}` : String(message));
     } finally {
-      setBusy("");
+      setBusy(false);
     }
   };
 
   const virgin = row.last_probe_at == null;
   const unreachable = !virgin && !row.last_probe_ok;
+
+  // Designer reconciliation: the fact SET itself differs by reachability
+  // (matching the mockup's own reachable vs. unreachable examples
+  // exactly), not a single combined list every card shows a subset of -
+  // a reachable row's operationally useful facts (how much it serves,
+  // what depends on it, whether a key is set) are different questions
+  // than an unreachable row's (why, and since when). Every row maps to
+  // a REAL served field; "failover" from the mockup's unreachable
+  // example has NO backend counterpart on a plain LLMProvider (it only
+  // exists inside an aggregated row's own config - primer/model/
+  // providers/llm.py's AggregatedLLMConfig), so it is not rendered here
+  // at all rather than invented - flagged in the PR body.
+  const facts = [];
+  if (!unreachable) {
+    if (modelCount != null) {
+      facts.push({ key: "models", value: `${modelCount} probed live` });
+    }
+    if (klass.profiles && profileCount != null) {
+      facts.push({
+        key: "default for",
+        value: `${profileCount} profile${profileCount === 1 ? "" : "s"}`,
+      });
+    }
+    if (row.config && row.config.api_key) {
+      facts.push({ key: "key", value: row.config.api_key, mono: true });
+    }
+  } else {
+    if (row.last_error) {
+      facts.push({ key: "error", value: row.last_error, mono: true, danger: true });
+    }
+    facts.push({
+      key: "last probe",
+      value: relativeTime((Date.now() - new Date(row.last_probe_at).getTime()) / 1000),
+    });
+  }
 
   return (
     <div className="pc-card" data-testid={`provider-card-${row.id}`}>
@@ -324,55 +346,45 @@ function PC_InstanceCard({ klass, row, onOpen, onChanged }) {
       <div className="pc-card-subtitle">
         {[row.provider, row.config && row.config.url].filter(Boolean).join(" · ")}
       </div>
-      <div className="pc-card-facts">
-        {modelCount != null ? (
-          <div className="pc-card-fact">
-            <span className="muted">models</span>
-            <span>{modelCount} probed live</span>
-          </div>
-        ) : null}
-        {!virgin ? (
-          <div className="pc-card-fact">
-            <span className="muted">last probed</span>
-            <span>{relativeTime((Date.now() - new Date(row.last_probe_at).getTime()) / 1000)}</span>
-          </div>
-        ) : null}
-        {unreachable && row.last_error ? (
-          <div className="pc-card-fact" data-testid={`provider-card-probe-error-${row.id}`}>
-            <span className="muted">error</span>
-            <span className="mono text-sm" style={{ color: "var(--red)" }}>{row.last_error}</span>
-          </div>
-        ) : null}
-      </div>
+      {facts.length ? (
+        <div className="pc-card-facts">
+          {facts.map((f) => (
+            <div className="pc-card-fact" key={f.key}
+              data-testid={f.key === "error" ? `provider-card-probe-error-${row.id}` : undefined}>
+              <span className="muted">{f.key}</span>
+              <span className={f.mono ? "mono text-sm" : ""}
+                style={f.danger ? { color: "var(--red)" } : undefined}>
+                {f.value}
+              </span>
+            </div>
+          ))}
+        </div>
+      ) : null}
       <div className="pc-card-footer">
-        <Btn kind="primary" size="sm" data-testid={`provider-card-open-${row.id}`}
+        <button type="button" className="pc-card-open"
+          data-testid={`provider-card-open-${row.id}`}
           onClick={() => onOpen(row)}>
           Open
-        </Btn>
+        </button>
         <span style={{ flex: 1 }} />
-        {klass.invalidate ? (
-          <Btn kind="ghost" size="sm" disabled={busy !== ""}
-            data-testid={`provider-card-invalidate-${row.id}`}
-            onClick={() => run("invalidate", "POST", `/${klass.plural}/${encoded}/invalidate`)}>
-            Invalidate
-          </Btn>
-        ) : null}
         {confirmDelete ? (
-          <>
-            <Btn kind="danger" size="sm" disabled={busy !== ""}
+          <React.Fragment>
+            <button type="button" className="pc-card-delete-confirm" disabled={busy}
               data-testid={`provider-card-delete-confirm-${row.id}`}
-              onClick={() => run("delete", "DELETE", `/${klass.plural}/${encoded}`)}>
+              onClick={remove}>
               Confirm
-            </Btn>
-            <Btn kind="ghost" size="sm" onClick={() => setConfirmDelete(false)}>
+            </button>
+            <button type="button" className="pc-card-delete"
+              onClick={() => setConfirmDelete(false)}>
               Cancel
-            </Btn>
-          </>
+            </button>
+          </React.Fragment>
         ) : (
-          <Btn kind="ghost" size="sm" data-testid={`provider-card-delete-${row.id}`}
+          <button type="button" className="pc-card-delete"
+            data-testid={`provider-card-delete-${row.id}`}
             onClick={() => { setErr(""); setConfirmDelete(true); }}>
             Delete
-          </Btn>
+          </button>
         )}
       </div>
       {err ? (
@@ -382,7 +394,49 @@ function PC_InstanceCard({ klass, row, onOpen, onChanged }) {
   );
 }
 
-function PC_InstanceGrid({ klass, onSelect, onRegisterRefetch }) {
+// Designer reconciliation: "default for N profiles" - one combined
+// fetch grouped client-side by provider_id, same shape PC_ProfilesPanel
+// already uses below (no server-side provider_id filter is wired for
+// this list route - POST /model_profiles/find takes a Predicate and
+// COULD do this server-side, unused here only to match the existing
+// pattern). `enabled=false` (any class but LLM) skips the fetch
+// entirely rather than running it and discarding the result.
+function PC_useProfileCounts(enabled) {
+  const { useResource, apiFetch } = window.primerApi;
+  const profiles = useResource(
+    "pc:profile-counts",
+    (signal) => enabled
+      ? apiFetch("GET", "/model_profiles?limit=200", null, { signal })
+      : Promise.resolve({ items: [] }),
+    { pollMs: null },
+  );
+  return React.useMemo(() => {
+    const map = {};
+    ((profiles.data && profiles.data.items) || []).forEach((p) => {
+      map[p.provider_id] = (map[p.provider_id] || 0) + 1;
+    });
+    return map;
+  }, [profiles.data]);
+}
+
+// Designer reconciliation: client-side substring filter over name (id)
+// and kind (provider) - "over the visible cards" per the mockup spec,
+// so it narrows THIS page's already-fetched rows rather than issuing a
+// new server query; a filter that hides every row on the current page
+// while matches exist on another page is a known, accepted limit of
+// that scope (Pager itself is untouched by it - it reflects the real
+// server-side list, not the filtered view).
+function PC_filterRows(items, filterQuery) {
+  const q = (filterQuery || "").trim().toLowerCase();
+  if (!q) return items;
+  return items.filter((row) => {
+    const name = String(row.id || "").toLowerCase();
+    const kind = String(row.provider || "").toLowerCase();
+    return name.indexOf(q) >= 0 || kind.indexOf(q) >= 0;
+  });
+}
+
+function PC_InstanceGrid({ klass, onSelect, onRegisterRefetch, filterQuery, onCountChange }) {
   const { usePagedList } = window.primerApi;
   const list = usePagedList({
     key: `catalog:${klass.plural}`,
@@ -399,6 +453,15 @@ function PC_InstanceGrid({ klass, onSelect, onRegisterRefetch }) {
     if (onRegisterRefetch) onRegisterRefetch(() => list.refetch());
   }, [onRegisterRefetch, list.refetch]);
 
+  const items = list.items || [];
+  // The header's "N entities" count - this class's own list, unaffected
+  // by the filter narrowing what's actually drawn below.
+  React.useEffect(() => {
+    if (onCountChange) onCountChange(items.length);
+  }, [items.length, onCountChange]);
+
+  const profileCounts = PC_useProfileCounts(!!klass.profiles);
+
   if (list.error) {
     return (
       <Banner
@@ -408,7 +471,6 @@ function PC_InstanceGrid({ klass, onSelect, onRegisterRefetch }) {
       />
     );
   }
-  const items = list.items || [];
   if (!list.loading && items.length === 0) {
     return (
       <div className="empty-state" data-testid={`provider-empty-${klass.key}`}>
@@ -418,22 +480,31 @@ function PC_InstanceGrid({ klass, onSelect, onRegisterRefetch }) {
     );
   }
 
+  const filtered = PC_filterRows(items, filterQuery);
+
   return (
     <div data-testid={`provider-instances-${klass.key}`} style={{ minWidth: 0, flex: "1 1 0" }}>
-      <div className="pc-card-grid">
-        {items.map((row) => (
-          <PC_InstanceCard
-            key={row.id}
-            klass={klass}
-            row={row}
-            onOpen={onSelect}
-            onChanged={(what) => {
-              list.refetch();
-              if (what === "delete" && onSelect) onSelect(null);
-            }}
-          />
-        ))}
-      </div>
+      {filtered.length === 0 ? (
+        <div className="empty-state" data-testid={`provider-filter-empty-${klass.key}`}>
+          <p>No providers match "{filterQuery}".</p>
+        </div>
+      ) : (
+        <div className="pc-card-grid">
+          {filtered.map((row) => (
+            <PC_InstanceCard
+              key={row.id}
+              klass={klass}
+              row={row}
+              profileCount={profileCounts[row.id]}
+              onOpen={onSelect}
+              onChanged={(what) => {
+                list.refetch();
+                if (what === "delete" && onSelect) onSelect(null);
+              }}
+            />
+          ))}
+        </div>
+      )}
       <Pager pager={list} label="providers" />
     </div>
   );
@@ -449,7 +520,7 @@ function PC_InstanceGrid({ klass, onSelect, onRegisterRefetch }) {
 // pair with real, class-specific actions (reindex, channel rules, ...) a
 // generic card would either omit or fake; reachable via their own type
 // filter chip instead, unchanged from before this restructure.
-function PC_AllInstancesGrid({ onSelect, reloadKey }) {
+function PC_AllInstancesGrid({ onSelect, reloadKey, filterQuery, onCountChange }) {
   const { apiFetch, useResource } = window.primerApi;
   const crudClasses = PROVIDER_CLASSES.filter((c) => c.form === "crud");
   const all = useResource(
@@ -468,6 +539,11 @@ function PC_AllInstancesGrid({ onSelect, reloadKey }) {
     { pollMs: 15000 },
   );
   const rows = (all.data && all.data.rows) || [];
+  const profileCounts = PC_useProfileCounts(true);
+
+  React.useEffect(() => {
+    if (onCountChange) onCountChange(rows.length);
+  }, [rows.length, onCountChange]);
 
   if (all.error) {
     return (
@@ -485,22 +561,34 @@ function PC_AllInstancesGrid({ onSelect, reloadKey }) {
     );
   }
 
+  const q = (filterQuery || "").trim().toLowerCase();
+  const filtered = q
+    ? rows.filter(({ row }) => PC_filterRows([row], filterQuery).length > 0)
+    : rows;
+
   return (
     <div data-testid="provider-instances-all" style={{ minWidth: 0, flex: "1 1 0" }}>
-      <div className="pc-card-grid">
-        {rows.map(({ klass, row }) => (
-          <div key={`${klass.key}:${row.id}`} className="pc-card-wrap">
-            <span className="pc-card-type-label"
-              data-testid={`provider-card-type-${row.id}`}>{klass.label}</span>
-            <PC_InstanceCard
-              klass={klass}
-              row={row}
-              onOpen={() => onSelect(klass, row)}
-              onChanged={() => all.refetch()}
-            />
-          </div>
-        ))}
-      </div>
+      {filtered.length === 0 ? (
+        <div className="empty-state" data-testid="provider-filter-empty-all">
+          <p>No providers match "{filterQuery}".</p>
+        </div>
+      ) : (
+        <div className="pc-card-grid">
+          {filtered.map(({ klass, row }) => (
+            <div key={`${klass.key}:${row.id}`} className="pc-card-wrap">
+              <span className="pc-card-type-label"
+                data-testid={`provider-card-type-${row.id}`}>{klass.label}</span>
+              <PC_InstanceCard
+                klass={klass}
+                row={row}
+                profileCount={klass.profiles ? profileCounts[row.id] : null}
+                onOpen={() => onSelect(klass, row)}
+                onChanged={() => all.refetch()}
+              />
+            </div>
+          ))}
+        </div>
+      )}
     </div>
   );
 }
@@ -748,10 +836,23 @@ function PC_ActiveWebSearchPanel() {
 }
 
 function ProviderCatalog({ initialClass, initialInstanceId, onNavigate }) {
-  // IA restructure 01a04d6a: "all" is the default - the user directive's
-  // "ONE page, all types together" - not the first real class.
-  const [classKey, setClassKey] = React.useState(initialClass || "all");
+  // Designer reconciliation (uiv2 mockup, supersedes IA restructure
+  // 01a04d6a's "all is the default" directive per the user's own
+  // ratified exhibit): LLM is the default selection, not the merged
+  // "All" grid. isAll/PC_AllInstancesGrid/PC_RegisterAll below are ALL
+  // still fully intact, just unreached from the chip row now that "All"
+  // is not one of its entries - restoring that view is a one-line
+  // PC_TypeFilter classes={PC_ALL_TYPE_CHIPS} swap below, not a rewrite.
+  const [classKey, setClassKey] = React.useState(initialClass || "llm");
   const [instanceId, setInstanceId] = React.useState(initialInstanceId || null);
+  // Header row: entity count (of the current class's own list, not the
+  // filter-narrowed count - a stable "how many exist" stat beside a
+  // separate "narrow what's visible" control) and the client-side
+  // substring filter itself, both threaded down to whichever grid is
+  // showing (PC_InstanceGrid today; PC_AllInstancesGrid if "All" is ever
+  // restored - both accept the same two props).
+  const [entityCount, setEntityCount] = React.useState(0);
+  const [filterQuery, setFilterQuery] = React.useState("");
   // The addressed instance wins. This was seeded once and never looked at
   // again, so a page inside the catalog that navigates on its own -- the
   // vector-store list does, to /ssp/<id> -- updated the url and the crumb
@@ -785,6 +886,10 @@ function ProviderCatalog({ initialClass, initialInstanceId, onNavigate }) {
   const selectClass = (key) => {
     setClassKey(key);
     setInstanceId(null);
+    // A filter narrowing THIS type's cards has no meaning once the type
+    // itself changes - carrying it over would silently hide cards in
+    // the new type with no visible reason why.
+    setFilterQuery("");
     if (typeof onNavigate === "function") {
       onNavigate({ kind: "provider-class", classKey: key });
     }
@@ -810,6 +915,18 @@ function ProviderCatalog({ initialClass, initialInstanceId, onNavigate }) {
     setFormKlass(k);
     setEditingRow(null);
     setDraft({});
+    setFormOpen(true);
+  }
+
+  // Designer reconciliation: with a type always selected, Register lists
+  // that type's KINDS directly (PC_RegisterDropdown) rather than naming
+  // the type again - picking a kind opens the SAME create modal above,
+  // just pre-seeded with `provider` so the in-form kind picker (now
+  // removed per exhibit 2) is never needed at all, for create or edit.
+  function openCreateWithKind(k, kind) {
+    setFormKlass(k);
+    setEditingRow(null);
+    setDraft({ provider: kind });
     setFormOpen(true);
   }
 
@@ -875,7 +992,8 @@ function ProviderCatalog({ initialClass, initialInstanceId, onNavigate }) {
   let body;
   if (isAll) {
     body = (
-      <PC_AllInstancesGrid onSelect={openEdit} reloadKey={reloadKey} />
+      <PC_AllInstancesGrid onSelect={openEdit} reloadKey={reloadKey}
+        filterQuery={filterQuery} onCountChange={setEntityCount} />
     );
   } else if (cls.form === "panel") {
     const Detail = instanceId && cls.detail ? cls.detail() : null;
@@ -916,6 +1034,8 @@ function ProviderCatalog({ initialClass, initialInstanceId, onNavigate }) {
           openEdit(cls, row);
         }}
         onRegisterRefetch={(fn) => { listRefetchRef.current = fn; }}
+        filterQuery={filterQuery}
+        onCountChange={setEntityCount}
       />
     );
   }
@@ -924,11 +1044,30 @@ function ProviderCatalog({ initialClass, initialInstanceId, onNavigate }) {
     <div className="col pc-catalog" style={{ gap: 16 }}>
       <div className="row" style={{ alignItems: "center", gap: 16, flexWrap: "wrap" }}>
         <h2 className="text-lg" style={{ margin: 0 }}>Providers</h2>
+        <span className="muted text-sm" data-testid="provider-entity-count">
+          {entityCount} {entityCount === 1 ? "entity" : "entities"}
+        </span>
         <span style={{ flex: 1 }} />
-        <PC_RegisterAll onPick={openCreate} />
+        <input
+          type="text"
+          className="input"
+          placeholder="Filter…"
+          value={filterQuery}
+          onChange={(e) => setFilterQuery(e.target.value)}
+          data-testid="provider-filter"
+        />
+        {/* Designer reconciliation: a type is always selected now, so
+            Register lists that type's KINDS (PC_RegisterDropdown) - the
+            type-listing PC_RegisterAll stays reachable for the "All"
+            path if that view is ever restored (isAll above). */}
+        {klass ? (
+          <PC_RegisterDropdown klass={klass} onPick={(kind) => openCreateWithKind(klass, kind)} />
+        ) : (
+          <PC_RegisterAll onPick={openCreate} />
+        )}
       </div>
       <PC_TypeFilter
-        classes={PC_ALL_TYPE_CHIPS}
+        classes={PROVIDER_CLASSES}
         selected={classKey}
         onSelect={selectClass}
       />
@@ -944,13 +1083,25 @@ function ProviderCatalog({ initialClass, initialInstanceId, onNavigate }) {
       {formOpen ? (
         <Modal
           width={720}
-          title={`${editingRow ? "Edit" : "New"} ${formKlass.label} provider`}
+          // Designer reconciliation: title is now "{name} — {kind}" once
+          // an id exists (edit) or "New {type} provider — {kind}" before
+          // it does (create) - the schema badge moves INLINE beside it
+          // (Modal renders `title` as-is inside its own title span, so a
+          // fragment here works with no change to the shared component)
+          // rather than as a separate line inside the form body below.
+          title={(
+            <React.Fragment>
+              {editingRow
+                ? `${editingRow.id} — ${draft.provider || formKlass.key}`
+                : `New ${formKlass.key} provider — ${draft.provider || ""}`}
+              <span className="pc-modal-chip-inline mono text-sm muted"
+                data-testid="provider-modal-schema-chip">
+                schema-driven from /providers/_types
+              </span>
+            </React.Fragment>
+          )}
           onClose={closeForm}
         >
-          <div className="pc-modal-chip mono text-sm muted"
-            data-testid="provider-modal-schema-chip">
-            schema-driven from /providers/_types
-          </div>
           <window.PC_ProviderForm
             plural={formKlass.plural}
             typesPath={`/${formKlass.plural}/_types`}
@@ -959,6 +1110,8 @@ function ProviderCatalog({ initialClass, initialInstanceId, onNavigate }) {
             onSubmit={save}
             onCancel={closeForm}
             editing={!!editingRow}
+            existingId={editingRow ? editingRow.id : null}
+            canInvalidate={!!formKlass.invalidate}
           />
         </Modal>
       ) : null}

--- a/ui/components/provider-catalog.jsx
+++ b/ui/components/provider-catalog.jsx
@@ -1059,8 +1059,19 @@ function ProviderCatalog({ initialClass, initialInstanceId, onNavigate }) {
         {/* Designer reconciliation: a type is always selected now, so
             Register lists that type's KINDS (PC_RegisterDropdown) - the
             type-listing PC_RegisterAll stays reachable for the "All"
-            path if that view is ever restored (isAll above). */}
-        {klass ? (
+            path if that view is ever restored (isAll above).
+            BUGFIX: a panel class (ssp/workspace/channel) has no generic
+            form to open - openCreateWithKind unconditionally opened
+            PC_ProviderForm regardless of class.form, which for these
+            three opened the WRONG modal on top of their own native
+            create affordance (test_ssp_lance_create_journey caught
+            this live: picking pgvector from the header dropdown opened
+            the generic provider form instead of routing to SSP's own
+            semantic-search.jsx modal). Same guard openCreate() already
+            has for PC_RegisterAll - the panel's own body is the only
+            register affordance for these three, so the header renders
+            nothing rather than a dropdown that opens the wrong thing. */}
+        {klass && klass.form === "panel" ? null : klass ? (
           <PC_RegisterDropdown klass={klass} onPick={(kind) => openCreateWithKind(klass, kind)} />
         ) : (
           <PC_RegisterAll onPick={openCreate} />

--- a/ui/components/provider-form.jsx
+++ b/ui/components/provider-form.jsx
@@ -31,6 +31,20 @@ function PC_fieldType(name) {
   return PC_FIELD_TYPES[name] || "text";
 }
 
+// Designer reconciliation: "no raw snake_case labels where a human name
+// is obvious" - the model-family classes' own /_types response already
+// serves real labels ("Base URL", "API key (optional)", ...primer/api/
+// routers/providers.py's _form_field calls), left untouched below; this
+// is the fallback for the bare-string classes (web_search, web_fetch,
+// speech - see the comment on PC_normalizeField) whose served "label" IS
+// just the raw key, which PC_normalizeField's old `field.label || field.
+// key` fallback rendered verbatim.
+function PC_humanizeKey(key) {
+  return String(key || "")
+    .replace(/_/g, " ")
+    .replace(/\b\w/g, (c) => c.toUpperCase());
+}
+
 // _types answers in two shapes. web_search, web_fetch and the speech
 // classes serve bare field NAMES (routers/web_search.py:216-222); the
 // model-family classes serve DESCRIPTORS (routers/providers.py
@@ -39,7 +53,7 @@ function PC_normalizeField(field) {
   if (typeof field === "string") {
     return {
       key: field,
-      label: field,
+      label: PC_humanizeKey(field),
       type: PC_fieldType(field),
       required: false,
       help: "",
@@ -49,7 +63,7 @@ function PC_normalizeField(field) {
   }
   return {
     key: field.key,
-    label: field.label || field.key,
+    label: field.label || PC_humanizeKey(field.key),
     type: field.type || PC_fieldType(field.key),
     required: !!field.required,
     help: field.help || "",
@@ -134,14 +148,18 @@ function PC_Field({ field, value, onChange, disabled }) {
   // Platform wave P1a item 4: secret fields (api_key/token/password/
   // secret_access_key - PC_fieldType above) get the reference's own label
   // pattern rather than an unlabeled password box. The value itself is
-  // whatever the operator types (a plain password input) - see PC_Field's
-  // caller comment for why there is no masked-tail DISPLAY here.
+  // whatever is in `draft` already - on edit that is the served MASK
+  // STRING verbatim (see the input's own comment above), so a masked
+  // secret renders as "**********xxxx"-shaped text with no extra code
+  // here: the mask IS the value, displayed the same as any other field.
   const isSecret = field.type === "password";
   return (
-    <label className="field" data-field={field.key} data-locked={disabled ? "true" : "false"}>
-      <span>
-        {field.label}
-        {isSecret ? " secret — masked on read" : ""}
+    <label className="field pc-field" data-field={field.key} data-locked={disabled ? "true" : "false"}>
+      <span className="pc-field-label">
+        <span className="pc-field-label-main">{field.label}</span>
+        {isSecret ? (
+          <span className="pc-field-label-annotation muted">secret — masked on read</span>
+        ) : null}
         {field.required ? <em className="req"> *</em> : null}
       </span>
       {input}
@@ -191,24 +209,31 @@ function PC_ProbePanel({ plural, draft, selectedType }) {
 
   return (
     <div className="pc-probe" data-testid="provider-probe-panel">
-      <div className="pc-probe-head">Live model probe</div>
-      <Btn kind="primary" size="sm" disabled={busy}
-        data-testid="provider-probe-test" onClick={probe}>
-        Test connect
-      </Btn>
+      {/* Designer reconciliation: heading + compact green-outline Test
+          connect on ONE row - kind="ghost" (transparent bg + border,
+          the closest existing Btn variant to "outline") plus a scoped
+          CSS override for the green tint, rather than a new Btn kind
+          just for this one button. */}
+      <div className="pc-probe-head-row">
+        <div className="pc-probe-head">Live model probe</div>
+        <Btn kind="ghost" size="sm" disabled={busy}
+          data-testid="provider-probe-test" onClick={probe}>
+          Test connect
+        </Btn>
+      </div>
       {result ? (
         result.ok ? (
           <div className="pc-probe-result" data-testid="provider-probe-result">
             <div className="pc-probe-count">
               {models.length} models · probed on the DRAFT config
             </div>
-            <ul className="pc-probe-models">
+            <div className="pc-probe-models">
               {shown.map((m, i) => (
-                <li key={i} className="mono">{(m && m.name) || m}</li>
+                <div key={i} className="pc-probe-model-row mono">{(m && m.name) || m}</div>
               ))}
-            </ul>
+            </div>
             {overflow > 0 ? (
-              <div className="muted text-sm">+ {overflow} more</div>
+              <div className="pc-probe-model-row muted text-sm">+ {overflow} more</div>
             ) : null}
           </div>
         ) : (
@@ -216,6 +241,49 @@ function PC_ProbePanel({ plural, draft, selectedType }) {
             {result.error}
           </div>
         )
+      ) : null}
+    </div>
+  );
+}
+
+// Lead ruling (designer reconciliation, Invalidate stop-and-flag): the
+// card footer drops Invalidate to match the mockup exactly, but the
+// capability itself is real and stays reachable - moved here, beside
+// the panel above, as a deliberate capability-preserving addition the
+// mockup itself doesn't show. Genuinely distinct from Test connect: that
+// probes the DRAFT config pre-save, this drops the STORED adapter cache
+// for the row that already exists (api/registries/provider_registry.py)
+// - edit-mode only (nothing to invalidate before Save has ever run).
+function PC_InvalidateAction({ plural, existingId }) {
+  const { apiFetch } = window.primerApi;
+  const [busy, setBusy] = React.useState(false);
+  const [err, setErr] = React.useState("");
+
+  const run = async () => {
+    setErr("");
+    setBusy(true);
+    try {
+      await apiFetch("POST", `/${plural}/${encodeURIComponent(existingId)}/invalidate`);
+      const toast = window.primerApi && window.primerApi.toastPush;
+      if (typeof toast === "function") {
+        toast({ kind: "success", title: "Cache dropped", detail: existingId });
+      }
+    } catch (invalidateErr) {
+      setErr((invalidateErr && (invalidateErr.detail || invalidateErr.message))
+        || String(invalidateErr));
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  return (
+    <div className="pc-invalidate" data-testid="provider-form-invalidate">
+      <button type="button" className="pc-invalidate-link" disabled={busy}
+        data-testid="provider-form-invalidate-action" onClick={run}>
+        Invalidate model cache
+      </button>
+      {err ? (
+        <span className="field-help" data-testid="provider-form-invalidate-error">{err}</span>
       ) : null}
     </div>
   );
@@ -233,6 +301,16 @@ const PC_CAPABILITIES_FOOTNOTE =
 // max_concurrency inside it has no default, so the form has to offer it.
 // The optional timeouts are left blank by default: an empty box means
 // "use the model default", which is what the backend's None means.
+// Designer reconciliation: the boxed <fieldset> dissolves into the same
+// full-width, humanized-label fields every other field above/below it
+// uses - a subtle group heading (not a border/legend box) is enough to
+// keep the three fields visually together. Distinct labels for the two
+// timeout fields (not a shared "Timeout (s)"): a provider row carries
+// BOTH simultaneously (primer/model/providers/_shared.py), so one
+// ambiguous label would leave an operator unable to tell which box sets
+// which - the mockup's single "Timeout (s)" was for a kind (anthropic)
+// whose real schema has no config-level timeout field at all, i.e. not
+// a real precedent to generalize from (flagged in the PR body).
 function PC_LimitsFieldset({ value, onChange }) {
   const limits = value || { max_concurrency: 1 };
   const set = (key, raw) => {
@@ -242,10 +320,13 @@ function PC_LimitsFieldset({ value, onChange }) {
     onChange(next);
   };
   return (
-    <fieldset className="limits" data-testid="provider-form-limits">
-      <legend>Limits</legend>
-      <label className="field">
-        <span>max_concurrency<em className="req"> *</em></span>
+    <div className="pc-limits-group" data-testid="provider-form-limits">
+      <div className="pc-field-group-heading muted text-sm">Limits</div>
+      <label className="field pc-field">
+        <span className="pc-field-label">
+          <span className="pc-field-label-main">Max concurrency</span>
+          <em className="req"> *</em>
+        </span>
         <input
           type="number"
           min="1"
@@ -253,8 +334,10 @@ function PC_LimitsFieldset({ value, onChange }) {
           onChange={(e) => set("max_concurrency", e.target.value || "1")}
         />
       </label>
-      <label className="field">
-        <span>request_timeout_seconds</span>
+      <label className="field pc-field">
+        <span className="pc-field-label">
+          <span className="pc-field-label-main">Request timeout (s)</span>
+        </span>
         <input
           type="number"
           min="0"
@@ -262,8 +345,10 @@ function PC_LimitsFieldset({ value, onChange }) {
           onChange={(e) => set("request_timeout_seconds", e.target.value)}
         />
       </label>
-      <label className="field">
-        <span>connect_timeout_seconds</span>
+      <label className="field pc-field">
+        <span className="pc-field-label">
+          <span className="pc-field-label-main">Connect timeout (s)</span>
+        </span>
         <input
           type="number"
           min="0"
@@ -271,7 +356,7 @@ function PC_LimitsFieldset({ value, onChange }) {
           onChange={(e) => set("connect_timeout_seconds", e.target.value)}
         />
       </label>
-    </fieldset>
+    </div>
   );
 }
 
@@ -350,6 +435,7 @@ function PC_submittable(draft, shape, selectedType) {
 
 function PC_ProviderForm({
   plural, typesPath, value, onChange, onSubmit, onTest, onCancel, editing,
+  existingId, canInvalidate,
 }) {
   const { useResource, apiFetch, useCapabilities, capabilityHint,
     EXTRA_FOR_PROVIDER_TYPE } = window.primerApi;
@@ -455,37 +541,17 @@ function PC_ProviderForm({
   const showProbePanel = !!shape.discoverable
     && PC_DISCOVER_MODELS_PLURALS.indexOf(plural) >= 0;
 
+  // Designer reconciliation: the in-form kind dropdown (and the T0379
+  // mismatch warning it existed to explain) is REMOVED - kind arrives
+  // preselected from the catalog's own kind-listing Register dropdown
+  // (create) or is simply the row's own real value (edit), so
+  // `selectedType`/`shape` above are never actually driven by a control
+  // in this form any more, only read from `draft.provider`. The T0379
+  // mismatch class this warning existed for mostly evaporates once kind
+  // can no longer be picked independently of the fields shown for it -
+  // flagged in the PR body per the task's own instruction.
   const fields = (
     <div className="col" style={{ gap: 12, minWidth: 0 }}>
-      <div className="field">
-        <label className="field-label" htmlFor="pf-provider">provider</label>
-        <select
-          id="pf-provider"
-          className="input"
-          value={selectedType}
-          disabled={editing}
-          onChange={(e) => setField("row", "provider", e.target.value)}
-        >
-          {typeKeys.map((k) => (
-            <option key={k} value={k}>{(typeMap[k] || {}).label || k}</option>
-          ))}
-        </select>
-        {/* Documented anomaly, surfaced in place rather than hidden
-            (docs/dev/subsystems/ui-pages.md). The per-class create
-            modals carried this line and the catalog that replaced them
-            dropped it, so nothing warned an operator before they
-            submitted a mismatched pair. */}
-        <div className="field-help" data-testid="provider-form-t0379">
-          {editing
-            ? "Locked on edit: a provider's kind decides its config shape " +
-              "(T0379) - changing it here would leave stale fields from " +
-              "the old kind behind."
-            : "Provider and config alignment is NOT cross-validated " +
-              "server-side (T0379): make sure the vendor name matches " +
-              "the config shape you are filling in."}
-        </div>
-      </div>
-
       {missingExtra ? (
         <Banner kind="info" title="Optional dependency required">
           {capabilityHint(extra)}
@@ -493,7 +559,10 @@ function PC_ProviderForm({
       ) : null}
 
       <PC_Field
-        field={PC_normalizeField({ key: "id", label: "id", required: true })}
+        field={PC_normalizeField({
+          key: "id", label: "Name", required: true,
+          placeholder: selectedType ? `e.g. ${selectedType}-prod` : "e.g. my-provider",
+        })}
         value={draft.id}
         disabled={editing}
         onChange={(next) => setField("row", "id", next)}
@@ -544,6 +613,16 @@ function PC_ProviderForm({
     </div>
   );
 
+  // Invalidate is edit-mode-only (nothing to invalidate before Save has
+  // ever run) and class-gated (canInvalidate, from the catalog's own
+  // klass.invalidate flag - llm/embedding/cross_encoder only). It needs
+  // a right column even for a kind/class with no probe panel (cross_
+  // encoder has no discover_models route at all, so showProbePanel is
+  // always false for it, but it DOES carry klass.invalidate) - the two
+  // gates are independent, so the column renders whenever EITHER wants it.
+  const showInvalidate = editing && canInvalidate && !!existingId;
+  const showRightColumn = showProbePanel || showInvalidate;
+
   return (
     <div className="col" style={{ gap: 12 }}
       data-testid={`provider-form-${plural}`}>
@@ -561,16 +640,23 @@ function PC_ProviderForm({
           auto minimum forces content-based sizing without it). */}
       <div className="pc-form-grid" style={{
         display: "grid",
-        gridTemplateColumns: showProbePanel ? "minmax(0, 1fr) 240px" : "minmax(0, 1fr)",
+        gridTemplateColumns: showRightColumn ? "minmax(0, 1fr) 240px" : "minmax(0, 1fr)",
         gap: 20, alignItems: "start",
       }}>
         {fields}
-        {showProbePanel ? (
+        {showRightColumn ? (
           <div className="col pc-form-right" style={{ gap: 10, minWidth: 0 }}>
-            <PC_ProbePanel plural={plural} draft={draft} selectedType={selectedType} />
-            <div className="field-help" data-testid="provider-form-capabilities-footnote">
-              {PC_CAPABILITIES_FOOTNOTE}
-            </div>
+            {showProbePanel ? (
+              <React.Fragment>
+                <PC_ProbePanel plural={plural} draft={draft} selectedType={selectedType} />
+                <div className="field-help" data-testid="provider-form-capabilities-footnote">
+                  {PC_CAPABILITIES_FOOTNOTE}
+                </div>
+              </React.Fragment>
+            ) : null}
+            {showInvalidate ? (
+              <PC_InvalidateAction plural={plural} existingId={existingId} />
+            ) : null}
           </div>
         ) : null}
       </div>
@@ -581,18 +667,29 @@ function PC_ProviderForm({
             Cancel
           </Btn>
         ) : null}
-        <Btn
-          kind="ghost"
-          data-testid="provider-form-test"
-          onClick={runTest}
-          disabled={busy}
-        >
-          Test
-        </Btn>
+        {/* Designer reconciliation: the footer Test button is redundant
+            ONLY where the probe panel already offers Test connect - for
+            classes with no probe panel (no discover_models route: stt/
+            tts/web_search/web_fetch/artifact_storage/cross_encoder),
+            removing it would leave NO way at all to test a draft config
+            before saving, which the task's own tripwire says to flag
+            rather than drop. Kept, conditionally, for exactly those. */}
+        {!showProbePanel ? (
+          <Btn
+            kind="ghost"
+            data-testid="provider-form-test"
+            onClick={runTest}
+            disabled={busy}
+          >
+            Test
+          </Btn>
+        ) : null}
         <Btn data-testid="provider-form-save"
           onClick={() => onSubmit && onSubmit(PC_submittable(draft, shape, selectedType))}
           disabled={busy || missingRequired()
-            || modelRowsIncomplete(shape.row_fields)}>Save</Btn>
+            || modelRowsIncomplete(shape.row_fields)}>
+          Save provider
+        </Btn>
       </div>
     </div>
   );

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -5299,28 +5299,29 @@ button.nv-rail-ws-session {
   line-height: 1.5;
   max-width: 560px;
 }
-.nv-legacy-host .limits {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(190px, 1fr));
-  gap: 10px 14px;
-  border: 1px solid var(--border);
-  border-radius: var(--r-8);
-  padding: 12px 14px;
-  max-width: 560px;
-}
-
 /* ---------------------------------------------------------------------
    Platform wave P1a: providers surface reconciliation.
    Family chips replaced the rail (item 1); the register dropdown, card
    grid and probe panel are new (items 2/3/4).
    ------------------------------------------------------------------ */
-/* Item 1: the family selector reuses .chip-group/.chip (the app's own
-   proven segmented-control pattern) - .pc-chips only adds the reference's
-   accent-colored active state, since the generic .chip.active (background
-   highlight only) is shared with surfaces that should not always turn
-   green just because this one wants to. */
-.pc-chips { flex-wrap: wrap; height: auto; }
-.pc-chips .chip.active { background: var(--accent-dim); color: var(--accent); }
+/* Designer reconciliation (uiv2 mockup): compact rounded PILLS, each
+   individually outlined and gapped, rather than .chip-group's shared-
+   border segmented-control look - overrides .chip-group's own
+   container chrome entirely (background/border/padding/gap) rather
+   than layering on top of it, since the two are now visually distinct
+   families, not variations on one. */
+.pc-chips.chip-group {
+  background: transparent; border: none; padding: 0; gap: 8px;
+  flex-wrap: wrap; height: auto;
+}
+.pc-chips .chip {
+  border: 1px solid var(--border); border-radius: 999px;
+  padding: 5px 14px; color: var(--text-3); background: transparent;
+}
+.pc-chips .chip:hover { border-color: var(--border-strong); color: var(--text); }
+.pc-chips .chip.active {
+  border-color: var(--green); background: var(--green-dim); color: var(--green);
+}
 
 /* Item 2/3: "Register provider" dropdown. */
 .pc-register { position: relative; }
@@ -5360,23 +5361,69 @@ button.nv-rail-ws-session {
   grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
   gap: 12px;
 }
+/* Designer reconciliation: tighter padding/gap per the mockup's denser
+   card. */
 .pc-card {
   border: 1px solid var(--border); border-radius: var(--r-6);
-  background: var(--bg-1); padding: 12px 14px;
-  display: flex; flex-direction: column; gap: 8px; min-width: 0;
+  background: var(--bg-1); padding: 10px 12px;
+  display: flex; flex-direction: column; gap: 6px; min-width: 0;
 }
 .pc-card-head { display: flex; align-items: center; gap: 8px; }
 .pc-card-title { font-weight: 600; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .pc-card-subtitle { color: var(--text-2); font-size: 12px; }
-.pc-card-facts { display: flex; flex-direction: column; gap: 3px; }
-.pc-card-fact { display: flex; gap: 6px; font-size: 12px; }
-.pc-card-footer { display: flex; align-items: center; gap: 6px; margin-top: 2px; }
+/* Designer reconciliation: status moves from a pill (background + dot)
+   to plain colored text, top-right of the card head. */
+.pc-card-status { font-size: 11px; font-weight: 500; white-space: nowrap; }
+.pc-card-status.ok { color: var(--green); }
+.pc-card-status.down { color: var(--red); }
+/* Designer reconciliation: two-column ALIGNED key-value rows - the
+   parent is the grid (auto label column, value column takes the rest),
+   each .pc-card-fact is `display: contents` so its own two spans become
+   direct grid items positioned by the PARENT, not a wrapper the grid
+   can only place as ONE cell - this is what makes every row's value
+   start at the same x regardless of label length. */
+.pc-card-facts {
+  display: grid; grid-template-columns: auto 1fr;
+  column-gap: 10px; row-gap: 3px; font-size: 12px;
+}
+.pc-card-fact { display: contents; }
+.pc-card-fact > .muted { white-space: nowrap; }
+.pc-card-fact > :last-child {
+  overflow: hidden; text-overflow: ellipsis; white-space: nowrap;
+}
+/* Designer reconciliation: Open is a green TEXT LINK bottom-left (not a
+   filled button); Delete is muted text bottom-right. Invalidate no
+   longer lives on the card at all (moved to the edit overlay - see
+   PC_InvalidateAction in provider-form.jsx). */
+.pc-card-footer { display: flex; align-items: center; gap: 10px; margin-top: 2px; }
+.pc-card-open, .pc-card-delete, .pc-card-delete-confirm {
+  border: none; background: transparent; padding: 0; cursor: pointer;
+  font-size: 12.5px; font-family: inherit;
+}
+.pc-card-open { color: var(--green); }
+.pc-card-open:hover { text-decoration: underline; }
+.pc-card-delete { color: var(--text-3); }
+.pc-card-delete:hover { color: var(--text); text-decoration: underline; }
+.pc-card-delete-confirm { color: var(--red); font-weight: 600; }
+.pc-card-delete-confirm:hover { text-decoration: underline; }
+.pc-card-delete-confirm:disabled { opacity: 0.6; cursor: default; }
 
 /* Item 4: the create modal's schema-driven chip + two-column form + the
    live probe panel's own small result list. */
+/* Designer reconciliation: the schema badge moved from its own line
+   inside the form body to INLINE beside the modal title (see the
+   `title` fragment ProviderCatalog now passes to Modal) - .pc-modal-chip
+   itself is dead (nothing renders it any more) but left defined in case
+   a future non-inline usage wants the original standalone-line look;
+   the active style is the -inline variant below. */
 .pc-modal-chip {
   border: 1px solid var(--border); border-radius: var(--r-4);
   padding: 2px 8px; display: inline-block; margin-bottom: 10px;
+}
+.pc-modal-chip-inline {
+  border: 1px solid var(--border); border-radius: var(--r-4);
+  padding: 1px 7px; margin-left: 10px; font-weight: 400;
+  vertical-align: middle;
 }
 .pc-form-right {
   border-left: 1px solid var(--border); padding-left: 16px;
@@ -5385,9 +5432,52 @@ button.nv-rail-ws-session {
   border: 1px solid var(--border); border-radius: var(--r-6);
   padding: 10px; display: flex; flex-direction: column; gap: 8px;
 }
+/* Designer reconciliation: heading + Test connect on one row. */
+.pc-probe-head-row { display: flex; align-items: center; justify-content: space-between; gap: 8px; }
 .pc-probe-head { font-weight: 600; font-size: 12.5px; }
+/* Test connect: kind="ghost" (transparent + border) tinted green, since
+   Btn has no dedicated "outline" kind and spreading a className prop
+   onto Btn would clobber its own base classes (see Btn's props order in
+   shared.jsx) - a scoped selector is the non-invasive way to reach it. */
+.pc-probe [data-testid="provider-probe-test"] {
+  border-color: var(--green); color: var(--green);
+}
+.pc-probe [data-testid="provider-probe-test"]:hover { background: var(--green-dim); }
 .pc-probe-count { font-size: 12px; color: var(--text-2); }
-.pc-probe-models { margin: 0; padding-left: 18px; font-size: 12px; }
+/* Designer reconciliation: each probed model is its own bordered row,
+   not a bare <li> in a <ul>. */
+.pc-probe-models { display: flex; flex-direction: column; gap: 4px; }
+.pc-probe-model-row {
+  border: 1px solid var(--border); border-radius: var(--r-4);
+  padding: 5px 8px; font-size: 12px;
+}
+
+/* Designer reconciliation: humanized field labels - bold main label +
+   a distinctly muted inline annotation for secret fields (was one
+   plain-weight concatenated string), full-width single-column rhythm. */
+.pc-field-label { display: flex; align-items: baseline; gap: 8px; flex-wrap: wrap; }
+.pc-field-label-main { font-weight: 600; }
+.pc-field-label-annotation { font-size: 11px; }
+
+/* Designer reconciliation: the boxed Limits <fieldset> dissolves into
+   normally-styled fields with a subtle group heading, not a bordered
+   box - same field rhythm as everything above it. */
+.pc-limits-group { display: flex; flex-direction: column; gap: 12px; }
+.pc-field-group-heading {
+  font-size: 10.5px; text-transform: uppercase; letter-spacing: 0.06em;
+  margin-top: 4px;
+}
+
+/* Lead ruling: Invalidate moves from the card footer into the edit
+   overlay, adjacent to the Live-model-probe panel - muted, unobtrusive,
+   a deliberate capability-preserving addition beyond the mockup. */
+.pc-invalidate { padding-top: 2px; }
+.pc-invalidate-link {
+  border: none; background: transparent; padding: 0; cursor: pointer;
+  font-size: 11.5px; font-family: inherit; color: var(--text-3);
+}
+.pc-invalidate-link:hover { color: var(--text); text-decoration: underline; }
+.pc-invalidate-link:disabled { opacity: 0.6; cursor: default; }
 
 /* Workspace events: a row EXPANDS to its full envelope - actor,
    entity, correlation and the raw payload - a one-line type + id was


### PR DESCRIPTION
Wave 1 of the uiv2 full-surface reconciliation, implementing two user-ratified exhibits (providers page + create overlay) against the canonical uiv2 mockup.

**Page**: header entity count + filter input, icon-free pill family chips (renames: TTS/ASR/Cross encoding/sentence case), LLM as default selection, aligned key-value card fact rows, plain-text reachability status, Open as link, kind-listing Register dropdown ('KIND — DECIDES THE FORM' + served annotations). **Overlay**: 'New {type} provider — {kind}' title with inline schema badge, no in-form kind picker or T0379 warning, humanized full-width fields, 'secret — masked on read' annotation, probe panel with bordered model rows, Cancel + 'Save provider' footer.

**Deliberate flags**:
1. The All chip is dropped per the mockup — PC_ALL_TYPE_CHIPS/PC_AllInstancesGrid/PC_RegisterAll kept intact and unreferenced, trivially restorable.
2. The mockup's 'failover' fact row is omitted on LLM cards — no such served field on a plain LLMProvider (exists only inside AggregatedLLMConfig).
3. The implementer-notes' 'Model profiles' family chip question is left open — chip list follows the ratified exhibit; no page restructuring.
4. Invalidate relocated into the edit overlay (PC_InvalidateAction, beside the probe panel) — capability-preserving addition beyond the mockup (it clears the stored probe cache; the overlay's Test connect probes the draft config).
5. The footer Test button survives for classes with no probe panel (stt/tts/web_search/web_fetch/artifact_storage/cross_encoder) — removing it there would lose real capability.
6. Field help text kept verbatim rather than inventing shortened copy.

Also fixes forward a pre-existing e2e navigation gap: U0091/U0098 navigated to providers/{class}/{id} expecting an auto-opened edit form that never existed post-IA-restructure; both now reach the overlay through the card's own Open button.

**Verification**: tests/ui full suite 1660 passed / 1 skipped; 14 live Playwright tests across the 5 touched ui_e2e files green against a fresh bringup running this tree; ruff + transpile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)