### PR TITLE
feat(console): studio shell, palette, and terminal match the designer's version

### DIFF
--- a/tests/ui/test_console_palette.py
+++ b/tests/ui/test_console_palette.py
@@ -85,10 +85,15 @@ def test_wiki_source_opens_a_wiki_tab():
 
 
 def test_empty_query_shows_recent_sessions():
-    assert '"Recent"' in SRC
+    # uiv2 Wave 1: relabeled "Recent" -> "Sessions" to match the
+    # mockup's own taxonomy (Verbs, Sessions, Files) - it already only
+    # ever held sessions. Scoped to the else-branch body, not a bare
+    # SRC-wide check, since "Sessions" also names the searched group
+    # below (NV_matchRows(..., q, "Sessions")) for a different reason.
     start = SRC.index("} else {", SRC.index("if (q.trim())"))
     end = SRC.index("\n  }\n\n  var flat", start)
     body = SRC[start:end]
+    assert 'label: "Sessions"' in body
     assert "sessions.data" in body
     assert "last_activity_at" in body
     assert "NV_PALETTE_CAP" in body
@@ -113,11 +118,17 @@ def test_empty_query_also_shows_recent_files_from_the_already_open_cache():
 
 
 def test_recents_absent_once_a_query_is_typed():
+    # uiv2 Wave 1: both branches now push a "Sessions" group (relabeled
+    # from "Recent" to match the mockup taxonomy), so the two are no
+    # longer told apart by label - check the empty-query-only recents
+    # machinery (the capped/sorted variables) is absent here instead.
     start = SRC.index("if (q.trim()) {")
     end = SRC.index("} else {", start)
     body = SRC[start:end]
-    assert '"Recent"' not in body
+    assert "NV_PALETTE_CAP" not in body
+    assert "last_activity_at" not in body
     assert "recentFiles" not in body
+    assert 'label: "Sessions"' not in body
 
 
 # ---------------------------------------------------------------------------
@@ -140,3 +151,78 @@ def test_the_shared_row_testid_is_unchanged():
     silently break every caller of that helper, so data-row-key must be a
     second attribute alongside it, not a replacement."""
     assert 'data-testid="nv-palette-row"' in SRC
+
+
+# ---------------------------------------------------------------------------
+# uiv2 reconciliation Wave 1 (studio shell): group taxonomy, row
+# iconography, FREQUENT tags, the self-referential "Open Palette" filter.
+# Session/agent qualifier dedupe itself is a separate backend task
+# (01a06431); this wave only builds the UI to render it once served.
+# ---------------------------------------------------------------------------
+
+
+def test_session_rows_carry_an_agent_glyph_not_a_text_badge():
+    fn = SRC[SRC.index("function sessionRow("):SRC.index("function fileRow(")]
+    assert "NV_identity(s.binding)" in fn
+    assert "glyph: ident" in fn
+    assert "tag: null" in fn
+
+
+def test_file_and_verb_rows_lead_with_a_dot_not_a_text_badge():
+    file_fn = SRC[SRC.index("function fileRow("):SRC.index("if (q.trim()) {")]
+    assert "dot: true" in file_fn
+    assert "tag: null" in file_fn
+    assert 'f.is_dir ? "folder" : "file"' not in SRC
+
+    verb_rows = SRC[SRC.index("var verbRows ="):SRC.index("if (verbRows.length)")]
+    assert "dot: true" in verb_rows
+
+
+def test_session_rows_carry_an_agent_at_workspace_sub_label():
+    """Client-computable disambiguator for the triplicate-'main'-rows live
+    bug (backend dedupe/qualifier work is a separate task, not this one) -
+    workspace/agent are already on every session row (s.workspace_id,
+    s.binding), so this does not wait on that batch landing."""
+    fn = SRC[SRC.index("function sessionRow("):SRC.index("function fileRow(")]
+    assert "agentLabel + \" @ \"" in fn
+    assert "sub: " in fn
+
+
+def test_frequent_tag_reflects_in_session_frecency_not_invented():
+    assert 'con.frecency.scoreFor(verb.id) > 0 ? "frequent" : null' in SRC
+
+
+def test_open_palette_filters_itself_from_its_own_results():
+    m = re.search(r"var rankedVerbsVisible = rankedVerbs\.filter\(([\s\S]{0,120})", SRC)
+    assert m
+    assert 'verb.id !== "palette.open"' in m.group(1)
+    assert "rankedVerbsVisible.slice(0, 8)" in SRC
+
+
+def test_recents_endpoint_404_degrades_to_the_client_derived_fallback():
+    """The approved recents endpoint (sh-api.jsx's SH_api.recentSessions)
+    may land on a separate branch after this one - a 404 must fall back
+    to the exact same allSessions()-derived computation the palette
+    shipped with before that endpoint existed, not surface an error."""
+    assert "SH_api.recentSessions(signal)" in SRC
+    m = re.search(r"\.catch\(function \(err\) \{([\s\S]{0,120})", SRC)
+    assert m
+    assert 'err.status === 404' in m.group(1)
+    assert "return null;" in m.group(1)
+
+    empty_start = SRC.index("} else {", SRC.index("if (q.trim())"))
+    empty_end = SRC.index("\n  }\n\n  var flat", empty_start)
+    body = SRC[empty_start:empty_end]
+    assert "recents.data && recents.data.items" in body
+    assert ".map(sessionRowFromRecent)" in body
+    assert ".map(sessionRow)" in body, "the fallback branch must still exist"
+
+
+def test_recent_endpoint_rows_read_the_agreed_field_names_defensively():
+    fn = SRC[SRC.index("function sessionRowFromRecent("):SRC.index("function fileRow(")]
+    assert "r.workspace_name" in fn
+    assert "r.graph_ref" in fn
+    assert "r.agent_id" in fn
+    # Never throws on an unexpected shape - always resolves to something
+    # renderable, same default sessionRow() uses.
+    assert '"operator"' in fn

--- a/tests/ui/test_console_terminal_events.py
+++ b/tests/ui/test_console_terminal_events.py
@@ -99,9 +99,15 @@ def test_resize_clamps_both_bounds():
 # ---------------------------------------------------------------------------
 
 
-def test_header_resolves_the_workspace_name_not_the_raw_wid():
+def test_header_resolves_the_workspace_short_id_not_the_raw_wid():
+    """uiv2 Wave 1: retargeted from name-preferred (ws.name || ws.id) to
+    the workspace id alone - the mockup's own literal example
+    ("TERMINAL ws-3f8a9bc . pty", implementer-notes 2.6) names the short
+    id specifically, unlike the Files/Inbox headers which prefer the
+    human name. con.workspaces is still consulted (not the raw prop wid)
+    so a resolvable ws still wins over the bare con.wid fallback."""
     assert "con.workspaces" in TERM
-    assert "ws.name || ws.id" in TERM
+    assert "(ws && ws.id) || con.wid" in TERM
     assert "· pty" in TERM
     # The old bare "terminal · {con.wid}" header text must be gone.
     assert "terminal · {con.wid}" not in TERM

--- a/tests/ui/test_studio_tab_groups_integration.py
+++ b/tests/ui/test_studio_tab_groups_integration.py
@@ -114,28 +114,31 @@ def test_studio_mounts_rail_and_tab_groups_unconditionally() -> None:
 
 
 def test_rail_props_are_wired_to_console_verbs() -> None:
-    m = re.search(r"<window\.NV_Rail[\s\S]{0,2000}?\n {8}/>", STUDIO)
+    m = re.search(r"<window\.NV_Rail[\s\S]{0,2500}?\n {8}/>", STUDIO)
     assert m
     body = m.group(0)
     for prop in (
         "selectedWorkspaceId={con.wid}",
         "onSelectWorkspace=",
         "onOpenSession=",
-        # F2 follow-up (2026-08-29 UI review): the plain onCreateSession
-        # prop retired with US-012b item 4's Inbox "+" - the workspace
-        # context menu's "New session" is the only caller left, and it
-        # needs a target wid, so nv-studio.jsx wires the combined
-        # switch-and-open (con.createSessionInWorkspace) instead.
+        # onCreateSessionInWorkspace: the workspace context menu's own
+        # "New session" (targeted, not-necessarily-selected wid) - a
+        # combined switch-and-open (F2 follow-up, 2026-08-29 UI review),
+        # so it calls con.createSessionInWorkspace directly rather than
+        # the plain registry verb.
         "onCreateSessionInWorkspace=",
+        # onCreateSession: the Inbox header "+" (uiv2 Wave 1, 01a06431)
+        # un-retires US-012b item 4 per the ratified mockup - runs the
+        # plain session.create verb against the currently selected
+        # workspace, coexisting with the context-menu's targeted case
+        # above rather than replacing it.
+        "onCreateSession=",
         "onCreateWorkspace=",
     ):
         assert prop in body, prop
     assert 'con.registry.get("workspace.switch")' in body
-    # session.create no longer runs through the registry from here - the
-    # workspace context menu needs a combined switch-and-open (F2 follow-
-    # up), so onCreateSessionInWorkspace calls con.createSessionInWorkspace
-    # directly instead.
     assert "con.createSessionInWorkspace" in body
+    assert 'con.registry.get("session.create")' in body
     assert 'con.registry.get("workspace.create")' in body
 
 

--- a/ui/components/console/nv-chrome.jsx
+++ b/ui/components/console/nv-chrome.jsx
@@ -136,10 +136,73 @@ function NV_ProfileMenu() {
   );
 }
 
+// uiv2 Wave 1 (01a06431): the workspace-selector chip un-retires the
+// topbar switcher US-012b (2026-08-29) folded into the rail tree alone
+// ("the two were redundant"). The mockup shows both coexisting - the
+// chip is an always-visible, rail-scroll-independent entry point; the
+// rail stays the detailed browse/session view. No new switching logic:
+// both the row click and the footer "+ New workspace…" run the SAME
+// workspace.switch/workspace.create verbs the rail already uses, and
+// this also fixes a live dead path - workspace.switch's own run(),
+// called with no wid (palette row, Ctrl+Shift+o), already did
+// setOpenMenu("ws") expecting a listener; nothing rendered against
+// "ws" until now, so the chord/palette verb was silently a no-op.
+function NV_WorkspaceChip() {
+  var con = NV_useConsole();
+  var workspaces = con.workspaces || [];
+  var active = workspaces.filter(function (w) { return w.id === con.wid; })[0];
+  return (
+    <div className="nv-ws-wrap">
+      <button type="button" className="nv-ws-chip" title="Switch workspace"
+        data-verb="workspace.switch" data-testid="nv-ws-chip"
+        onClick={function (ev) { ev.stopPropagation(); con.toggleMenu("ws"); }}>
+        <svg width="12" height="12" viewBox="0 0 12 12" fill="none"
+          stroke="currentColor" strokeWidth="1.3" style={{ flexShrink: 0 }}>
+          <path d="M1.5 3.5 6 1l4.5 2.5v5L6 11 1.5 8.5Z M6 6v5M1.5 3.5 6 6l4.5-2.5" />
+        </svg>
+        <span className="nv-ws-chip-name">{active ? (active.name || active.id) : "Workspace"}</span>
+        <svg width="9" height="9" viewBox="0 0 10 10" fill="none" stroke="currentColor"
+          strokeWidth="1.5" style={{ flexShrink: 0 }}>
+          <path d="M2.5 3.5 5 6.5 7.5 3.5" />
+        </svg>
+      </button>
+      {con.openMenu === "ws" ? (
+        <div className="nv-ws-menu" data-testid="nv-ws-menu"
+          onClick={function (ev) { ev.stopPropagation(); }}>
+          {workspaces.map(function (w) {
+            return (
+              <button type="button" key={w.id} className="nv-ws-menu-row"
+                data-testid={"nv-ws-menu-row:" + w.id}
+                data-current={w.id === con.wid ? "true" : "false"}
+                onClick={function () {
+                  con.toggleMenu(null);
+                  var verb = con.registry.get("workspace.switch");
+                  if (verb) verb.run({ wid: w.id });
+                }}>
+                <span className="nv-ws-menu-name">{w.name || w.id}</span>
+                {w.name ? <span className="nv-ws-menu-id mono">{w.id}</span> : null}
+              </button>
+            );
+          })}
+          <div className="nv-menu-sep" />
+          <button type="button" className="nv-ws-menu-new"
+            data-verb="workspace.create" data-testid="nv-ws-menu-new"
+            onClick={function () {
+              con.toggleMenu(null);
+              var verb = con.registry.get("workspace.create");
+              if (verb) verb.run();
+            }}>+ New workspace…</button>
+        </div>
+      ) : null}
+    </div>
+  );
+}
+
 function NV_Topbar() {
   var con = NV_useConsole();
   return (
     <div className="nv-topbar" data-testid="nv-topbar">
+      {con.view.name === "studio" ? <NV_WorkspaceChip /> : null}
       <div className="nv-search-wrap">
         <button type="button" className="nv-search-btn" data-verb="palette.open"
           data-testid="nv-search-btn"

--- a/ui/components/console/nv-files-sidebar.jsx
+++ b/ui/components/console/nv-files-sidebar.jsx
@@ -219,7 +219,8 @@ function NV_FilesSidebar() {
   return (
     <div className="nv-files-panel" data-testid="nv-files-panel">
       <div className="nv-rail-section-head">
-        <span>Files - {(ws && (ws.name || ws.id)) || con.wid}</span>
+        <span>Files</span>
+        <span className="nv-rail-section-ws mono">{(ws && (ws.name || ws.id)) || con.wid}</span>
         <div style={{ flex: 1 }} />
         <button type="button" className="nv-rail-iconbtn" title="New file"
           data-testid="nv-file-new"

--- a/ui/components/console/nv-palette.jsx
+++ b/ui/components/console/nv-palette.jsx
@@ -1,4 +1,4 @@
-/* global React, SH_api, SH_rankVerbs, NV_useConsole */
+/* global React, SH_api, SH_rankVerbs, NV_useConsole, NV_identity */
 // The universal search bar (wiring plan P1 T5): one field over verbs,
 // sessions (every workspace), files (current workspace), and platform
 // entities. Grouped rows, arrow keys spanning every group, Enter runs.
@@ -45,6 +45,25 @@ function NV_Palette() {
     "nv-rail-all-sessions",
     function (signal) { return SH_api.allSessions(signal); },
     { pollMs: 0 }
+  );
+  // uiv2 Wave 1: the approved recents endpoint (sh-api.jsx's own
+  // comment has the full row shape) - a 404 means it is not deployed on
+  // this server yet (its own branch may land after this one), so that
+  // specific status degrades to null rather than throwing; every other
+  // error still surfaces through useResource's normal error state. null
+  // data is exactly what the empty-query Sessions group below already
+  // treats as "fall back to deriving it from allSessions/con.workspaces".
+  var recents = window.primerApi.useResource(
+    "nv-palette-recents",
+    function (signal) {
+      return open
+        ? SH_api.recentSessions(signal).catch(function (err) {
+            if (err && err.status === 404) return null;
+            throw err;
+          })
+        : Promise.resolve(null);
+    },
+    { pollMs: 0, deps: [open] }
   );
   var agents = window.primerApi.useResource(
     "nv-palette-agents",
@@ -140,12 +159,25 @@ function NV_Palette() {
     });
     rankedVerbs = sessionVerbs.concat(otherVerbs);
   }
-  var verbRows = rankedVerbs.slice(0, 8).map(function (verb) {
+  // uiv2 Wave 1: "Open Palette" inside the already-open palette is a
+  // self-referential registry entry the mockup never surfaces in this
+  // state - filtered before the top-8 slice so it never displaces a
+  // real result either.
+  var rankedVerbsVisible = rankedVerbs.filter(function (verb) {
+    return verb.id !== "palette.open";
+  });
+  var verbRows = rankedVerbsVisible.slice(0, 8).map(function (verb) {
     return {
       key: "v:" + verb.id,
       label: verb.label,
       chord: verb.chord || null,
-      tag: null,
+      dot: true,
+      // FREQUENT (mockup): at minimum render what in-session frecency
+      // already tracks (record()/remember() below feed it) rather than
+      // overpromise a footer that says "frecency-ranked" with nothing to
+      // show for it - per-user persistence across sessions is the
+      // backend half (c-2), unimplemented here.
+      tag: con.frecency && con.frecency.scoreFor(verb.id) > 0 ? "frequent" : null,
       run: runAndClose(function () {
         if (con.frecency) {
           con.frecency.record(verb.id);
@@ -161,12 +193,32 @@ function NV_Palette() {
   // AND route a cross-workspace target through the combined
   // con.openInWorkspace nav, one history entry either way. Shared by
   // both the searched "Sessions" group below and the empty-query
-  // "Recent" group (F9) so the two never drift.
+  // "Sessions" group (F9) so the two never drift.
+  //
+  // uiv2 Wave 1: the trailing "SESSION" text badge is gone - a session
+  // row now leads with the same colored agent glyph the rail/tab-groups
+  // already use (NV_identity(s.binding)), matching the mockup, and
+  // reserving the trailing tag slot for the Platform group where
+  // multiple entity kinds share one heading. The sub label ("agent @
+  // workspace") is a client-computable disambiguator for the live
+  // triplicate-"main"-rows bug (workspace/agent already ride on every
+  // session row - s.workspace_id, s.binding) - it does not wait on the
+  // backend dedupe/qualifier batch (01a06431 item 1), which fixes the
+  // actual data-scoping bug (stale/cross-scope rows) a display label
+  // cannot: two rows that are genuinely different sessions both named
+  // "main" stay two rows, just no longer indistinguishable ones.
   function sessionRow(s) {
+    var ws = (con.workspaces || []).filter(function (w) { return w.id === s.workspace_id; })[0];
+    var ident = NV_identity(s.binding);
+    var agentLabel = s.binding && s.binding.kind === "graph"
+      ? "graph"
+      : (s.binding && s.binding.agent_id) || "operator";
     return {
       key: "s:" + s.session_id,
       label: s.name || s.session_id,
-      tag: "session",
+      sub: agentLabel + " @ " + ((ws && (ws.name || ws.id)) || s.workspace_id || "?"),
+      glyph: ident,
+      tag: null,
       run: runAndClose(function () {
         con.goView("studio");
         if (s.workspace_id && s.workspace_id !== con.wid && con.openInWorkspace) {
@@ -179,13 +231,51 @@ function NV_Palette() {
     };
   }
 
+  // uiv2 Wave 1: the recents-endpoint row shape, when it's actually
+  // deployed (see the `recents` resource above) - pre-composed
+  // workspace_name/agent fields replace the client-side lookups
+  // sessionRow() above does, so this only feeds the empty-query group,
+  // never the searched one (which still needs the FULL session list to
+  // search over, not a capped "recent 20"). Field names beyond
+  // workspace_name are read defensively (a few plausible candidates,
+  // then a plain fallback) since this endpoint's own branch had not
+  // landed as of this wave - if the real names differ once it does,
+  // this degrades to the same "operator" default sessionRow() uses
+  // rather than showing an unresolved value.
+  function sessionRowFromRecent(r) {
+    var agentLabel = r.graph_ref ? "graph"
+      : r.agent_display_name || r.agent_name || r.agent_id || "operator";
+    var syntheticBinding = r.graph_ref ? { kind: "graph" }
+      : r.agent_id ? { agent_id: r.agent_id } : null;
+    return {
+      key: "s:" + r.session_id,
+      label: r.name || r.session_id,
+      sub: agentLabel + " @ " + (r.workspace_name || r.workspace_id || "?"),
+      glyph: NV_identity(syntheticBinding),
+      tag: null,
+      run: runAndClose(function () {
+        con.goView("studio");
+        if (r.workspace_id && r.workspace_id !== con.wid && con.openInWorkspace) {
+          con.openInWorkspace(r.workspace_id, { kind: "session", ref: r.session_id });
+        } else {
+          con.setDoc({ kind: "session", ref: r.session_id });
+        }
+        if (con.promoteDoc) con.promoteDoc("session:" + r.session_id);
+      }),
+    };
+  }
+
   // Shared by both the searched "Files" group below and the empty-query
   // recent-files group (F9), same reason sessionRow is shared above.
+  // uiv2 Wave 1: folder/file text badge dropped for the same reason -
+  // the group heading already says "Files"; a leading dot (dot: true)
+  // takes its place per the mockup's row iconography.
   function fileRow(f) {
     return {
       key: "f:" + f.path,
       label: f.path,
-      tag: f.is_dir ? "folder" : "file",
+      tag: null,
+      dot: true,
       run: runAndClose(function () {
         con.goView("studio");
         if (!f.is_dir) con.setDoc({ kind: "file", ref: f.path });
@@ -273,19 +363,41 @@ function NV_Palette() {
     // recent sessions + files under the verbs"). last_activity_at is
     // stamped onto every row by SH_api.allSessions' own normalisation,
     // independent of the list's server-side order.
-    var recent = ((sessions.data && sessions.data.items) || [])
-      .slice()
-      .sort(function (a, b) {
-        return String(b.last_activity_at || "").localeCompare(
-          String(a.last_activity_at || ""));
-      })
-      .slice(0, NV_PALETTE_CAP)
-      .map(sessionRow);
-    if (recent.length) groups.push({ label: "Recent", rows: recent });
+    // uiv2 Wave 1: prefer the recents endpoint's own pre-composed rows
+    // (already ordered last_activity_at desc, live-workspaces only -
+    // no client-side sort/dedupe needed) when it is actually deployed;
+    // recents.data is null on a 404 (see the resource above), so this
+    // degrades to the exact same client-derived computation the wave
+    // shipped with before that endpoint existed.
+    var recent = recents.data && recents.data.items
+      ? recents.data.items.slice(0, NV_PALETTE_CAP).map(sessionRowFromRecent)
+      : ((sessions.data && sessions.data.items) || [])
+        .slice()
+        .sort(function (a, b) {
+          return String(b.last_activity_at || "").localeCompare(
+            String(a.last_activity_at || ""));
+        })
+        .slice(0, NV_PALETTE_CAP)
+        .map(sessionRow);
+    // uiv2 Wave 1: the empty-query group label matches the mockup's own
+    // taxonomy now (Verbs, Sessions, Files) - it already only ever held
+    // sessions, the old label just said otherwise.
+    if (recent.length) groups.push({ label: "Sessions", rows: recent });
 
     // files/tree stamps a real mtime per entry (workspaces.py file_tree);
     // only leaf files carry an "open this" action, so directories (no
     // recency signal worth surfacing here) are left out.
+    //
+    // KNOWN GAP, flagged not built: /files/tree is a documented
+    // one-level listing (recursive=False, workspaces.py file_tree) - a
+    // workspace whose root holds only folders (this dogfood workspace's
+    // does: .tmp, artifacts) legitimately produces zero leaf files here,
+    // same as the mockup's own src/api.ts example would if its root
+    // were listed one level deep. Matching the mockup for a real nested
+    // repo needs either a capped recursive walk (N extra calls, no
+    // natural depth bound) or a backend "recent files" endpoint -
+    // either is out of this UI-only wave's scope, so this stays a
+    // one-level fetch rather than growing ad hoc recursion here.
     var recentFiles = ((files.data && files.data.items) || [])
       .filter(function (f) { return !f.is_dir; })
       .slice()
@@ -368,7 +480,18 @@ function NV_Palette() {
                       data-row-key={r.key}
                       data-active={idx === selIdx ? "true" : "false"}
                       onClick={r.run}>
-                      <span className="nv-palette-label">{r.label}</span>
+                      {r.glyph ? (
+                        <svg width="11" height="11" viewBox="0 0 12 12"
+                          style={{ flexShrink: 0, color: r.glyph.color }}>
+                          <path d={r.glyph.d} fill="currentColor" />
+                        </svg>
+                      ) : r.dot ? (
+                        <span className="nv-palette-dot" />
+                      ) : null}
+                      <span className="nv-palette-main">
+                        <span className="nv-palette-label">{r.label}</span>
+                        {r.sub ? <span className="nv-palette-sub">{r.sub}</span> : null}
+                      </span>
                       {r.tag ? (
                         <span className="nv-palette-tag">{r.tag}</span>
                       ) : null}

--- a/ui/components/console/nv-rail.jsx
+++ b/ui/components/console/nv-rail.jsx
@@ -30,11 +30,14 @@
 //                         menu "New session" (bound to THAT row's wid,
 //                         not necessarily the selected one - a single
 //                         combined switch-and-open, F2 follow-up 2026-
-//                         08-29 UI review). The Inbox header's own "+"
-//                         retired in US-012b item 4 - this is the only
-//                         pointer affordance left for session.create now
-//                         (the dual-render guard still requires one; see
-//                         NV_Rail_WorkspaceContextMenu's data-verb).
+//                         08-29 UI review).
+//   onCreateSession() - the Inbox header "+" (uiv2 Wave 1, 01a06431):
+//                         un-retires US-012b item 4 per the mockup,
+//                         bound to the currently selected workspace
+//                         (same session.create verb Alt+n/palette run,
+//                         which already opens against con.wid) - the
+//                         context-menu row above stays for the
+//                         targeted, not-necessarily-selected case.
 //   onCreateWorkspace() - the workspace-tree header "+".
 //   onOpenWorkspaceSettings(wid) - the workspace row's context-menu
 //                         "Settings" entry (US-012b item 5a); replaces the
@@ -193,11 +196,12 @@ function NV_Rail_WorkspaceContextMenu(props) {
     return { slug: slug, label: label, fn: fn, danger: !!danger, verb: verb || null };
   }
   var rows = [
-    // data-verb="session.create" here is load-bearing, not decorative:
-    // item 4 (2026-08-29 dogfood) retired the Inbox header "+", the
-    // verb's only other rendered pointer affordance - the dual-render
-    // guard (test_shell_dual_render_guard.py) requires every registered
-    // verb with a non-palette surface to render data-verb SOMEWHERE.
+    // data-verb="session.create" here is one of two rendered pointer
+    // affordances now - the Inbox header "+" (nv-rail.jsx's own inbox
+    // section head) un-retired item 4's 2026-08-29 removal in uiv2 Wave
+    // 1 (01a06431); this row stays as the targeted, workspace-specific
+    // entry point. The dual-render guard (test_shell_dual_render_guard.py)
+    // only requires at least one - either satisfies it on its own.
     act("new-session", "New session", function () {
       if (typeof props.onCreateSessionInWorkspace === "function") {
         props.onCreateSessionInWorkspace(w.id);
@@ -376,9 +380,15 @@ function NV_Rail(props) {
     <div className="nv-rail-sections" data-testid="nv-rail-sections">
       <div className="nv-rail-inbox" data-testid="nv-rail-inbox">
         <div className="nv-rail-section-head">
-          <span>Inbox - needs you</span>
+          <span>Inbox — needs you</span>
           <span className="nv-rail-count">{inboxItems.length}</span>
           <div style={{ flex: 1 }} />
+          <button type="button" className="nv-rail-iconbtn" title="Create session"
+            data-verb="session.create"
+            data-testid="nv-rail-create-session"
+            onClick={function () {
+              if (typeof props.onCreateSession === "function") props.onCreateSession();
+            }}>+</button>
         </div>
         {!inboxItems.length ? (
           <div className="nv-rail-empty">Nothing needs you right now.</div>

--- a/ui/components/console/nv-studio.jsx
+++ b/ui/components/console/nv-studio.jsx
@@ -143,6 +143,10 @@ function NV_Studio() {
             var verb = con.registry.get("workspace.create");
             if (verb) verb.run();
           }}
+          onCreateSession={function () {
+            var verb = con.registry.get("session.create");
+            if (verb) verb.run();
+          }}
           onOpenWorkspaceSettings={function (wid) {
             con.openOverlay("workspaces", "detail", wid);
           }}

--- a/ui/components/console/nv-terminal.jsx
+++ b/ui/components/console/nv-terminal.jsx
@@ -43,7 +43,11 @@ function NV_Terminal() {
   var setHeight = heightState[1];
 
   var ws = (con.workspaces || []).find(function (w) { return w.id === con.wid; });
-  var wsLabel = (ws && (ws.name || ws.id)) || con.wid;
+  // uiv2 Wave 1: the mockup's header names the workspace ID short form
+  // ("ws-3f8a9bc"), not the display name other rail/files headers
+  // prefer - implementer-notes 2.6's own literal example, kept as-is
+  // rather than switched to name-preferred for cross-file consistency.
+  var wsLabel = (ws && ws.id) || con.wid;
 
   React.useEffect(function () {
     if (!hostRef.current || !window.Terminal) return undefined;
@@ -64,10 +68,29 @@ function NV_Terminal() {
     // the pre-connect value (the closure was created once, above), so
     // this is a plain local the two handlers share within one effect run.
     var gotExit = false;
+    // uiv2 Wave 1: the mockup's terminal content sits flush on the
+    // console theme, not xterm's own default black viewport (xterm.min.
+    // css hardcodes .xterm-viewport background-color: #000, overridden
+    // per-panel below via .nv-terminal-host .xterm-viewport - CSS
+    // custom properties resolve to real color strings at construction
+    // time here since xterm's theme option needs actual values, not
+    // var() references, and switching theme requires a fresh Terminal
+    // instance anyway (this effect already reruns per con.wid/retry,
+    // not per theme change - a live theme toggle mid-session keeps the
+    // colors it opened with, same as fontFamily/fontSize above).
+    var rootStyle = getComputedStyle(document.documentElement);
+    var termAccent = rootStyle.getPropertyValue("--accent").trim() || "#61d46a";
+    var termText = rootStyle.getPropertyValue("--text").trim() || "#e7e7e7";
     var term = new window.Terminal({
       fontFamily: "IBM Plex Mono, monospace",
       fontSize: 12,
-      theme: { background: "transparent" },
+      theme: {
+        background: "transparent",
+        foreground: termAccent,
+        cursor: termAccent,
+        cursorAccent: termText,
+        selectionBackground: rootStyle.getPropertyValue("--accent-dim").trim() || undefined,
+      },
     });
     var fit = window.FitAddon ? new window.FitAddon.FitAddon() : null;
     if (fit) term.loadAddon(fit);
@@ -181,7 +204,8 @@ function NV_Terminal() {
         onMouseDown={startResize}
       />
       <div className="nv-trace-head">
-        <span>{wsLabel} · pty</span>
+        <span>Terminal</span>
+        <span className="nv-rail-section-ws mono">{wsLabel} · pty</span>
         {exitCode != null ? (
           <span className="nv-term-exit">exit {exitCode}</span>
         ) : null}

--- a/ui/components/shell/sh-api.jsx
+++ b/ui/components/shell/sh-api.jsx
@@ -52,6 +52,21 @@ var SH_api = {
     });
   },
 
+  // uiv2 Wave 1 (studio-command-palette): the approved recents endpoint
+  // (Dev-Backend, concurrent with this wave, may land after it) - rows
+  // carry {session_id, name, workspace_id, workspace_name, agent
+  // qualifier, status, session_state, last_activity_at}, ordered
+  // last_activity_at desc, live-workspaces only. Callers must treat a
+  // 404 as "not deployed yet" and fall back to deriving the same
+  // qualifiers from allSessions()/con.workspaces client-side (nv-palette
+  // .jsx's sessionRow) rather than erroring - this endpoint not
+  // existing yet must not block the rest of the wave.
+  recentSessions: function (signal, limit) {
+    return window.primerApi.apiFetch(
+      "GET", "/sessions/recent?limit=" + encodeURIComponent(limit || 20),
+      null, { signal: signal });
+  },
+
   // response_model=WorkspaceSession (primer/api/routers/sessions.py:643-656):
   // a FLAT row. binding, binding_epoch, turn_status and parked_status are
   // top-level siblings, there is no `session` sub-object, and the bound

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -3069,12 +3069,84 @@ input, textarea, select { font: inherit; color: inherit; }
   position: relative;
   z-index: 60;
 }
-/* Shared dropdown panel (session-doc menus, profile menu). US-012b
-   (2026-08-29 dogfood, item 3) retired the topbar workspace dropdown -
-   its own .nv-ws-wrap/.nv-ws-btn and the workspace-list-only
-   .nv-menu-scroll/[data-current]/.nv-menu-id/.nv-menu-new went with it;
-   .nv-menu/.nv-menu-row/.nv-menu-sep stay, still rendered by
-   nv-session-doc.jsx and nv-chrome.jsx's profile menu. */
+/* uiv2 Wave 1 (01a06431): the topbar workspace chip un-retires US-012b
+   (2026-08-29, item 3) - the mockup shows the chip and the rail tree
+   coexisting (chip = always-visible entry point, rail = detailed
+   browse), so this is a deliberate un-revert, not a redundant rebuild.
+   Fresh classnames (.nv-ws-chip/.nv-ws-menu), not the old removed
+   .nv-ws-btn/.nv-menu-scroll ones - the row/footer shape here differs
+   (dim mono id per row, green "+ New workspace…" footer row). */
+.nv-ws-wrap { position: relative; flex-shrink: 0; }
+.nv-ws-chip {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+  height: 28px;
+  padding: 0 9px;
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-8);
+  background: var(--bg-2);
+  color: var(--text-2);
+  font-size: 12px;
+  font-weight: 600;
+  cursor: pointer;
+}
+.nv-ws-chip:hover { border-color: var(--accent-border); color: var(--text); }
+.nv-ws-chip-name {
+  max-width: 160px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.nv-ws-menu {
+  position: absolute;
+  top: 34px;
+  left: 0;
+  width: 240px;
+  background: var(--bg-elev);
+  border: 1px solid var(--border-strong);
+  border-radius: var(--r-8);
+  box-shadow: var(--shadow);
+  padding: 5px;
+  z-index: 60;
+  animation: nv-pop-in 0.14s ease-out;
+}
+.nv-ws-menu-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 7px 9px;
+  border: none;
+  border-radius: var(--r-6);
+  background: transparent;
+  color: var(--text);
+  font: inherit;
+  text-align: left;
+  cursor: pointer;
+}
+.nv-ws-menu-row:hover { background: var(--bg-hover); }
+.nv-ws-menu-row[data-current="true"] { background: var(--accent-dim); color: var(--accent); }
+.nv-ws-menu-name { flex: 1; min-width: 0; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+.nv-ws-menu-id { font-size: 10.5px; color: var(--text-4); flex-shrink: 0; }
+.nv-ws-menu-new {
+  display: block;
+  width: 100%;
+  padding: 7px 9px;
+  border: none;
+  border-radius: var(--r-6);
+  background: transparent;
+  color: var(--accent);
+  font: inherit;
+  font-weight: 600;
+  text-align: left;
+  cursor: pointer;
+}
+.nv-ws-menu-new:hover { background: var(--accent-dim); }
+/* Shared dropdown panel (session-doc menus, profile menu, workspace
+   menu). .nv-menu/.nv-menu-row/.nv-menu-sep are reused as the divider
+   above; nv-session-doc.jsx and nv-chrome.jsx's profile menu also
+   render against them. */
 .nv-menu {
   position: absolute;
   top: 40px;
@@ -3216,6 +3288,14 @@ input, textarea, select { font: inherit; color: inherit; }
   align-items: flex-start;
   padding-top: 12vh;
 }
+/* uiv2 Wave 1: the palette's own scrim dims heavier than the shared
+   .nv-scrim other overlays use (mockup - the app behind it barely
+   reads) - .nv-scrim itself is reused by nv-overlays.jsx below with a
+   DIFFERENT layout (grid/place-items, defined later in this file, so
+   its shared `background` declaration would otherwise win the cascade
+   for every .nv-scrim including this one). The testid attribute
+   selector scopes the override to the palette's own instance only. */
+[data-testid="nv-palette-scrim"] { background: oklch(0 0 0 / 0.72); }
 .nv-palette {
   width: min(580px, 90vw);
   max-height: 62vh;
@@ -3273,7 +3353,29 @@ input, textarea, select { font: inherit; color: inherit; }
   text-align: left;
 }
 .nv-palette-row:hover, .nv-palette-row[data-active="true"] { background: var(--bg-hover); }
-.nv-palette-label { font-size: 13px; }
+/* uiv2 Wave 1: leading row icon (mockup - every verb/file row starts
+   with a small dim dot; session rows use their own colored agent glyph
+   svg instead, sized to match). */
+.nv-palette-dot {
+  width: 5px;
+  height: 5px;
+  border-radius: 50%;
+  background: var(--text-4);
+  flex-shrink: 0;
+}
+.nv-palette-main { display: flex; flex-direction: column; min-width: 0; gap: 1px; }
+.nv-palette-label { font-size: 13px; white-space: nowrap; overflow: hidden; text-overflow: ellipsis; }
+/* The "agent @ workspace" disambiguator for otherwise-identical session
+   rows (the triplicate-"main" live bug) - dim so it stays secondary to
+   the label on rows that are already unambiguous by name alone. */
+.nv-palette-sub {
+  font-size: 10.5px;
+  color: var(--text-4);
+  font-family: var(--font-mono, monospace);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
 .nv-palette-tag {
   font-family: var(--font-mono);
   font-size: 8.5px;
@@ -3368,6 +3470,11 @@ input, textarea, select { font: inherit; color: inherit; }
   border-bottom: 1px solid var(--border);
 }
 .nv-rail-count { font-family: var(--font-mono, monospace); color: var(--attention); }
+/* uiv2 Wave 1 (01a06431): the Files header's workspace name escapes the
+   section head's inherited uppercase transform - "FILES payments-revamp",
+   not "FILES PAYMENTS-REVAMP" - and reads dim/accent-tinted per the
+   mockup rather than the plain label color. */
+.nv-rail-section-ws { text-transform: none; color: var(--accent); font-size: 10px; opacity: 0.85; }
 .nv-rail-inbox-row {
   display: flex;
   align-items: flex-start;
@@ -4343,6 +4450,13 @@ button.nv-trace-line { cursor: pointer; }
 }
 .nv-terminal-resize-handle:hover { background: var(--accent); opacity: 0.4; }
 .nv-terminal-host { flex: 1; min-height: 0; padding: 6px 10px; }
+/* uiv2 Wave 1: xterm.min.css hardcodes .xterm-viewport background-color:
+   #000 (its own vendored default) - that pure-black rectangle against
+   this panel's --bg-1 read as an inset box with a visible border in the
+   mockup comparison. Scoped to this panel only (not a global .xterm-
+   viewport override, in case xterm mounts anywhere else later) so the
+   canvas reads flush on the console theme instead. */
+.nv-terminal-host .xterm-viewport { background-color: transparent; }
 .nv-term-exit { font-family: var(--font-mono); font-size: 10px; color: var(--red); text-transform: none; letter-spacing: 0; }
 .nv-events {
   width: 300px;


### PR DESCRIPTION
uiv2 reconciliation Wave 1 (studio-empty / session-doc / terminal / command-palette).

**Headline**: the workspace-selector chip returns to the top bar and the + shortcut to the inbox header — both reverse deliberate US-012b (2026-08-29 dogfood) removals, on the newer mockup-is-authoritative directive; the mockup shows chip and rail coexisting with distinct roles. Restoring the chip also fixes a live bug: the palette's Switch Workspace verb has been a silent no-op since US-012b (its handler opened a menu nothing rendered).

**Palette**: Verbs/Sessions/Files taxonomy, agent glyphs + 'agent @ workspace' sub-labels, prefers GET /sessions/recent (landing separately) with a tested 404-degrade fallback, honest FREQUENT tags, self-filtering, instance-scoped scrim darkening.

**Terminal**: 'TERMINAL {ws-short-id} · pty' header, xterm themed from console tokens, vendored black-viewport CSS overridden panel-scoped.

**Deliberate non-changes**: mic + voice-replies toggle (capability-gated, already implemented — capture env lacked a speech provider); ended/failed session chips (no mockup target exists for those states; current styling is deliberate).

**Verification**: tests/ui 1667 passed / 1 skipped; 26 live Playwright tests across 8 studio-adjacent journeys green against a fresh stack running this tree; ruff + transpile clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)