### PR TITLE
fix(workspace): local ls emits the mtime its description promises

### DIFF
--- a/primer/workspace/local/tools/ls.py
+++ b/primer/workspace/local/tools/ls.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+from datetime import datetime, timezone
 from pathlib import Path
 from typing import ClassVar
 
@@ -48,9 +49,11 @@ class LsArgs(BaseModel):
 class Ls(WorkspaceTool):
     """List entries in a workspace directory.
 
-    Output: one line per entry, ``<type> <size> <name>`` where type is
-    ``f`` / ``d`` / ``l`` (file / dir / symlink). Sorted alphabetically.
-    Sizes are in bytes; directories and symlinks report 0.
+    Output: one line per entry, ``<type> <size> <mtime> <name>`` where
+    type is ``f`` / ``d`` / ``l`` (file / dir / symlink). Sorted
+    alphabetically. Sizes are in bytes; directories and symlinks report
+    0. mtime is UTC ISO-8601 (``YYYY-MM-DDTHH:MM:SSZ``), matching the
+    sandbox backend's rendering.
     """
 
     id: ClassVar[str] = "ls"
@@ -148,6 +151,11 @@ def _walk(
 
 
 def _format_entry(entry: Path, base: Path) -> str:
+    # lstat for symlinks so a broken link still formats instead of raising.
+    try:
+        st = entry.lstat() if entry.is_symlink() else entry.stat()
+    except OSError:
+        st = None
     if entry.is_symlink():
         kind = "l"
         size = 0
@@ -156,12 +164,15 @@ def _format_entry(entry: Path, base: Path) -> str:
         size = 0
     else:
         kind = "f"
-        try:
-            size = entry.stat().st_size
-        except OSError:
-            size = 0
+        size = st.st_size if st is not None else 0
+    if st is not None:
+        mtime = datetime.fromtimestamp(st.st_mtime, tz=timezone.utc).strftime(
+            "%Y-%m-%dT%H:%M:%SZ"
+        )
+    else:
+        mtime = "?"
     rel = entry.relative_to(base).as_posix()
-    return f"{kind} {size:>10} {rel}"
+    return f"{kind} {size:>10} {mtime} {rel}"
 
 
 __all__ = ["Ls", "LsArgs"]

--- a/tests/workspace/tools/test_tools.py
+++ b/tests/workspace/tools/test_tools.py
@@ -7,6 +7,8 @@ real AgentSession). Per-tool sections separate the assertions.
 from __future__ import annotations
 
 import asyncio
+import os
+import re
 import shutil
 import sys
 from pathlib import Path
@@ -99,9 +101,20 @@ class TestLs:
         (workspace_root / "b.txt").write_text("bbb")
         (workspace_root / "sub").mkdir()
         result = await Ls(workspace_root).execute(LsArgs(), ctx)
-        assert "f          2 a.txt" in result.output
-        assert "f          3 b.txt" in result.output
-        assert "d          0 sub" in result.output
+        mtime = r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}Z"
+        assert re.search(rf"^f +2 {mtime} a\.txt$", result.output, re.M)
+        assert re.search(rf"^f +3 {mtime} b\.txt$", result.output, re.M)
+        assert re.search(rf"^d +0 {mtime} sub$", result.output, re.M)
+
+    async def test_mtime_reflects_the_file(
+        self, workspace_root: Path, ctx: ToolCallContext
+    ) -> None:
+        f = workspace_root / "old.txt"
+        f.write_text("x")
+        # 2001-09-09T01:46:40Z -- a fixed instant well in the past.
+        os.utime(f, (1_000_000_000, 1_000_000_000))
+        result = await Ls(workspace_root).execute(LsArgs(), ctx)
+        assert "2001-09-09T01:46:40Z old.txt" in result.output
 
     async def test_skips_dotfiles_by_default(
         self, workspace_root: Path, ctx: ToolCallContext


### PR DESCRIPTION
Board item 01a06607: the shared `ls` tool description (kept byte-identical across backends by the `test_local_tool_descriptions.py` drift guard) promises `kind, size, mtime, and name` per line. SandboxLs delivers that; the local backend's `_format_entry` emitted only kind/size/name, so an agent on a local workspace saw a column short of its own tool doc.

Since the description is what the LLM reads (it already expects mtime) and the sandbox twin already renders it, the fix implements rather than shrinking the doc: one `stat`/`lstat` per entry (`lstat` for symlinks so a broken link still formats instead of raising), rendered as UTC ISO-8601 `%Y-%m-%dT%H:%M:%SZ` — the exact rendering SandboxLs uses — degrading to `?` on a stat race instead of dropping the line.

Tests: `test_lists_files` assertions updated to the new line shape (anchored regex), plus a new `test_mtime_reflects_the_file` pinning a fixed `os.utime` instant through to the rendered timestamp. Verified locally by direct module smoke (all four entry kinds incl. broken symlink) + ruff; suite verification deferred to CI per the local test-run policy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)