### PR TITLE
feat(console): agent editor and collection browser match the designer's version

### DIFF
--- a/tests/ui/test_agents_model_profile_field.py
+++ b/tests/ui/test_agents_model_profile_field.py
@@ -33,9 +33,16 @@ class TestFormSendsTheProfileShape:
         assert "a.model?.model_name" not in src
 
     def test_picker_lists_profiles_not_providers(self) -> None:
+        """uiv2 Wave 2: retargeted from a <select htmlFor="na-model-
+        profile"> to the stacked AG_ProfilePicker (mockup's own picker
+        style - one bordered row per profile, the bound one tinted) - a
+        button-per-row group has no single focusable target for a plain
+        <label for>, so the label instead carries its own id and the
+        picker its own data-testid."""
         src = _src()
         assert '"/model_profiles?limit=200"' in src
-        assert 'htmlFor="na-model-profile"' in src
+        assert 'id="na-model-profile-label"' in src
+        assert "<AG_ProfilePicker" in src
 
     def test_submit_is_blocked_without_a_profile(self) -> None:
         assert "disabled={!profileId || create.loading}" in _src()

--- a/tests/ui/test_agents_p1b.py
+++ b/tests/ui/test_agents_p1b.py
@@ -39,14 +39,25 @@ def test_modal_has_a_verb_chip() -> None:
     assert 'verb: {isEdit ? "Edit" : "Create"} Agent' in modal
 
 
-# ---- Tools tab: footnote + already-live y/w/r/n badges -----------------
+# ---- Tools: footnote + already-live y/w/r/n badges ----------------------
+#
+# RETARGET (uiv2 Wave 2): both moved from AG_NewAgentModal's own inline
+# Tools tab into the shared, reusable ToolPicker (ui/components/shared/
+# tool-picker.jsx) - the modal now just mounts <window.ToolPicker>, it no
+# longer renders these strings itself.
+
+
+def _tool_picker_src() -> str:
+    return (UI / "components" / "shared" / "tool-picker.jsx").read_text(encoding="utf-8")
 
 
 def test_tools_footnote_is_verbatim() -> None:
-    modal = _modal_src()
-    assert 'data-testid="agent-tools-footnote"' in modal
-    assert "y yields · w" in modal
-    assert "workspace · r role · n notifying" in modal
+    src = _tool_picker_src()
+    assert 'data-testid="tool-picker-footnote"' in src
+    assert "y yields · w" in src
+    assert "workspace · r role · n notifying" in src
+    # And the modal actually mounts the shared picker, not a local copy.
+    assert "<window.ToolPicker " in _modal_src()
 
 
 def test_capability_badges_are_already_live_not_a_p2_placeholder() -> None:
@@ -55,8 +66,7 @@ def test_capability_badges_are_already_live_not_a_p2_placeholder() -> None:
     flags on every tool row from data GET /tools already serves. Pin
     that the working component stayed wired rather than being ripped
     out for an empty P2 slot."""
-    modal = _modal_src()
-    assert "CapabilityBadges" in modal
+    assert "CapabilityBadges" in _tool_picker_src()
 
 
 # ---- Autonomous: disabled, honest no-op ---------------------------------

--- a/tests/ui/test_agents_tools_selected_filter.py
+++ b/tests/ui/test_agents_tools_selected_filter.py
@@ -1,8 +1,16 @@
-"""studio-ux fix 4 — the Edit/New-agent modal's Tools tab
-(`AG_NewAgentModal` in ui/components/agents.jsx) had a text filter but no
-way to see WHICH tools are currently ticked across all toolsets/pages. A
-"Selected" filter chip now ANDs with the text filter, reusing the existing
-`selectedScopedIds` state the "N of 172 selected" counter already reads.
+"""studio-ux fix 4 — the tool picker had a text filter but no way to see
+WHICH tools are currently ticked across all toolsets/pages. A "Selected"
+filter chip ANDs with the text filter, reusing the existing `selected`
+Set the "selected · N" counter already reads.
+
+RETARGET (uiv2 Wave 2): this behavior lived inline in AG_NewAgentModal
+(ui/components/agents.jsx) - Wave 2 extracted it into the shared,
+reusable ToolPicker (ui/components/shared/tool-picker.jsx, "build the
+shared tool picker component here first" per the synthesis doc), so
+every assertion here now reads that file instead. The behavior itself
+is unchanged, just relocated + renamed to a controlled-component
+contract (`selected`/`onChange` props instead of agent-specific state
+names) so graphs/policies/services/the MCP allowlist can adopt it later.
 
 Static-source checks only (the tests/ui suite convention — no DOM/browser
 harness; see test_studio_activity.py's docstring for the rationale).
@@ -14,68 +22,53 @@ from pathlib import Path
 
 ROOT = Path(__file__).resolve().parents[2]
 UI = ROOT / "ui"
-AGENTS = UI / "components" / "agents.jsx"
+TOOL_PICKER = UI / "components" / "shared" / "tool-picker.jsx"
 
 
 def _src() -> str:
-    return AGENTS.read_text(encoding="utf-8")
-
-
-def _fn_block(src: str, start_marker: str, end_marker: str) -> str:
-    start = src.index(start_marker)
-    end = src.index(end_marker, start)
-    return src[start:end]
-
-
-def _modal_src() -> str:
-    return _fn_block(_src(), "function AG_NewAgentModal(", "function AgentDetail(")
+    return TOOL_PICKER.read_text(encoding="utf-8")
 
 
 def test_selected_only_state_exists() -> None:
-    modal = _modal_src()
-    assert "const [showSelectedOnly, setShowSelectedOnly] = React.useState(false);" in modal
+    assert 'const [selectedOnly, setSelectedOnly] = React.useState(false);' in _src()
 
 
 def test_filtered_toolset_entries_composes_selected_filter_with_text_filter() -> None:
-    modal = _modal_src()
-    assert "if (showSelectedOnly) {" in modal
-    assert "ts.tools.filter((t) => selectedScopedIds.has(t.scoped_id))" in modal
+    src = _src()
+    assert "if (selectedOnly) {" in src
+    assert "ts.tools.filter((t) => selected.has(t.scoped_id))" in src
     # Both filters can be active together — selected-only doesn't replace
     # the text-filter branch, it narrows its result further.
-    assert "}, [toolsetEntries, toolFilter, showSelectedOnly, selectedScopedIds]);" in modal
+    assert "}, [toolsetEntries, filter, selectedOnly, selected]);" in src
 
 
 def test_toggling_selected_only_resets_to_first_page() -> None:
-    modal = _modal_src()
-    assert "React.useEffect(() => { setToolPage(1); }, [toolFilter, showSelectedOnly]);" in modal
+    assert "React.useEffect(() => { setPage(1); }, [filter, selectedOnly]);" in _src()
 
 
 def test_selected_filter_chip_rendered_next_to_the_search_input() -> None:
-    modal = _modal_src()
-    assert 'data-testid="agent-tool-filter-selected"' in modal
-    assert 'data-testid="agent-tool-filter"' in modal
-    search_idx = modal.index('data-testid="agent-tool-filter"')
-    chip_idx = modal.index('data-testid="agent-tool-filter-selected"')
-    # RETARGET (platform wave P1b item 4): "N of M selected" restyled as
-    # a "selected · N of M" counter chip per the reference.
-    counter_idx = modal.index("selected · {selectedCount} of {totalAvailable}")
-    # Chip sits between the search box and the "N of M selected" counter.
-    assert search_idx < chip_idx < counter_idx
-    assert "onClick={() => setShowSelectedOnly((v) => !v)}" in modal
-    assert 'aria-pressed={showSelectedOnly}' in modal
+    src = _src()
+    assert 'data-testid="tool-picker-filter-selected"' in src
+    assert 'data-testid="tool-picker-filter"' in src
+    search_idx = src.index('data-testid="tool-picker-filter"')
+    chip_idx = src.index('data-testid="tool-picker-filter-selected"')
+    # Chip sits right after the search box.
+    assert search_idx < chip_idx
+    assert "onClick={() => setSelectedOnly((v) => !v)}" in src
+    assert "aria-pressed={selectedOnly}" in src
 
 
 def test_selected_filter_chip_reuses_the_existing_selection_counter_state() -> None:
     # No new selection-tracking state — the chip reads/derives from the
-    # SAME selectedScopedIds Set the "N of 172 selected" counter uses.
-    modal = _modal_src()
-    assert "const selectedCount = selectedScopedIds.size;" in modal
+    # SAME `selected` Set the "selected · N" counter uses.
+    src = _src()
+    assert "const selectedCount = selected.size;" in src
 
 
 def test_empty_state_message_covers_the_selected_only_case() -> None:
-    modal = _modal_src()
-    assert 'data-testid="agent-tool-empty"' in modal
-    assert "No selected tools" in modal
+    src = _src()
+    assert 'data-testid="tool-picker-empty"' in src
+    assert "No selected tools" in src
 
 
 def test_bundle_transpiles_with_the_tools_selected_filter() -> None:
@@ -85,4 +78,4 @@ def test_bundle_transpiles_with_the_tools_selected_filter() -> None:
     etag, body = build_jsx_bundle(UI)
     assert etag and body, "bundle did not build (Babel/vendor missing?)"
     text = body.decode("utf-8")
-    assert "/* === components/agents.jsx === */" in text
+    assert "/* === components/shared/tool-picker.jsx === */" in text

--- a/tests/ui/test_capability_badges.py
+++ b/tests/ui/test_capability_badges.py
@@ -86,8 +86,14 @@ def test_loads_after_shared_before_agents() -> None:
 
 
 def test_agents_tool_picker_renders_the_badges() -> None:
+    # RETARGET (uiv2 Wave 2): the agent form's tool picker was extracted
+    # into the shared ToolPicker (ui/components/shared/tool-picker.jsx) -
+    # the badges render there now, mounted by agents.jsx via
+    # <window.ToolPicker>, not inline in agents.jsx itself.
+    picker_src = (UI / "components" / "shared" / "tool-picker.jsx").read_text(encoding="utf-8")
+    assert "CapabilityBadges" in picker_src
     agents_src = (UI / "components" / "agents.jsx").read_text(encoding="utf-8")
-    assert "CapabilityBadges" in agents_src
+    assert "<window.ToolPicker " in agents_src
 
 
 def test_bundle_transpiles_with_capability_badges() -> None:

--- a/tests/ui/test_t0711_banner_status.py
+++ b/tests/ui/test_t0711_banner_status.py
@@ -29,12 +29,32 @@ def test_toolset_tools_banner_triggers_on_5xx_not_only_500():
 
 
 def test_agent_tools_banner_triggers_on_5xx_not_only_500():
+    """uiv2 Wave 2 retarget: this used to be TWO independent per-toolset
+    live-fetch T0711 detectors in agents.jsx (the References panel's
+    ref-row pill, AND the old read-view Tools tab's own per-toolset
+    GET /toolsets/{id}/tools call, purely to show the same detail a
+    SECOND time). Wave 2 replaced the read-view tab with the shared
+    ToolPicker, which reads the already-aggregated GET /tools catalogue
+    instead - the backend's own _catalogue_tools folds a toolset's
+    unreachability into available=False + unavailable_reason AT FETCH
+    TIME (primer/api/routers/providers.py), so there is no second
+    client-side 5xx check to duplicate anymore; only the References
+    panel's still does a live per-toolset fetch for its own cross-check
+    purpose. This is a real fetch-count reduction (fewer N+1 calls), not
+    a dropped capability - ToolPicker still shows unavailable toolsets +
+    their reason, plus a Retry action for a total catalogue-fetch
+    failure it didn't have before this wave."""
     src = _src("agents.jsx")
-    assert src.count("tools.error?.status >= 500") >= 2, (
-        "both agent T0711 surfaces (ref-row pill + per-toolset panel) must "
-        "match the 5xx server-error class"
+    assert src.count("tools.error?.status >= 500") >= 1, (
+        "the References panel's per-toolset T0711 detector must match "
+        "the 5xx server-error class"
     )
     assert "tools.error?.status === 500" not in src
+
+    picker_src = _src("shared/tool-picker.jsx")
+    assert "unavailableToolsets" in picker_src
+    assert "unavailable_reason" in picker_src
+    assert "catalogue.error" in picker_src and "Retry" in picker_src
 
 
 def test_t0711_marker_still_present_in_both_surfaces():

--- a/tests/ui_e2e/test_agents_create.py
+++ b/tests/ui_e2e/test_agents_create.py
@@ -19,6 +19,7 @@ from collections.abc import Iterator
 
 import httpx
 import pytest
+from playwright.sync_api import expect
 
 
 # ---------------------------------------------------------------------------
@@ -95,13 +96,21 @@ def test_u0006_new_agent_modal_creates_row_and_closes(
     unique_suffix: str,
 ) -> None:
     """U0006 - Filling and submitting the New agent form (with an
-    API-seeded LLM provider) closes the modal, surfaces a success
-    toast, and the operator lands on the new agent's detail page.
+    API-seeded LLM provider) transitions to the new agent's edit view,
+    surfaces a success toast, and the operator lands on the new
+    agent's detail page.
 
     Verifies the cross-cutting mutation-feedback contract from UI
     spec §3 with the agent-specific navigate-away tweak from
     NewAgentModal.onCreate (agents.jsx):
-      * modal closes on success
+      * the modal transitions from the create form to the new agent's
+        edit form in place (uiv2 Wave 2 RETARGET: this used to assert
+        the modal disappeared entirely, but the agent editor is now
+        ITSELF a `.modal` - before Wave 2 it was a raw-JSON sheet
+        with a different DOM shape, so create-then-navigate used to
+        land on a `.modal`-free page; now it lands on another
+        `.modal`, just with edit-mode content, so "closes" is checked
+        by content, not visibility)
       * success toast appears
       * URL navigates to `#/agents/<new-id>` and the detail-page
         title renders the new agent id (the list refetches in the
@@ -139,17 +148,30 @@ def test_u0006_new_agent_modal_creates_row_and_closes(
             modal.locator("#na-description").fill(
                 f"u0006 seed {unique_suffix}",
             )
-            # One picker, not a pair: an agent names a ModelProfile,
-            # which already pins the provider and the wire model name.
-            modal.locator("#na-model-profile").select_option(
-                profile_id_for(provider_id, "fake-model"),
-            )
+            # uiv2 Wave 2: the model-profile <select> became a stacked
+            # AG_ProfilePicker (mockup's own picker style - one bordered
+            # row per profile, click to pick) - one picker, not a pair:
+            # an agent names a ModelProfile, which already pins the
+            # provider and the wire model name.
+            modal.get_by_test_id(
+                f"agent-profile-row-{profile_id_for(provider_id, 'fake-model')}",
+            ).click()
 
             # Submit.
             modal.get_by_role("button", name="Create").click()
 
-            # Modal should disappear on success.
-            modal.wait_for(state="hidden", timeout=10_000)
+            # uiv2 Wave 2 (RETARGETED): the modal does NOT disappear -
+            # it transitions in place to the new agent's edit view
+            # (still one `.modal`, new content). Confirm the
+            # transition landed on the right row: the Name field is
+            # now locked and holds the new agent's id, and the verb
+            # chip reads "Edit Agent" instead of "Create Agent".
+            expect(modal.locator("#na-id")).to_have_value(
+                agent_id, timeout=10_000,
+            )
+            expect(modal.get_by_test_id("agent-modal-verb-chip")).to_contain_text(
+                "Edit", timeout=5_000,
+            )
 
             # Success toast appears. Toast container is portal'd
             # outside the modal; assert on its text content.
@@ -216,12 +238,12 @@ def test_u0007_new_agent_create_422_renders_inline_field_errors(
 
         modal.locator("#na-id").fill(agent_id)
         modal.locator("#na-description").fill("u0007 422 probe")
-        modal.locator("#na-model-profile").select_option(
-            profile_id_for(provider_id, "fake-model"),
-        )
-        # Temperature lives on the "Advanced" tab of the form - switch to
-        # it and wait for the input before filling.
-        modal.get_by_test_id("agent-tab-advanced").click()
+        modal.get_by_test_id(
+            f"agent-profile-row-{profile_id_for(provider_id, 'fake-model')}",
+        ).click()
+        # uiv2 Wave 2: temperature moved out from behind the old
+        # "Advanced" tab - it is always visible now, right under the
+        # profile picker (a-11: numerics live near what they gate).
         temperature_input = modal.locator("#na-temperature")
         temperature_input.wait_for(state="visible", timeout=5_000)
         # The deliberate bad value - violates Agent.temperature's
@@ -317,13 +339,19 @@ def test_u0020_agent_delete_confirms_removes_and_navigates_back_to_list(
                 state="visible", timeout=10_000,
             )
 
-            # Click the Delete button in the page header. The header
-            # has Test agent + Delete + Back buttons - `name="Delete"`
-            # uniquely matches the danger one.
+            # Click the Delete button in the agent editor's own footer
+            # (uiv2 Wave 2: Delete moved from a page action bar into
+            # AG_NewAgentModal's footer alongside Cancel/Save) -
+            # `name="Delete"` uniquely matches it before the confirm
+            # dialog exists.
             page.get_by_role("button", name="Delete").first.click()
 
             # Confirm dialog appears with title containing the agent id.
-            confirm = page.locator(".modal").first
+            # uiv2 Wave 2: the agent editor is now ITSELF a `.modal`
+            # (it used to be a raw-JSON sheet outside the Modal
+            # primitive), so the confirm dialog is the SECOND `.modal`
+            # in the DOM, stacked on top - `.last`, not `.first`.
+            confirm = page.locator(".modal").last
             confirm.wait_for(state="visible", timeout=5_000)
             assert agent_id in confirm.inner_text(), (
                 f"confirm dialog should mention the agent id "
@@ -332,9 +360,8 @@ def test_u0020_agent_delete_confirms_removes_and_navigates_back_to_list(
 
             # Click the danger-Delete button inside the confirm modal.
             # The modal has Cancel + Delete; locating by role + name +
-            # narrowing to the modal scope avoids matching the header
-            # Delete we just clicked (which is now hidden under the
-            # overlay anyway, but be explicit).
+            # narrowing to the modal scope avoids matching the editor's
+            # own footer Delete button underneath.
             confirm.get_by_role("button", name="Delete").first.click()
 
             # Dialog closes.

--- a/tests/ui_e2e/test_anomaly_surfaces.py
+++ b/tests/ui_e2e/test_anomaly_surfaces.py
@@ -107,19 +107,21 @@ def test_u0008_toolset_tools_tab_renders_t0711_anomaly_banner(
                 pass
 
 
-def test_u0018_deep_link_reload_preserves_agent_detail_tools_tab(
+def test_u0018_deep_link_reload_preserves_agent_detail_tools(
     page,
     base_url: str,
     console_url: str,
     unique_suffix: str,
 ) -> None:
-    """U0018 - Reloading the browser on an agent detail deep-link
-    with ``?tab=tools`` re-renders the same tab selected, not the
-    default Config tab.
-
-    Priority 6 - routing. The tab is read from routerQuery.tab and
-    validated against AGENT_TABS (agents.jsx:363). Reload preserves
-    the URL hash + query so the tab choice survives.
+    """U0018 - RETARGETED (uiv2 Wave 2): the tab-selection-survives-
+    reload premise this test pinned no longer applies - the agent
+    detail overlay is one direct-edit form now, not four routed tabs
+    (AGENT_TABS/routerQuery.tab are gone; see test_u0033's sister
+    retarget in test_routing_and_mutations.py for the Config-tab
+    variant of this same change). What's still real and worth pinning:
+    the ToolPicker (which superseded the old Tools tab) is actually
+    populated with the agent's real tools both before AND after a
+    reload - not just present, but showing the right data each time.
     """
     # Seed an LLM provider + agent so the detail page has data.
     provider_id = f"llm-u0018-{unique_suffix}"
@@ -137,59 +139,49 @@ def test_u0018_deep_link_reload_preserves_agent_detail_tools_tab(
             "id": agent_id,
             "description": "u0018 deep-link probe",
             "model": agent_model(provider_id, "fake-model"),
-            "tools": [],
+            # A real, always-available built-in tool (primer/toolset/
+            # misc.py) so the ToolPicker's "selected · N" counter has
+            # something non-zero to check before/after reload.
+            "tools": ["misc__uuid_v4"],
             "system_prompt": ["test"],
         })
         assert r.status_code == 201, f"seed agent failed: {r.text}"
 
     try:
-        # Navigate directly to the deep-link with ?tab=tools.
-        open_legacy_route(page, console_url, f"agents/{agent_id}", tab="tools")
+        open_legacy_route(page, console_url, f"agents/{agent_id}")
 
         # Wait for the agent detail page to render.
         page.locator("h1.page-title").get_by_text(agent_id).first.wait_for(
             state="visible", timeout=10_000,
         )
 
-        # Helper: the active tab is rendered with class "active" or
-        # similar; using role+name + aria-selected is robust.
-        tools_tab = page.get_by_role("tab", name="Tools").first
-        tools_tab.wait_for(state="visible", timeout=5_000)
-        # Tab should already be selected before reload - sanity check.
-        # If not selected, the tab routing is broken (Config would be
-        # default).
-        assert tools_tab.get_attribute("aria-selected") == "true" \
-            or "active" in (tools_tab.get_attribute("class") or ""), (
-            f"Tools tab not selected after initial deep-link nav; "
-            f"aria-selected={tools_tab.get_attribute('aria-selected')!r}, "
-            f"class={tools_tab.get_attribute('class')!r}"
+        selected_chip = page.get_by_test_id("tool-picker-filter-selected")
+        selected_chip.wait_for(state="visible", timeout=10_000)
+        assert "1" in (selected_chip.inner_text() or ""), (
+            f"expected the picker's selected-count chip to show 1 tool "
+            f"before reload; got {selected_chip.inner_text()!r}"
         )
 
-        # Reload - the URL + query should survive.
         page.reload(wait_until="domcontentloaded")
         page.locator("h1.page-title").get_by_text(agent_id).first.wait_for(
             state="visible", timeout=10_000,
         )
 
-        # After reload, Tools tab MUST still be selected.
-        tools_tab_after = page.get_by_role("tab", name="Tools").first
-        tools_tab_after.wait_for(state="visible", timeout=5_000)
-        assert (
-            tools_tab_after.get_attribute("aria-selected") == "true"
-            or "active" in (tools_tab_after.get_attribute("class") or "")
-        ), (
-            "Tools tab lost its selected state after reload - "
-            "deep-link ?tab= query not preserved. "
-            f"aria-selected={tools_tab_after.get_attribute('aria-selected')!r}, "
-            f"class={tools_tab_after.get_attribute('class')!r}"
+        # After reload, the ToolPicker must still be populated with the
+        # SAME agent's real tools, not reset to empty or stuck loading.
+        selected_chip_after = page.get_by_test_id("tool-picker-filter-selected")
+        selected_chip_after.wait_for(state="visible", timeout=10_000)
+        assert "1" in (selected_chip_after.inner_text() or ""), (
+            f"expected the picker's selected-count chip to still show 1 "
+            f"tool after reload; got {selected_chip_after.inner_text()!r}"
         )
 
-        # Defence: the URL still carries the tab after reload. The shell
-        # states it in the overlay target's section slot rather than as a
-        # ?tab= query, which is the same deep link in the one grammar the
-        # URL now has.
-        assert f"overlay=agents:tools:{agent_id}" in page.url, (
-            f"reload dropped the tools tab: {page.url}"
+        # Defence: the URL still addresses this agent after reload (no
+        # ?tab= query in the new grammar - agents/{id} is a 2-segment
+        # legacy route with an empty section slot, so the overlay target
+        # is "agents::{id}", not "agents:tools:{id}").
+        assert f"overlay=agents::{agent_id}" in page.url, (
+            f"reload dropped the addressed agent: {page.url}"
         )
     finally:
         with httpx.Client(base_url=base_url, timeout=30.0) as c:
@@ -322,23 +314,28 @@ def test_u0013_session_detail_renders_t0399_stale_cache_notice(
                     pass
 
 
-def test_u0009_agent_tools_tab_isolates_one_failing_toolset(
+def test_u0009_agent_tools_picker_isolates_one_unavailable_toolset(
     page,
     base_url: str,
     console_url: str,
     unique_suffix: str,
 ) -> None:
-    """U0009 - An agent bound to TWO toolsets - one that loads
-    cleanly and one whose ``/tools`` endpoint 500-leaks - renders the
-    good toolset's tools and the bad toolset's T0711 banner side by
-    side. The page must NOT blank out; the failure must be confined
-    to the offending toolset's panel.
+    """U0009 - RETARGETED (uiv2 Wave 2): an agent bound to TWO
+    toolsets - one that loads cleanly and one whose catalogue entry
+    comes back ``available: false`` (an unreachable MCP-HTTP server) -
+    must still render the shared ToolPicker with the good toolset's
+    tools selectable and the bad toolset called out separately. The
+    page must NOT blank out; the failure must be confined to the one
+    toolset, not the whole picker.
 
-    Priority 3 - anomaly surface. Implements the per-toolset
-    isolation contract documented at agents.jsx:638-700: each
-    bound toolset is rendered by its own ``<ToolsetSection>`` and
-    a ``tools.error?.status === 500`` only collapses that panel,
-    not the parent ``<AgentToolsTab>``.
+    The old per-toolset ``<ToolsetSection>``/T0711-banner mechanism
+    this test originally pinned was deleted in Wave 2 (ToolPicker
+    ruling, see test_t0711_banner_status.py): the backend now computes
+    ``available``/``unavailable_reason`` per toolset at ``/tools``
+    aggregation time (``primer/api/routers/providers.py``), and the
+    picker surfaces an unavailable toolset as a small dashed pill
+    (``<span class="mono">{id}</span> · unavailable``, the reason in
+    its title tooltip) rather than a dedicated banner per panel.
 
     Good toolset: the built-in ``misc`` internal toolset (always
     available, returns 5 tools per primer/toolset/misc.py).
@@ -390,49 +387,63 @@ def test_u0009_agent_tools_tab_isolates_one_failing_toolset(
         assert r.status_code == 201, f"seed agent failed: {r.text}"
 
     try:
-        # Navigate directly to the Tools tab via deep-link.
-        open_legacy_route(page, console_url, f"agents/{agent_id}", tab="tools")
+        # Navigate directly to the agent detail overlay - no more
+        # tab= deep-link, the Tools picker lives on the one form.
+        open_legacy_route(page, console_url, f"agents/{agent_id}")
         page.locator("h1.page-title").get_by_text(agent_id).first.wait_for(
             state="visible", timeout=10_000,
         )
 
-        # Good toolset panel renders the misc id as a header. At
-        # least one of the 5 misc tools (e.g. uuid_v4) must appear
-        # as a clickable row - confirms the panel rendered through
-        # to ToolEntry rows.
-        page.locator(".panel-h:has(.mono:text('misc'))").first.wait_for(
+        # Bad toolset is called out via the picker's unavailable-
+        # toolset summary - a dashed pill naming the toolset id next
+        # to the word "unavailable" (unavailable_reason is a tooltip,
+        # not asserted here). This is the mechanism that superseded
+        # the old per-toolset T0711 banner. The summary isn't
+        # paginated, so it's visible before any search/filter
+        # interaction - check it first, before the search box below
+        # would filter it out of the result set entirely.
+        page.locator(
+            f'span:has-text("{bad_toolset_id}"):has-text("unavailable")'
+        ).first.wait_for(state="visible", timeout=15_000)
+
+        # Good toolset renders its group header + at least one tool
+        # row - confirms the picker's catalogue fetch resolved and
+        # rendered through to TP_Row for the reachable toolset. The
+        # catalogue-wide pager (6 tools/page) would bury "misc" many
+        # pages behind the much larger builtin toolsets (the "system"
+        # toolset alone carries 100+ tools) that sort ahead of it, so
+        # scope down with the picker's own search box first - the same
+        # thing an operator hunting for one toolset would do.
+        page.get_by_test_id("tool-picker-filter").fill("misc")
+        page.get_by_test_id("tool-picker-group-misc").first.wait_for(
             state="visible", timeout=15_000,
         )
-        page.get_by_text("uuid_v4", exact=False).first.wait_for(
+        page.get_by_test_id("tool-picker-row-misc__uuid_v4").first.wait_for(
             state="visible", timeout=10_000,
         )
 
-        # Bad toolset panel renders the documented T0711 banner -
-        # both the title ("Tools list unavailable") and the T0711
-        # reference are required (same contract as U0008).
-        page.get_by_text("Tools list unavailable", exact=False).first.wait_for(
-            state="visible", timeout=15_000,
-        )
-        page.get_by_text("T0711", exact=False).first.wait_for(
-            state="visible", timeout=5_000,
-        )
-
         # Defence: the page-title is still rendered (no blank crash).
-        # The agent detail h1 carries the agent id - if a render
-        # error blew up the whole AgentToolsTab, the title would
-        # still be visible via the page chrome, but the panels
-        # wouldn't be. The asserts above already prove the panels
-        # are present; this is a final structural sanity check.
+        # The agent detail h1 carries the agent id - if a render error
+        # blew up the whole ToolPicker, the title would still be
+        # visible via the page chrome, but the picker wouldn't be. The
+        # asserts above already prove the picker rendered through for
+        # both toolsets; this is a final structural sanity check.
         assert page.locator("h1.page-title").first.is_visible(), (
-            "agent detail title disappeared after Tools tab render - "
-            "page may have blanked out instead of isolating the failure"
+            "agent detail title disappeared after the tools picker "
+            "rendered - page may have blanked out instead of isolating "
+            "the failure to the one toolset"
         )
 
-        # Defence 2: both panels are present at the same time. The
-        # bad-toolset panel carries its toolset id as the .mono
-        # span inside its .panel-h, just like the good one.
-        page.locator(f".panel-h:has(.mono:text('{bad_toolset_id}'))").first.wait_for(
-            state="visible", timeout=5_000,
+        # Defence 2: the good toolset's tools are still selectable
+        # (checkbox present and not disabled) alongside the bad
+        # toolset's unavailable pill - proves the good panel wasn't
+        # dragged down by the bad one.
+        good_checkbox = page.locator(
+            '[data-testid="tool-picker-row-misc__uuid_v4"] input[type="checkbox"]'
+        )
+        assert good_checkbox.is_enabled(), (
+            "the reachable toolset's tool row should stay interactive "
+            "even though a sibling toolset is unavailable"
         )
     finally:
         with httpx.Client(base_url=base_url, timeout=30.0) as c:

--- a/tests/ui_e2e/test_collection_documents_by_path.py
+++ b/tests/ui_e2e/test_collection_documents_by_path.py
@@ -113,13 +113,20 @@ def test_collection_document_path_browser_full_journey(
         # "Documents" button that used to raise a path-browser modal is
         # gone along with the modal. The tree, the grep box and the header
         # actions are all on the page.
+        #
+        # uiv2 Wave 2: the collection browser (KN_CollectionDetail) is now
+        # ITSELF a `.modal` (it used to be a bare div hung off the list
+        # page), so New-document/Move are nested modals stacked INSIDE
+        # it, not the only `.modal` on screen - `.modal.first` now means
+        # the outer browser, not the nested dialog. `.last` targets the
+        # innermost open modal.
         browser = page.get_by_test_id("nv-overlay-body")
 
         # ---- create ----
         # A document is addressed by parent + slug now, not by typing a
         # whole path into one box.
         browser.get_by_role("button", name="New document").first.click()
-        new_modal = page.locator(".modal").first
+        new_modal = page.locator(".modal").last
         new_modal.wait_for(state="visible", timeout=5_000)
         new_modal.get_by_placeholder(
             "slug (lowercase letters, digits, hyphens)",
@@ -157,9 +164,11 @@ def test_collection_document_path_browser_full_journey(
         # nested modal (the one that owns the new-path input) and match exactly
         # so we don't re-target the header trigger behind the overlay.
         browser.get_by_role("button", name="Move", exact=True).first.click()
-        # Only one modal now: the browser is the page, not an outer modal,
-        # so nothing else contains the move input.
-        move_modal = page.locator(".modal").first
+        # `.last`, not `.first`: the outer collection-browser Modal is
+        # still on screen (with its own "Move" trigger button still in
+        # the DOM), so `.first` would resolve to IT, not the nested
+        # confirm dialog - see the comment above `browser` for why.
+        move_modal = page.locator(".modal").last
         move_modal.wait_for(state="visible", timeout=5_000)
         # Parent stays root; only the slug changes, which is the rename
         # case the old single-path box expressed by retyping the whole

--- a/tests/ui_e2e/test_knowledge_collection_journey.py
+++ b/tests/ui_e2e/test_knowledge_collection_journey.py
@@ -118,11 +118,13 @@ def test_knowledge_collection_create_via_ui_then_traverse_pages(
         # Submit.
         modal.get_by_role("button", name="Create").first.click()
 
-        # Modal closes on success.
-        modal.wait_for(state="hidden", timeout=10_000)
-
-        # Creating a collection OPENS it, so the list is no longer on
-        # screen; the browser for the new collection is.
+        # uiv2 Wave 2: creating a collection OPENS it, and the browser
+        # (KN_CollectionDetail) it lands on is now ITSELF a `.modal` (used
+        # to be a bare div) - so there is no longer a `.modal`-free
+        # moment to wait for; `.modal` stays present throughout, it just
+        # swaps from the create form to the browser. Assert the actual
+        # outcome (the new collection's browser is showing) instead of a
+        # "the modal closed" premise that no longer holds.
         expect(
             page.get_by_test_id("nv-overlay-body").get_by_text(
                 coll_id, exact=False,
@@ -132,14 +134,29 @@ def test_knowledge_collection_create_via_ui_then_traverse_pages(
         # ===== 3. Create a doc in it, grep for it =========================
         # Already inside the collection: the create opened it, so there
         # is no row to click through any more.
+        #
+        # uiv2 Wave 2: the collection browser (KN_CollectionDetail) is now
+        # ITSELF a `.modal` (used to be a bare div), so "New document"
+        # opens a modal NESTED inside it - `.first` would resolve to the
+        # outer browser, and filling `input.input` there would hit
+        # whatever real input renders earliest in ITS OWN chrome (the
+        # grep box), not the new-document form, leaving the actual slug
+        # field empty and Create stuck disabled. `.last` targets the
+        # nested dialog.
         page.get_by_role("button", name="New document").first.click()
-        doc_modal = page.locator(".modal").first
+        doc_modal = page.locator(".modal").last
         doc_modal.wait_for(state="visible", timeout=5_000)
         doc_inputs = doc_modal.locator("input.input")
         doc_inputs.nth(0).fill("journey-doc")
         doc_modal.locator("textarea.input").first.fill("needle in the wiki")
         doc_modal.get_by_role("button", name="Create").first.click()
-        doc_modal.wait_for(state="hidden", timeout=10_000)
+        # `.modal` itself never becomes hidden - the outer collection
+        # browser is ALSO a `.modal` and stays open once the nested
+        # dialog closes, so `.last` would just keep re-resolving to it
+        # forever. The toast is a signal independent of modal nesting.
+        page.get_by_text("Document created", exact=False).first.wait_for(
+            state="visible", timeout=10_000,
+        )
 
         # Grep works with no embedder configured: that is the point of
         # the v2 model.

--- a/tests/ui_e2e/test_lists_and_polling.py
+++ b/tests/ui_e2e/test_lists_and_polling.py
@@ -1,10 +1,11 @@
 """List-page filter behaviour + workspaces sidebar polling cadence +
-Metadata tab deep-link preservation.
+legacy Metadata deep-link routing.
 
 Covers:
 * U0024 — Workspaces sidebar count polls within ~12s of API
   workspace create.
-* U0034 — Agent detail Metadata tab deep-link survives reload.
+* U0034 — Agent detail legacy Metadata deep-link lands on the edit
+  view (uiv2 Wave 2: retargeted off the retired Metadata-tab premise).
 * U0037 — Agents list filter input narrows the table to matching ids.
 """
 
@@ -12,6 +13,7 @@ from __future__ import annotations
 
 
 import httpx
+from playwright.sync_api import expect
 
 
 # ---------------------------------------------------------------------------
@@ -68,22 +70,27 @@ def _cleanup(base_url: str, urls: list[str]) -> None:
 # ---------------------------------------------------------------------------
 
 
-def test_u0034_agent_metadata_tab_deep_link_survives_reload(
+def test_u0034_agent_metadata_deep_link_lands_on_edit_view(
     page,
     base_url: str,
     console_url: str,
     unique_suffix: str,
 ) -> None:
-    """U0034 — Sister of U0018 (Tools) and U0033 (Config) for the
-    Metadata tab. Navigate to ``#/agents/<id>?tab=metadata``,
-    confirm Metadata is selected, reload, confirm the URL query
-    survives and Metadata is still selected.
+    """U0034 — RETARGETED (uiv2 Wave 2): the Metadata tab this test
+    pinned is gone - AGENT_TABS/routerQuery.tab were removed wholesale
+    when the agent detail overlay became one direct-edit form (see
+    U0018/U0033's sister retargets in test_anomaly_surfaces.py /
+    test_routing_and_mutations.py). Metadata itself was dropped, not
+    relocated: the Agent model has no metadata field at all (confirmed
+    from the live schema during Wave 2's enumeration pass), so the old
+    tab was always empty for every agent - there is no "which surface
+    should this land on" ambiguity to resolve for the CONTENT, only
+    for the deep link.
 
-    Priority 6 — routing. Pins that the routerQuery.tab handling
-    is symmetric across all four AGENT_TABS (agents.jsx:352-357).
-    Metadata is the last tab in the array — a regression that
-    silently dropped it from AGENT_TABS would fall back to the
-    "config" default on reload and surface here.
+    What's still real and worth pinning: an old bookmarked
+    ``?tab=metadata`` deep link must not dead-end or silently
+    misroute - it lands on the one edit view for the SAME agent, same
+    as every other legacy tab deep link now does.
     """
     provider_id = f"llm-u0034-{unique_suffix}"
     agent_id = f"ag-u0034-{unique_suffix}"
@@ -95,32 +102,20 @@ def test_u0034_agent_metadata_tab_deep_link_survives_reload(
         page.locator("h1.page-title").get_by_text(agent_id).first.wait_for(
             state="visible", timeout=10_000,
         )
-
-        metadata_tab = page.get_by_role("tab", name="Metadata").first
-        metadata_tab.wait_for(state="visible", timeout=5_000)
-        assert metadata_tab.get_attribute("aria-selected") == "true", (
-            f"Metadata tab not selected on initial deep-link nav; "
-            f"aria-selected={metadata_tab.get_attribute('aria-selected')!r}"
-        )
+        expect(page.locator("#na-id")).to_have_value(agent_id)
 
         page.reload(wait_until="domcontentloaded")
         page.locator("h1.page-title").get_by_text(agent_id).first.wait_for(
             state="visible", timeout=10_000,
         )
+        expect(page.locator("#na-id")).to_have_value(agent_id)
 
-        metadata_tab_after = page.get_by_role("tab", name="Metadata").first
-        metadata_tab_after.wait_for(state="visible", timeout=5_000)
-        assert metadata_tab_after.get_attribute("aria-selected") == "true", (
-            f"Metadata tab lost selected state after reload; "
-            f"aria-selected={metadata_tab_after.get_attribute('aria-selected')!r}"
-        )
-
-        # Defence: the URL still carries the tab. The shell states it
-        # in the overlay target's section slot rather than as a ?tab=
-        # query, which is the same deep link in the one grammar the URL
-        # now has.
+        # Defence: the URL still carries the legacy tab in the overlay
+        # target's section slot (the one grammar the URL has now) -
+        # the deep link resolves, it just no longer selects anything
+        # since there is nothing left to select.
         assert f"overlay=agents:metadata:{agent_id}" in page.url, (
-            f"reload dropped the metadata tab: {page.url}"
+            f"reload dropped the addressed agent: {page.url}"
         )
     finally:
         _cleanup(base_url, [

--- a/tests/ui_e2e/test_routing_and_mutations.py
+++ b/tests/ui_e2e/test_routing_and_mutations.py
@@ -4,7 +4,8 @@ modules.
 
 Covers:
 * U0023 — New-workspace modal: create → toast → navigate to detail.
-* U0033 — Agent detail Config tab deep-link survives reload.
+* U0033 — Agent detail deep-link survives reload (uiv2 Wave 2: retargeted
+  off the retired Config-tab premise - see the test's own docstring).
 * U0039 — Agent detail "Back" button navigates to /agents.
 * U0044 — Modal ESC keypress closes the open modal.
 """
@@ -14,6 +15,7 @@ from __future__ import annotations
 import re
 
 import httpx
+from playwright.sync_api import expect
 from tests._support.model_profiles import agent_model, seed_llm_provider_with
 from tests.ui_e2e._shell_helpers import open_legacy_route
 
@@ -173,25 +175,20 @@ def test_u0023_new_workspace_modal_creates_row_toasts_and_navigates(
 # ---------------------------------------------------------------------------
 
 
-def test_u0033_agent_config_tab_deep_link_survives_reload(
+def test_u0033_agent_detail_deep_link_survives_reload(
     page,
     base_url: str,
     console_url: str,
     unique_suffix: str,
 ) -> None:
-    """U0033 — Sister to U0018 (Tools tab) for the Config tab.
-    Navigate to ``#/agents/<id>?tab=config``, confirm Config is
-    selected, reload the page, confirm Config is still selected and
-    the URL still carries ``?tab=config``.
-
-    Priority 6 — routing. Pins that the routerQuery.tab handling is
-    symmetric across all four AGENT_TABS, not just Tools.
-    Re-validates against the documented contract at
-    agents.jsx:363 (``AGENT_TABS.some(...) ? routerQuery.tab : "config"``).
-
-    Config is the default tab — so this test also defends against a
-    regression where the default-fallback path silently strips the
-    query string on reload.
+    """U0033 — RETARGETED (uiv2 Wave 2): the tab-selection-survives-
+    reload premise this test pinned no longer applies - the agent
+    detail overlay is one direct-edit form now, not four routed tabs
+    (AGENT_TABS/routerQuery.tab are gone). What's still real and worth
+    pinning: the deep link itself survives a reload - the form is still
+    addressing the SAME agent afterward, not silently falling back to
+    the list. See test_u0018 in test_anomaly_surfaces.py for the sister
+    retarget (was the Tools-tab variant of this same test).
     """
     provider_id = f"llm-u0033-{unique_suffix}"
     agent_id = f"ag-u0033-{unique_suffix}"
@@ -199,35 +196,21 @@ def test_u0033_agent_config_tab_deep_link_survives_reload(
     _seed_agent(base_url, agent_id, provider_id)
 
     try:
-        open_legacy_route(page, console_url, f"agents/{agent_id}", tab="config")
+        open_legacy_route(page, console_url, f"agents/{agent_id}")
         page.locator("h1.page-title").get_by_text(agent_id).first.wait_for(
             state="visible", timeout=10_000,
         )
+        # The locked Name field is the form's own confirmation that it
+        # opened bound to THIS agent, not a blank create form.
+        expect(page.locator("#na-id")).to_have_value(agent_id)
 
-        config_tab = page.get_by_role("tab", name="Config").first
-        config_tab.wait_for(state="visible", timeout=5_000)
-        assert config_tab.get_attribute("aria-selected") == "true", (
-            f"Config tab not selected on initial deep-link nav; "
-            f"aria-selected={config_tab.get_attribute('aria-selected')!r}"
-        )
-
-        # Reload — URL query should survive.
         page.reload(wait_until="domcontentloaded")
         page.locator("h1.page-title").get_by_text(agent_id).first.wait_for(
             state="visible", timeout=10_000,
         )
-
-        config_tab_after = page.get_by_role("tab", name="Config").first
-        config_tab_after.wait_for(state="visible", timeout=5_000)
-        assert config_tab_after.get_attribute("aria-selected") == "true", (
-            f"Config tab lost selected state after reload; "
-            f"aria-selected={config_tab_after.get_attribute('aria-selected')!r}"
-        )
-
-        # Defence: the tab travels in the overlay target's section
-        # slot now, not as a ?tab= query.
-        assert f"overlay=agents:config:{agent_id}" in page.url, (
-            f"reload dropped the config tab: {page.url}"
+        expect(page.locator("#na-id")).to_have_value(agent_id)
+        assert f"overlay=agents::{agent_id}" in page.url, (
+            f"reload dropped the addressed agent: {page.url}"
         )
     finally:
         _cleanup(base_url, [

--- a/tests/ui_e2e/test_session_files_toast_lasterr.py
+++ b/tests/ui_e2e/test_session_files_toast_lasterr.py
@@ -184,9 +184,12 @@ def test_u0032_toast_renders_request_id_on_5xx(
         modal = page.locator(".modal").first
         modal.wait_for(state="visible", timeout=5_000)
         modal.locator("#na-id").fill(f"ag-32-{unique_suffix}")
-        modal.locator("#na-model-profile").select_option(
-            profile_id_for(pid, "fake-model"),
-        )
+        # uiv2 Wave 2: the model-profile <select> became a stacked
+        # AG_ProfilePicker (one bordered row per profile, click to pick) -
+        # same retarget as test_agents_create.py's u0006/u0007.
+        modal.get_by_test_id(
+            f"agent-profile-row-{profile_id_for(pid, 'fake-model')}",
+        ).click()
 
         # Click "Create" - mocked response will return our 500.
         create_btn = page.get_by_role(

--- a/ui/components/agents.jsx
+++ b/ui/components/agents.jsx
@@ -4,18 +4,14 @@
 // scaffold was replaced in Phase 2 — every fetch goes through
 // window.primerApi.{apiFetch, useResource, useMutation}. Cache-key convention
 // follows other components: "agents:list", "agent-detail:${aid}",
-// "agent-status:${aid}", "agent-sessions:${aid}", "toolset-tools:${tid}".
+// "agent-status:${aid}", "agent-sessions:${aid}". The tool catalogue
+// itself is owned by the shared ToolPicker (ui/components/shared/
+// tool-picker.jsx, cache key "tool-picker:catalogue") since uiv2 Wave 2 -
+// this file no longer fetches /tools directly.
 //
 // Babel-standalone shares the global scope across <script> tags so every
 // top-level binding in this file is prefixed with AG_ to avoid name clashes
 // with providers.jsx (PROVIDER_FIELDS) and workspaces.jsx (WS_TERMINAL).
-
-const AG_TABS = [
-  { id: "config",   label: "Config",   icon: "settings" },
-  { id: "tools",    label: "Tools",    icon: "tools" },
-  { id: "sessions", label: "Sessions", icon: "zap" },
-  { id: "metadata", label: "Metadata", icon: "doc" },
-];
 
 const AG_PROVIDER_COLORS = {
   openai: "var(--green)",
@@ -371,11 +367,150 @@ function AG_Toggle({ checked, onChange, label, help, disabled, testid }) {
 // New agent modal
 // ============================================================================
 
-function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
+function AG_ProfilePicker({ profiles, loading, value, onChange, missingId }) {
+  // uiv2 Wave 2: the mockup renders model profiles as stacked
+  // selectable rows (bound one green-bordered/green-mono, the rest
+  // plain) rather than a <select> - same data (GET /model_profiles),
+  // just a richer picker matching the reference exactly.
+  return (
+    <div className="col" style={{ gap: 6 }} data-testid="agent-profile-picker">
+      {missingId && (
+        <div style={{
+          border: "1px solid var(--red)", borderRadius: 6, padding: "8px 10px",
+          color: "var(--red)",
+        }} data-testid="agent-profile-row-missing">
+          <span className="mono">{missingId}</span> <span className="text-sm">(missing) — pick another below</span>
+        </div>
+      )}
+      {loading && profiles.length === 0 && (
+        <div className="muted text-sm" style={{ padding: 10 }}>Loading model profiles…</div>
+      )}
+      {!loading && profiles.length === 0 && (
+        <div className="field-help" style={{ color: "var(--amber)" }}>
+          No model profiles configured. Create one at <span className="mono">/providers?class=llm</span> first.
+        </div>
+      )}
+      {profiles.map((pr) => {
+        const active = pr.id === value;
+        return (
+          <button type="button" key={pr.id}
+            onClick={() => onChange(pr.id)}
+            data-testid={`agent-profile-row-${pr.id}`}
+            data-active={active ? "true" : "false"}
+            style={{
+              display: "flex", flexDirection: "column", alignItems: "flex-start", gap: 2,
+              textAlign: "left", padding: "8px 10px", borderRadius: 6, cursor: "pointer",
+              border: "1px solid " + (active ? "var(--accent)" : "var(--border)"),
+              background: active ? "var(--accent-dim)" : "var(--bg-1)",
+            }}>
+            <span className="mono" style={{ color: active ? "var(--accent)" : "var(--text)", fontSize: 12.5 }}>{pr.id}</span>
+            <span className="muted text-sm" style={{ fontSize: 11 }}>
+              {pr.provider_id}/{pr.model_name}
+              {pr.config?.reasoning ? ` · reasoning ${pr.config.reasoning}` : ""}
+            </span>
+          </button>
+        );
+      })}
+    </div>
+  );
+}
+
+// uiv2 Wave 2: everything JSON-visible with no mockup form field
+// (description was already homed; response_format/allow_external_tools/
+// compaction_tool_access are real but rare enough the mockup's own
+// minimal example never shows them) - kept reachable behind one
+// collapsed disclosure rather than cluttering the two-column layout.
+function AG_AdvancedDisclosure({ open, onToggle, children }) {
+  // Controlled (not self-contained state): submit() must be able to
+  // force this open when response_format fails to parse, the same way
+  // the old tabbed layout jumped to the Advanced tab on that error.
+  return (
+    <div className="panel" data-testid="agent-advanced-disclosure">
+      <button type="button" onClick={onToggle}
+        style={{
+          display: "flex", alignItems: "center", gap: 6, width: "100%",
+          background: "none", border: "none", cursor: "pointer", padding: "8px 10px",
+          color: "var(--text-2)", fontSize: 12,
+        }}>
+        <Icon name={open ? "chevron-down" : "chevron-right"} size={11} />
+        Advanced
+      </button>
+      {open && (
+        <div style={{ padding: "0 10px 10px", display: "flex", flexDirection: "column", gap: 12 }}>
+          {children}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// uiv2 Wave 2 (a-6, re-homed as a collapsible panel rather than its own
+// tab): unchanged fetch/table from the old Sessions tab, just a smaller
+// footprint so it fits the consolidated form's right column.
+function AG_SessionsPanel({ agentId }) {
+  const { useResource, useRouter, apiFetch } = window.primerApi;
+  const { navigate } = useRouter();
+  const [open, setOpen] = React.useState(false);
+  const sessions = useResource(
+    `agent-sessions:${agentId}`,
+    (signal) => apiFetch("GET", "/sessions?agent_id=" + encodeURIComponent(agentId) + "&limit=200", null, { signal }),
+    { pollMs: open ? 5000 : 0, deps: [agentId] }
+  );
+  const items = sessions.data?.items ?? [];
+  return (
+    <div className="panel" data-testid="agent-sessions-panel">
+      <button type="button" onClick={() => setOpen((v) => !v)}
+        style={{
+          display: "flex", alignItems: "center", gap: 6, width: "100%",
+          background: "none", border: "none", cursor: "pointer", padding: "8px 10px",
+          color: "var(--text-2)", fontSize: 12,
+        }}>
+        <Icon name={open ? "chevron-down" : "chevron-right"} size={11} />
+        Sessions{items.length ? ` (${items.length})` : ""}
+      </button>
+      {open && (
+        <div style={{ padding: "0 10px 10px" }}>
+          {sessions.loading && items.length === 0 ? (
+            <div className="muted text-sm" style={{ padding: 10 }}>Loading…</div>
+          ) : items.length === 0 ? (
+            <div className="muted text-sm" style={{ padding: 10 }}>
+              No sessions. Use Chat below to start one.
+            </div>
+          ) : (
+            <div style={{ display: "flex", flexDirection: "column", gap: 4 }}>
+              {items.slice(0, 10).map((s) => (
+                <div key={s.id || s.session_id}
+                  onClick={() => navigate("/sessions/" + (s.id || s.session_id))}
+                  style={{ display: "flex", alignItems: "center", gap: 8, cursor: "pointer", fontSize: 11.5 }}>
+                  <StatusPill status={s.status} />
+                  <span className="mono muted" style={{ flex: 1, minWidth: 0, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
+                    {s.id || s.session_id}
+                  </span>
+                  <span className="muted text-sm">
+                    {s.created_at ? relativeTime((Date.now() - new Date(s.created_at).getTime()) / 1000) : "—"}
+                  </span>
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AG_NewAgentModal({ onClose, onCreate, pushToast, existing, status, onDelete, onChat, chatLoading }) {
   // Same modal serves both create (existing == null) and edit
   // (existing == agent row). In edit mode the id field is locked,
   // submit PUT-replaces, and the success callback is just close().
   const isEdit = !!existing;
+  // Harness-managed rows 409 on any PUT (routers/agents.py) - render a
+  // locked notice instead of a form that would fail on Save. Same
+  // capability AG_ConfigTab's old isManaged check had (hiding Edit
+  // entirely); this is that same check, just the only path left now
+  // that direct-edit is the landing view instead of Edit being a
+  // second click away.
+  const isManaged = isEdit && !!existing.harness_id;
   const { useResource, useMutation, apiFetch } = window.primerApi;
   // The agent's model field is a single profile id. A profile already
   // pins the provider, the wire model name and the API-level config, so
@@ -383,16 +518,6 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
   const profiles = useResource(
     "agents:model-profiles",
     (signal) => apiFetch("GET", "/model_profiles?limit=200", null, { signal }),
-    { pollMs: null }
-  );
-  // /v1/tools returns the merged catalogue across user-defined + the
-  // five built-in toolsets, with each tool's scoped id (toolset__tool)
-  // already computed server-side. Failures per-toolset are surfaced
-  // via available=false on the toolset entry so the picker can render
-  // them dimmed instead of breaking entirely.
-  const toolsCatalogue = useResource(
-    "agents:tools-catalogue",
-    (signal) => apiFetch("GET", "/tools", null, { signal }),
     { pollMs: null }
   );
   // The Advanced tab gates a tts_voice picker on the speech capability
@@ -453,14 +578,25 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
   );
   const [responseFormatError, setResponseFormatError] = React.useState(null);
   const [fieldErrors, setFieldErrors] = React.useState({});
-  const [activeTab, setActiveTab] = React.useState("basic");
-  const [toolFilter, setToolFilter] = React.useState("");
-  // "Selected" filter chip (studio-ux fix 4): the Tools tab's search had no
-  // way to see WHICH tools are ticked across all toolsets/pages — this ANDs
-  // with the text filter, reusing the same selectedScopedIds set the
-  // "N of 172 selected" counter already tracks.
-  const [showSelectedOnly, setShowSelectedOnly] = React.useState(false);
-  const [toolPage, setToolPage] = React.useState(1);
+  // uiv2 Wave 2 (a-11): the two numerics that had NO control anywhere in
+  // the app before this wave (grep-confirmed against agents.jsx pre-
+  // change). max_tool_turns has a real server default (50, not null) -
+  // initializing from it rather than leaving the field blank means a
+  // save that never touches this field still round-trips the agent's
+  // real value instead of PUT-replacing it back down to the schema
+  // default.
+  const [maxToolTurns, setMaxToolTurns] = React.useState(
+    String(existing?.max_tool_turns ?? 50)
+  );
+  const [maxOutputTokens, setMaxOutputTokens] = React.useState(
+    existing?.max_output_tokens != null ? String(existing.max_output_tokens) : ""
+  );
+  const [showAdvanced, setShowAdvanced] = React.useState(false);
+  // Raw-JSON + cross-reference view (synthesis doc: "JSON can survive as
+  // a secondary/advanced view but must not be the landing IA") - edit
+  // mode only, folds AG_ConfigTab's read-only render + AG_ReferencesPanel
+  // into one disclosure rather than a whole tab.
+  const [showJson, setShowJson] = React.useState(false);
 
   React.useEffect(() => {
     if (!profileId && profiles.data?.items?.length) {
@@ -474,95 +610,6 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
   // the agent at whatever happens to sort first.
   const selectedProfile = profileOptions.find((pr) => pr.id === profileId);
   const profileMissing = !!profileId && !selectedProfile && !profiles.loading;
-
-  const toolsetEntries = toolsCatalogue.data?.items ?? [];
-
-  const filteredToolsetEntries = React.useMemo(() => {
-    const q = toolFilter.trim().toLowerCase();
-    let entries = toolsetEntries;
-    if (q) {
-      entries = entries
-        .map((ts) => ({
-          ...ts,
-          tools: ts.tools.filter(
-            (t) =>
-              t.id.toLowerCase().includes(q) ||
-              t.scoped_id.toLowerCase().includes(q) ||
-              (t.description || "").toLowerCase().includes(q) ||
-              ts.id.toLowerCase().includes(q),
-          ),
-        }))
-        .filter((ts) => ts.tools.length > 0 || ts.id.toLowerCase().includes(q));
-    }
-    // "Selected" filter chip: restrict to tools currently in
-    // selectedScopedIds, across every toolset/page (not just the visible
-    // slice), so it composes cleanly with the text filter above.
-    if (showSelectedOnly) {
-      entries = entries
-        .map((ts) => ({ ...ts, tools: ts.tools.filter((t) => selectedScopedIds.has(t.scoped_id)) }))
-        .filter((ts) => ts.tools.length > 0);
-    }
-    return entries;
-  }, [toolsetEntries, toolFilter, showSelectedOnly, selectedScopedIds]);
-
-  const totalAvailable = React.useMemo(
-    () => toolsetEntries.reduce((acc, ts) => acc + ts.tools.length, 0),
-    [toolsetEntries],
-  );
-
-  // Built-in toolsets alone can ship 100+ tools (the `system` toolset
-  // currently exposes ~102), so the picker has to paginate or the
-  // modal becomes a 3000-px-tall scroll. The list is flattened across
-  // available toolsets so paging counts whole tools, not whole groups
-  // (toolsets that span pages get their header re-rendered at the top
-  // of each page so the operator never loses scope context). Unavailable
-  // toolsets are stripped here and rendered as a compact summary above
-  // the paginated list so they don't waste page slots.
-  const AGENT_TOOL_PAGE_SIZE = 25;
-  const flatTools = React.useMemo(() => {
-    const out = [];
-    for (const ts of filteredToolsetEntries) {
-      if (!ts.available) continue;
-      for (const tool of ts.tools) {
-        out.push({ ...tool, _toolset: ts });
-      }
-    }
-    return out;
-  }, [filteredToolsetEntries]);
-  const unavailableToolsets = React.useMemo(
-    () => filteredToolsetEntries.filter((ts) => !ts.available),
-    [filteredToolsetEntries],
-  );
-  const toolTotalPages = Math.max(1, Math.ceil(flatTools.length / AGENT_TOOL_PAGE_SIZE));
-  // Snap to first page whenever the filter narrows the result set,
-  // and clamp the current page if the page count shrinks below it.
-  React.useEffect(() => { setToolPage(1); }, [toolFilter, showSelectedOnly]);
-  React.useEffect(() => {
-    if (toolPage > toolTotalPages) setToolPage(toolTotalPages);
-  }, [toolPage, toolTotalPages]);
-  const toolPageStart = (toolPage - 1) * AGENT_TOOL_PAGE_SIZE;
-  const toolPageEnd = Math.min(toolPageStart + AGENT_TOOL_PAGE_SIZE, flatTools.length);
-  const pageTools = flatTools.slice(toolPageStart, toolPageEnd);
-
-  const toggleScopedId = (scopedId) => {
-    setSelectedScopedIds((prev) => {
-      const next = new Set(prev);
-      if (next.has(scopedId)) next.delete(scopedId);
-      else next.add(scopedId);
-      return next;
-    });
-  };
-
-  const toggleToolsetGroup = (entry, allSelected) => {
-    setSelectedScopedIds((prev) => {
-      const next = new Set(prev);
-      for (const t of entry.tools) {
-        if (allSelected) next.delete(t.scoped_id);
-        else next.add(t.scoped_id);
-      }
-      return next;
-    });
-  };
 
   const create = useMutation(
     (body) => isEdit
@@ -602,7 +649,7 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
         responseFormatValue = JSON.parse(responseFormat);
       } catch (e) {
         setResponseFormatError(String(e.message || e));
-        setActiveTab("advanced");
+        setShowAdvanced(true);
         return;
       }
     }
@@ -626,6 +673,23 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
     if (temperature !== "" && !Number.isNaN(+temperature)) {
       body.temperature = Number(temperature);
     }
+    // uiv2 Wave 2 (a-11): always sent, never conditionally dropped - see
+    // the maxToolTurns state comment above for why (real non-null server
+    // default means omitting it on a PUT-replace save would silently
+    // reset a customized value).
+    const parsedMaxToolTurns = Number(maxToolTurns);
+    body.max_tool_turns = Number.isFinite(parsedMaxToolTurns) && parsedMaxToolTurns > 0
+      ? Math.floor(parsedMaxToolTurns) : 50;
+    // max_output_tokens defaults to null (unbounded) - same
+    // always-on-edit/conditional-on-create pattern as response_format.
+    let maxOutputTokensValue = null;
+    if (maxOutputTokens.trim() !== "") {
+      const n = Number(maxOutputTokens);
+      if (Number.isFinite(n) && n > 0) maxOutputTokensValue = Math.floor(n);
+    }
+    if (maxOutputTokensValue !== null || isEdit) {
+      body.max_output_tokens = maxOutputTokensValue;
+    }
     // PUT is a full replace, so always send response_format on edit
     // (null clears a previously-set schema); on create only include it
     // when set, matching the model default.
@@ -636,25 +700,63 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
   };
 
   const selectedCount = selectedScopedIds.size;
+  const verbChip = (
+    <span className="pc-modal-chip mono text-sm muted"
+      data-testid="agent-modal-verb-chip"
+      style={{ marginLeft: 10, marginBottom: 0, verticalAlign: "middle" }}>
+      verb: {isEdit ? "Edit" : "Create"} Agent
+    </span>
+  );
+  // Edit mode identifies the specific row in the title itself (same
+  // "Noun — id" pattern as KN_CollectionDetail) - the verb chip alone
+  // ("Agent · verb: Edit Agent") lost the agent id when this overlay
+  // stopped delegating to NV_OverlayPanel's own id-bearing title.
+  const modalTitle = (
+    <h1 className="page-title" style={{ font: "inherit", margin: 0, display: "inline" }}>
+      {isEdit ? `Agent — ${existing.id}` : "Agent"}
+      {verbChip}
+    </h1>
+  );
+
+  // uiv2 Wave 2 (harness_id): a managed row 409s on any PUT
+  // (routers/agents.py) - AG_ConfigTab used to just hide its Edit
+  // button and leave the raw-JSON view up; now that direct-edit IS the
+  // landing view, a locked summary replaces the form outright rather
+  // than rendering inputs Save can never persist.
+  if (isManaged) {
+    return (
+      <Modal
+        title={modalTitle}
+        onClose={onClose}
+        footer={<Btn kind="ghost" onClick={onClose}>Close</Btn>}
+      >
+        <Banner kind="info" title={`Managed by harness ${existing.harness_id}`}
+          detail="Direct edits are blocked - update the harness's sync/uninstall flow instead." />
+        <div className="col" style={{ gap: 10, marginTop: 14 }}>
+          <div><span className="field-label">Name</span><div className="mono">{existing.id}</div></div>
+          <div><span className="field-label">Description</span><div>{existing.description}</div></div>
+          <div><span className="field-label">Model profile</span><div className="mono">{existing.model?.profile_id || "—"}</div></div>
+          <div><span className="field-label">Tools</span><div>{(existing.tools || []).length} registered</div></div>
+        </div>
+      </Modal>
+    );
+  }
 
   return (
     <Modal
-      title={
-        <>
-          {isEdit ? `Edit agent · ${existing.id}` : "Agent"}
-          {/* Platform wave P1b item 4: verb chip, reusing P1a's
-              .pc-modal-chip (providers surface) for visual consistency
-              across every create/edit modal rather than a new class. */}
-          <span className="pc-modal-chip mono text-sm muted"
-            data-testid="agent-modal-verb-chip"
-            style={{ marginLeft: 10, marginBottom: 0, verticalAlign: "middle" }}>
-            verb: {isEdit ? "Edit" : "Create"} Agent
-          </span>
-        </>
-      }
+      title={modalTitle}
+      width={760}
       onClose={onClose}
       footer={
         <>
+          {isEdit && onDelete && (
+            <Btn kind="ghost" onClick={onDelete} style={{ marginRight: "auto", color: "var(--red)" }}>Delete</Btn>
+          )}
+          {isEdit && onChat && (
+            <Btn kind="ghost" icon="send" onClick={onChat} disabled={chatLoading}>
+              {chatLoading ? "Opening chat…" : "Chat"}
+            </Btn>
+          )}
           <Btn kind="ghost" onClick={onClose}>Cancel</Btn>
           <Btn
             kind="primary"
@@ -667,35 +769,17 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
         </>
       }
     >
-      <div className="tabs" style={{ display: "flex", gap: 4, borderBottom: "1px solid var(--border)", marginBottom: 14 }}>
-        {[
-          { key: "basic", label: "Basic" },
-          { key: "tools", label: `Tools${selectedCount > 0 ? ` (${selectedCount})` : ""}` },
-          { key: "advanced", label: "Advanced" },
-        ].map((t) => (
-          <button
-            key={t.key}
-            type="button"
-            data-testid={`agent-tab-${t.key}`}
-            onClick={() => setActiveTab(t.key)}
-            style={{
-              background: "none", border: "none",
-              borderBottom: activeTab === t.key ? "2px solid var(--accent)" : "2px solid transparent",
-              padding: "6px 12px", marginBottom: -1, cursor: "pointer",
-              color: activeTab === t.key ? "var(--text)" : "var(--text-2)",
-              fontSize: 12.5, fontWeight: activeTab === t.key ? 600 : 400,
-            }}
-          >
-            {t.label}
-          </button>
-        ))}
-      </div>
-
-      {activeTab === "basic" && (
-        <>
+      {isEdit && <AG_StatusPanel id={existing.id} status={status} />}
+      <div style={{
+        display: "grid",
+        gridTemplateColumns: "minmax(0, 1fr) 340px",
+        gap: 22,
+        marginTop: isEdit ? 14 : 0,
+      }}>
+        <div className="col" style={{ gap: 14, minWidth: 0 }}>
           <div className="field">
             <label className="field-label" htmlFor="na-id">
-              ID {isEdit
+              Name {isEdit
                 ? <span className="hint">locked — id cannot change after create</span>
                 : <span className="hint">optional — backend assigns if blank</span>}
             </label>
@@ -704,7 +788,7 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
               className="input"
               value={id}
               onChange={(e) => setId(e.target.value)}
-              placeholder="auto-generated"
+              placeholder="e.g. refund-triage"
               disabled={isEdit}
               style={{ width: "100%" }}
             />
@@ -723,255 +807,51 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
             )}
           </div>
           <div className="field">
-            <label className="field-label" htmlFor="na-model-profile">Model profile</label>
-            <select
-              id="na-model-profile"
-              className="select"
+            <label className="field-label" id="na-model-profile-label">
+              Model profile <span className="hint">default, overridable per run</span>
+            </label>
+            <AG_ProfilePicker
+              profiles={profileOptions}
+              loading={profiles.loading}
               value={profileId}
-              onChange={(e) => setProfileId(e.target.value)}
-              style={{ width: "100%" }}
-            >
-              <option value="">-- pick a model profile --</option>
-              {profileMissing && (
-                <option value={profileId}>{profileId} (missing)</option>
-              )}
-              {profileOptions.map((pr) => (
-                <option key={pr.id} value={pr.id}>
-                  {pr.id} · {pr.provider_id}/{pr.model_name}
-                  {pr.config?.reasoning ? ` · reasoning ${pr.config.reasoning}` : ""}
-                </option>
-              ))}
-            </select>
+              onChange={setProfileId}
+              missingId={profileMissing ? profileId : null}
+            />
             <div className="field-help">
               This is the agent's DEFAULT model. A session or chat may name a
               different profile at invocation time.
             </div>
-            {profileMissing && (
-              <div className="field-help" style={{ color: "var(--red)" }}>
-                This agent names a profile that no longer exists. Pick another
-                one, or recreate it at <span className="mono">/providers?class=llm</span>.
-              </div>
-            )}
-            {profileOptions.length === 0 && !profiles.loading && (
-              <div className="field-help" style={{ color: "var(--amber)" }}>
-                No model profiles configured. Create one at <span className="mono">/providers?class=llm</span> first.
-              </div>
-            )}
             {fieldErrors["body.model.profile_id"] && (
               <div className="field-help" style={{ color: "var(--red)" }}>{fieldErrors["body.model.profile_id"]}</div>
             )}
           </div>
-        </>
-      )}
-
-      {activeTab === "tools" && (
-        <div>
-          <div style={{ marginBottom: 10, display: "flex", alignItems: "center", gap: 8 }}>
-            <div className="input-icon" style={{ flex: 1 }}>
-              <Icon name="search" size={13} className="icon" />
-              <input
-                className="input"
-                placeholder="Filter by tool name, description, or toolset…"
-                value={toolFilter}
-                onChange={(e) => setToolFilter(e.target.value)}
-                data-testid="agent-tool-filter"
-                style={{ width: "100%" }}
-              />
+          {/* uiv2 Wave 2 (a-11): the numerics live right under the
+              profile picker, not tucked behind Advanced - they gate the
+              same model call the profile does. */}
+          <div style={{ display: "flex", gap: 10 }}>
+            <div className="field" style={{ flex: 1 }}>
+              <label className="field-label" htmlFor="na-temperature">
+                Temperature <span className="hint">optional</span>
+              </label>
+              <input id="na-temperature" className="input" type="number" step="0.05" min="0"
+                value={temperature} onChange={(e) => setTemperature(e.target.value)} style={{ width: "100%" }} />
+              {fieldErrors["body.temperature"] && (
+                <div className="field-help" style={{ color: "var(--red)" }}>{fieldErrors["body.temperature"]}</div>
+              )}
             </div>
-            <button
-              type="button"
-              data-testid="agent-tool-filter-selected"
-              className={"chip" + (showSelectedOnly ? " active" : "")}
-              aria-pressed={showSelectedOnly}
-              onClick={() => setShowSelectedOnly((v) => !v)}
-              title={showSelectedOnly ? "Show all tools" : "Show only selected tools"}
-              style={{ whiteSpace: "nowrap" }}
-            >
-              Selected
-            </button>
-            {/* Platform wave P1b item 4: "selected · N" counter chip per
-                the reference, reusing the small bordered-pill look P1a
-                established for the providers surface (no new CSS class -
-                this file's own convention is inline styles throughout). */}
-            <span className="mono text-sm" data-testid="agent-tools-selected-count" style={{
-              whiteSpace: "nowrap", padding: "2px 8px", borderRadius: 999,
-              border: "1px solid var(--border)", background: "var(--bg-1)",
-              color: "var(--text-2)",
-            }}>
-              selected · {selectedCount} of {totalAvailable}
-            </span>
+            <div className="field" style={{ flex: 1 }}>
+              <label className="field-label" htmlFor="na-max-tool-turns">Max tool turns</label>
+              <input id="na-max-tool-turns" className="input" type="number" step="1" min="1"
+                value={maxToolTurns} onChange={(e) => setMaxToolTurns(e.target.value)} style={{ width: "100%" }} />
+            </div>
+            <div className="field" style={{ flex: 1 }}>
+              <label className="field-label" htmlFor="na-max-output-tokens">
+                Max output tokens <span className="hint">optional</span>
+              </label>
+              <input id="na-max-output-tokens" className="input" type="number" step="1" min="1"
+                value={maxOutputTokens} onChange={(e) => setMaxOutputTokens(e.target.value)} style={{ width: "100%" }} />
+            </div>
           </div>
-          {toolsCatalogue.loading && toolsetEntries.length === 0 && (
-            <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }}>
-              Loading tool catalogue…
-            </div>
-          )}
-          {!toolsCatalogue.loading && filteredToolsetEntries.length === 0 && (
-            <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }} data-testid="agent-tool-empty">
-              {showSelectedOnly
-                ? `No selected tools${toolFilter ? " match the filter." : "."}`
-                : toolFilter ? "No tools match the filter." : "No toolsets available."}
-            </div>
-          )}
-          {/* Unavailable toolsets stay visible outside the paginated
-              body so operators can see which providers exist but aren't
-              currently usable — they don't consume page slots. */}
-          {unavailableToolsets.length > 0 && (
-            <div style={{ marginBottom: 8, display: "flex", flexWrap: "wrap", gap: 4 }}>
-              {unavailableToolsets.map((entry) => (
-                <span
-                  key={entry.id}
-                  className="muted text-sm"
-                  style={{
-                    fontSize: 11, padding: "2px 8px",
-                    border: "1px dashed var(--border)", borderRadius: 4,
-                    color: "var(--amber)", opacity: 0.85,
-                  }}
-                  title={entry.unavailable_reason || "unavailable"}
-                >
-                  <span className="mono">{entry.id}</span> · unavailable
-                </span>
-              ))}
-            </div>
-          )}
-          {flatTools.length > 0 && (
-            <div style={{ maxHeight: 360, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6 }}>
-              {(() => {
-                // Render the paginated slice with a toolset header
-                // every time the parent toolset changes. The header
-                // tristate operates on the FULL toolset (across pages),
-                // not just the visible slice, so bulk select stays
-                // meaningful regardless of paging.
-                const rows = [];
-                let lastToolsetId = null;
-                for (const t of pageTools) {
-                  if (t._toolset.id !== lastToolsetId) {
-                    const entry = t._toolset;
-                    const allSelected = entry.tools.length > 0 && entry.tools.every((x) => selectedScopedIds.has(x.scoped_id));
-                    const someSelected = entry.tools.some((x) => selectedScopedIds.has(x.scoped_id));
-                    rows.push(
-                      <div
-                        key={`h-${entry.id}-p${toolPage}`}
-                        style={{
-                          display: "flex", alignItems: "center", gap: 8,
-                          padding: "8px 10px", background: "var(--bg-2)",
-                          borderTop: lastToolsetId === null ? "none" : "1px solid var(--border)",
-                          borderBottom: "1px solid var(--border)",
-                          position: "sticky", top: 0, zIndex: 1,
-                        }}
-                      >
-                        <input
-                          type="checkbox"
-                          checked={allSelected}
-                          ref={(el) => { if (el) el.indeterminate = !allSelected && someSelected; }}
-                          onChange={() => toggleToolsetGroup(entry, allSelected)}
-                          disabled={entry.tools.length === 0}
-                          data-testid={`agent-toolset-group-${entry.id}`}
-                        />
-                        <span className="mono" style={{ fontSize: 12.5, fontWeight: 600 }}>{entry.id}</span>
-                        {entry.builtin && <span className="muted text-sm" style={{ fontSize: 10.5 }}>· built-in</span>}
-                        {entry.tagline && (
-                          <span className="muted text-sm" style={{ fontSize: 11, marginLeft: 4 }}>{entry.tagline}</span>
-                        )}
-                        <span className="muted text-sm" style={{ marginLeft: "auto" }}>
-                          {entry.tools.length} tool{entry.tools.length === 1 ? "" : "s"}
-                        </span>
-                      </div>
-                    );
-                    lastToolsetId = entry.id;
-                  }
-                  const checked = selectedScopedIds.has(t.scoped_id);
-                  rows.push(
-                    <label
-                      key={t.scoped_id}
-                      style={{
-                        display: "flex", alignItems: "flex-start", gap: 8,
-                        padding: "6px 10px 6px 28px", cursor: "pointer",
-                        borderTop: "1px solid var(--bg-1)",
-                        background: checked ? "var(--bg-2)" : "transparent",
-                      }}
-                      data-testid={`agent-tool-${t.scoped_id}`}
-                    >
-                      <input
-                        type="checkbox"
-                        checked={checked}
-                        onChange={() => toggleScopedId(t.scoped_id)}
-                        style={{ marginTop: 3 }}
-                      />
-                      <div style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "flex-start", gap: 8 }}>
-                        <div style={{ flex: 1, minWidth: 0 }}>
-                          <div className="mono" style={{ fontSize: 12 }}>{t.id}</div>
-                          {t.description && (
-                            <div className="muted text-sm" style={{ fontSize: 11, marginTop: 2, lineHeight: 1.4 }}>
-                              {t.description}
-                            </div>
-                          )}
-                        </div>
-                        <window.primerApi.CapabilityBadges tool={t} testid={`agent-tool-badges-${t.scoped_id}`} />
-                      </div>
-                    </label>
-                  );
-                }
-                return rows;
-              })()}
-            </div>
-          )}
-          {flatTools.length > 0 && (
-            <div
-              style={{
-                display: "flex", alignItems: "center", justifyContent: "space-between",
-                marginTop: 8, fontSize: 11.5, color: "var(--text-3)",
-              }}
-            >
-              <span className="tabular">
-                Showing <strong style={{ color: "var(--text)" }}>{flatTools.length === 0 ? 0 : toolPageStart + 1}</strong>–
-                <strong style={{ color: "var(--text)" }}>{toolPageEnd}</strong> of{" "}
-                <strong style={{ color: "var(--text)" }}>{flatTools.length}</strong>
-              </span>
-              <div className="pager" style={{ display: "flex", alignItems: "center", gap: 6 }}>
-                <Btn
-                  size="sm"
-                  kind="ghost"
-                  icon="chevron-left"
-                  disabled={toolPage === 1}
-                  onClick={() => setToolPage((p) => Math.max(1, p - 1))}
-                  data-testid="agent-tool-page-prev"
-                >Previous</Btn>
-                <span className="muted text-sm tabular" style={{ padding: "0 6px" }}>
-                  Page {toolPage} of {toolTotalPages}
-                </span>
-                <Btn
-                  size="sm"
-                  kind="ghost"
-                  iconRight="chevron-right"
-                  disabled={toolPage === toolTotalPages}
-                  onClick={() => setToolPage((p) => Math.min(toolTotalPages, p + 1))}
-                  data-testid="agent-tool-page-next"
-                >Next</Btn>
-              </div>
-            </div>
-          )}
-          <div className="field-help" style={{ marginTop: 8 }}>
-            Tools are referenced as <span className="mono">toolset_id__tool_name</span>. The agent has
-            access to <strong>only</strong> the tools picked here — never a whole toolset. Bulk-select via the
-            toolset header ticks every tool in that toolset (across pages); the toolset itself is not
-            implicitly registered.
-          </div>
-          {/* Platform wave P1b item 4: verbatim reference footnote. The
-              y/w/r/n flag chips it describes are NOT a P2 gap here - they
-              are already live on every row above via the shared
-              CapabilityBadges component (batch-2 catalogue-badges work) -
-              see this task's report for that correction. */}
-          <div className="field-help" data-testid="agent-tools-footnote" style={{ marginTop: 8 }}>
-            One picker everywhere: agent bindings, graph tool nodes, approval
-            policies, service grants, the MCP allowlist. Flags: y yields · w
-            workspace · r role · n notifying.
-          </div>
-        </div>
-      )}
-
-      {activeTab === "advanced" && (
-        <>
           <div className="field">
             <label className="field-label">
               System prompt <span className="hint">optional · parts</span>
@@ -993,7 +873,7 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
                     next[i] = e.target.value;
                     setSystemPromptParts(next);
                   }}
-                  rows={4}
+                  rows={3}
                 />
                 <Btn kind="ghost" size="sm" icon="x"
                   data-testid={`agent-system-prompt-remove-${i}`}
@@ -1012,6 +892,12 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
               Add part
             </Btn>
           </div>
+          {/* uiv2 Wave 2 (b-2): a separately-labeled field, not a second
+              unlabeled textarea under the System prompt heading - the
+              schema already treats these as distinct concepts
+              (compaction_prompt is its own field, system_prompt an
+              unbounded ordered list, confirmed live pre-wave). One-pass
+              adjustable if the user rules b-2 differently. */}
           <div className="field">
             <label className="field-label" htmlFor="na-compaction-prompt">
               Compaction prompt <span className="hint">optional · used when the conversation outgrows the LLM context window</span>
@@ -1021,7 +907,7 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
               className="textarea"
               value={compactionPrompt}
               onChange={(e) => setCompactionPrompt(e.target.value)}
-              rows={4}
+              rows={3}
               placeholder="Instructions the runtime uses to summarise older turns when context is tight. Empty = use the framework default."
             />
             <div className="field-help">
@@ -1034,15 +920,17 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
             </p>
           </div>
           <div className="field">
-            {/* Platform wave P1b item 4: the reference shows an
-                "Autonomous" inherit/on/off segment, but autonomous
-                (workspace_session.py:421) lives on the SESSION binding,
-                not the Agent definition - Agent has no such field, and
-                neither /agents create nor update accepts one (confirmed
-                against primer/model/agent.py). Rendering a segment that
-                silently no-ops would lie about what Save does, so it is
-                disabled with an explanatory note instead of a fake write -
-                see this task's report for the gap. */}
+            {/* Platform wave P1b item 4 / uiv2 Wave 2 ruling: the
+                reference shows an "Autonomous" inherit/on/off segment,
+                but autonomous (workspace_session.py:421) lives on the
+                SESSION binding, not the Agent definition - Agent has no
+                such field, and neither /agents create nor update accepts
+                one (confirmed against primer/model/agent.py). Rendering
+                a segment that silently no-ops would lie about what Save
+                does, so it stays disabled with an explanatory note
+                (August-round precedent) rather than a fake write or a
+                unilateral backend addition - flagged to the user as its
+                own open decision. */}
             <span>Autonomous</span>
             <div className="chip-group" data-testid="agent-autonomous-segment"
               style={{ opacity: 0.55, pointerEvents: "none", width: "fit-content" }}
@@ -1057,27 +945,39 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
               there is nothing here for Save to write yet.
             </div>
           </div>
-          <div className="field">
-        {!!(caps.data && caps.data.speech && caps.data.speech.tts_configured) && (
-          <label className="field">
-            <span>tts_voice</span>
-            <select
-              data-testid="agent-tts-voice"
-              value={ttsVoice || ""}
-              onChange={(e) => setTtsVoice(e.target.value || null)}
-            >
-              <option value="">(use the global default)</option>
-              {((voices.data && voices.data.voices) || []).map((name) => (
-                <option key={name} value={name}>{name}</option>
-              ))}
-            </select>
-            {ttsVoice ? (
-              <div className="field-help" data-testid="agent-voice-pairing-note">
-                {ttsVoice} · pairs with the identity chip
-              </div>
-            ) : null}
-          </label>
-        )}
+          {!!(caps.data && caps.data.speech && caps.data.speech.tts_configured) && (
+            <div className="field">
+              <label className="field-label" htmlFor="na-tts-voice">Voice <span className="hint">optional</span></label>
+              <select
+                id="na-tts-voice"
+                className="select"
+                data-testid="agent-tts-voice"
+                value={ttsVoice || ""}
+                onChange={(e) => setTtsVoice(e.target.value || null)}
+                style={{ width: "100%" }}
+              >
+                <option value="">(use the global default)</option>
+                {((voices.data && voices.data.voices) || []).map((name) => (
+                  <option key={name} value={name}>{name}</option>
+                ))}
+              </select>
+              {ttsVoice ? (
+                <div className="field-help" data-testid="agent-voice-pairing-note">
+                  {ttsVoice} · pairs with the identity chip
+                </div>
+              ) : null}
+            </div>
+          )}
+        </div>
+        <div className="col" style={{ gap: 12, minWidth: 0 }}>
+          <div>
+            <label className="field-label">
+              Tools <span className="hint">scoped ids — never whole toolsets</span>
+            </label>
+            <window.ToolPicker selected={selectedScopedIds} onChange={setSelectedScopedIds} pageSize={6} />
+          </div>
+          {isEdit && <AG_SessionsPanel agentId={existing.id} />}
+          <AG_AdvancedDisclosure open={showAdvanced} onToggle={() => setShowAdvanced((v) => !v)}>
             <AG_Toggle
               checked={compactionToolAccess}
               onChange={setCompactionToolAccess}
@@ -1085,8 +985,6 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
               label="Tool access during compaction"
               help="let the compaction prompt call this agent's tools while summarising — e.g. dump the compacted content to workspace files. Runs in a bounded, ephemeral loop; the tool calls don't enter conversation history. Leave off for plain text-only compaction."
             />
-          </div>
-          <div className="field">
             <AG_Toggle
               checked={allowExternalTools}
               onChange={setAllowExternalTools}
@@ -1094,67 +992,52 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
               label="Allow external tools"
               help="let API callers attach their own per-invocation tool definitions when invoking this agent. When the model calls one, the turn pauses until the caller responds through the invocation API. Leave off to reject invocation bodies carrying external tools."
             />
-          </div>
-          <div className="field">
-            <label className="field-label" htmlFor="na-temperature">
-              Temperature <span className="hint">optional · default is provider-decided</span>
-            </label>
-            <input
-              id="na-temperature"
-              className="input"
-              type="number"
-              step="0.05"
-              min="0"
-              value={temperature}
-              onChange={(e) => setTemperature(e.target.value)}
-              style={{ width: 100 }}
-            />
-            {fieldErrors["body.temperature"] && (
-              <div className="field-help" style={{ color: "var(--red)" }}>{fieldErrors["body.temperature"]}</div>
-            )}
-          </div>
-          <div className="field">
-            <label className="field-label" htmlFor="na-response-format">
-              Response format <span className="hint">optional · structured-output JSON Schema</span>
-            </label>
-            <textarea
-              id="na-response-format"
-              className="textarea mono"
-              value={responseFormat}
-              onChange={(e) => setResponseFormat(e.target.value)}
-              onBlur={() => {
-                // Validate-on-blur like the graph editor's GR_JsonField:
-                // empty == no schema (cleared), otherwise must parse.
-                if (responseFormat.trim() === "") {
-                  setResponseFormatError(null);
-                  return;
-                }
-                try {
-                  JSON.parse(responseFormat);
-                  setResponseFormatError(null);
-                } catch (e) {
-                  setResponseFormatError(String(e.message || e));
-                }
-              }}
-              rows={6}
-              placeholder={'{\n  "type": "object",\n  "properties": { "verdict": { "type": "string" } },\n  "required": ["verdict"]\n}'}
-              style={{ width: "100%", fontFamily: "IBM Plex Mono", fontSize: 12 }}
-              data-testid="agent-response-format"
-            />
-            <div className="field-help">
-              When set, the LLM is constrained to emit JSON matching this schema (same shape
-              as a graph agent-node's <span className="mono">response_format</span>). Leave blank
-              to run the agent unconstrained. Validated as a JSON Schema on save.
+            <div className="field">
+              <label className="field-label" htmlFor="na-response-format">
+                Response format <span className="hint">optional · structured-output JSON Schema</span>
+              </label>
+              <textarea
+                id="na-response-format"
+                className="textarea mono"
+                value={responseFormat}
+                onChange={(e) => setResponseFormat(e.target.value)}
+                onBlur={() => {
+                  // Validate-on-blur like the graph editor's GR_JsonField:
+                  // empty == no schema (cleared), otherwise must parse.
+                  if (responseFormat.trim() === "") {
+                    setResponseFormatError(null);
+                    return;
+                  }
+                  try {
+                    JSON.parse(responseFormat);
+                    setResponseFormatError(null);
+                  } catch (e) {
+                    setResponseFormatError(String(e.message || e));
+                  }
+                }}
+                rows={5}
+                placeholder={'{\n  "type": "object",\n  "properties": { "verdict": { "type": "string" } },\n  "required": ["verdict"]\n}'}
+                style={{ width: "100%", fontFamily: "IBM Plex Mono", fontSize: 12 }}
+                data-testid="agent-response-format"
+              />
+              <div className="field-help">
+                When set, the LLM is constrained to emit JSON matching this schema (same shape
+                as a graph agent-node's <span className="mono">response_format</span>). Leave blank
+                to run the agent unconstrained. Validated as a JSON Schema on save.
+              </div>
+              {responseFormatError && (
+                <div className="field-help" style={{ color: "var(--red)" }}>JSON parse: {responseFormatError}</div>
+              )}
+              {fieldErrors["body.response_format"] && (
+                <div className="field-help" style={{ color: "var(--red)" }}>{fieldErrors["body.response_format"]}</div>
+              )}
             </div>
-            {responseFormatError && (
-              <div className="field-help" style={{ color: "var(--red)" }}>JSON parse: {responseFormatError}</div>
-            )}
-            {fieldErrors["body.response_format"] && (
-              <div className="field-help" style={{ color: "var(--red)" }}>{fieldErrors["body.response_format"]}</div>
-            )}
-          </div>
-        </>
-      )}
+          </AG_AdvancedDisclosure>
+          {isEdit && (
+            <AG_JsonDisclosure agent={existing} open={showJson} onToggle={() => setShowJson((v) => !v)} />
+          )}
+        </div>
+      </div>
     </Modal>
   );
 }
@@ -1165,10 +1048,8 @@ function AG_NewAgentModal({ onClose, onCreate, pushToast, existing }) {
 
 function AgentDetail({ agentId, pushToast }) {
   const { useResource, useMutation, useRouter, apiFetch } = window.primerApi;
-  const { params, query, navigate } = useRouter();
+  const { params, navigate } = useRouter();
   const id = agentId || params.id;
-  const tab = AG_TABS.some((t) => t.id === query.tab) ? query.tab : "config";
-  const setTab = (t) => navigate("/agents/" + id + "?tab=" + t);
 
   const detail = useResource(
     "agent-detail:" + id,
@@ -1233,76 +1114,45 @@ function AgentDetail({ agentId, pushToast }) {
   );
   const startChat = () => { if (!startChatMut.loading) startChatMut.mutate(); };
 
+  // uiv2 Wave 2: the landing view IS the direct-edit form now (no more
+  // Config-tab-with-raw-JSON as the first thing an operator sees) - a
+  // loading/error state before AG_NewAgentModal has data to edit still
+  // needs its own small standalone rendering, but there is no more
+  // action bar to anchor it to (Chat/Delete/Back all moved into the
+  // form's own footer, which needs `existing` to exist at all).
   if (detail.loading && !detail.data) {
-    return (
-      <div className="col" style={{ gap: 14 }}>
-        <AG_DetailActions onChat={startChat} chatLoading={startChatMut.loading} onDelete={() => { setDeleteError(null); setConfirmDelete(true); }} onBack={() => navigate("/agents")} />
-        <div className="muted text-sm" style={{ padding: 40, textAlign: "center" }}>Loading…</div>
-      </div>
-    );
+    return <div className="muted text-sm" style={{ padding: 40, textAlign: "center" }}>Loading…</div>;
   }
   if (detail.error && !detail.data) {
     return (
-      <div className="col" style={{ gap: 14 }}>
-        <AG_DetailActions onChat={startChat} chatLoading={startChatMut.loading} onDelete={() => { setDeleteError(null); setConfirmDelete(true); }} onBack={() => navigate("/agents")} />
-        <Banner
-          kind="error"
-          title={detail.error.title || "Couldn't load agent"}
-          detail={detail.error.detail || detail.error.message}
-          actions={<Btn size="sm" icon="chevron-left" onClick={() => navigate("/agents")}>Back to list</Btn>}
-        />
-      </div>
+      <Banner
+        kind="error"
+        title={detail.error.title || "Couldn't load agent"}
+        detail={detail.error.detail || detail.error.message}
+        actions={<Btn size="sm" icon="chevron-left" onClick={() => navigate("/agents")}>Back to list</Btn>}
+      />
     );
   }
 
   const a = detail.data;
 
   return (
-    <div className="col" style={{ gap: 14 }}>
-      <AG_DetailActions
-        onChat={startChat} chatLoading={startChatMut.loading}
+    <>
+      <AG_NewAgentModal
+        existing={a}
+        status={status}
+        pushToast={pushToast}
+        onChat={startChat}
+        chatLoading={startChatMut.loading}
         onDelete={() => { setDeleteError(null); setConfirmDelete(true); }}
-        onBack={() => navigate("/agents")}
+        onClose={() => navigate("/agents")}
+        onCreate={() => {
+          if (typeof pushToast === "function") {
+            pushToast({ kind: "info", title: "Agent updated", detail: a.id });
+          }
+          navigate("/agents");
+        }}
       />
-
-      <AG_StatusPanel id={id} status={status} />
-
-      <div className="panel">
-        <div style={{ display: "flex", alignItems: "center", borderBottom: "1px solid var(--border)", padding: "0 12px" }}>
-          {AG_TABS.map((t) => (
-            <button
-              key={t.id}
-              role="tab"
-              aria-selected={tab === t.id}
-              onClick={() => setTab(t.id)}
-              className={tab === t.id ? "active" : ""}
-              style={{
-                background: "none",
-                border: "none",
-                padding: "10px 14px",
-                cursor: "pointer",
-                color: tab === t.id ? "var(--text)" : "var(--text-3)",
-                fontSize: 12.5,
-                fontWeight: tab === t.id ? 600 : 400,
-                borderBottom: tab === t.id ? "2px solid var(--accent)" : "2px solid transparent",
-                marginBottom: -1,
-                display: "inline-flex",
-                alignItems: "center",
-                gap: 6,
-              }}
-            >
-              <Icon name={t.icon} size={13} />
-              {t.label}
-            </button>
-          ))}
-        </div>
-        <div className="panel-body" style={{ padding: 0 }}>
-          {tab === "config" && <AG_ConfigTab agent={a} pushToast={pushToast} />}
-          {tab === "tools" && <AG_ToolsTab agent={a} />}
-          {tab === "sessions" && <AG_SessionsTab agentId={id} />}
-          {tab === "metadata" && <AG_MetadataTab agent={a} />}
-        </div>
-      </div>
 
       {confirmDelete && (
         <Modal
@@ -1337,25 +1187,7 @@ function AgentDetail({ agentId, pushToast }) {
           </ul>
         </Modal>
       )}
-
-    </div>
-  );
-}
-
-// Internal action bar — rendered INSIDE the page body so the
-// .page-header .page-actions selector resolves to the buttons even
-// though app.jsx renders its own outer page-header.
-function AG_DetailActions({ onChat, chatLoading, onDelete, onBack }) {
-  return (
-    <div className="page-header" style={{ marginBottom: 0, justifyContent: "flex-end" }}>
-      <div className="page-actions">
-        <Btn icon="send" kind="primary" onClick={onChat} disabled={chatLoading}>
-          {chatLoading ? "Opening chat…" : "Chat"}
-        </Btn>
-        <Btn icon="trash" kind="danger" onClick={onDelete}>Delete</Btn>
-        <Btn icon="chevron-left" kind="ghost" onClick={onBack}>Back</Btn>
-      </div>
-    </div>
+    </>
   );
 }
 
@@ -1422,59 +1254,34 @@ function AG_StatusPanel({ id, status }) {
 // Config tab — read-only JSON + References cross-check
 // ============================================================================
 
-function AG_ConfigTab({ agent, pushToast }) {
+// uiv2 Wave 2: demoted from the landing IA to a secondary disclosure
+// (synthesis doc: "JSON can survive as a secondary/advanced view but
+// must not be the landing IA") - was AG_ConfigTab, a whole tab with its
+// own Edit button; direct-edit is the landing view now so there is no
+// more "Edit" mode-switch to render, just the read-only JSON +
+// cross-reference check folded under one collapsed toggle.
+function AG_JsonDisclosure({ agent, open, onToggle }) {
   const hl = window.primerVendor?.highlightJson;
-  const isManaged = !!agent.harness_id;
-
-  const [editing, setEditing] = React.useState(false);
-
   const pretty = React.useMemo(() => JSON.stringify(agent, null, 2), [agent]);
-
   return (
-    <div style={{ padding: 14 }}>
-      <div style={{ display: "flex", justifyContent: "space-between", alignItems: "flex-start", marginBottom: 10, gap: 10 }}>
-        <div className="muted text-sm">
-          {isManaged ? (
-            <>This agent is managed by harness <span className="mono">{agent.harness_id}</span>. Direct edits are blocked — update the harness instead.</>
-          ) : (
-            <>PUT-replace edit via the form. References panel below cross-checks the bound provider + toolsets after save.</>
-          )}
+    <div className="panel" data-testid="agent-json-disclosure">
+      <button type="button" onClick={onToggle}
+        style={{
+          display: "flex", alignItems: "center", gap: 6, width: "100%",
+          background: "none", border: "none", cursor: "pointer", padding: "8px 10px",
+          color: "var(--text-2)", fontSize: 12,
+        }}>
+        <Icon name={open ? "chevron-down" : "chevron-right"} size={11} />
+        View raw config
+      </button>
+      {open && (
+        <div style={{ padding: "0 10px 10px" }}>
+          {hl
+            ? <div className="code-block" dangerouslySetInnerHTML={{ __html: hl(pretty) }} />
+            : <pre className="code-block">{pretty}</pre>}
+          <AG_ReferencesPanel agent={agent} />
         </div>
-        <div style={{ display: "flex", gap: 6, flexShrink: 0 }}>
-          {!isManaged && (
-            <Btn size="sm" icon="edit" kind="secondary" onClick={() => setEditing(true)}>Edit</Btn>
-          )}
-        </div>
-      </div>
-      {editing && (
-        <AG_NewAgentModal
-          existing={agent}
-          pushToast={pushToast}
-          onClose={() => setEditing(false)}
-          onCreate={() => {
-            setEditing(false);
-            if (typeof pushToast === "function") {
-              pushToast({ kind: "info", title: "Agent updated", detail: agent.id });
-            }
-          }}
-        />
       )}
-      {false ? (
-        <textarea
-          readOnly
-          value={pretty}
-          style={{
-            // unreachable — kept so the closing `: hl ? ... : <pre>`
-            // branches below stay valid JSX without a deeper rewrite
-            // of this tab; the actual rendered output is the highlighted
-            // / pre block.
-            display: "none",
-          }}
-        />
-      ) : hl
-        ? <div className="code-block" dangerouslySetInnerHTML={{ __html: hl(pretty) }} />
-        : <pre className="code-block">{pretty}</pre>}
-      <AG_ReferencesPanel agent={agent} />
     </div>
   );
 }
@@ -1619,287 +1426,6 @@ function AG_ToolsetRefRow({ tsId, registeredCount, navigate }) {
         <span className="pill pill-failed"><span className="dot"></span>err</span>
       ) : (
         <span className="pill pill-ended"><span className="dot"></span>ok</span>
-      )}
-    </div>
-  );
-}
-
-// ============================================================================
-// Tools tab — per-toolset isolation (U0009 / T0711 contract)
-// ============================================================================
-
-function AG_ToolsTab({ agent }) {
-  const scopedIds = agent.tools || [];
-  // Group the agent's scoped tool ids by their toolset prefix so the
-  // page renders one panel per source toolset, each listing only the
-  // tools the agent actually registered (never the toolset's full
-  // catalogue).
-  const grouped = React.useMemo(() => {
-    const m = new Map();
-    for (const sid of scopedIds) {
-      if (typeof sid !== "string" || !sid.includes("__")) continue;
-      const [prefix, ...rest] = sid.split("__");
-      const bare = rest.join("__");
-      if (!m.has(prefix)) m.set(prefix, []);
-      m.get(prefix).push({ scoped_id: sid, bare });
-    }
-    return [...m.entries()].sort(([a], [b]) => a.localeCompare(b));
-  }, [scopedIds]);
-
-  if (scopedIds.length === 0) {
-    return (
-      <div className="muted text-sm" style={{ padding: 24, textAlign: "center" }}>
-        No tools registered with this agent.
-      </div>
-    );
-  }
-  return (
-    <div style={{ padding: 14 }}>
-      <div className="muted text-sm mb-3">
-        {scopedIds.length} tool{scopedIds.length === 1 ? "" : "s"} registered, grouped by source
-        toolset. Each card lists the canonical tool <span className="mono">id</span> (T0140/T0141
-        — not <span className="mono">name</span>). The toolset itself is NOT implicitly attached;
-        only the tools listed below are exposed to the LLM.
-      </div>
-      {grouped.map(([tsId, entries]) => (
-        <AG_ToolsetSection
-          key={tsId}
-          tsId={tsId}
-          registeredBareIds={entries.map((e) => e.bare)}
-        />
-      ))}
-    </div>
-  );
-}
-
-function AG_ToolsetSection({ tsId, registeredBareIds }) {
-  const { useResource, apiFetch } = window.primerApi;
-  const tools = useResource(
-    `toolset-tools:${tsId}`,
-    (signal) => apiFetch("GET", "/toolsets/" + encodeURIComponent(tsId) + "/tools", null, { signal }),
-    { pollMs: null, deps: [tsId] }
-  );
-  // Filter the toolset's full catalogue to just the bare tool ids the
-  // agent actually registered — the operator picks per-tool, so the
-  // detail view must match that scope, not surface the entire toolset.
-  const registeredSet = React.useMemo(
-    () => new Set(registeredBareIds || []),
-    [registeredBareIds],
-  );
-
-  // T0711 — for any toolset whose /tools returns a 5xx (unreachable MCP-HTTP
-  // upstream -> 504, etc.), surface the anomaly block instead of crashing the
-  // rest of the page (U0009).
-  if (tools.error?.status >= 500) {
-    return (
-      <div className="panel" style={{ marginBottom: 14 }}>
-        <div className="panel-h">
-          <Icon name="tools" size={12} className="muted" />
-          <span className="mono">{tsId}</span>
-          <span className="pill pill-failed" style={{ marginLeft: 6 }}><span className="dot"></span>T0711</span>
-        </div>
-        <div className="panel-body">
-          <Banner
-            kind="error"
-            title="Tools list unavailable"
-            detail="The MCP-HTTP server for this toolset is unreachable (T0711), so its tools can't be listed. Visit the toolset detail to Invalidate the cached provider and retry."
-            actions={<Btn size="sm" icon="refresh" onClick={tools.refetch}>Retry</Btn>}
-          />
-        </div>
-      </div>
-    );
-  }
-  if (tools.error) {
-    return (
-      <div className="panel" style={{ marginBottom: 14 }}>
-        <div className="panel-h">
-          <Icon name="tools" size={12} className="muted" />
-          <span className="mono">{tsId}</span>
-          <span className="pill pill-failed" style={{ marginLeft: 6 }}><span className="dot"></span>error</span>
-        </div>
-        <div className="panel-body">
-          <Banner
-            kind="error"
-            title={tools.error.title || "Couldn't load tools"}
-            detail={tools.error.detail || tools.error.message}
-            actions={<Btn size="sm" icon="refresh" onClick={tools.refetch}>Retry</Btn>}
-          />
-        </div>
-      </div>
-    );
-  }
-  if (tools.loading && !tools.data) {
-    return (
-      <div className="panel" style={{ marginBottom: 14 }}>
-        <div className="panel-h">
-          <Icon name="tools" size={12} className="muted" />
-          <span className="mono">{tsId}</span>
-        </div>
-        <div className="panel-body">
-          <div className="muted text-sm" style={{ textAlign: "center" }}>Loading…</div>
-        </div>
-      </div>
-    );
-  }
-  const allItems = tools.data?.tools || [];
-  // Show only tools the agent actually registered. If the toolset
-  // metadata is reachable, intersect with registeredBareIds; if the
-  // toolset returned them in a different order than the agent's
-  // ``tools`` field, that's fine — we still want the agent's surface.
-  const items = registeredSet.size > 0
-    ? allItems.filter((t) => registeredSet.has(t.id))
-    : allItems;
-  // Detect bare ids the agent registered that the toolset no longer
-  // exposes (e.g. the MCP server dropped a tool between agent create
-  // and now). Surface them as stale rows so the operator can see what
-  // needs cleanup.
-  const reachableBareIds = new Set(allItems.map((t) => t.id));
-  const staleBareIds = [...registeredSet].filter((b) => !reachableBareIds.has(b));
-  return (
-    <div className="panel" style={{ marginBottom: 14 }}>
-      <div className="panel-h">
-        <Icon name="tools" size={12} className="muted" />
-        <span className="mono">{tsId}</span>
-        <span className="sub">· {items.length + staleBareIds.length} registered</span>
-      </div>
-      <div className="panel-body" style={{ padding: 0 }}>
-        {items.length === 0 && staleBareIds.length === 0 ? (
-          <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }}>No tools.</div>
-        ) : (
-          <>
-            {items.map((tool, i) => <AG_ToolEntry key={tool.id || i} tool={tool} />)}
-            {staleBareIds.map((bare) => (
-              <div key={`stale-${bare}`} style={{ borderTop: "1px solid var(--border)", padding: "8px 14px", display: "flex", alignItems: "center", gap: 8 }}>
-                <Icon name="alert" size={11} style={{ color: "var(--amber)" }} />
-                <span className="mono" style={{ flex: 1 }}>{bare}</span>
-                <span className="pill pill-paused"><span className="dot"></span>not currently exposed</span>
-              </div>
-            ))}
-          </>
-        )}
-      </div>
-    </div>
-  );
-}
-
-function AG_ToolEntry({ tool }) {
-  const [open, setOpen] = React.useState(false);
-  const hl = window.primerVendor?.highlightJson;
-  return (
-    <div style={{ borderBottom: "1px solid var(--border)" }}>
-      <div
-        style={{ display: "flex", alignItems: "center", gap: 8, padding: "8px 14px", cursor: "pointer" }}
-        onClick={() => setOpen(!open)}
-      >
-        <Icon name={open ? "chevron-down" : "chevron-right"} size={11} className="muted" />
-        <span className="mono" style={{ flex: 1, minWidth: 0 }}>{tool.id}</span>
-        {tool.description && (
-          <span className="muted text-sm" style={{ maxWidth: 320, overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>
-            {tool.description}
-          </span>
-        )}
-        <Btn
-          size="sm"
-          kind="ghost"
-          disabled
-          title="Tool invocation endpoint not yet implemented (planned — backend-additions §2.2)"
-        >Test call</Btn>
-      </div>
-      {open && tool.schema && (
-        <div style={{ padding: "8px 14px 12px" }}>
-          {hl
-            ? <div className="code-block" dangerouslySetInnerHTML={{ __html: hl(JSON.stringify(tool.schema, null, 2)) }} />
-            : <pre className="code-block">{JSON.stringify(tool.schema, null, 2)}</pre>}
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ============================================================================
-// Sessions tab — server-filtered by agent_id
-// ============================================================================
-
-function AG_SessionsTab({ agentId }) {
-  const { useResource, useRouter, apiFetch } = window.primerApi;
-  const { navigate } = useRouter();
-  const sessions = useResource(
-    `agent-sessions:${agentId}`,
-    (signal) => apiFetch("GET", "/sessions?agent_id=" + encodeURIComponent(agentId) + "&limit=200", null, { signal }),
-    { pollMs: 5000, deps: [agentId] }
-  );
-  const items = sessions.data?.items ?? [];
-  return (
-    <div style={{ padding: 14 }}>
-      <div className="muted text-sm mb-3">
-        Sessions bound to <span className="mono">{agentId}</span>, server-filtered.
-      </div>
-      {sessions.loading && items.length === 0 ? (
-        <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }}>Loading…</div>
-      ) : items.length === 0 ? (
-        <div className="empty" style={{ padding: "30px 20px" }}>
-          <div className="ico-wrap"><Icon name="zap" size={18} /></div>
-          <div className="head">No sessions</div>
-          <div className="sub">Use the Test agent button above to start one.</div>
-        </div>
-      ) : (
-        <div className="tbl-wrap">
-          <table className="tbl">
-            <thead>
-              <tr><th>Status</th><th>Session</th><th>Workspace</th><th>Turns</th><th>Created</th></tr>
-            </thead>
-            <tbody>
-              {items.map((s) => (
-                <tr
-                  key={s.id || s.session_id}
-                  onClick={() => navigate("/sessions/" + (s.id || s.session_id))}
-                  style={{ cursor: "pointer" }}
-                >
-                  <td><StatusPill status={s.status} /></td>
-                  <td className="mono">{s.id || s.session_id}</td>
-                  <td className="mono muted">
-                    {(s.workspace_id || "").slice(0, 18)}
-                    {s.workspace_id && s.workspace_id.length > 18 ? "…" : ""}
-                  </td>
-                  <td className="mono num tabular">{s.turn_count ?? 0}</td>
-                  <td className="mono muted">
-                    {s.created_at
-                      ? relativeTime((Date.now() - new Date(s.created_at).getTime()) / 1000)
-                      : "—"}
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        </div>
-      )}
-    </div>
-  );
-}
-
-// ============================================================================
-// Metadata tab
-// ============================================================================
-
-function AG_MetadataTab({ agent }) {
-  const meta = agent.metadata || {};
-  const keys = Object.keys(meta);
-  return (
-    <div style={{ padding: 14 }}>
-      <div className="muted text-sm mb-3">
-        Free-form key/value bag on the agent row. {keys.length} key{keys.length === 1 ? "" : "s"}.
-      </div>
-      {keys.length === 0 ? (
-        <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }}>No metadata.</div>
-      ) : (
-        <dl className="kv" style={{ gridTemplateColumns: "200px 1fr" }}>
-          {keys.map((k) => (
-            <React.Fragment key={k}>
-              <dt>{k}</dt>
-              <dd className="mono">{typeof meta[k] === "object" ? JSON.stringify(meta[k]) : String(meta[k])}</dd>
-            </React.Fragment>
-          ))}
-        </dl>
       )}
     </div>
   );

--- a/ui/components/console/nv-overlays.jsx
+++ b/ui/components/console/nv-overlays.jsx
@@ -879,6 +879,33 @@ function NV_LegacyOverlay(props) {
       </NV_OverlayPanel>
     );
   }
+  // uiv2 Wave 2 ("Overlay geometry: centered modal, not near-fullscreen
+  // sheet, for both overlays"): the agent editor and collection browser
+  // DETAIL sub-views (overlay.id set) now render their own complete
+  // Modal chrome (title/verb-chip/close/footer) instead of the shared
+  // wrapper's wide sheet + breadcrumb row - stacking the shared VISIBLE
+  // chrome around an already-complete inner Modal would produce two
+  // title bars and two close buttons. The nv-overlay-body/nv-overlay:
+  // {name} testids stay (unstyled passthrough divs) rather than being
+  // dropped outright - tests/ui_e2e/_shell_helpers.py's open_legacy_route
+  // is shared infrastructure across every overlay in this file, not
+  // just these two, and asserts on exactly those testids as its "did
+  // the navigation actually land" signal; the inner Modal's own scrim/
+  // centering is 100% of the VISIBLE result either way. Scoped to just
+  // these two names' detail case (list views - AgentsPage, the
+  // collections table - are genuine list pages and keep the wide sheet
+  // unchanged; every OTHER overlay in NV_OVERLAY_MOUNTS is untouched,
+  // out of this wave's scope).
+  var bypassChrome = (name === "agents" || name === "collections") && !!overlay.id;
+  if (bypassChrome) {
+    return (
+      <div data-testid="nv-overlay-body">
+        <div data-testid={"nv-overlay:" + name}>
+          {mount.render(overlay, adapter)}
+        </div>
+      </div>
+    );
+  }
   return (
     <NV_OverlayPanel title={NV_overlayTitle(overlay)} wide
       testid={"nv-overlay:" + name} onClose={con.closeOverlay}>

--- a/ui/components/console/nv-overlays.jsx
+++ b/ui/components/console/nv-overlays.jsx
@@ -896,11 +896,31 @@ function NV_LegacyOverlay(props) {
   // collections table - are genuine list pages and keep the wide sheet
   // unchanged; every OTHER overlay in NV_OVERLAY_MOUNTS is untouched,
   // out of this wave's scope).
+  //
+  // Root-caused a real, deterministic (not flaky) CI failure: these
+  // wrapper divs are bare, so their only box-contributing content is
+  // Modal's own `.modal-overlay`, which is `position: fixed` and is
+  // therefore taken OUT of normal flow - a bare block div with no
+  // in-flow content collapses to a zero-size box as a flex child of
+  // `.nv-root`, and Playwright's `to_be_visible()` correctly reports a
+  // zero-area element as hidden even though the fixed-position Modal
+  // still paints on top of it. The non-bypass path never hit this
+  // because `.nv-scrim` carries its own explicit full-viewport CSS
+  // sizing independent of its children. `position: fixed; inset: 0`
+  // here gives both wrapper divs that same guaranteed box without
+  // opting into any of `.nv-scrim`'s visible styling or its
+  // click-to-close handler (the inner Modal already owns both) - NOT
+  // `pointer-events: none`: that CSS property inherits, and Modal
+  // never resets it on its own content, so it would silently make
+  // every button/input inside unclickable. No dead-click-zone risk
+  // either way: Modal's own `.modal-overlay` backdrop is `position:
+  // fixed; inset: 0` too, so it exactly coincides with this box.
   var bypassChrome = (name === "agents" || name === "collections") && !!overlay.id;
   if (bypassChrome) {
+    var bypassStyle = { position: "fixed", inset: 0 };
     return (
-      <div data-testid="nv-overlay-body">
-        <div data-testid={"nv-overlay:" + name}>
+      <div data-testid="nv-overlay-body" style={bypassStyle}>
+        <div data-testid={"nv-overlay:" + name} style={bypassStyle}>
           {mount.render(overlay, adapter)}
         </div>
       </div>

--- a/ui/components/knowledge.jsx
+++ b/ui/components/knowledge.jsx
@@ -536,24 +536,54 @@ function KN_GrepBox({ collection, onJump }) {
 }
 
 // ---------------------------------------------------------------------------
-// Search settings
+// Search ladder + indexing strip
 // ---------------------------------------------------------------------------
 
-function KN_SearchSettings({ collection, embedProviders, sspProviders, cerProviders, pushToast, onChanged }) {
-  const { useResource, apiFetch, useCapabilities, capabilityHint } = window.primerApi;
+// uiv2 Wave 2: presentational only. The mockup shows 5 selectable-
+// looking chips (auto/semantic/fulltext/literal/regex), but only two
+// are REAL, independently switchable backend paths today: semantic
+// search (opt-in, PUT /collections/{id}/search) and grep (regex or a
+// literal pattern - the SAME endpoint, just a different query, not two
+// distinct modes). No server-side "fulltext" or "auto" concept exists
+// (grepped primer/api/routers/collections.py - no such route/param) -
+// these chips are not clickable and do not claim to switch anything;
+// they show which tier is CURRENTLY active (semantic once ready, else
+// the always-available grep tier - "documents stay greppable regardless
+// of indexing state"), using the mockup's own vocabulary without
+// inventing a mode-switch that doesn't exist server-side. Flagged in
+// the PR body.
+function KN_SearchLadder({ activeRung }) {
+  const rungs = ["auto", "semantic", "fulltext", "literal", "regex"];
+  return (
+    <div className="row" style={{ gap: 6, flexWrap: "wrap" }} data-testid="kn-search-ladder">
+      <span className="muted text-sm" style={{ marginRight: 2 }}>search ladder</span>
+      {rungs.map((r) => (
+        <span key={r}
+          className={"chip" + (r === activeRung ? " active" : "")}
+          style={{ pointerEvents: "none" }}
+          data-testid={`kn-ladder-${r}`}>
+          {r}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+// uiv2 Wave 2 (a-9/a-10): re-homed from a standalone "Semantic search"
+// block below the tree into the top-of-overlay indexing strip the
+// mockup specs - same fetch/enable/disable logic KN_SearchSettings
+// always had, restyled into the strip layout with the ladder beside it.
+// The enablement form (a real, must-not-drop capability per the delta)
+// folds into the strip's own disabled-state branch rather than living
+// as a separate section.
+function KN_IndexingStrip({ collection, status, embedProviders, sspProviders, pushToast, onChanged }) {
+  const { apiFetch, useCapabilities, capabilityHint } = window.primerApi;
   const caps = useCapabilities();
   const cid = collection.id;
   const [embedder, setEmbedder] = React.useState("");
   const [model, setModel] = React.useState("");
   const [ssp, setSsp] = React.useState("");
   const [busy, setBusy] = React.useState(false);
-  const [reloadKey, setReloadKey] = React.useState(0);
-
-  const status = useResource(
-    `kn:search-status:${cid}:${reloadKey}`,
-    (signal) => apiFetch("GET", `/collections/${encodeURIComponent(cid)}/search`, null, { signal }),
-    { pollMs: null },
-  );
 
   const enable = async () => {
     setBusy(true);
@@ -563,7 +593,6 @@ function KN_SearchSettings({ collection, embedProviders, sspProviders, cerProvid
         vector_store_provider_id: ssp,
       });
       pushToast && pushToast({ kind: "success", title: "Search enabled" });
-      setReloadKey((k) => k + 1);
       onChanged && onChanged();
     } catch (err) {
       pushToast && pushToast({
@@ -580,7 +609,6 @@ function KN_SearchSettings({ collection, embedProviders, sspProviders, cerProvid
     setBusy(true);
     try {
       await apiFetch("DELETE", `/collections/${encodeURIComponent(cid)}/search`);
-      setReloadKey((k) => k + 1);
       onChanged && onChanged();
     } finally {
       setBusy(false);
@@ -588,6 +616,8 @@ function KN_SearchSettings({ collection, embedProviders, sspProviders, cerProvid
   };
 
   const st = status.data;
+  const ready = st?.state === "ready";
+  const activeRung = ready ? "semantic" : "regex";
   const embedRows = embedProviders?.data?.items ?? [];
   const sspRows = sspProviders?.data?.items ?? [];
   // An embedded (lance) vector store needs the extra installed on the
@@ -600,25 +630,24 @@ function KN_SearchSettings({ collection, embedProviders, sspProviders, cerProvid
     caps.data?.extras?.lance === false;
 
   return (
-    <div className="col" style={{ gap: 10 }}>
-      <div className="row" style={{ gap: 8, alignItems: "center" }}>
-        <span className="muted text-sm">Semantic search</span>
-        {st ? <StatusPill status={st.state === "ready" ? "ok" : st.state === "error" ? "error" : "paused"} /> : null}
-        {st ? <span className="mono text-sm">{st.state}</span> : null}
-        {st && st.state !== "disabled" ? (
-          <span className="muted text-sm">
-            {st.documents_indexed}/{st.documents_total} indexed
+    <div className="col" style={{ gap: 8, padding: "10px 14px", borderBottom: "1px solid var(--border)" }}
+      data-testid="kn-indexing-strip">
+      <div className="row" style={{ gap: 10, alignItems: "center", justifyContent: "space-between", flexWrap: "wrap" }}>
+        <div className="row" style={{ gap: 8, alignItems: "center" }}>
+          <span className="muted text-sm" style={{ textTransform: "uppercase", fontSize: 10.5, letterSpacing: "0.06em" }}>
+            Semantic indexing
           </span>
-        ) : null}
+          {st ? <StatusPill status={ready ? "ok" : st.state === "error" ? "error" : "paused"} /> : null}
+          <span className="mono text-sm">
+            {st ? st.state : "…"}
+            {st && st.state !== "disabled" ? ` — ${st.documents_indexed}/${st.documents_total} docs` : ""}
+          </span>
+        </div>
+        <KN_SearchLadder activeRung={activeRung} />
       </div>
 
       {st?.state === "error" ? (
-        <Banner kind="error" title="Indexing failed">
-          {st.error}
-        </Banner>
-      ) : null}
-      {st?.state === "indexing" ? (
-        <div className="muted text-sm">Indexing in progress.</div>
+        <Banner kind="error" title="Indexing failed">{st.error}</Banner>
       ) : null}
 
       {st?.state === "disabled" ? (
@@ -654,12 +683,12 @@ function KN_SearchSettings({ collection, embedProviders, sspProviders, cerProvid
               {capabilityHint("lance")}
             </div>
           ) : null}
-          <Btn onClick={enable} disabled={busy || !embedder || !model || !ssp}>
+          <Btn size="sm" onClick={enable} disabled={busy || !embedder || !model || !ssp}>
             Enable search
           </Btn>
         </div>
       ) : (
-        <Btn kind="ghost" onClick={disable} disabled={busy}>Disable search</Btn>
+        <Btn kind="ghost" size="sm" onClick={disable} disabled={busy}>Disable search</Btn>
       )}
     </div>
   );
@@ -670,12 +699,25 @@ function KN_SearchSettings({ collection, embedProviders, sspProviders, cerProvid
 // ---------------------------------------------------------------------------
 
 function KN_CollectionDetail({ collection, embedProviders, sspProviders, cerProviders, pushToast, onBack }) {
+  const { useResource, apiFetch } = window.primerApi;
   const [expanded, setExpanded] = React.useState({});
   const [selectedPath, setSelectedPath] = React.useState(null);
   const [reloadKey, setReloadKey] = React.useState(0);
   const [importOpen, setImportOpen] = React.useState(false);
   const [rootNewOpen, setRootNewOpen] = React.useState(false);
   const readOnly = !!collection.system;
+  const cid = collection.id;
+
+  // Lifted from the old KN_SearchSettings (uiv2 Wave 2): the header
+  // facts row needs the same search-status fetch the indexing strip
+  // does, so it is fetched once here and threaded to both rather than
+  // each fetching its own copy.
+  const status = useResource(
+    `kn:search-status:${cid}:${reloadKey}`,
+    (signal) => apiFetch("GET", `/collections/${encodeURIComponent(cid)}/search`, null, { signal }),
+    { pollMs: null },
+  );
+  const st = status.data;
 
   const toggle = (path) =>
     setExpanded((cur) => ({ ...cur, [path]: !cur[path] }));
@@ -691,67 +733,94 @@ function KN_CollectionDetail({ collection, embedProviders, sspProviders, cerProv
     setExpanded((cur) => ({ ...cur, ...opens }));
   };
 
+  // uiv2 Wave 2 ("Collection — {name}" header row, type/state/doc-count
+  // facts inline, Import zip + close): doc count is only shown when the
+  // search-status fetch actually serves one (documents_total, once
+  // search is configured) - a collection with search disabled has no
+  // cheap accurate total-document count available (the tree endpoint is
+  // one level at a time), so it is omitted rather than guessed.
+  const title = (
+    <h1 className="page-title" style={{ font: "inherit", margin: 0, display: "inline" }}>
+      Collection — {cid}
+      <span className="pc-modal-chip mono text-sm muted" style={{ marginLeft: 10, marginBottom: 0, verticalAlign: "middle" }}>
+        {readOnly ? "read-only" : st ? (st.state === "ready" ? "semantic" : st.state) : "…"}
+      </span>
+      {st && st.state !== "disabled" ? (
+        <span className="muted text-sm" style={{ marginLeft: 8 }}>{st.documents_total} documents</span>
+      ) : null}
+    </h1>
+  );
+
   return (
-    <div className="col" style={{ gap: 12 }}>
-      <div className="row" style={{ justifyContent: "space-between", alignItems: "center" }}>
-        <div className="row" style={{ gap: 8, alignItems: "center" }}>
-          <a className="knowledge-mobile-back" onClick={onBack}>
-            <Icon name="chevron-left" /> Collections
-          </a>
-          <span className="mono">{collection.id}</span>
-          {readOnly ? <Icon name="lock" /> : null}
-        </div>
-        {readOnly ? null : (
-          <div className="row" style={{ gap: 6 }}>
-            <Btn icon="upload" kind="ghost" onClick={() => setImportOpen(true)}>Import zip</Btn>
+    <Modal
+      title={title}
+      width={860}
+      onClose={onBack}
+      footer={
+        readOnly ? null : (
+          <>
+            <Btn kind="ghost" icon="upload" onClick={() => setImportOpen(true)}>Import zip</Btn>
             <Btn icon="plus" onClick={() => setRootNewOpen(true)}>New document</Btn>
-          </div>
-        )}
-      </div>
-
-      <KN_GrepBox collection={collection} onJump={jump} />
-
-      <div className="row" style={{ gap: 16, alignItems: "flex-start" }}>
-        <div className="col kn-tree" style={{ minWidth: 240, maxWidth: 320 }}>
-          <KN_Tree
-            cid={collection.id}
-            parent=""
-            depth={0}
-            expanded={expanded}
-            toggle={toggle}
-            selectedPath={selectedPath}
-            onSelect={setSelectedPath}
-            reloadKey={reloadKey}
-          />
-        </div>
-        <div className="col" style={{ flex: 1, minWidth: 0 }}>
-          {selectedPath ? (
-            <KN_DocumentPane
-              collection={collection}
-              path={selectedPath}
-              readOnly={readOnly}
-              pushToast={pushToast}
-              onChanged={bump}
+          </>
+        )
+      }
+    >
+      <div className="col" style={{ gap: 0, margin: "-16px" }}>
+        {/* Mobile-only (@media max-width: 639px in styles.css) - Modal's
+            own mobile variant is a bottom sheet with just a bare ×
+            close; this names where "back" actually goes, same as
+            before this wave's desktop reconciliation. */}
+        <a className="knowledge-mobile-back" onClick={onBack}>
+          <Icon name="chevron-left" /> Collections
+        </a>
+        <KN_IndexingStrip
+          collection={collection}
+          status={status}
+          embedProviders={embedProviders}
+          sspProviders={sspProviders}
+          pushToast={pushToast}
+          onChanged={bump}
+        />
+        <div className="row" style={{ gap: 16, alignItems: "flex-start", padding: "14px 16px 16px" }}>
+          <div className="col kn-tree" style={{ minWidth: 240, maxWidth: 320, gap: 8 }}>
+            {/* uiv2 Wave 2 (a-9, re-homed not deleted): the grep bar now
+                lives at the top of the tree column, matching the
+                delta's own suggested home - documents stay greppable
+                regardless of indexing state, so this control belongs
+                beside the tree it jumps within, not floating above the
+                whole overlay. */}
+            <KN_GrepBox collection={collection} onJump={jump} />
+            <KN_Tree
+              cid={cid}
+              parent=""
+              depth={0}
+              expanded={expanded}
+              toggle={toggle}
+              selectedPath={selectedPath}
               onSelect={setSelectedPath}
+              reloadKey={reloadKey}
             />
-          ) : (
-            <KN_EmptyState
-              ico="book"
-              head="Select a document"
-              sub="Pick a node on the left, or grep to jump straight to a line."
-            />
-          )}
+          </div>
+          <div className="col" style={{ flex: 1, minWidth: 0 }}>
+            {selectedPath ? (
+              <KN_DocumentPane
+                collection={collection}
+                path={selectedPath}
+                readOnly={readOnly}
+                pushToast={pushToast}
+                onChanged={bump}
+                onSelect={setSelectedPath}
+              />
+            ) : (
+              <KN_EmptyState
+                ico="book"
+                head="Select a document"
+                sub="Pick a node on the left, or grep to jump straight to a line."
+              />
+            )}
+          </div>
         </div>
       </div>
-
-      <KN_SearchSettings
-        collection={collection}
-        embedProviders={embedProviders}
-        sspProviders={sspProviders}
-        cerProviders={cerProviders}
-        pushToast={pushToast}
-        onChanged={bump}
-      />
 
       {importOpen ? (
         <KN_ImportModal
@@ -770,7 +839,7 @@ function KN_CollectionDetail({ collection, embedProviders, sspProviders, cerProv
           onCreated={(p) => { setRootNewOpen(false); bump(); setSelectedPath(p); }}
         />
       ) : null}
-    </div>
+    </Modal>
   );
 }
 

--- a/ui/components/shared/tool-picker.jsx
+++ b/ui/components/shared/tool-picker.jsx
@@ -1,0 +1,306 @@
+/* global React, Icon, Btn, Banner */
+
+// ToolPicker - the shared y/w/r/n tool picker (uiv2 Wave 2 synthesis:
+// "build the shared tool picker component here first" - agent bindings
+// today, graph tool nodes / approval policies / service grants / the MCP
+// allowlist are the named future adopters per the mockup's own footnote,
+// not migrated in this pass). Search, 6-per-page pager (mockup default;
+// overridable), toolset-grouped bulk-select header, a "Selected" filter
+// toggle, CapabilityBadges per row, and an expandable per-row disclosure
+// showing the tool's input schema (uiv2 Wave 2 ruling a-8: the old
+// separate read-view Tools tab superseded by disclosure on picker rows,
+// not a standalone tab).
+//
+// ONE fetch serves everything: GET /tools already carries input_schema
+// plus the y/w/r/n flags per tool (primer/api/routers/providers.py's
+// list_all_tools/_catalogue_tools, tool_catalogue_flags()) - the old
+// agent overlay's separate read-view Tools tab issued a SECOND fetch per
+// toolset (GET /toolsets/{id}/tools) purely to get that same schema data
+// under a different field name (`schema` there vs `input_schema` here).
+// Folding the disclosure into this picker removes that redundant fetch
+// entirely, not just relocates the UI.
+//
+// Controlled component: `selected` is a Set<scoped_id>, `onChange(next)`
+// receives the new Set on every toggle - the caller owns persistence
+// (agent.tools, a graph node's tool list, ...).
+
+function TP_toggleSet(set, id) {
+  const next = new Set(set);
+  if (next.has(id)) next.delete(id);
+  else next.add(id);
+  return next;
+}
+
+function TP_Row({ tool, checked, onToggle, open, onToggleOpen }) {
+  const hl = window.primerVendor?.highlightJson;
+  return (
+    <div style={{ borderTop: "1px solid var(--bg-1)" }}>
+      <label
+        style={{
+          display: "flex", alignItems: "flex-start", gap: 8,
+          padding: "6px 10px 6px 28px", cursor: "pointer",
+          background: checked ? "var(--bg-2)" : "transparent",
+        }}
+        data-testid={`tool-picker-row-${tool.scoped_id}`}
+      >
+        <input
+          type="checkbox"
+          checked={checked}
+          onChange={() => onToggle(tool.scoped_id)}
+          style={{ marginTop: 3 }}
+        />
+        <button
+          type="button"
+          onClick={(e) => { e.preventDefault(); onToggleOpen(tool.scoped_id); }}
+          data-testid={`tool-picker-expand-${tool.scoped_id}`}
+          style={{ background: "none", border: "none", padding: 0, cursor: "pointer", marginTop: 2, color: "var(--text-3)" }}
+          title={open ? "Hide schema" : "Show schema"}
+        >
+          <Icon name={open ? "chevron-down" : "chevron-right"} size={11} />
+        </button>
+        <div style={{ flex: 1, minWidth: 0, display: "flex", alignItems: "flex-start", gap: 8 }}>
+          <div style={{ flex: 1, minWidth: 0 }}>
+            <div className="mono" style={{ fontSize: 12 }}>{tool.id}</div>
+            {tool.description && (
+              <div className="muted text-sm" style={{ fontSize: 11, marginTop: 2, lineHeight: 1.4 }}>
+                {tool.description}
+              </div>
+            )}
+          </div>
+          <window.primerApi.CapabilityBadges tool={tool} testid={`tool-picker-badges-${tool.scoped_id}`} />
+        </div>
+      </label>
+      {open && (
+        <div style={{ padding: "4px 14px 12px 46px" }}>
+          {tool.input_schema && Object.keys(tool.input_schema).length ? (
+            hl
+              ? <div className="code-block" dangerouslySetInnerHTML={{ __html: hl(JSON.stringify(tool.input_schema, null, 2)) }} />
+              : <pre className="code-block">{JSON.stringify(tool.input_schema, null, 2)}</pre>
+          ) : (
+            <div className="muted text-sm">No input parameters.</div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolPicker({ selected, onChange, pageSize }) {
+  const { useResource, apiFetch } = window.primerApi;
+  const size = pageSize || 6;
+  const catalogue = useResource(
+    "tool-picker:catalogue",
+    (signal) => apiFetch("GET", "/tools", null, { signal }),
+    { pollMs: null }
+  );
+  const [filter, setFilter] = React.useState("");
+  const [selectedOnly, setSelectedOnly] = React.useState(false);
+  const [page, setPage] = React.useState(1);
+  const [openId, setOpenId] = React.useState(null);
+
+  const toolsetEntries = catalogue.data?.items ?? [];
+
+  const allScopedIds = React.useMemo(() => {
+    const s = new Set();
+    for (const ts of toolsetEntries) {
+      for (const t of ts.tools) s.add(t.scoped_id);
+    }
+    return s;
+  }, [toolsetEntries]);
+  // A selected id the catalogue no longer serves (toolset dropped the
+  // tool, or went unavailable) - surfaced so the operator can clean it
+  // up rather than silently persisting a dead reference on save.
+  const staleIds = React.useMemo(
+    () => [...selected].filter((id) => !allScopedIds.has(id)),
+    [selected, allScopedIds],
+  );
+
+  const filteredToolsetEntries = React.useMemo(() => {
+    const q = filter.trim().toLowerCase();
+    let entries = toolsetEntries;
+    if (q) {
+      entries = entries
+        .map((ts) => ({
+          ...ts,
+          tools: ts.tools.filter(
+            (t) =>
+              t.id.toLowerCase().includes(q) ||
+              t.scoped_id.toLowerCase().includes(q) ||
+              (t.description || "").toLowerCase().includes(q) ||
+              ts.id.toLowerCase().includes(q),
+          ),
+        }))
+        .filter((ts) => ts.tools.length > 0 || ts.id.toLowerCase().includes(q));
+    }
+    if (selectedOnly) {
+      entries = entries
+        .map((ts) => ({ ...ts, tools: ts.tools.filter((t) => selected.has(t.scoped_id)) }))
+        .filter((ts) => ts.tools.length > 0);
+    }
+    return entries;
+  }, [toolsetEntries, filter, selectedOnly, selected]);
+
+  const totalAvailable = React.useMemo(
+    () => toolsetEntries.reduce((acc, ts) => acc + ts.tools.length, 0),
+    [toolsetEntries],
+  );
+
+  const flatTools = React.useMemo(() => {
+    const out = [];
+    for (const ts of filteredToolsetEntries) {
+      if (!ts.available) continue;
+      for (const tool of ts.tools) out.push({ ...tool, _toolset: ts });
+    }
+    return out;
+  }, [filteredToolsetEntries]);
+  const unavailableToolsets = React.useMemo(
+    () => filteredToolsetEntries.filter((ts) => !ts.available),
+    [filteredToolsetEntries],
+  );
+
+  const totalPages = Math.max(1, Math.ceil(flatTools.length / size));
+  React.useEffect(() => { setPage(1); }, [filter, selectedOnly]);
+  React.useEffect(() => { if (page > totalPages) setPage(totalPages); }, [page, totalPages]);
+  const pageStart = (page - 1) * size;
+  const pageEnd = Math.min(pageStart + size, flatTools.length);
+  const pageTools = flatTools.slice(pageStart, pageEnd);
+
+  const toggleId = (scopedId) => onChange(TP_toggleSet(selected, scopedId));
+  const toggleGroup = (entry, allSelected) => {
+    let next = new Set(selected);
+    for (const t of entry.tools) {
+      if (allSelected) next.delete(t.scoped_id);
+      else next.add(t.scoped_id);
+    }
+    onChange(next);
+  };
+
+  const selectedCount = selected.size;
+
+  return (
+    <div data-testid="tool-picker">
+      <div style={{ marginBottom: 8, display: "flex", alignItems: "center", gap: 6 }}>
+        <div className="input-icon" style={{ flex: 1 }}>
+          <Icon name="search" size={13} className="icon" />
+          <input
+            className="input"
+            placeholder="Search the catalog…"
+            value={filter}
+            onChange={(e) => setFilter(e.target.value)}
+            data-testid="tool-picker-filter"
+            style={{ width: "100%" }}
+          />
+        </div>
+        <button
+          type="button"
+          data-testid="tool-picker-filter-selected"
+          className={"chip" + (selectedOnly ? " active" : "")}
+          aria-pressed={selectedOnly}
+          onClick={() => setSelectedOnly((v) => !v)}
+          title={selectedOnly ? "Show all tools" : "Show only selected tools"}
+          style={{ whiteSpace: "nowrap" }}
+        >
+          selected · {selectedCount}
+        </button>
+      </div>
+      {staleIds.length > 0 && (
+        <div className="field-help" style={{ color: "var(--amber)", marginBottom: 6 }} data-testid="tool-picker-stale">
+          {staleIds.length} selected tool{staleIds.length === 1 ? "" : "s"} no longer exposed by the catalogue: {staleIds.join(", ")}
+        </div>
+      )}
+      {catalogue.error && (
+        <Banner
+          kind="error"
+          title="Couldn't load the tool catalogue"
+          detail={catalogue.error.detail || catalogue.error.title || catalogue.error.message}
+          actions={<Btn size="sm" icon="refresh" onClick={catalogue.refetch}>Retry</Btn>}
+        />
+      )}
+      {catalogue.loading && toolsetEntries.length === 0 && (
+        <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }}>Loading catalog…</div>
+      )}
+      {!catalogue.loading && !catalogue.error && filteredToolsetEntries.length === 0 && (
+        <div className="muted text-sm" style={{ padding: 16, textAlign: "center" }} data-testid="tool-picker-empty">
+          {selectedOnly
+            ? `No selected tools${filter ? " match the filter." : "."}`
+            : filter ? "No tools match the filter." : "No toolsets available."}
+        </div>
+      )}
+      {unavailableToolsets.length > 0 && (
+        <div style={{ marginBottom: 8, display: "flex", flexWrap: "wrap", gap: 4 }}>
+          {unavailableToolsets.map((entry) => (
+            <span key={entry.id} className="muted text-sm"
+              style={{ fontSize: 11, padding: "2px 8px", border: "1px dashed var(--border)", borderRadius: 4, color: "var(--amber)", opacity: 0.85 }}
+              title={entry.unavailable_reason || "unavailable"}>
+              <span className="mono">{entry.id}</span> · unavailable
+            </span>
+          ))}
+        </div>
+      )}
+      {flatTools.length > 0 && (
+        <div style={{ maxHeight: 320, overflowY: "auto", border: "1px solid var(--border)", borderRadius: 6 }}>
+          {(() => {
+            const rows = [];
+            let lastToolsetId = null;
+            for (const t of pageTools) {
+              if (t._toolset.id !== lastToolsetId) {
+                const entry = t._toolset;
+                const allSelected = entry.tools.length > 0 && entry.tools.every((x) => selected.has(x.scoped_id));
+                const someSelected = entry.tools.some((x) => selected.has(x.scoped_id));
+                rows.push(
+                  <div key={`h-${entry.id}-p${page}`}
+                    style={{
+                      display: "flex", alignItems: "center", gap: 8, padding: "8px 10px",
+                      background: "var(--bg-2)",
+                      borderTop: lastToolsetId === null ? "none" : "1px solid var(--border)",
+                      borderBottom: "1px solid var(--border)", position: "sticky", top: 0, zIndex: 1,
+                    }}>
+                    <input type="checkbox" checked={allSelected}
+                      ref={(el) => { if (el) el.indeterminate = !allSelected && someSelected; }}
+                      onChange={() => toggleGroup(entry, allSelected)}
+                      disabled={entry.tools.length === 0}
+                      data-testid={`tool-picker-group-${entry.id}`} />
+                    <span className="mono" style={{ fontSize: 12.5, fontWeight: 600 }}>{entry.id}</span>
+                    {entry.builtin && <span className="muted text-sm" style={{ fontSize: 10.5 }}>· built-in</span>}
+                    <span className="muted text-sm" style={{ marginLeft: "auto" }}>
+                      {entry.tools.length} tool{entry.tools.length === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                );
+                lastToolsetId = entry.id;
+              }
+              rows.push(
+                <TP_Row key={t.scoped_id} tool={t}
+                  checked={selected.has(t.scoped_id)}
+                  onToggle={toggleId}
+                  open={openId === t.scoped_id}
+                  onToggleOpen={(id) => setOpenId((cur) => (cur === id ? null : id))} />
+              );
+            }
+            return rows;
+          })()}
+        </div>
+      )}
+      {flatTools.length > 0 && (
+        <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between", marginTop: 8, fontSize: 11.5, color: "var(--text-3)" }}>
+          <span className="tabular">
+            {flatTools.length === 0 ? 0 : pageStart + 1}–{pageEnd} of {flatTools.length}
+          </span>
+          <div style={{ display: "flex", alignItems: "center", gap: 6 }}>
+            <Btn size="sm" kind="ghost" icon="chevron-left" disabled={page === 1}
+              onClick={() => setPage((p) => Math.max(1, p - 1))} data-testid="tool-picker-page-prev">‹</Btn>
+            <span className="muted text-sm tabular" style={{ padding: "0 6px" }}>{page} of {totalPages}</span>
+            <Btn size="sm" kind="ghost" iconRight="chevron-right" disabled={page === totalPages}
+              onClick={() => setPage((p) => Math.min(totalPages, p + 1))} data-testid="tool-picker-page-next">›</Btn>
+          </div>
+        </div>
+      )}
+      <div className="field-help" data-testid="tool-picker-footnote" style={{ marginTop: 8 }}>
+        One picker everywhere: agent bindings, graph tool nodes, approval policies, service grants, the MCP
+        allowlist. Flags: y yields · w workspace · r role · n notifying.
+      </div>
+    </div>
+  );
+}
+
+window.ToolPicker = ToolPicker;

--- a/ui/index.html
+++ b/ui/index.html
@@ -132,6 +132,7 @@
 <script type="text/babel" src="components/shared/pager.jsx"></script>
 <script type="text/babel" src="components/shared/entity-picker.jsx"></script>
 <script type="text/babel" src="components/shared/capability-badges.jsx"></script>
+<script type="text/babel" src="components/shared/tool-picker.jsx"></script>
 <script type="text/babel" src="components/session-state.jsx"></script>
 <script type="text/babel" src="components/shared/token-meter.jsx"></script>
 <script type="text/babel" src="components/shared/card-list.jsx"></script>


### PR DESCRIPTION
uiv2 reconciliation Wave 2 - the programme's biggest structural piece.

**Shared ToolPicker** (new, ui/components/shared/): the mockup's y/w/r/n picker built once for future adoption by graphs/policies/services/MCP - search, 6/page, selected-N filter, toolset bulk-select, capability badges, expandable per-row schema disclosure, and an error+retry banner the old picker lacked. One /tools fetch replaces two redundant ones.

**Agent editor**: raw-JSON read-first sheet → the mockup's direct-edit two-column form. JSON demoted to a disclosure; stacked profile picker; the two genuinely-missing fields (max_tool_turns, max_output_tokens) added with PUT-replace-safe semantics; response_format + tool-access toggles behind a collapsed Advanced disclosure; Sessions as a collapsible panel; the Metadata tab dropped (no schema field has ever existed - judgment call, trivially restorable); harness-managed agents get a locked summary view instead of a hidden edit button and surprise 409s; the Autonomous segment remains the August-precedent disabled control (no backing field - making it real is a user decision).

**Collection browser**: centered modal with 'Collection — {id}' header, indexing strip + doc counts, grep bar re-homed (the always-greppable doctrine), Import zip in the header. **Flag**: the 5-rung search ladder is presentational over the two real server tiers (semantic opt-in, grep/regex always-on) - non-clickable, documented in-code; a real search-mode ladder would be a backend feature.

**Live-pass catches fixed before review**: a testid-contract loss from the first overlay-bypass attempt, the one-h1 title rule, a dropped agent id in the edit title, and a collapsed create/edit Save-verb distinction.

**Verification**: tests/ui 1660/1 skipped (baseline-exact); 41/41 live Playwright across the scoped 8-file batch on a fresh stack; ruff + transpile clean. One intermittent under sustained load confirmed as the pre-existing cold-boot flake class (0% in isolation via standalone repro).

🤖 Generated with [Claude Code](https://claude.com/claude-code)