### PR TITLE
fix(graph): fan-out instances stop collapsing onto their base node id

### DIFF
--- a/primer/api/routers/compute.py
+++ b/primer/api/routers/compute.py
@@ -19,6 +19,9 @@ already supports out of the box.
 
 from __future__ import annotations
 
+import re
+from collections import defaultdict
+
 from fastapi import APIRouter, Depends, Path, Query
 from pydantic import BaseModel
 
@@ -242,6 +245,27 @@ async def get_graph_node_turn_log(
     )
 
 
+# _FanoutInstance.synthesized_id's broadcast/map format (primer/graph/
+# _node_refs.py): "{target}[{i}]" -- e.g. "worker[2]". tee's synthesized
+# id has no bracket (it's a distinct node id already, no base-id
+# ambiguity), so it never matches this and is treated as its own base.
+_FANOUT_INSTANCE_RE = re.compile(r"^(?P<base>.+)\[(?P<idx>\d+)\]$")
+
+
+def _base_node_id(node_id: str) -> str:
+    """Strip a fan-out instance suffix ("worker[2]" -> "worker").
+    Returns node_id unchanged when it isn't instance-qualified."""
+    m = _FANOUT_INSTANCE_RE.match(node_id)
+    return m.group("base") if m else node_id
+
+
+def _instance_sort_key(node_id: str) -> tuple[str, int]:
+    m = _FANOUT_INSTANCE_RE.match(node_id)
+    if m:
+        return (m.group("base"), int(m.group("idx")))
+    return (node_id, -1)
+
+
 class _NodeStateOut(BaseModel):
     """One node's runtime snapshot for the run-view canvas + inspector."""
 
@@ -274,6 +298,15 @@ async def get_graph_run_node_states(
     ``kind``. Nodes that have not run yet (absent from the persisted
     state map) surface as ``pending``.
 
+    A fan-out target (broadcast/map) runs as N instances keyed
+    ``"{base}[{i}]"`` in the state map (``_FanoutInstance.synthesized_id``),
+    not under its bare graph-definition id -- each live instance is
+    surfaced as its own row (``node_id="worker[0]"`` etc.), grouped
+    under the base node's declared ``kind``, rather than one row per
+    graph-definition node that a bare-id lookup would never match (the
+    lookup always missed, so every fan-out node showed "pending"
+    forever regardless of its real status -- 01a05935 item 1).
+
     Resolution mirrors the graph turn-log routes:
     1. ``run_id`` is a WorkspaceSession bound to a graph -> read
        ``<state_path>/graphs/<run_id>/state.json`` via the workspace.
@@ -292,19 +325,27 @@ async def get_graph_run_node_states(
         storage_provider=storage_provider,
     )
 
+    by_base_id: dict[str, list[str]] = defaultdict(list)
+    for state_key in state_map:
+        by_base_id[_base_node_id(state_key)].append(state_key)
+    for instance_keys in by_base_id.values():
+        instance_keys.sort(key=_instance_sort_key)
+
     items: list[dict] = []
     for node_id, kind in kinds.items():
-        ns = state_map.get(node_id) or {}
-        items.append(
-            _NodeStateOut(
-                node_id=node_id,
-                kind=kind,
-                status=ns.get("status", "pending"),
-                iteration=ns.get("last_run_iteration"),
-                last_run_at=ns.get("last_run_at"),
-                error=ns.get("error"),
-            ).model_dump()
-        )
+        instance_keys = by_base_id.get(node_id) or [None]
+        for key in instance_keys:
+            ns = (state_map.get(key) or {}) if key is not None else {}
+            items.append(
+                _NodeStateOut(
+                    node_id=key if key is not None else node_id,
+                    kind=kind,
+                    status=ns.get("status", "pending"),
+                    iteration=ns.get("last_run_iteration"),
+                    last_run_at=ns.get("last_run_at"),
+                    error=ns.get("error"),
+                ).model_dump()
+            )
     return {"items": items, "run_id": run_id, "graph_id": graph_id}
 
 

--- a/primer/graph/_agent_node.py
+++ b/primer/graph/_agent_node.py
@@ -156,8 +156,15 @@ class _AgentNodeMixin:
         )
         new_user_msg = Message(role="user", parts=[TextPart(text=rendered)])
 
+        # 01a05935 item 3: instance-qualified, same reasoning as the
+        # event-tagging line below - concurrent fan-out siblings of this
+        # SAME agent node must not read/write the SAME history rows.
+        # Both storage backends key purely on whatever string they're
+        # given, so this is the complete fix (no storage-layer change).
+        history_node_id = current_graph_node_id() or node.id
+
         # Build the prompt: system + history + new user msg.
-        history = await self._load_node_history(node.id)
+        history = await self._load_node_history(history_node_id)
         prompt: list[Message] = []
         if agent.system_prompt:
             sys_text = render_system_prompt_or_raw(agent.system_prompt, context.ctx)
@@ -209,7 +216,7 @@ class _AgentNodeMixin:
         # Persist the new user msg + every message produced this turn
         # (assistant + any tool result messages from the loop).
         all_new = [new_user_msg] + produced_messages
-        await self._persist_node_turn(node.id, context.iteration, all_new)
+        await self._persist_node_turn(history_node_id, context.iteration, all_new)
 
         return self._agent_node_output(
             produced_messages, node.response_format,
@@ -242,7 +249,15 @@ class _AgentNodeMixin:
             node.input_template, context=context, extra_scope=None
         )
         new_user_msg = Message(role="user", parts=[TextPart(text=rendered)])
-        history = await self._load_node_history(node.id)
+        # 01a05935 item 3: pending.node_id is the fan-out-instance-
+        # qualified id this specific park record belongs to (node.id
+        # above is the base node's DEFINITION - _resolve_node_def
+        # already collapsed the instance id to look it up), so it's the
+        # authoritative key here, not a contextvar lookup - this method
+        # isn't necessarily called from the same dispatch path that sets
+        # current_graph_node_id, and pending.node_id is already exactly
+        # right without depending on that ambient state being set.
+        history = await self._load_node_history(pending.node_id)
         prompt: list[Message] = []
         if agent.system_prompt:
             sys_text = render_system_prompt_or_raw(agent.system_prompt, context.ctx)
@@ -269,7 +284,7 @@ class _AgentNodeMixin:
             pass
 
         all_new = [new_user_msg, *rehydrated_assistant, tool_result_msg, *produced_messages]
-        await self._persist_node_turn(node.id, pending.iteration, all_new)
+        await self._persist_node_turn(pending.node_id, pending.iteration, all_new)
 
         return self._agent_node_output(
             produced_messages, node.response_format,

--- a/primer/graph/_checkpoint.py
+++ b/primer/graph/_checkpoint.py
@@ -52,9 +52,18 @@ class _CheckpointMixin:
             first = self._pending_toolcalls[0]
             primary_event_key = first.parked_event_key
             primary_tcid = first.tool_call_id
-            node_def = next(
-                (n for n in self._graph.nodes if n.id == first.node_id), None
-            )
+            # _resolve_node_def (mixed in from _NodeDispatchMixin) resolves
+            # a fan-out instance id (e.g. "worker[2]") to its TARGET node's
+            # definition via _fanout_instances -- a bare `n.id == node_id`
+            # scan over the graph definition never matches an instance id,
+            # which silently dropped tool_id (and therefore the whole
+            # original_call block) for every fan-out TOOL_CALL approval
+            # (01a05935 item 2). KeyError -> None mirrors this file's other
+            # "topology drifted between checkpoint and resume" fallbacks.
+            try:
+                node_def = self._resolve_node_def(first.node_id)
+            except KeyError:
+                node_def = None
             tool_id = getattr(node_def, "tool_id", None)
             resume_meta: dict[str, Any] = {}
             if tool_id is not None:
@@ -220,6 +229,13 @@ class _CheckpointMixin:
                 "tool_call_id": p.tool_call_id,
                 "resume_metadata": dict(p.resume_metadata or {}),
             }
+        # Same fan-out-instance resolution as _build_pending_park_yield
+        # above (01a05935 item 2) -- p.node_id may be "worker[2]", which a
+        # bare graph-definition scan never matches.
+        try:
+            node_def = self._resolve_node_def(p.node_id)
+        except KeyError:
+            node_def = None
         return {
             "kind": "_approval",
             "node_id": p.node_id,
@@ -227,11 +243,7 @@ class _CheckpointMixin:
             "resume_metadata": {
                 "original_call": {
                     "id": p.tool_call_id,
-                    "name": getattr(
-                        next((n for n in self._graph.nodes
-                              if n.id == p.node_id), None),
-                        "tool_id", "<unknown>",
-                    ),
+                    "name": getattr(node_def, "tool_id", "<unknown>"),
                     "arguments": dict(p.arguments),
                 },
             },

--- a/tests/api/test_node_states_route.py
+++ b/tests/api/test_node_states_route.py
@@ -188,6 +188,105 @@ async def test_node_states_storage_backed(
 
 
 @pytest.mark.asyncio
+async def test_node_states_fanout_instances_are_not_pending_forever(
+    client: httpx.AsyncClient, app, fake_storage_provider,
+):
+    """01a05935 item 1: a fan-out target ("worker") runs as N instances
+    keyed "worker[0]"/"worker[1]"/etc in the state map
+    (_FanoutInstance.synthesized_id) - a bare-id lookup against
+    state_map["worker"] never matches any of them, so every fan-out
+    node showed "pending" forever regardless of its real status. Each
+    instance must surface as its own row, grouped under the base node's
+    declared kind."""
+    from primer.model.graph import Graph
+
+    graph = Graph(
+        id="g-fanout",
+        description="probe",
+        nodes=[
+            {"kind": "begin", "id": "begin"},
+            {
+                "kind": "fan_out", "id": "spread",
+                "specs": [
+                    {"kind": "broadcast", "target_node_id": "worker", "count": 3},
+                ],
+            },
+            {"kind": "agent", "id": "worker", "agent_id": "ag1"},
+            {"kind": "fan_in", "id": "gather"},
+            {"kind": "end", "id": "end", "output_template": ""},
+        ],
+        edges=[
+            {"kind": "static", "from_node": "begin", "to_node": "spread"},
+            {"kind": "static", "from_node": "worker", "to_node": "gather"},
+            {"kind": "static", "from_node": "gather", "to_node": "end"},
+        ],
+    )
+    await fake_storage_provider.get_storage(Graph).create(graph)
+
+    from primer.model.workspace_session import (
+        GraphSessionBinding, SessionStatus, WorkspaceSession,
+    )
+
+    sess = WorkspaceSession(
+        id="run-fanout-1",
+        workspace_id="ws-fanout",
+        binding=GraphSessionBinding(graph_id="g-fanout"),
+        status=SessionStatus.RUNNING,
+        created_at=_now(),
+        turn_status="running",
+    )
+    await fake_storage_provider.get_storage(WorkspaceSession).create(sess)
+
+    ws = _FakeWorkspace()
+    ws.write(
+        ".state/graphs/run-fanout-1/state.json",
+        '{"iteration":1,"status":"running","ended_reason":null,'
+        '"ended_detail":null,"node_states":{'
+        '"begin":{"status":"ended","last_run_iteration":0,'
+        '"last_run_at":"2026-06-05T10:00:00+00:00","error":null},'
+        '"worker[0]":{"status":"ended","last_run_iteration":1,'
+        '"last_run_at":"2026-06-05T10:00:05+00:00","error":null},'
+        '"worker[1]":{"status":"running","last_run_iteration":1,'
+        '"last_run_at":"2026-06-05T10:00:06+00:00","error":null},'
+        '"worker[2]":{"status":"failed","last_run_iteration":1,'
+        '"last_run_at":"2026-06-05T10:00:07+00:00",'
+        '"error":"boom"}}}',
+    )
+
+    async def _get(wid):
+        return ws if wid == "ws-fanout" else None
+
+    app.state.workspace_registry.get_workspace = _get  # type: ignore[assignment]
+
+    r = await client.get("/v1/graphs/g-fanout/runs/run-fanout-1/node_states")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    by_id = {it["node_id"]: it for it in body["items"]}
+
+    # Three distinct instance rows, NOT a single "worker" row stuck on
+    # pending, NOT collapsed/deduped into one entry.
+    assert {"worker[0]", "worker[1]", "worker[2]"} <= set(by_id)
+    assert "worker" not in by_id  # never ran under its bare id
+    assert by_id["worker[0]"]["kind"] == "agent"
+    assert by_id["worker[0]"]["status"] == "ended"
+    assert by_id["worker[1]"]["kind"] == "agent"
+    assert by_id["worker[1]"]["status"] == "running"
+    assert by_id["worker[2]"]["kind"] == "agent"
+    assert by_id["worker[2]"]["status"] == "failed"
+    assert by_id["worker[2]"]["error"] == "boom"
+
+    # Nodes downstream of the fan-out that never ran still surface as
+    # a single pending row under their own bare id (no instances yet).
+    assert by_id["gather"]["status"] == "pending"
+    assert by_id["end"]["status"] == "pending"
+
+    # Instance count matches exactly what ran - no phantom extra rows,
+    # no dedup collapsing distinct siblings together.
+    worker_rows = [it for it in body["items"] if it["node_id"].startswith("worker")]
+    assert len(worker_rows) == 3
+
+
+@pytest.mark.asyncio
 async def test_node_states_404_for_unknown_run(
     client: httpx.AsyncClient, app, fake_storage_provider,
 ):

--- a/tests/graph/test_agent_node_fanout_history_isolation.py
+++ b/tests/graph/test_agent_node_fanout_history_isolation.py
@@ -1,0 +1,166 @@
+"""01a05935 item 3: fan-out agent-node siblings must not share turn history.
+
+_stream_agent_node's live-dispatch path is covered end-to-end by
+tests.graph.test_spec_b_end_to_end (3 concurrent broadcast workers, each
+persists under its own instance-qualified node_id). This file covers the
+OTHER call path with the same bug: _resume_agent_node, continuing a
+parked fan-out instance's turn after an ask_user/approval answer arrives.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from primer.graph._node_refs import _FanoutInstance, _PendingAgentYield
+from primer.graph.executor import GraphExecutor
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import (
+    Done, Message, StreamEvent, TextDelta, TextPart, ToolResultPart,
+)
+from primer.model.graph import (
+    FanOutSpec,
+    Graph,
+    GraphContext,
+    GraphNodeMessage,
+    GraphThread,
+    NodeOutput,
+    _AgentNodeRef,
+    _BeginNode,
+    _EndNode,
+    _FanInNode,
+    _FanOutNode,
+    _StaticEdge,
+)
+from primer.model.model_profile import ModelProfileConfig
+from primer.model_profile import ResolvedModel
+
+from tests.graph.test_toolcall_dispatch import _InMemoryStorage
+
+
+class _ContinuationLLM:
+    async def list_models(self):
+        return ["m"]
+
+    def stream(self, **kw: Any) -> AsyncIterator[StreamEvent]:
+        async def _g():
+            yield TextDelta(text="continued", index=0)
+            yield Done(stop_reason="stop", raw_reason="stop")
+        return _g()
+
+
+def _graph() -> Graph:
+    return Graph(
+        id="g-resume-fanout",
+        description="begin -> fan_out -> worker(agent) -> fan_in -> end",
+        nodes=[
+            _BeginNode(id="begin"),
+            _FanOutNode(
+                id="fo",
+                specs=[FanOutSpec(
+                    kind="broadcast", target_node_id="worker", count=2,
+                )],
+            ),
+            _AgentNodeRef(id="worker", agent_id="ag", input_template="continue"),
+            _FanInNode(id="fi", aggregate_template="{{ nodes.worker | length }}"),
+            _EndNode(id="end"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="fo"),
+            _StaticEdge(from_node="worker", to_node="fi"),
+            _StaticEdge(from_node="fi", to_node="end"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_agent_node_persists_history_under_the_instance_id() -> None:
+    """A parked fan-out agent instance ("worker[1]") resuming its turn
+    must load/persist history under "worker[1]", not the shared base id
+    "worker" that _resolve_node_def collapses pending.node_id to when
+    looking up the node DEFINITION (a different, correct use of that
+    collapse - the definition is shared, the history must not be)."""
+    graph = _graph()
+
+    async def agent_resolver(agent_id: str) -> Agent:
+        return Agent(id=agent_id, description="x",
+                     model=AgentModel(profile_id="p--m"), system_prompt=[])
+
+    llm = _ContinuationLLM()
+
+    async def llm_resolver(agent: Agent):
+        return (llm, ResolvedModel(
+            profile_id="test-profile", provider_id="test-provider",
+            model_name="m", context_length=128_000,
+            config=ModelProfileConfig(),
+        ))
+
+    thread_storage: _InMemoryStorage[GraphThread] = _InMemoryStorage(GraphThread)
+    message_storage: _InMemoryStorage[GraphNodeMessage] = _InMemoryStorage(
+        GraphNodeMessage
+    )
+    thread = await GraphExecutor.open_thread(
+        graph=graph, thread_storage=thread_storage,  # type: ignore[arg-type]
+    )
+    executor = GraphExecutor(
+        graph=graph, agent_resolver=agent_resolver,
+        llm_resolver=llm_resolver,  # type: ignore[arg-type]
+        thread_storage=thread_storage,  # type: ignore[arg-type]
+        message_storage=message_storage,  # type: ignore[arg-type]
+        graph_thread_id=thread.id,
+    )
+
+    # Sibling worker[0] already finished and left history under its own
+    # id - proves worker[1]'s resume doesn't read or write into it.
+    await executor._persist_node_turn(
+        "worker[0]", 0,
+        [Message(role="user", parts=[TextPart(text="sibling 0's turn")])],
+    )
+
+    executor._context = GraphContext(
+        initial_input="seed", iteration=1,
+        nodes={"begin": NodeOutput(text="seed", parsed=None, history=[], iteration=0)},
+    )
+    executor._fanout_instances = {
+        "worker[1]": _FanoutInstance(
+            synthesized_id="worker[1]", target_node_id="worker",
+            fanout_index=1, fanout_item=None,
+        ),
+    }
+    pending = _PendingAgentYield(
+        node_id="worker[1]",
+        tool_call_id="tc-1",
+        event_key="ask_user:gsid:tc-1",
+        tool_name="ask_user",
+        resume_metadata={"prompt": "continue?"},
+        llm_messages=[
+            Message(role="assistant", parts=[TextPart(text="(asking)")])
+            .model_dump(mode="json"),
+        ],
+        iteration=1,
+    )
+    tool_result_msg = Message(
+        role="tool", parts=[ToolResultPart(id="tc-1", output="yes")],
+    )
+
+    await executor._resume_agent_node(pending, tool_result_msg)
+
+    persisted_node_ids = {m.node_id for m in message_storage._data.values()}
+    assert persisted_node_ids == {"worker[0]", "worker[1]"}, (
+        f"worker[1]'s resume must persist under its own instance id, "
+        f"not merge into worker[0]'s or the shared base 'worker' - "
+        f"got {sorted(persisted_node_ids)}"
+    )
+
+    sibling_rows = [
+        m for m in message_storage._data.values() if m.node_id == "worker[0]"
+    ]
+    assert len(sibling_rows) == 1, "worker[1]'s resume must not touch worker[0]'s history"
+    assert sibling_rows[0].parts[0].text == "sibling 0's turn"  # type: ignore[union-attr]
+
+    worker1_rows = [
+        m for m in message_storage._data.values() if m.node_id == "worker[1]"
+    ]
+    assert len(worker1_rows) >= 1

--- a/tests/graph/test_spec_b_end_to_end.py
+++ b/tests/graph/test_spec_b_end_to_end.py
@@ -327,7 +327,37 @@ async def test_spec_b_end_to_end_graph_runs_to_completion() -> None:
     # ToolCall ran; the bare ``worker``-tagged events confirm graph
     # event multiplexing for agent nodes.
 
-    # -------- 7. Thread state ENDED completed ------------------------
+    # -------- 7. Each fan-out sibling persists its OWN turn history ---
+    # 01a05935 item 3: _stream_agent_node used to load/persist history
+    # keyed by the base node.id ("worker") regardless of which fan-out
+    # instance was running, so all 3 concurrent siblings read and wrote
+    # the SAME GraphNodeMessage rows - one sibling's turn could clobber
+    # or interleave with another's. Persisted rows must land under each
+    # instance's own qualified node_id, matching the same
+    # current_graph_node_id()-or-node.id convention the event-tagging
+    # line above already uses.
+    persisted_node_ids = {m.node_id for m in message_storage._data.values()}
+    worker_history_ids = {
+        nid for nid in persisted_node_ids
+        if nid == "worker" or nid.startswith("worker[")
+    }
+    assert worker_history_ids == {"worker[0]", "worker[1]", "worker[2]"}, (
+        f"expected each fan-out sibling's history under its own "
+        f"instance-qualified node_id, got {sorted(worker_history_ids)}"
+    )
+    for i in range(3):
+        rows = [
+            m for m in message_storage._data.values()
+            if m.node_id == f"worker[{i}]"
+        ]
+        user_rows = [m for m in rows if m.role == "user"]
+        assert len(user_rows) == 1, (
+            f"worker[{i}] should have exactly its own one user turn "
+            f"persisted, found {len(user_rows)}"
+        )
+        assert user_rows[0].parts[0].text == f"W{i}"  # type: ignore[union-attr]
+
+    # -------- 8. Thread state ENDED completed ------------------------
     loaded = await thread_storage.get(thread.id)
     assert loaded is not None
     assert loaded.ended_reason == "completed"

--- a/tests/graph/test_toolcall_yields_writes_checkpoint.py
+++ b/tests/graph/test_toolcall_yields_writes_checkpoint.py
@@ -17,15 +17,19 @@ from collections.abc import AsyncIterator
 
 import pytest
 
+from primer.graph.base import _FanoutInstance, _PendingToolCall
 from primer.graph.executor import GraphExecutor
 from primer.model.agent import Agent
 from primer.model.chat import Message, StreamEvent, ToolResultPart
 from primer.model.graph import (
+    FanOutSpec,
     Graph,
     GraphNodeMessage,
     GraphThread,
     _BeginNode,
     _EndNode,
+    _FanInNode,
+    _FanOutNode,
     _StaticEdge,
     _ToolCallNode,
 )
@@ -262,3 +266,89 @@ async def test_toolcall_yield_carries_original_call_metadata() -> None:
     assert oc is not None, "outer approval yield dropped original_call"
     assert oc["name"] == "workspace__write"
     assert oc["arguments"] == {"path": "release.txt", "content": "hi"}
+
+
+@pytest.mark.asyncio
+async def test_toolcall_yield_carries_original_call_for_fanout_instance() -> None:
+    """01a05935 item 2: a fan-out TOOL_CALL instance's node_id is
+    instance-qualified ("worker[1]"), not the graph-definition's bare id
+    ("worker"). Both places that rebuild original_call from the node's
+    tool_id -- the outer park yield and the checkpoint's pending_dispatch
+    entry -- must resolve through the fan-out instance record (like
+    _resolve_node_def already does for every other node lookup), not
+    scan the graph definition for a literal id match, which never
+    matches an instance id and silently drops tool_id to "<unknown>"."""
+    graph = Graph(
+        id="g-fanout-meta",
+        description="begin -> fan_out -> tool(yields) -> fan_in -> end",
+        nodes=[
+            _BeginNode(id="begin"),
+            _FanOutNode(
+                id="fo",
+                specs=[FanOutSpec(
+                    kind="broadcast", target_node_id="worker", count=2,
+                )],
+            ),
+            _ToolCallNode(id="worker", tool_id="web__search",
+                          arguments={"q": "x"}),
+            _FanInNode(id="fi", aggregate_template="{{ nodes.worker | length }}"),
+            _EndNode(id="exit"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="fo"),
+            _StaticEdge(from_node="worker", to_node="fi"),
+            _StaticEdge(from_node="fi", to_node="exit"),
+        ],
+    )
+
+    async def agent_resolver(agent_id: str) -> Agent:
+        raise KeyError(agent_id)
+
+    async def llm_resolver(agent):
+        raise NotImplementedError
+
+    thread_storage: _InMemoryStorage[GraphThread] = _InMemoryStorage(GraphThread)
+    message_storage: _InMemoryStorage[GraphNodeMessage] = _InMemoryStorage(GraphNodeMessage)
+    thread = await GraphExecutor.open_thread(
+        graph=graph, thread_storage=thread_storage,  # type: ignore[arg-type]
+    )
+    executor = GraphExecutor(
+        graph=graph, agent_resolver=agent_resolver,
+        llm_resolver=llm_resolver,  # type: ignore[arg-type]
+        thread_storage=thread_storage,  # type: ignore[arg-type]
+        message_storage=message_storage,  # type: ignore[arg-type]
+        graph_thread_id=thread.id,
+    )
+
+    # Synthesize exactly the state a real fan-out dispatch leaves behind:
+    # one live instance record for "worker[1]", and that instance parked
+    # on an approval.
+    executor._fanout_instances = {
+        "worker[1]": _FanoutInstance(
+            synthesized_id="worker[1]", target_node_id="worker",
+            fanout_index=1, fanout_item=None,
+        ),
+    }
+    executor._pending_toolcalls = [
+        _PendingToolCall(
+            node_id="worker[1]",
+            tool_call_id="tc-fo-1",
+            parked_event_key="tool_approval:gsid-1:tc-fo-1",
+            arguments={"q": "y"},
+        ),
+    ]
+
+    yld = executor._build_pending_park_yield()
+    oc = (yld.yielded.resume_metadata or {}).get("original_call")
+    assert oc is not None, "fan-out instance dropped original_call entirely"
+    assert oc["name"] == "web__search", (
+        f"expected the fan-out target's tool_id, got {oc['name']!r} - "
+        "the node lookup fell through to the graph-definition scan and "
+        "missed the instance id"
+    )
+    assert oc["arguments"] == {"q": "y"}
+
+    # The checkpoint's pending_dispatch entry (channel/REST surface)
+    # resolves the same way.
+    entry = executor._toolcall_dispatch_entry(executor._pending_toolcalls[0])
+    assert entry["resume_metadata"]["original_call"]["name"] == "web__search"


### PR DESCRIPTION
Closes the three pre-existing base-id-lookup bugs the tool-call-identity sweep (PR #212) surfaced but scoped out:

- **/node_states**: fan-out nodes no longer sit 'pending' forever - state entries group by base id and each live instance surfaces as its own row, sorted by instance index.
- **Checkpoint approval metadata**: a fan-out TOOL_CALL node's approval no longer drops its tool_id/name - both checkpoint builders resolve node definitions through the instance-aware resolver instead of a base-id-only scan.
- **Agent-node history isolation**: fan-out siblings stop reading and writing one shared history log (concurrent siblings raced and interleaved) - dispatch keys history by the instance-qualified id; resume uses the pending entry's own authoritative instance id. Storage layers needed zero changes. One-time edge documented in the commit: anything parked mid-fan-out-agent-node across this deploy resumes with fresh instance history (no live deployment currently has graph entities, so the window is empty in practice).

Verification includes a revert-and-rerun proof that the isolation test fails without the fix (exact shared-key assertion mismatch), plus a real concurrent 3-way fan-out asserting per-instance content. 396 tests green across graph/api/worker suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)