### PR TITLE
fix(toolset): call_tool's approval gate shares the app-level resolver

### DIFF
--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -220,6 +220,11 @@ def _make_lifespan(config: AppConfig):
             provider_registry=provider_registry,
             semantic_search_registry=semantic_search_registry,
             workspace_registry=workspace_registry,
+            # Share the app-level resolver (01a06610): the
+            # /tool_approval_policies/invalidate endpoint clears THIS
+            # instance, and call_tool's meta-dispatch gate must see that
+            # immediately rather than serving stale verdicts until TTL.
+            approval_resolver=approval_resolver,
         )
         provider_registry._system_toolset_provider = system_toolset  # noqa: SLF001
         # NOTE: the always-on _workspaces toolset is built later in this

--- a/primer/api/app.py
+++ b/primer/api/app.py
@@ -194,6 +194,8 @@ def create_test_app(
             provider_registry=provider_registry,
             semantic_search_registry=_test_ssp_registry,
             workspace_registry=workspace_registry,
+            # Same sharing invariant as the real lifespan (01a06610).
+            approval_resolver=_test_approval_resolver,
         )
     if workspaces_toolset is None:
         # The test factory builds its scheduler/event_bus/claim_engine

--- a/primer/toolset/system.py
+++ b/primer/toolset/system.py
@@ -188,6 +188,7 @@ def build_system_toolset(
     semantic_search_registry: "SemanticSearchRegistry | None" = None,
     workspace_registry: "WorkspaceRegistry | None" = None,
     toolset_id: str = SYSTEM_TOOLSET_ID,
+    approval_resolver: "ApprovalResolver | None" = None,
 ) -> InternalToolsetProvider:
     """Construct the immutable ``_system`` toolset.
 
@@ -195,6 +196,11 @@ def build_system_toolset(
     a single :class:`InternalToolsetProvider`. Mutation cascades are
     threaded into the provider/vector-store registries so the system
     toolset stays consistent with the REST routers.
+
+    ``approval_resolver`` is the app-level :class:`ApprovalResolver` when
+    the caller has one (the API lifespan does); the meta-dispatch gate
+    shares its cache so an operator ``/invalidate`` takes effect here
+    too. ``None`` builds a private resolver (standalone/test builders).
     """
     registry: dict[str, tuple[Tool, ToolHandler]] = {}
 
@@ -649,12 +655,17 @@ def build_system_toolset(
         registry[name] = entry
 
     # ---- Toolset extras ---------------------------------------------
-    # Build a ToolApprovalPolicy resolver so call_tool's meta-dispatch
-    # path enforces the same approval gate the agent loop applies; without
-    # this a gated tool invoked via system__call_tool would run unguarded.
-    approval_resolver = ApprovalResolver(
-        storage=storage_provider.get_storage(ToolApprovalPolicy),
-    )
+    # call_tool's meta-dispatch path enforces the same approval gate the
+    # agent loop applies; without a resolver a gated tool invoked via
+    # system__call_tool would run unguarded. Callers with an app-level
+    # ApprovalResolver MUST pass it in (01a06610): the operator-facing
+    # /tool_approval_policies/invalidate endpoint clears only that
+    # instance, so a private one here would keep serving stale verdicts
+    # for its full cache TTL after an explicit invalidate.
+    if approval_resolver is None:
+        approval_resolver = ApprovalResolver(
+            storage=storage_provider.get_storage(ToolApprovalPolicy),
+        )
     name, entry = _list_toolset_tools_tool(provider_registry)
     registry[name] = entry
     name, entry = _call_tool_tool(provider_registry, approval_resolver)
@@ -1034,7 +1045,12 @@ def build_system_toolset(
     )
 
 
-    return InternalToolsetProvider(toolset_id=toolset_id, registry=registry)
+    provider = InternalToolsetProvider(toolset_id=toolset_id, registry=registry)
+    # The resolver the call_tool/invoke_agent closures captured -- exposed
+    # so wiring can be asserted (app.state.approval_resolver must be this
+    # same object for the /invalidate endpoint to reach meta-dispatch).
+    provider.approval_resolver = approval_resolver
+    return provider
 
 
 # Register the ask_user yielding-tool resume hook at import time. The

--- a/tests/toolset/test_system.py
+++ b/tests/toolset/test_system.py
@@ -1409,3 +1409,67 @@ class TestCallToolApprovalGate:
         )
         assert result.is_error
         assert json.loads(result.output)["type"] == "approval-required"
+
+
+# ===========================================================================
+# 01a06610: the meta-dispatch gate shares the app-level resolver's cache
+# ===========================================================================
+
+
+class TestCallToolResolverSharing:
+    @pytest.mark.asyncio
+    async def test_injected_resolver_invalidate_reaches_meta_dispatch(
+        self, sp: _SP, pr: ProviderRegistry
+    ) -> None:
+        """The operator ``/invalidate`` clears ONE shared cache: after
+        call_tool caches policy=None for an inner tool, creating a policy
+        row and invalidating the injected (app-level) resolver re-gates
+        the very next dispatch, instead of a private second resolver
+        serving the stale verdict until its TTL runs out."""
+        from primer.agent.approval import ApprovalResolver
+        from primer.model.tool_approval import ToolApprovalPolicy
+        from primer.model.yield_ import YieldToWorker
+
+        resolver = ApprovalResolver(
+            storage=sp.get_storage(ToolApprovalPolicy),
+            cache_ttl_seconds=600.0,  # a TTL expiry can't mask the miss
+        )
+        provider = build_system_toolset(
+            storage_provider=sp,  # type: ignore[arg-type]
+            provider_registry=pr,
+            approval_resolver=resolver,
+        )
+        pr._system_toolset_provider = provider  # type: ignore[attr-defined]
+        assert provider.approval_resolver is resolver
+
+        await provider.call(
+            tool_name="create_llm_provider",
+            arguments={"entity": _llm().model_dump(mode="json")},
+        )
+        call_args = {
+            "toolset_id": SYSTEM_TOOLSET_ID,
+            "tool_name": "get_llm_provider",
+            "arguments": {"id": "anthropic-1"},
+        }
+        # First dispatch caches policy=None for the inner tool's key.
+        result = await provider.call(
+            tool_name="call_tool", arguments=call_args, ctx=_ctx(),
+        )
+        assert not result.is_error, result.output
+
+        await sp.get_storage(ToolApprovalPolicy).create(
+            _required_policy(SYSTEM_TOOLSET_ID, "get_llm_provider")
+        )
+        # Still cached: the new row is invisible until an invalidate.
+        result = await provider.call(
+            tool_name="call_tool", arguments=call_args, ctx=_ctx(),
+        )
+        assert not result.is_error, result.output
+
+        # What POST /tool_approval_policies/invalidate does to the
+        # app-level instance -- must re-gate meta-dispatch immediately.
+        resolver.invalidate()
+        with pytest.raises(YieldToWorker):
+            await provider.call(
+                tool_name="call_tool", arguments=call_args, ctx=_ctx(),
+            )


### PR DESCRIPTION
Board item 01a06610 (found during Dev-Backend's Phase-3 Q3 verification). `build_system_toolset` constructed a private `ApprovalResolver` for the `system__call_tool` meta-dispatch (and `invoke_agent`) path. The operator-facing `POST /tool_approval_policies/invalidate` endpoint clears only the app.state instance, so after an explicit invalidate the meta-dispatch gate kept serving stale verdicts for up to the private cache's full 30s TTL — the endpoint's immediate-effect contract held on the agent-loop path but silently not on this one. (Narrower than the board item's original phrasing: the TTL means ordinary edits did eventually propagate; the explicit-invalidate contract was the real break.)

Fix is consolidation: `build_system_toolset` accepts an optional `approval_resolver`, threaded from both construction sites (real lifespan + lightweight test app); `None` still builds a private one for standalone builders. The captured instance is exposed on the returned provider so wiring is assertable.

New test pins the operator scenario end-to-end: call_tool caches policy=None → policy row created → `invalidate()` on the injected instance re-gates the very next dispatch (with a long TTL so cache expiry can't mask the miss, and a mid-sequence assert proving the cache was genuinely consulted).

Verified: `tests/toolset/test_system.py -k 'TestCallToolResolverSharing or TestCallToolApprovalGate'` → 4 passed; ruff clean on all four touched files. Full suite is CI's.

🤖 Generated with [Claude Code](https://claude.com/claude-code)