### PR TITLE
fix(session): transcript/trace/status live-bug cluster from the staged-capture sweep

### DIFF
--- a/primer/session/persistence.py
+++ b/primer/session/persistence.py
@@ -264,6 +264,17 @@ class _CoalesceState:
     # ToolCallStart can reuse the same raw id). Keyed by (node_id, raw_id)
     # like tool_names above, for the identical reason.
     scoped_call_ids: dict[tuple[str | None, str], str] = field(default_factory=dict)
+    # (turn_no, coalesced text) of the most recent ASSISTANT_TOKEN record
+    # actually written to the log, whichever node produced it — a plain
+    # global tracker, not per-node, because "the immediately preceding
+    # ASSISTANT_TOKEN" is a messages.jsonl-order concept, not a graph-
+    # topology one. Live finding 01a064d3: a graph's End node renders its
+    # own ASSISTANT_TOKEN from output_template (see the _GraphEndOutputEvent
+    # branch below); when that template is a passthrough of the immediately
+    # preceding node's answer, the two records are byte-identical and the
+    # transcript shows the same paragraph twice. Set wherever a real
+    # ASSISTANT_TOKEN record is emitted, consulted only by that branch.
+    last_assistant_token: tuple[int, str] | None = None
 
 
 class _DeltaSink(Protocol):
@@ -402,6 +413,32 @@ def translate_stream_event(
         )
 
     if isinstance(event, _GraphEndOutputEvent):
+        # Live finding 01a064d3: two suppressions, both approved rulings,
+        # a distinct record kind for graph results (the long-term shape)
+        # deliberately deferred to Phase 3 stage 7a's record-vocabulary
+        # work rather than done here as part of a bug fix.
+        #
+        # (c) An End node with no/empty output_template renders "" -
+        # writing that as an ASSISTANT_TOKEN is pure noise in every graph
+        # transcript, so skip it outright rather than persist an empty
+        # answer bubble.
+        if not event.text:
+            return None
+        # (a) A passthrough output_template (the common case: End just
+        # echoes the last node's answer) renders byte-identical text to
+        # the ASSISTANT_TOKEN immediately preceding it in THIS turn - the
+        # worker's answer IS the graph's result, so a second record adds
+        # no information, only a visible duplicate paragraph. Compare the
+        # final COALESCED text (state.last_assistant_token), never raw
+        # deltas, and only within the same turn_no - a genuine
+        # transformation (the template actually changes the text) still
+        # gets its own finish-attributed record, which is semantically
+        # correct. Fragility bound, accepted: a template that changes
+        # only whitespace still writes both records (byte equality, not
+        # a semantic diff).
+        if state.last_assistant_token == (turn_no, event.text):
+            return None
+        state.last_assistant_token = (turn_no, event.text)
         return SessionMessageRecord(
             seq=1,  # WorkspaceMessageWriter overwrites
             kind=SessionMessageKind.ASSISTANT_TOKEN,
@@ -507,6 +544,7 @@ def translate_stream_event(
                 )
             )
             state.text_buffers[node_id] = ""
+            state.last_assistant_token = (turn_no, buffered)
         # 01a0518f: the durable TOOL_CALL id is the SCOPED id minted at
         # ToolCallStart (was the raw provider id verbatim, which
         # restarts at the same value every llm.stream() call and can
@@ -663,6 +701,7 @@ def translate_stream_event(
                 )
             )
             state.text_buffers[node_id] = ""
+            state.last_assistant_token = (turn_no, buffered)
         done_payload: dict = {"stop_reason": event.stop_reason, "raw_reason": event.raw_reason}
         last_usage = state.last_usage_by.get(node_id)
         if last_usage is not None:

--- a/tests/graph/test_end_execution.py
+++ b/tests/graph/test_end_execution.py
@@ -162,7 +162,12 @@ async def _run_through_writer(
 async def test_empty_output_template_emits_no_payload(tmp_path: Path) -> None:
     """An End with an empty ``output_template`` still terminates the
     graph (completed) but produces no ``assistant_token`` record in
-    messages.jsonl — the rendered text is the empty string."""
+    messages.jsonl at all. Live finding 01a064d3, ruling (c): an empty
+    ASSISTANT_TOKEN was pure noise in every graph transcript (an empty
+    answer bubble) - translate_stream_event's _GraphEndOutputEvent
+    branch (primer/session/persistence.py) now returns None outright
+    for empty text rather than persisting an empty payload, so this is
+    a single definite outcome now, not "either is fine"."""
     graph = Graph(
         id="g-empty-end",
         description="Begin -> End (empty template)",
@@ -176,20 +181,12 @@ async def test_empty_output_template_emits_no_payload(tmp_path: Path) -> None:
         graph=graph, tmp_path=tmp_path, session_id="sid-empty",
     )
 
-    # The event is still emitted (even with empty text) — but it carries
-    # an empty payload. The translator + writer's behaviour: emit the
-    # assistant_token only when there's something to say.
     end_records = [
         r for r in persisted
         if r["kind"] == SessionMessageKind.ASSISTANT_TOKEN.value
         and r["payload"].get("end_node_id") == "end"
     ]
-    if end_records:
-        # If the implementation chooses to emit anyway, the payload's
-        # text MUST be empty (so the UI's collapsible block renders
-        # nothing). Both behaviours satisfy the spec; the contract is
-        # "no payload reaches the user."
-        assert end_records[0]["payload"]["text"] == ""
+    assert end_records == []
 
 
 # ===========================================================================

--- a/tests/session/test_persistence.py
+++ b/tests/session/test_persistence.py
@@ -879,6 +879,111 @@ def test_graph_end_output_record_carries_node_id() -> None:
     assert rec.payload["end_node_id"] == "end1"
 
 
+def test_graph_end_output_with_empty_text_writes_no_record() -> None:
+    """Live finding 01a064d3, ruling (c): an End node with no/empty
+    output_template renders "" - writing that as an ASSISTANT_TOKEN put
+    an empty answer bubble into every graph transcript. Suppress at the
+    source rather than persist noise."""
+    from primer.graph.base import _GraphEndOutputEvent
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+    rec = translate_stream_event(
+        _GraphEndOutputEvent(text="", parsed=None, end_node_id="end1"), state
+    )
+    assert rec is None
+
+
+def test_graph_end_output_suppresses_a_passthrough_duplicate() -> None:
+    """Live finding 01a064d3, ruling (a): an End node whose
+    output_template just echoes the immediately preceding node's answer
+    (the common case) renders byte-identical text to that node's own
+    ASSISTANT_TOKEN, already written this turn. The worker's answer IS
+    the graph's result - a second record adds no information, only a
+    duplicate paragraph in the transcript. Compare the final coalesced
+    text (not deltas), scoped to the same turn_no."""
+    from primer.model.chat import Done, TextDelta
+    from primer.graph.base import _GraphEndOutputEvent
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+    translate_stream_event(
+        TextDelta(text="the worker's answer", index=0), state,
+        node_id="worker", turn_no=3,
+    )
+    worker_done = translate_stream_event(
+        Done(stop_reason="stop", raw_reason="stop"), state,
+        node_id="worker", turn_no=3,
+    )
+    assert isinstance(worker_done, list)
+    assert worker_done[0].kind == SessionMessageKind.ASSISTANT_TOKEN
+    assert worker_done[0].payload["text"] == "the worker's answer"
+
+    # Passthrough: byte-identical text, same turn -> suppressed.
+    rec = translate_stream_event(
+        _GraphEndOutputEvent(
+            text="the worker's answer", parsed=None, end_node_id="end1",
+        ),
+        state, turn_no=3,
+    )
+    assert rec is None
+
+
+def test_graph_end_output_keeps_a_genuine_transformation() -> None:
+    """The other half of ruling (a): when output_template actually
+    transforms the text (not a bare passthrough), the End record is
+    semantically distinct from the worker's answer and must still be
+    written - only a BYTE-IDENTICAL echo is noise."""
+    from primer.model.chat import Done, TextDelta
+    from primer.graph.base import _GraphEndOutputEvent
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+    translate_stream_event(
+        TextDelta(text="raw worker text", index=0), state,
+        node_id="worker", turn_no=1,
+    )
+    translate_stream_event(
+        Done(stop_reason="stop", raw_reason="stop"), state,
+        node_id="worker", turn_no=1,
+    )
+
+    rec = translate_stream_event(
+        _GraphEndOutputEvent(
+            text="{summary: raw worker text}", parsed=None, end_node_id="end1",
+        ),
+        state, turn_no=1,
+    )
+    assert isinstance(rec, SessionMessageRecord)
+    assert rec.payload["text"] == "{summary: raw worker text}"
+
+
+def test_graph_end_output_passthrough_check_is_scoped_to_the_same_turn() -> None:
+    """The equality suppression only looks BACK within the same turn -
+    an End node in a LATER turn that happens to render the same text as
+    a PRIOR turn's last answer is not a duplicate of anything in this
+    turn's transcript and must still be written."""
+    from primer.model.chat import Done, TextDelta
+    from primer.graph.base import _GraphEndOutputEvent
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    state = _CoalesceState()
+    translate_stream_event(
+        TextDelta(text="same text", index=0), state, node_id="worker", turn_no=1,
+    )
+    translate_stream_event(
+        Done(stop_reason="stop", raw_reason="stop"), state,
+        node_id="worker", turn_no=1,
+    )
+
+    rec = translate_stream_event(
+        _GraphEndOutputEvent(text="same text", parsed=None, end_node_id="end1"),
+        state, turn_no=2,
+    )
+    assert isinstance(rec, SessionMessageRecord)
+    assert rec.payload["text"] == "same text"
+
+
 def test_translate_reasoning_delta_coalesces_and_flushes_before_text() -> None:
     """ReasoningDeltas coalesce; Done flushes thought BEFORE the answer.
 

--- a/tests/ui/test_console_session_doc.py
+++ b/tests/ui/test_console_session_doc.py
@@ -718,6 +718,34 @@ def test_decision_card_diff_preview_via_mini_racer():
     assert ctx.call("SH_looksLikeDiff", "") is False
 
 
+def test_decision_and_ask_cards_disable_when_the_session_has_ended():
+    """Live finding 01a064d3: a park can outlive its session (a sweep/
+    timeout continuation that then fails ends the session without
+    clearing parked_status), so the decision/ask card could still render
+    as if a human could act on it - live Approve/Reject/Answer buttons
+    on an already-ended session, contradicting the header's own "Ended"
+    pill. The ended state must win: keep the card for historical
+    context, but its controls are disabled and annotated rather than
+    live-looking."""
+    decision = DOC[DOC.index("function NV_DecisionCard"):
+                   DOC.index("function NV_AskCard")]
+    assert 'data-testid="nv-approve" disabled={!!props.ended}' in decision
+    assert 'data-testid="nv-reject" disabled={!!props.ended}' in decision
+    assert "session ended before this could be resolved" in decision
+
+    ask = DOC[DOC.index("function NV_AskCard"):]
+    assert 'data-testid="nv-ask-submit" disabled={!!props.ended}' in ask
+    assert 'data-testid="nv-ask-answer" disabled={!!props.ended}' in ask
+    assert "session ended before this could be answered" in ask
+
+    # ended is threaded from the SAME NV_sessionIsOver check the fold
+    # line and header pill already use - one source of truth, not a
+    # second computation that could drift from it.
+    assert "var ended = NV_sessionIsOver(session);" in DOC
+    assert "<NV_DecisionCard key={item.id} item={item} ended={ended}" in DOC
+    assert "<NV_AskCard key={item.id} item={item} ended={ended}" in DOC
+
+
 def test_decision_card_uses_the_diff_helpers_only_when_diff_shaped():
     card = DOC[DOC.index("function NV_DecisionCard"):
                DOC.index("function NV_AskCard")]
@@ -882,12 +910,12 @@ def test_composer_wait_note_uses_the_shared_parked_status_line():
     ctx.eval(STATUS[wait_start:wait_end])
     ctx.eval(STATUS[parked_start:parked_end])
 
-    approval_gate = [{"kind": "approval", "toolName": "workspace__write_file"}]
+    approval_gate = [{"kind": "approval", "gatedTool": "workspace__write_file"}]
     assert ctx.call(
         "SH_parkedStatusLine", {"parked_status": "parked"}, approval_gate,
     ) == "waiting on approval — workspace__write_file (parked, worker released)"
 
-    ask_gate = [{"kind": "question", "toolName": "ask_user"}]
+    ask_gate = [{"kind": "question", "gatedTool": "ask_user"}]
     assert ctx.call(
         "SH_parkedStatusLine", {"parked_status": "parked"}, ask_gate,
     ) == "waiting on your answer — ask_user (parked, worker released)"
@@ -940,12 +968,20 @@ def test_short_time_formats_like_the_transcript_helper_via_mini_racer():
 
 
 def test_trace_header_label_via_mini_racer():
-    """Audit A item 5: NV_TraceSplit's header enriches "trace · turn N"
-    to "trace · {calls} · {span}s" using the turn's own rows (already
-    fetched for the transcript - no new request). Span is the last tool
-    activity minus the first (not a sum of individual durations - see
-    SH_traceHeaderLabel's own comment for why), and a turn with zero tool
-    calls keeps the plain form exactly as before."""
+    """Audit A item 5, amended by the live finding in 01a064d3:
+    NV_TraceSplit's header enriches "trace · turn N" to "trace ·
+    {calls} · {span}s" using the SAME timeline nodes the trace body
+    renders below it (tool_call AND llm_call - both get a T/A glyph row
+    per NV_traceGlyph). The header used to count only over the
+    transcript's own turnRows, which SA_toTranscript deliberately never
+    populates with llm_call records (session-adapter.jsx's
+    SA_SKIP_IN_TRANSCRIPT), so a turn with any llm_call undercounted
+    against what the body actually showed ("1 CALL" above three visible
+    rows, live capture evidence). Span is the latest node end (ts +
+    duration_ms) minus the earliest node start, not a sum of individual
+    durations (a sum here would read 4s + 3s = 7s, not the correct 8s
+    below), and a turn with zero tool/llm calls keeps the plain form
+    exactly as before."""
     from py_mini_racer import MiniRacer
 
     start = TURNS.index("function SH_traceHeaderLabel")
@@ -955,32 +991,30 @@ def test_trace_header_label_via_mini_racer():
     ctx = MiniRacer()
     ctx.eval(src)
 
-    # Zero tool calls (pure reasoning + answer) - unchanged plain form.
+    # No tool/llm calls (just a graph boundary marker) - unchanged plain form.
     assert ctx.eval(
-        'SH_traceHeaderLabel(3, [{kind: "reasoning"}, {kind: "user_message"}])'
+        'SH_traceHeaderLabel(3, [{kind: "node"}])'
     ) == "trace · turn 3"
     assert ctx.eval("SH_traceHeaderLabel(3, [])") == "trace · turn 3"
 
-    # One call - singular "call", span from its own call/result pair.
+    # One call - singular "call", span from its own start + duration.
     one = ctx.eval(
         """
         SH_traceHeaderLabel(1, [
-          {kind: "tool_call", createdAt: "2026-08-29T00:00:00Z"},
-          {kind: "tool_result", createdAt: "2026-08-29T00:00:04Z"},
+          {kind: "tool_call", ts: "2026-08-29T00:00:00Z", duration_ms: 4000},
         ])
         """
     )
     assert one == "trace · 1 call · 4s"
 
-    # Multiple calls - plural, span is last-end minus first-start across
-    # ALL of them, not a sum (a sum here would read 4s + 3s = 7s).
+    # tool_call + llm_call (the exact shape that previously undercounted)
+    # - plural, both count, span is last-end minus first-start across
+    # ALL of them, not a sum.
     multi = ctx.eval(
         """
         SH_traceHeaderLabel(2, [
-          {kind: "tool_call", createdAt: "2026-08-29T00:00:00Z"},
-          {kind: "tool_result", createdAt: "2026-08-29T00:00:04Z"},
-          {kind: "tool_call", createdAt: "2026-08-29T00:00:05Z"},
-          {kind: "tool_result", createdAt: "2026-08-29T00:00:08Z"},
+          {kind: "tool_call", ts: "2026-08-29T00:00:00Z", duration_ms: 4000},
+          {kind: "llm_call", ts: "2026-08-29T00:00:05Z", duration_ms: 3000},
         ])
         """
     )
@@ -1173,17 +1207,29 @@ def test_trace_row_expand_toggle_via_mini_racer():
 
 
 def test_trace_split_uses_the_enriched_header_label():
-    """NV_TraceSplit's header renders SH_traceHeaderLabel(turnNo, turnRows)
-    rather than the bare "trace · turn N" string directly, and the caller
-    passes the turn's own rows (turnRowsFor, filtered from the same flat
-    transcript array traceTurnFor already indexes - no new fetch)."""
+    """NV_TraceSplit's header renders SH_traceHeaderLabel(turnNo, ...)
+    rather than the bare "trace · turn N" string directly. Live finding
+    01a064d3: the header used to be fed props.turnRows - the TRANSCRIPT's
+    own rows, which SA_toTranscript deliberately never populates with
+    llm_call records (session-adapter.jsx's SA_SKIP_IN_TRANSCRIPT) - so
+    it silently undercounted against the trace BODY, which renders the
+    turn's full timeline node tree (tool_call AND llm_call) fetched
+    separately via SH_api.timeline. The header must aggregate over that
+    SAME node list the body renders, not a narrower transcript-derived
+    one - so both NV_TraceSplit's sidebar header and NV_TraceMaximize's
+    overlay header now read the flattened timeline nodes (traceNodes),
+    and the now-dead turnRowsFor/turnRows plumbing is gone, not just
+    unused."""
     trace = DOC[DOC.index("function NV_TraceSplit"):]
     trace = trace[:trace.index("function NV_Composer")]
-    assert "SH_traceHeaderLabel(props.turnNo, props.turnRows)" in trace
+    assert "var traceNodes = flatRows.map(function (r) { return r.node; });" in trace
+    assert "SH_traceHeaderLabel(props.turnNo, traceNodes)" in trace
+    assert "SH_traceHeaderLabel(props.turnNo, props.traceNodes)" in trace
     assert "trace · turn {props.turnNo}" not in trace
 
-    assert "function turnRowsFor(turnNo)" in DOC
-    assert "turnRows={turnRowsFor(traceTurn)}" in DOC
+    assert "function turnRowsFor(turnNo)" not in DOC
+    assert "turnRows={turnRowsFor(traceTurn)}" not in DOC
+    assert "props.turnRows" not in DOC
 
 
 def test_divider_renders_as_a_rule_not_a_bubble_via_mini_racer():

--- a/tests/ui/test_session_store.py
+++ b/tests/ui/test_session_store.py
@@ -367,6 +367,39 @@ def test_legacy_message_is_superseded_by_a_rest_shaped_real_record() -> None:
     assert records[0]["text"] == "hello world"
 
 
+def test_legacy_assistant_message_is_superseded_by_its_assistant_token_twin() -> None:
+    """Live finding 01a064d3: a legacy ASSISTANT placeholder races its
+    modern `assistant_token` twin the same way a legacy USER placeholder
+    races `user_input` (previous test) - _persist_turn writes the legacy
+    `{role: "assistant", parts}` line to messages.jsonl before dispatch's
+    flush lands the real assistant_token record, so REST-seeding this
+    session in file order applies the placeholder first. The eviction
+    used to be scoped to `recordKind === "user_input"` only, so this
+    placeholder was never dropped once its real record arrived - it
+    rendered a second, misattributed (hardcoded user_message, see the
+    console-session-doc test) copy of the final answer ahead of the
+    real transcript. Must dedupe exactly like the user_input case."""
+    ctx = _ctx()
+    rows = _transcript(ctx, "w8b", "s8b", [
+        {"role": "assistant",
+         "parts": [{"type": "text", "text": "the final answer"}],
+         "session_id": "s8b"},
+    ])
+    legacy = [r for r in rows if r["kind"] == "legacy"]
+    assert len(legacy) == 1
+    assert legacy[0]["role"] == "assistant"
+
+    rows = _transcript(ctx, "w8b", "s8b", [
+        {"class": "assistant_token", "session_id": "s8b", "seq": 9,
+         "payload": {"text": "the final answer"}},
+    ])
+    legacy = [r for r in rows if r["kind"] == "legacy"]
+    records = [r for r in rows if r["kind"] == "record"]
+    assert legacy == []
+    assert len(records) == 1
+    assert records[0]["text"] == "the final answer"
+
+
 def test_legacy_message_is_deduped_against_a_repeat_of_itself() -> None:
     """messages.jsonl can carry the same instruction's legacy line twice
     (e.g. session create with initial_instructions plus a later steer

--- a/tests/ui/test_shell_attention_model.py
+++ b/tests/ui/test_shell_attention_model.py
@@ -91,6 +91,25 @@ def test_the_decision_preview_survives_into_the_item() -> None:
     assert preview == "workspace__write_file(path=src/api.ts)"
 
 
+def test_gated_tool_names_the_real_tool_not_the_yield_kind() -> None:
+    """Live finding 01a064d3: item.toolName is the yield KIND ("approval"/
+    "ask_user"), reserved for SH_tierFor's tier routing - the decision
+    card's tool chip and the parked status strip need the actual gated
+    tool id instead, which is what gatedTool (SH_gatedToolOf) exposes.
+    A pending approval's gatedTool is resume_metadata.original_call.name;
+    a pending question's is the literal "ask_user" (it has no gated
+    call), same as toolName already read for that one case."""
+    ctx = _ctx()
+    out = json.loads(ctx.eval(
+        'JSON.stringify(SH_toAttentionItems({pending: PENDING.items, '
+        'records: []}).map(function (i) '
+        '{ return [i.toolName, i.gatedTool]; }))'
+    ))
+    by_kind = {row[0]: row[1] for row in out}
+    assert by_kind["approval"] == "workspace__write_file"
+    assert by_kind["ask_user"] == "ask_user"
+
+
 def test_snooze_and_mute_filter_without_deleting() -> None:
     ctx = _ctx()
     out = json.loads(ctx.eval(

--- a/tests/ui/test_shell_status.py
+++ b/tests/ui/test_shell_status.py
@@ -52,14 +52,14 @@ def test_long_runs_read_in_minutes() -> None:
 def test_wait_line_names_the_tool_for_an_approval() -> None:
     ctx = _ctx()
     assert ctx.eval(
-        'SH_waitLine({kind: "approval", toolName: "workspace__write_file"})'
-    ) == "waiting on approval — workspace__write_file (parked, worker released)"
+        'SH_waitLine({kind: "approval", gatedTool: "workspace__write"})'
+    ) == "waiting on approval — workspace__write (parked, worker released)"
 
 
 def test_wait_line_reads_as_an_answer_for_a_question() -> None:
     ctx = _ctx()
     assert ctx.eval(
-        'SH_waitLine({kind: "question", toolName: "ask_user"})'
+        'SH_waitLine({kind: "question", gatedTool: "ask_user"})'
     ) == "waiting on your answer — ask_user (parked, worker released)"
 
 
@@ -71,6 +71,21 @@ def test_wait_line_falls_back_without_a_tool_name() -> None:
     assert ctx.eval('SH_waitLine({kind: "question"})') == (
         "waiting on your answer — ask_user (parked, worker released)"
     )
+
+
+def test_wait_line_names_the_gated_tool_not_the_yield_kind() -> None:
+    """Live finding 01a064d3: item.toolName is the yield KIND
+    ("approval"/"ask_user" - shell-attention.js's SH_tierFor tier
+    routing needs exactly that literal), never the actual gated tool -
+    but the status strip used to read toolName anyway and rendered
+    "waiting on approval — approval" for every approval gate regardless
+    of which tool it gated. Pin that a stale/irrelevant toolName is
+    ignored in favor of gatedTool (shell-attention.js's SH_gatedToolOf)."""
+    ctx = _ctx()
+    assert ctx.eval(
+        'SH_waitLine({kind: "approval", toolName: "approval", '
+        'gatedTool: "workspace__write"})'
+    ) == "waiting on approval — workspace__write (parked, worker released)"
 
 
 def test_wait_line_is_null_with_nothing_parked() -> None:
@@ -91,19 +106,32 @@ def test_parked_status_line_is_null_when_not_parked() -> None:
     assert ctx.eval("SH_parkedStatusLine(null, [])") is None
 
 
+def test_parked_status_line_is_null_once_the_session_has_ended() -> None:
+    """Live finding 01a064d3: a sweep/timeout continuation that then
+    fails can end a session without clearing parked_status - the
+    composer used to keep showing "waiting on your answer — ask_user
+    (parked, worker released)" underneath an "Ended" header on the SAME
+    session. A stale parked_status must never outrank status: "ended"."""
+    ctx = _ctx()
+    assert ctx.eval(
+        'SH_parkedStatusLine({parked_status: "parked", status: "ended"}, '
+        '[{kind: "question", gatedTool: "ask_user"}])'
+    ) is None
+
+
 def test_parked_status_line_names_the_approval_gate() -> None:
     ctx = _ctx()
     assert ctx.eval(
         'SH_parkedStatusLine({parked_status: "parked"}, '
-        '[{kind: "approval", toolName: "workspace__write_file"}])'
-    ) == "waiting on approval — workspace__write_file (parked, worker released)"
+        '[{kind: "approval", gatedTool: "workspace__write"}])'
+    ) == "waiting on approval — workspace__write (parked, worker released)"
 
 
 def test_parked_status_line_names_the_ask_gate() -> None:
     ctx = _ctx()
     assert ctx.eval(
         'SH_parkedStatusLine({parked_status: "parked"}, '
-        '[{kind: "question", toolName: "ask_user"}])'
+        '[{kind: "question", gatedTool: "ask_user"}])'
     ) == "waiting on your answer — ask_user (parked, worker released)"
 
 

--- a/ui/components/console/nv-session-doc.jsx
+++ b/ui/components/console/nv-session-doc.jsx
@@ -632,7 +632,7 @@ function NV_DecisionCard(props) {
       <div className="nv-card-head">
         <span className="nv-dot-attention" />
         <span className="nv-card-title">Approval required</span>
-        <span className="nv-card-tool">{item.toolName}</span>
+        <span className="nv-card-tool">{item.gatedTool}</span>
         <span style={{ flex: 1 }} />
         <span className="nv-card-routing">{routing}</span>
       </div>
@@ -653,7 +653,7 @@ function NV_DecisionCard(props) {
         ) : null}
         <div className="nv-card-actions">
           <button type="button" className="nv-btn-primary"
-            data-testid="nv-approve"
+            data-testid="nv-approve" disabled={!!props.ended}
             onClick={function () {
               SH_api.approve(item.sessionId, item.toolCallId).then(
                 props.onResolved,
@@ -661,7 +661,7 @@ function NV_DecisionCard(props) {
               );
             }}>Approve</button>
           <button type="button" className="nv-btn-reject"
-            data-testid="nv-reject"
+            data-testid="nv-reject" disabled={!!props.ended}
             onClick={function () {
               if (!rejOpen) { setRej(true); return; }
               SH_api.reject(item.sessionId, item.toolCallId, reason).then(
@@ -669,13 +669,15 @@ function NV_DecisionCard(props) {
                 function (err) { con.toast("Reject failed: " + (err.detail || err.message)); }
               );
             }}>Reject with feedback</button>
-          <span className="nv-card-note">
-            also in your attention feed — keep scrolling while you judge
+          <span className="nv-card-note" data-testid="nv-decision-ended-note">
+            {props.ended
+              ? "session ended before this could be resolved"
+              : "also in your attention feed — keep scrolling while you judge"}
           </span>
         </div>
         {rejOpen ? (
           <textarea className="nv-card-reason" value={reason}
-            data-testid="nv-reject-reason"
+            data-testid="nv-reject-reason" disabled={!!props.ended}
             placeholder="Why not — the agent reads this"
             onChange={function (ev) { setReason(ev.target.value); }} />
         ) : null}
@@ -737,7 +739,7 @@ function NV_AskCard(props) {
                   data-testid={"nv-ask-option:" + i}
                   data-selected={val === optVal ? "true" : "false"}>
                   <input type="radio" name={"nv-ask-" + item.toolCallId}
-                    checked={val === optVal}
+                    checked={val === optVal} disabled={!!props.ended}
                     onChange={function () { setVal(optVal); }} />
                   <span className="nv-ask-option-label">{opt.label}</span>
                 </label>
@@ -746,7 +748,7 @@ function NV_AskCard(props) {
           </div>
         ) : (
           <textarea className="nv-card-reason" value={val}
-            data-testid="nv-ask-answer"
+            data-testid="nv-ask-answer" disabled={!!props.ended}
             placeholder="Your answer — the agent resumes with it"
             onChange={function (ev) { setVal(ev.target.value); }}
             onKeyDown={function (ev) {
@@ -760,9 +762,14 @@ function NV_AskCard(props) {
         {err ? (
           <div className="nv-form-error" data-testid="nv-ask-error">{err}</div>
         ) : null}
+        {props.ended ? (
+          <div className="nv-card-note" data-testid="nv-ask-ended-note">
+            session ended before this could be answered
+          </div>
+        ) : null}
         <div className="nv-card-actions">
           <button type="button" className="nv-btn-primary"
-            data-testid="nv-ask-submit"
+            data-testid="nv-ask-submit" disabled={!!props.ended}
             onClick={submit}>Answer & resume</button>
         </div>
       </div>
@@ -957,13 +964,14 @@ function NV_TraceSplit(props) {
     return out;
   }
   var flatRows = flat(rows, 0, []);
+  var traceNodes = flatRows.map(function (r) { return r.node; });
   var maxState = React.useState(false);
   var maximized = maxState[0];
   var setMaximized = maxState[1];
   return (
     <div className="nv-trace-split" data-testid="nv-trace-split">
       <div className="nv-trace-head">
-        <span>{SH_traceHeaderLabel(props.turnNo, props.turnRows)}</span>
+        <span>{SH_traceHeaderLabel(props.turnNo, traceNodes)}</span>
         <span style={{ flex: 1 }} />
         <button type="button" className="nv-rail-iconbtn" title="Maximize"
           data-testid="nv-trace-maximize-open"
@@ -983,8 +991,8 @@ function NV_TraceSplit(props) {
         </div>
       </div>
       {maximized ? (
-        <NV_TraceMaximize flatRows={flatRows} turnNo={props.turnNo}
-          turnRows={props.turnRows} agentName={props.agentName}
+        <NV_TraceMaximize flatRows={flatRows} traceNodes={traceNodes}
+          turnNo={props.turnNo} agentName={props.agentName}
           isGraph={props.isGraph}
           onClose={function () { setMaximized(false); }} />
       ) : null}
@@ -1007,7 +1015,7 @@ function NV_TraceMaximize(props) {
         onClick={function (ev) { ev.stopPropagation(); }}>
         <div className="nv-overlay-head">
           <h3 className="nv-overlay-title">
-            {SH_traceHeaderLabel(props.turnNo, props.turnRows)}
+            {SH_traceHeaderLabel(props.turnNo, props.traceNodes)}
           </h3>
           <span style={{ flex: 1 }} />
           <button type="button" className="nv-rail-iconbtn"
@@ -1851,10 +1859,16 @@ function NV_SessionDoc(props) {
     // seqs never collide with a real one (persistence.py's
     // WorkspaceMessageWriter starts real seqs at 1).
     if (store && store.legacyMessages && store.legacyMessages.length) {
+      // Live finding 01a064d3: this placeholder isn't always a user
+      // instruction - a legacy ASSISTANT line races its modern
+      // assistant_token twin the same way (session-store.js's SS_apply
+      // comment), and hardcoding "user_message" rendered that case with
+      // the wrong avatar/name/side. Pick the row kind from the legacy
+      // line's own role instead.
       var legacyRows = store.legacyMessages.map(function (lm, li) {
         return {
           seq: li - store.legacyMessages.length,
-          kind: "user_message",
+          kind: lm.role === "assistant" ? "assistant_message" : "user_message",
           nodeId: null,
           label: lm.text,
           payload: { text: lm.text },
@@ -1988,15 +2002,6 @@ function NV_SessionDoc(props) {
     var t = turnOfSeq[row.seq];
     return t == null ? 0 : t;
   }
-  // Audit A item 5: the trace split's header needs the turn's OWN rows
-  // (tool_call/tool_result, each carrying createdAt from SA_toTranscript)
-  // to compute its enriched "{N} calls · {span}s" label - turnOfSeq
-  // already maps every seq to its ordinal turn, so this is a plain
-  // filter over the same flat array, not a new fetch.
-  function turnRowsFor(turnNo) {
-    return flat.filter(function (row) { return turnOfSeq[row.seq] === turnNo; });
-  }
-
   // US-008 R3 item 1: live tool-call ARGUMENTS as they stream in, before
   // the call's durable record even exists.
   //
@@ -2468,11 +2473,19 @@ function NV_SessionDoc(props) {
               );
             })}
             {gateItems.map(function (item) {
+              // Live finding 01a064d3: a park can outlive its session (a
+              // sweep/timeout continuation that then fails ends the
+              // session without clearing parked_status - the gate item
+              // is still here, but acting on it now would just 404/error
+              // against a dead session). The ended state must win: keep
+              // the card for historical context, but it can no longer be
+              // actionable.
+              var ended = NV_sessionIsOver(session);
               return item.kind === "approval" ? (
-                <NV_DecisionCard key={item.id} item={item}
+                <NV_DecisionCard key={item.id} item={item} ended={ended}
                   onResolved={refetchAll} />
               ) : (
-                <NV_AskCard key={item.id} item={item}
+                <NV_AskCard key={item.id} item={item} ended={ended}
                   onResolved={refetchAll} />
               );
             })}
@@ -2495,7 +2508,6 @@ function NV_SessionDoc(props) {
         </div>
         {traceTurn != null ? (
           <NV_TraceSplit sid={sid} turnNo={traceTurn}
-            turnRows={turnRowsFor(traceTurn)}
             agentName={agentId} isGraph={!!graphId}
             onClose={function () { setTraceTurn(null); }} />
         ) : null}

--- a/ui/foundation/session-store.js
+++ b/ui/foundation/session-store.js
@@ -305,9 +305,19 @@ function SS_apply(store, frame) {
     }
     // SEV-2 fix: a real record superseding an earlier legacy `{role,
     // parts}` placeholder (see the branch above) must drop that
-    // placeholder - otherwise the user's own message would render
-    // TWICE once the durable record catches up.
-    if (recordKind === "user_input" && store.legacyMessages.length) {
+    // placeholder - otherwise the same content would render TWICE once
+    // the durable record catches up. Originally scoped to user_input
+    // only; that missed the SAME race for a legacy ASSISTANT placeholder
+    // (live finding 01a064d3): the legacy assistant line is written to
+    // messages.jsonl before its modern `assistant_token` twin
+    // (primer/agent/workspace_executor.py's _persist_turn runs inside
+    // the turn loop, before dispatch's flush), so `alreadyReal` above
+    // sees nothing yet when the legacy line is applied and the
+    // placeholder gets queued - it still needs evicting once the real
+    // record lands, exactly like a user_input placeholder does. Match
+    // on text alone rather than a specific kind, so this covers
+    // whichever record kind eventually carries the same text.
+    if (store.legacyMessages.length) {
       var supersededText = SS_recordText(frame);
       if (supersededText) {
         store.legacyMessages = store.legacyMessages.filter(function (m) {

--- a/ui/foundation/shell-attention.js
+++ b/ui/foundation/shell-attention.js
@@ -65,6 +65,21 @@ function SH_yieldKind(row) {
   return (row && (row.kind || row.tool_name)) || "";
 }
 
+// Live finding 01a064d3: item.toolName is deliberately the YIELD KIND
+// ("approval"/"ask_user" - SH_tierFor/SH_isDecisionTool's tier-routing
+// allowlist needs exactly that literal), NOT the gated tool's own id -
+// but the decision card's "tool" chip (nv-session-doc.jsx's
+// nv-card-tool) and the parked status strip (shell-status.js's
+// SH_waitLine) both want the LATTER ("workspace__write", not
+// "approval"). Same original_call.name SH_titleOf already reads,
+// exposed as its own field so those two consumers stop reading
+// toolName for a purpose it was never named for.
+function SH_gatedToolOf(row) {
+  if (SH_yieldKind(row) === "ask_user") return "ask_user";
+  var call = ((row && row.resume_metadata) || {}).original_call || {};
+  return call.name || null;
+}
+
 function SH_titleOf(row) {
   var call = ((row && row.resume_metadata) || {}).original_call || {};
   if (SH_yieldKind(row) === "ask_user") return "Question";
@@ -138,6 +153,7 @@ function SH_toAttentionItems(input) {
       sessionId: row.session_id,
       toolCallId: row.tool_call_id,
       toolName: SH_yieldKind(row),
+      gatedTool: SH_gatedToolOf(row),
       kind: SH_yieldKind(row) === "ask_user" ? "question" : "approval",
       title: SH_titleOf(row),
       // Kind decides the preview source (BDD pass 2026-08-24): a
@@ -187,6 +203,7 @@ function SH_toAttentionItems(input) {
       sessionId: rec.session_id,
       toolCallId: rec.tool_call_id,
       toolName: rec.tool_name,
+      gatedTool: rec.tool_name,
       kind: "approval",
       // The records endpoint's field is `decision` (approved/rejected);
       // `status` never existed on ToolApprovalRecord (live-pass finding,

--- a/ui/foundation/shell-status.js
+++ b/ui/foundation/shell-status.js
@@ -45,7 +45,12 @@ function SH_statusLine(status) {
 // generic "parked - waiting on {waiting_reason}" line, not new data.
 function SH_waitLine(item) {
   if (!item) return null;
-  var tool = item.toolName || (item.kind === "question" ? "ask_user" : "a tool call");
+  // Live finding 01a064d3: item.toolName is the yield KIND ("approval"),
+  // used elsewhere for tier routing - the gated TOOL id lives on
+  // item.gatedTool (shell-attention.js's SH_gatedToolOf). Reading
+  // toolName here rendered "waiting on approval — approval" instead of
+  // "waiting on approval — workspace__write".
+  var tool = item.gatedTool || (item.kind === "question" ? "ask_user" : "a tool call");
   var lead = item.kind === "question" ? "waiting on your answer" : "waiting on approval";
   return lead + " — " + tool + " (parked, worker released)";
 }
@@ -62,6 +67,12 @@ function SH_waitLine(item) {
 // expression, not new data collection.
 function SH_parkedStatusLine(session, gateItems) {
   if (!session || !session.parked_status) return null;
+  // Live finding 01a064d3: a park can outlive its session (a sweep/
+  // timeout continuation that then fails ends the session without
+  // clearing parked_status), so parked_status alone is not sufficient -
+  // an ended session is never still "waiting" on anything, no matter
+  // what its stale parked_status column says. The ended state wins.
+  if (session.status === "ended") return null;
   var gate = (gateItems || [])[0];
   return gate ? SH_waitLine(gate) : "parked — waiting on a wake";
 }

--- a/ui/foundation/shell-turns.js
+++ b/ui/foundation/shell-turns.js
@@ -129,30 +129,41 @@ function SH_shortTime(createdAt) {
 
 // UX reconcile wave 2 (audit A item 5): the trace split's header - "trace
 // · turn N" names the turn but says nothing about what happened in it.
-// Enrich to "trace · {calls} · {span}" using the turn's OWN rows (already
-// fetched for the transcript, each carrying createdAt - no new request):
-// N = tool_call row count; span = last tool activity minus first (the
-// latest of any tool_call/tool_result timestamp, minus the earliest tool
-// call) rather than summing individual durations, since overlapping or
-// back-to-back calls would double-count shared time in a sum. A turn with
-// no tool calls (pure reasoning + answer) keeps the plain "turn N" form -
-// there is nothing to count.
-function SH_traceHeaderLabel(turnNo, turnRows) {
-  var toolCallCount = 0;
+// Enrich to "trace · {calls} · {span}" using the SAME node list the trace
+// body renders below it (the turn's timeline nodes, from the /timeline
+// endpoint - see NV_TraceSplit/NV_TraceMaximize's flatRows) rather than
+// the transcript's own turnRows: SA_toTranscript deliberately skips
+// llm_call records (SA_SKIP_IN_TRANSCRIPT in session-adapter.jsx - "the
+// Trace panel reads it from the timeline endpoint"), so turnRows can
+// never contain them and a header counting only over turnRows silently
+// undercounts against a body that renders both tool_call AND llm_call
+// rows (live finding 01a064d3: "1 CALL" above three visible rows).
+// N = tool_call + llm_call node count (every row the body actually
+// shows a T/A glyph for - see NV_traceGlyph); span = latest node end
+// (ts + duration_ms) minus earliest node start, using each node's own
+// authoritative duration_ms (primer/session/timeline.py already
+// computes it per node via _delta_ms) rather than reconstructing it
+// from paired tool_call/tool_result timestamps. A turn with no
+// tool/llm calls (pure reasoning + answer, or nothing yet) keeps the
+// plain "turn N" form - there is nothing to count.
+function SH_traceHeaderLabel(turnNo, traceNodes) {
+  var callCount = 0;
   var minMs = null;
   var maxMs = null;
-  for (var i = 0; i < (turnRows || []).length; i++) {
-    var row = turnRows[i];
-    if (row.kind !== "tool_call" && row.kind !== "tool_result") continue;
-    if (row.kind === "tool_call") toolCallCount += 1;
-    if (!row.createdAt) continue;
-    var ms = Date.parse(row.createdAt);
-    if (isNaN(ms)) continue;
-    if (minMs === null || ms < minMs) minMs = ms;
-    if (maxMs === null || ms > maxMs) maxMs = ms;
+  for (var i = 0; i < (traceNodes || []).length; i++) {
+    var node = traceNodes[i];
+    if (node.kind !== "tool_call" && node.kind !== "llm_call") continue;
+    callCount += 1;
+    if (!node.ts) continue;
+    var startMs = Date.parse(node.ts);
+    if (isNaN(startMs)) continue;
+    var endMs = startMs
+      + (typeof node.duration_ms === "number" ? node.duration_ms : 0);
+    if (minMs === null || startMs < minMs) minMs = startMs;
+    if (maxMs === null || endMs > maxMs) maxMs = endMs;
   }
-  if (!toolCallCount) return "trace · turn " + turnNo;
-  var callsLabel = toolCallCount + (toolCallCount === 1 ? " call" : " calls");
+  if (!callCount) return "trace · turn " + turnNo;
+  var callsLabel = callCount + (callCount === 1 ? " call" : " calls");
   if (minMs === null || maxMs === null) return "trace · " + callsLabel;
   var seconds = Math.max(0, Math.round((maxMs - minMs) / 1000));
   return "trace · " + callsLabel + " · " + seconds + "s";


### PR DESCRIPTION
Four live bugs found by adjudicating staged fixture captures against the uiv2 mockup, all live-verified in a browser plus API-level checks:

- **Duplicated final answer** - two mechanisms, one symptom: (a) client-side, the legacy assistant line was checked against modern records before the modern record arrived and was never evicted, rendering as a mislabeled duplicate at the transcript top; (b) backend, a graph's End node re-persisted the worker's final answer as a second ASSISTANT_TOKEN whenever its output template was a passthrough - now suppressed via same-turn byte-equality, and template-less End nodes stop writing an empty record entirely. A distinct graph-result record kind is deliberately deferred to Phase 3 stage 7a. Live check: exactly one assistant_token per session where there were two.
- **Trace header count/duration mismatch** - header aggregated the transcript's own rows (which deliberately exclude llm_call records) while the body rendered from the timeline endpoint; both now read the same timeline nodes with authoritative durations.
- **Status strip named the yield kind, not the gated tool** - the overloaded toolName field (needed verbatim for tier routing) is split from a new gatedTool display field; strip and card chip now read 'workspace__write' style ids.
- **Ended-vs-parked contradiction** - ended now wins: no parked wait-line once a session is ended, and gate cards disable with an inline annotation instead of rendering actionable. The disable path is unit-tested; the exact stale-gate-alongside-ended race wasn't forceable in one live pass (noted honestly, reproduction cleared gates server-side first).

Verification: 1665 UI statics + 702 graph/session tests green; browser verification of all four fixes on a fresh stack; refreshed staged captures including a proper enum-schema ask_user radio-path fixture.

🤖 Generated with [Claude Code](https://claude.com/claude-code)