### PR TITLE
feat(console): uiv2 Wave 3 — approvals surfaces reconciled

### DIFF
--- a/primer/api/routers/tool_approval.py
+++ b/primer/api/routers/tool_approval.py
@@ -478,25 +478,39 @@ def make_tool_approval_ops_router() -> APIRouter:
             Literal["all", "approved", "rejected", "timeout", "cancelled"],
             Query(),
         ] = "all",
+        session_id: Annotated[
+            str | None,
+            Query(
+                description=(
+                    "Scope to one session's resolved decisions - the "
+                    "session detail transcript's resolved-card renderer "
+                    "needs exactly this session's history, not a page of "
+                    "the whole instance's records to filter client-side."
+                ),
+            ),
+        ] = None,
         offset: Annotated[int, Query(ge=0)] = 0,
         length: Annotated[int, Query(ge=1, le=200)] = 50,
     ) -> OffsetPageResponse[ToolApprovalRecord]:
         """List resolved approval decisions, newest first.
 
-        ``status`` filters by decision (``all`` = no filter). Ordered by
-        ``decided_at`` descending so the most recent decisions lead, mirroring
-        the records view's default sort.
+        ``status`` filters by decision (``all`` = no filter). ``session_id``
+        optionally scopes to one session. Ordered by ``decided_at``
+        descending so the most recent decisions lead, mirroring the
+        records view's default sort.
         """
         sp = get_storage_provider(request)
         storage = sp.get_storage(ToolApprovalRecord)
         page = OffsetPage(offset=offset, length=length)
         order = [OrderBy(field="decided_at", direction="desc")]
-        if status == "all":
+        if status == "all" and session_id is None:
             return await storage.list(page, order_by=order)
-        predicate = (
-            Q(ToolApprovalRecord).where("decision", status).build()
-        )
-        return await storage.find(predicate, page, order_by=order)
+        query = Q(ToolApprovalRecord)
+        if session_id is not None:
+            query = query.where("session_id", session_id)
+        if status != "all":
+            query = query.where("decision", status)
+        return await storage.find(query.build(), page, order_by=order)
 
     return router
 

--- a/tests/api/test_tool_approval_records.py
+++ b/tests/api/test_tool_approval_records.py
@@ -9,14 +9,16 @@ import pytest
 from primer.model.tool_approval import ToolApprovalRecord
 
 
-def _rec(*, id_: str, decision: str, decided_at: datetime) -> ToolApprovalRecord:
+def _rec(
+    *, id_: str, decision: str, decided_at: datetime, session_id: str = "sess-1",
+) -> ToolApprovalRecord:
     return ToolApprovalRecord(
         id=id_,
         tool_name="delete_workspace",
         toolset_id="workspaces",
         arguments={"id": "ws-x"},
         tool_call_id=f"call-{id_}",
-        session_id="sess-1",
+        session_id=session_id,
         decided_at=decided_at,
         decision=decision,  # type: ignore[arg-type]
         policy_id="p1",
@@ -91,3 +93,47 @@ async def test_records_list_empty(client):
 async def test_records_list_bad_status_422(client):
     r = await client.get("/v1/tool_approval/records?status=bogus")
     assert r.status_code == 422
+
+
+@pytest.mark.asyncio
+async def test_records_list_filter_by_session_id(client, app):
+    # uiv2 Wave 3: the session-detail transcript's resolved-card
+    # renderer needs exactly one session's history, not a client-side
+    # filter over a page of the whole instance's records.
+    await _seed(app)
+    storage = app.state.storage_provider.get_storage(ToolApprovalRecord)
+    await storage.create(_rec(
+        id_="r5", decision="approved",
+        decided_at=datetime(2026, 6, 14, 9, 20, tzinfo=UTC),
+        session_id="sess-other",
+    ))
+    r = await client.get("/v1/tool_approval/records?session_id=sess-1")
+    assert r.status_code == 200, r.text
+    body = r.json()
+    ids = [it["id"] for it in body["items"]]
+    assert ids == ["r3", "r2", "r4", "r1"]
+    assert all(it["session_id"] == "sess-1" for it in body["items"])
+
+
+@pytest.mark.asyncio
+async def test_records_list_filter_by_session_id_and_status(client, app):
+    await _seed(app)
+    storage = app.state.storage_provider.get_storage(ToolApprovalRecord)
+    await storage.create(_rec(
+        id_="r5", decision="rejected",
+        decided_at=datetime(2026, 6, 14, 9, 20, tzinfo=UTC),
+        session_id="sess-other",
+    ))
+    r = await client.get(
+        "/v1/tool_approval/records?session_id=sess-1&status=rejected",
+    )
+    assert r.status_code == 200, r.text
+    assert [it["id"] for it in r.json()["items"]] == ["r2"]
+
+
+@pytest.mark.asyncio
+async def test_records_list_filter_by_session_id_no_match(client, app):
+    await _seed(app)
+    r = await client.get("/v1/tool_approval/records?session_id=sess-nope")
+    assert r.status_code == 200, r.text
+    assert r.json()["items"] == []

--- a/tests/ui/test_approval_policy_tool_picker.py
+++ b/tests/ui/test_approval_policy_tool_picker.py
@@ -1,12 +1,14 @@
-"""Approval policy form: searchable tool catalogue picker with y/w/r/n
-badges (R4 Governance group, notes 3.4/3.11's "one picker everywhere").
+"""Approval policy form: Tool row uses the shared y/w/r/n tool picker
+(uiv2 Wave 3, approved judgment call: ToolPicker's new single-select
+mode, added specifically for this consumer).
 
-Before this the policy form's only way to name the gated tool was two
-free-text inputs (a toolset select + a raw tool-name text box) with no
-way to see the tool's capabilities. This adds a searchable browser over
-GET /tools (the same endpoint TS_ToolsTab reads, batch-2 + its follow-up
-both carry the 4 badge fields there) that fills those same fields on
-pick, without removing them.
+RETARGETED: this used to pin a bespoke AP_ToolPicker search browser
+that sat ALONGSIDE a free-text toolset-select + tool-name-input pair -
+three controls for two fields. The mockup specs one compact field
+("Tool: workspace__write_file (the shared toolset__tool picker)"), so
+Wave 3 deleted AP_ToolPicker and the free-text pair entirely and wired
+window.ToolPicker (the same component agents.jsx uses, in mode="single")
+directly to toolsetId/toolName.
 """
 
 from __future__ import annotations
@@ -16,52 +18,64 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 UI = ROOT / "ui"
 APPROVALS = UI / "components" / "approvals.jsx"
+TOOL_PICKER = UI / "components" / "shared" / "tool-picker.jsx"
 
 
 def _src() -> str:
     return APPROVALS.read_text(encoding="utf-8")
 
 
-def test_picker_component_exists() -> None:
+def _picker_src() -> str:
+    return TOOL_PICKER.read_text(encoding="utf-8")
+
+
+def test_bespoke_picker_and_free_text_pair_are_gone() -> None:
     src = _src()
-    assert "function AP_ToolPicker(" in src
+    assert "function AP_ToolPicker(" not in src
+    assert "AP_INTERNAL_TOOLSETS" not in src
+    assert 'data-testid="approval-policy-toolset"' not in src
+    assert 'data-testid="approval-policy-tool"' not in src
 
 
-def test_picker_reads_the_real_tools_endpoint() -> None:
+def test_modal_mounts_the_shared_picker_in_single_mode() -> None:
     src = _src()
-    assert '"GET", "/tools"' in src
+    assert "<window.ToolPicker" in src
+    assert 'mode="single"' in src
 
 
-def test_picker_renders_capability_badges_per_row() -> None:
+def test_picking_a_tool_splits_the_scoped_id_into_toolset_and_name() -> None:
     src = _src()
-    assert "<CapabilityBadges tool={r.tool}" in src
+    assert "setToolsetId(sep < 0" in src
+    assert "setToolName(sep < 0" in src
 
 
-def test_picking_a_row_fills_toolset_and_tool_name() -> None:
-    src = _src()
-    assert "onPick(r.toolsetId, r.tool.id)" in src
-    assert "setToolsetId(pickedToolsetId)" in src
-    assert "setToolName(pickedToolName)" in src
+def test_shared_picker_supports_single_select_mode() -> None:
+    # The mode itself lives in tool-picker.jsx, not approvals.jsx -
+    # confirm the component that got the new capability actually has it.
+    src = _picker_src()
+    assert 'mode === "single"' in src
+    assert 'type={single ? "radio" : "checkbox"}' in src
 
 
-def test_free_text_fields_are_not_removed() -> None:
-    # The picker is additive -- typing a not-yet-indexed toolset/tool id
-    # must still work.
-    src = _src()
-    assert 'data-testid="approval-policy-toolset"' in src
-    assert 'data-testid="approval-policy-tool"' in src
+def test_single_mode_hides_bulk_select_and_selected_filter() -> None:
+    # Neither a toolset "select all" nor a "selected · N" filter make
+    # sense when at most one tool can ever be picked.
+    src = _picker_src()
+    assert "{!single && (" in src
 
 
-def test_unavailable_toolsets_are_skipped() -> None:
-    src = _src()
-    start = src.index("function AP_ToolPicker(")
-    end = src.index("\nfunction AP_NewPolicyModal(")
-    body = src[start:end]
-    assert "if (!g.available) continue;" in body
+def test_multi_select_default_is_unchanged() -> None:
+    # No `mode` prop = the exact behavior every existing multi-select
+    # consumer (agents.jsx) already depends on.
+    src = _picker_src()
+    assert "const single = mode ===" in src
+    assert "single ? new Set([scopedId]) : TP_toggleSet(selected, scopedId)" in src
 
 
-def test_bundle_transpiles_with_the_picker() -> None:
+def test_bundle_transpiles_with_the_shared_picker_wired_in() -> None:
     from primer.api._jsx_bundle import build_jsx_bundle
 
     _etag, body = build_jsx_bundle(UI)
-    assert "AP_ToolPicker" in body.decode("utf-8")
+    decoded = body.decode("utf-8")
+    assert "window.ToolPicker" in decoded
+    assert "AP_NewPolicyModal" in decoded

--- a/tests/ui/test_approvals_audit_derivation.py
+++ b/tests/ui/test_approvals_audit_derivation.py
@@ -1,0 +1,149 @@
+"""Approval-policy card + decisions-audit row derivation logic (Phase-2c:
+platform-approvals-staged / rev-2 synthesis Wave 3 item 49).
+
+Runs the real JS in MiniRacer (same technique as tests/ui/test_audio_
+resample.py) rather than grepping for source text, so branch logic in
+the status/decided-by derivation is actually exercised. The helpers
+(NV_approvalToolPattern..NV_approvalAt) are pure functions with no JSX
+and no window.* dependency, so they're sliced out and evaluated in
+isolation instead of transpiling the whole (JSX) file.
+
+Backend ground truth these pin against:
+* primer/model/tool_approval.py - ToolApprovalRecord/ToolApprovalPolicy
+  real field names (toolset_id, tool_name, decided_by, reason, ...).
+* primer/worker/yield_runtime.py's classify_approval_payload - a
+  session-bound timeout resolves to (decision="rejected",
+  reason="timed-out"); a cancel resolves to (decision="rejected",
+  reason=<given> or "cancelled"); decided_by is None for both
+  (ToolApprovalRecord's own field doc: "None for synthesized verdicts").
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+UI = Path(__file__).resolve().parents[2] / "ui"
+NV_PLATFORM = UI / "components" / "console" / "nv-platform.jsx"
+
+
+def _helpers_src() -> str:
+    src = NV_PLATFORM.read_text(encoding="utf-8")
+    start = src.index("function NV_approvalToolPattern(row)")
+    end = src.index("var NV_PLAT_PAGE_SIZE")
+    return src[start:end]
+
+
+def _ctx():
+    py_mini_racer = pytest.importorskip("py_mini_racer")
+    ctx = py_mini_racer.MiniRacer()
+    ctx.eval(_helpers_src())
+    return ctx
+
+
+def _call(ctx, fn: str, *args) -> object:
+    import json
+
+    args_js = ", ".join(json.dumps(a) for a in args)
+    return ctx.eval(f"JSON.stringify({fn}({args_js}))")
+
+
+def test_tool_pattern_is_the_mono_compound_id() -> None:
+    ctx = _ctx()
+    row = {"toolset_id": "_workspaces", "tool_name": "write_file"}
+    assert _call(ctx, "NV_approvalToolPattern", row) == '"_workspaces__write_file"'
+
+
+def test_explicit_human_reject_is_plain_rejected() -> None:
+    ctx = _ctx()
+    r = {"decision": "rejected", "decided_by": "usman", "reason": "bad idea"}
+    assert _call(ctx, "NV_approvalDerivedStatus", r) == '"rejected"'
+
+
+def test_session_bound_timeout_derives_to_timeout() -> None:
+    # decided_by is None (synthesized) and reason is the exact literal
+    # classify_approval_payload emits for a YieldTimeout.
+    ctx = _ctx()
+    r = {"decision": "rejected", "decided_by": None, "reason": "timed-out"}
+    assert _call(ctx, "NV_approvalDerivedStatus", r) == '"timeout"'
+
+
+def test_session_bound_cancel_derives_to_cancelled() -> None:
+    ctx = _ctx()
+    r = {"decision": "rejected", "decided_by": None, "reason": "cancelled"}
+    assert _call(ctx, "NV_approvalDerivedStatus", r) == '"cancelled"'
+
+
+def test_literal_timeout_and_cancelled_decisions_pass_through() -> None:
+    # Reachable via primer/session/abandon.py, not the session-bound
+    # gate path - already-literal values are honoured as-is.
+    ctx = _ctx()
+    assert _call(ctx, "NV_approvalDerivedStatus", {"decision": "timeout"}) == '"timeout"'
+    assert _call(ctx, "NV_approvalDerivedStatus", {"decision": "cancelled"}) == '"cancelled"'
+
+
+def test_approved_and_pending_pass_through_unchanged() -> None:
+    ctx = _ctx()
+    assert _call(ctx, "NV_approvalDerivedStatus", {"decision": "approved"}) == '"approved"'
+    assert _call(ctx, "NV_approvalDerivedStatus", {"decision": "pending"}) == '"pending"'
+
+
+def test_status_color_groups_timeout_and_cancelled_with_rejected() -> None:
+    ctx = _ctx()
+    for status in ("rejected", "timeout", "cancelled"):
+        assert _call(ctx, "NV_approvalStatusColor", status) == '"var(--red)"'
+    assert _call(ctx, "NV_approvalStatusColor", "approved") == '"var(--green)"'
+    assert _call(ctx, "NV_approvalStatusColor", "pending") == '"var(--text-3)"'
+
+
+def test_decided_by_quotes_the_reason_for_an_explicit_reject() -> None:
+    ctx = _ctx()
+    r = {"decision": "rejected", "decided_by": "usman", "reason": "use the test runner"}
+    assert _call(ctx, "NV_approvalDecidedBy", r, "rejected") == (
+        '"usman — \\"use the test runner\\""'
+    )
+
+
+def test_decided_by_has_no_actor_for_a_plain_approve() -> None:
+    ctx = _ctx()
+    r = {"decision": "approved", "decided_by": "usman", "reason": None}
+    assert _call(ctx, "NV_approvalDecidedBy", r, "approved") == '"usman"'
+
+
+def test_timeout_decided_by_derives_elapsed_minutes_from_the_record_itself() -> None:
+    # NOT the policy's configured timeout_seconds - the record's own
+    # requested_at/decided_at span is what actually elapsed, which is
+    # correct even when the GLOBAL yield cap fired instead of a
+    # per-policy timeout (the staging gotcha that surfaced this).
+    ctx = _ctx()
+    r = {
+        "decision": "rejected", "decided_by": None, "reason": "timed-out",
+        "requested_at": "2026-08-15T17:20:00Z",
+        "decided_at": "2026-08-15T17:50:00Z",
+    }
+    assert _call(ctx, "NV_approvalDecidedBy", r, "timeout") == '"30m elapsed → rejected"'
+
+
+def test_cancelled_decided_by_quotes_a_real_cancel_reason() -> None:
+    ctx = _ctx()
+    r = {"decision": "rejected", "decided_by": None, "reason": "operator abandoned chat"}
+    assert _call(ctx, "NV_approvalDecidedBy", r, "cancelled") == (
+        '"cancelled — \\"operator abandoned chat\\""'
+    )
+
+
+def test_cancelled_decided_by_has_no_quote_for_the_canned_default() -> None:
+    ctx = _ctx()
+    r = {"decision": "rejected", "decided_by": None, "reason": "cancelled"}
+    assert _call(ctx, "NV_approvalDecidedBy", r, "cancelled") == '"cancelled"'
+
+
+def test_at_renders_bare_time_for_same_day_and_dated_otherwise() -> None:
+    ctx = _ctx()
+    # Same-day: freeze "now" to a fixed instant on the same calendar day
+    # as the record so this doesn't depend on when the suite runs.
+    now_iso = "2026-08-15T23:00:00"
+    ctx.eval(f'var __RealDate = Date; Date = function(...a) {{ return a.length ? new __RealDate(...a) : new __RealDate("{now_iso}"); }};')
+    assert _call(ctx, "NV_approvalAt", "2026-08-15T17:50:00") == '"17:50"'
+    assert _call(ctx, "NV_approvalAt", "2026-08-14T17:50:00") == '"Aug 14 · 17:50"'

--- a/tests/ui/test_console_session_doc.py
+++ b/tests/ui/test_console_session_doc.py
@@ -1423,3 +1423,89 @@ def test_file_doc_keeps_the_etag_discipline():
 
 def test_diff_lines_are_toned():
     assert 'data-tone={tone}' in FDOCS
+
+
+# ---------------------------------------------------------------------------
+# uiv2 Wave 3 - resolved decision cards (Phase-2c missing-feature: gate
+# cards used to be built with records:[] hardcoded, so an approved/
+# rejected call vanished from the transcript instead of leaving the
+# notes §2.4 resolved line). Derivation-logic correctness itself
+# (timeout/cancelled classification, decided-by phrasing) is already
+# covered by tests/ui/test_approvals_audit_derivation.py's 13 MiniRacer
+# tests against the exact same nv-platform.jsx helpers this reuses -
+# these pin the WIRING: real records reach the card, the right
+# component renders, and it calls into that shared logic rather than
+# re-deriving its own.
+# ---------------------------------------------------------------------------
+
+
+def test_records_are_no_longer_hardcoded_empty():
+    assert "records: []" not in DOC
+    assert "resolvedRecords.data" in DOC
+
+
+def test_a_decide_refetches_resolved_records_not_just_gates():
+    # Without this, an approve/reject fires the "resumed" tap event,
+    # the pending card clears via gates.refetch(), and the new resolved
+    # record silently never appears until the operator reloads.
+    m = re.search(r"useWorkspaceTapListener\([\s\S]{0,600}", DOC)
+    assert m and "gates.refetch()" in m.group(0)
+    assert "resolvedRecords.refetch()" in m.group(0)
+
+
+def test_session_scoped_records_resource_is_wired():
+    assert "SH_api.sessionApprovalRecords(sid" in DOC
+    assert "SH_api.keys.sessionRecords(sid)" in DOC
+
+
+def test_resolved_items_render_the_dedicated_card_not_the_actionable_ones():
+    m = re.search(r"gateItems\.map\(function \(item\) \{[\s\S]{0,1000}", DOC)
+    assert m
+    body = m.group(0)
+    assert "if (item.resolved)" in body
+    assert "<NV_ResolvedDecisionCard" in body
+    # The branch must come BEFORE the pending approval/ask ternary, or a
+    # resolved item could still fall through to the live-action cards.
+    assert body.index("if (item.resolved)") < body.index("item.kind ===")
+
+
+def test_resolved_decision_card_reuses_the_shared_derivation_not_its_own():
+    card = DOC[DOC.index("function NV_ResolvedDecisionCard"):
+               DOC.index("function NV_AskCard")]
+    assert "NV_approvalDerivedStatus(rec)" in card
+    assert "NV_approvalStatusColor(status)" in card
+    assert "NV_approvalDecidedBy(rec, status)" in card
+    assert "NV_approvalAt(item.decidedAt)" in card
+    # No actions - a resolved record is already terminal (per Dev-
+    # Backend's own read when we agreed the nv-session-doc.jsx split).
+    assert "onClick" not in card
+    assert 'data-testid="nv-decision-resolved-line"' in card
+
+
+def test_resolved_decision_card_registers_no_new_css_debt():
+    assert ".nv-dot-resolved" in STYLES
+
+
+def test_shell_attention_records_carry_explicit_fields_for_the_card():
+    # Not just `preview` (which the OLD, never-fed stub overloaded to
+    # hold the reason text) - the card needs decision/decidedBy/reason/
+    # requestedAt/decidedAt as their own fields to feed
+    # NV_approvalDerivedStatus's real ToolApprovalRecord-shaped input.
+    m = re.search(r"for \(var j = 0; j < records\.length[\s\S]{0,1400}", ATTENTION)
+    assert m
+    body = m.group(0)
+    for field in ("decision: rec.decision", "decidedBy: rec.decided_by",
+                  "reason: rec.reason", "requestedAt: rec.requested_at",
+                  "decidedAt: rec.decided_at"):
+        assert field in body, field
+
+
+def test_records_endpoint_gained_a_session_filter_not_a_client_side_one():
+    # The per-session transcript fetch scopes server-side
+    # (session_id=...) rather than fetching a page of the whole
+    # instance's records and filtering in JS on every open session.
+    api = (ROOT / "primer" / "api" / "routers" / "tool_approval.py").read_text(
+        encoding="utf-8",
+    )
+    assert "session_id" in api
+    assert 'query = query.where("session_id", session_id)' in api

--- a/tests/ui_e2e/test_approval_policy_modal_journey.py
+++ b/tests/ui_e2e/test_approval_policy_modal_journey.py
@@ -98,34 +98,29 @@ def test_u0110_policy_modal_llm_judge_journey(
       1. Seed LLMProvider with a named judge model via API.
       2. Navigate /providers/llm → assert the seeded row is listed
          (proves the cross-page dropdown source is populated).
-      3. Navigate /approvals → click Policies tab.
-      4. Click "New policy" → modal opens.
-      5. Fill id + toolset + tool, then click "LLM judge" chip.
-      6. Provider dropdown shows the seeded provider; select it.
-      7. Model dropdown auto-enables + populates with the provider's
+      3. Navigate /approvals, open the New-policy modal via the
+         config hint.
+      4. Fill id, pick a real tool via the shared picker (uiv2 Wave 3),
+         then click "LLM judge" chip.
+      5. Provider dropdown shows the seeded provider; select it.
+      6. Model dropdown auto-enables + populates with the provider's
          model; select it. Fill the judge prompt.
-      8. Click "Create policy" → "Policy created" toast.
-      9. Policies table now contains a row with the new policy id.
-     10. Toggle the row's enabled checkbox → "Policy updated" toast.
-     11. Click the row's delete button → confirmation modal renders.
-     12. Click "Delete" in the confirm modal → "Policy deleted" toast
-         + row disappears within the next refetch cycle.
+      7. Click "Create policy" → "Policy created" toast, modal closes.
+      8. Verify the persisted policy via API (no more inline policies
+         table with toggle/delete on this page - see _cleanup for
+         teardown).
 
     Pinned invariants:
       * LLM-type form dropdowns are fed by live /v1/llm_providers
         — the seeded provider must appear within the modal open.
       * Provider→model effect: picking a provider unblocks the model
         select and prefills the first available model.
-      * Each mutation (create, toggle, delete) surfaces the documented
-        toast title via approvals.jsx + the console shell toaster wiring.
-      * The delete confirmation modal is a real gate — the row only
-        disappears after the confirm button in the modal is clicked.
+      * The create mutation surfaces the documented toast title via
+        approvals.jsx + the console shell toaster wiring.
     """
     judge_model = "judge-m1"
     pid = f"u0110-llm-{unique_suffix}"
     policy_id = f"u0110-pol-{unique_suffix}"
-    toolset_id = f"u0110-ts-{unique_suffix}"
-    tool_name = f"u0110-tool-{unique_suffix}"
 
     _seed_llm_provider(base_url, pid, judge_model)
 
@@ -154,8 +149,8 @@ def test_u0110_policy_modal_llm_judge_journey(
         # --- 2. Open the policy modal from the Tools page ----------
         # uiv2 cutover: the standalone Tools catalog page retired; the
         # Approvals page's config hint now opens the same
-        # AP_NewPolicyModal directly (free-form id / toolset / tool
-        # inputs are still editable, so we override them below).
+        # AP_NewPolicyModal directly (uiv2 Wave 3: Tool is now the
+        # shared picker, not free-form toolset/tool text inputs).
         open_legacy_route(page, console_url, "approvals")
 
         # --- 3. Open the New-policy modal via the config hint -------
@@ -168,15 +163,15 @@ def test_u0110_policy_modal_llm_judge_journey(
 
         # --- 4. Fill core identity fields --------------------------
         modal.locator("[data-testid='approval-policy-id']").fill(policy_id)
-        # The toolset select defaults to _workspaces; the input override
-        # below it accepts free-text. Use the override input to set a
-        # unique user-defined toolset id so this test doesn't collide
-        # with sibling tests' internal-toolset writes.
-        toolset_inputs = modal.locator("input.input.mono")
-        # First mono input is the id (already filled); second is the
-        # toolset override; third is the tool name.
-        toolset_inputs.nth(1).fill(toolset_id)
-        modal.locator("[data-testid='approval-policy-tool']").fill(tool_name)
+        # uiv2 Wave 3: Tool is now the shared window.ToolPicker in
+        # single-select mode - no more free-text toolset/tool-name
+        # override, so pick a real, always-available built-in tool
+        # (primer/toolset/misc.py) instead of a synthetic unique pair.
+        # The policy id above is what makes this test's row unique;
+        # this test's own `finally` cleanup deletes the policy, freeing
+        # the (toolset, tool) pair for the next run.
+        modal.get_by_test_id("tool-picker-filter").fill("uuid_v4")
+        modal.get_by_test_id("tool-picker-row-misc__uuid_v4").click()
 
         # --- 5. Switch to LLM-judge type ---------------------------
         modal.locator("[data-testid='approval-policy-type-llm']").click()

--- a/tests/ui_e2e/test_policy_modal_rego_validation_journey.py
+++ b/tests/ui_e2e/test_policy_modal_rego_validation_journey.py
@@ -107,15 +107,13 @@ def test_u0114_policy_modal_rego_compile_error_renders_inline(
     if the modal stays open.
     """
     policy_id = f"u0114-pol-{unique_suffix}"
-    toolset_id = f"u0114-ts-{unique_suffix}"
-    tool_name = f"u0114-tool-{unique_suffix}"
 
     try:
         # ----- 1. Open the policy modal from the Tools page ---------
         # uiv2 cutover: the standalone Tools catalog page retired; the
         # Approvals page's config hint now opens the same
-        # AP_NewPolicyModal directly (which still carries free-form
-        # id / toolset / tool inputs we override below).
+        # AP_NewPolicyModal directly (uiv2 Wave 3: Tool is now the
+        # shared picker, not free-form toolset/tool text inputs).
         open_legacy_route(page, console_url, "approvals")
 
         # ----- 2. New policy modal opens via the config hint --------
@@ -128,14 +126,13 @@ def test_u0114_policy_modal_rego_compile_error_renders_inline(
 
         # ----- 3. Fill required identity fields ---------------------
         modal.locator("[data-testid='approval-policy-id']").fill(policy_id)
-        # toolset override input is the second mono input in the
-        # modal (first is id; this lets us use a unique user-defined
-        # toolset so the test doesn't collide on the (toolset_id,
-        # tool_name) uniqueness constraint).
-        modal.locator("input.input.mono").nth(1).fill(toolset_id)
-        modal.locator(
-            "[data-testid='approval-policy-tool']",
-        ).fill(tool_name)
+        # uiv2 Wave 3: pick a real, always-available built-in tool via
+        # the shared picker (no more free-text toolset/tool override) -
+        # a DIFFERENT tool than U0110's misc__uuid_v4 so this test has
+        # no (toolset_id, tool_name) uniqueness-constraint coupling to
+        # a sibling test regardless of execution order.
+        modal.get_by_test_id("tool-picker-filter").fill("get_datetime")
+        modal.get_by_test_id("tool-picker-row-misc__get_datetime").click()
 
         # ----- 4. Switch to Policy (Rego) type ---------------------
         modal.locator("[data-testid='approval-policy-type-policy']").click()

--- a/ui/components/approvals.jsx
+++ b/ui/components/approvals.jsx
@@ -3,8 +3,6 @@
 // Top-level scope is shared with the babel-standalone IIFE; prefix all
 // consts with AP_ to avoid clashes with other components.
 
-const AP_INTERNAL_TOOLSETS = ["workspaces", "system", "misc", "search", "web"];
-
 function AP_ageSec(iso) {
   if (!iso) return null;
   if (iso instanceof Date) return (Date.now() - iso.getTime()) / 1000;
@@ -31,7 +29,7 @@ const AP_PARKED_PREDICATE = {
   right: { kind: "value", value: "parked" },
 };
 
-function ApprovalsPage({ pushToast, onNavigate }) {
+function ApprovalsPage({ pushToast, onNavigate, startCreate }) {
   const { useResource, useViewport, apiFetch } = window.primerApi;
   // eslint-disable-next-line no-unused-vars
   const { isMobile } = useViewport();
@@ -39,9 +37,16 @@ function ApprovalsPage({ pushToast, onNavigate }) {
   const [sortBy, setSortBy] = React.useState("time");
   const [sortDir, setSortDir] = React.useState("desc");
   // US-011a: the standalone Tools catalog page retired; configuring a
-  // gate opens AP_NewPolicyModal directly, with its own embedded
-  // AP_ToolPicker to find the tool - no page to navigate to anymore.
+  // gate opens AP_NewPolicyModal directly - no page to navigate to
+  // anymore.
   const [configuringPolicy, setConfiguringPolicy] = React.useState(false);
+  // uiv2 Wave 3 (routing fix, item 0): "New policy" now addresses this
+  // overlay with section="new" (same convention as AgentsPage's
+  // startCreate) instead of landing here and requiring a second click
+  // on the in-page config hint.
+  React.useEffect(() => {
+    if (startCreate) setConfiguringPolicy(true);
+  }, [startCreate]);
 
   // Parked sessions — sessions in parked_status="parked" state. Each row
   // may or may not be parked on tool_approval (could be ask_user, sleep,
@@ -585,107 +590,15 @@ function AP_RecordRow({ scope, id, record, onNavigate, pushToast }) {
 // =============================================================
 // Approval configuration modal - Required/Policy/LLM create + edit.
 // Opened directly from ApprovalsPage's AP_ConfigHint link (US-011a: the
-// standalone Tools catalog page retired; its own embedded AP_ToolPicker
-// below is the only way left to find a tool to gate).
+// standalone Tools catalog page retired) and from AP_PolicyDetail (uiv2
+// Wave 3 routing fix). The Tool row uses the shared window.ToolPicker
+// in single-select mode (uiv2 Wave 3, approved judgment call) - a
+// policy gates exactly one tool, so the bespoke browser this used to
+// have (plus the redundant toolset-select/tool-name-input pair right
+// below it - THREE controls for two fields) collapsed into the one
+// compact field the mockup specs ("Tool: workspace__write_file (the
+// shared toolset__tool picker)").
 // =============================================================
-
-// Searchable tool catalogue browser for the policy form: picking a row
-// fills toolset + tool name AND shows that tool's y/w/r/n capability
-// badges, so an operator gating a call can see up front whether it
-// yields, needs a workspace, is role-gated, or is fire-and-forget --
-// context the old free-text-only fields never surfaced. Reuses
-// GET /tools (same endpoint TS_ToolsTab reads, batch-2 + the
-// GET /toolsets/{id}/tools follow-up both carry the 4 fields there
-// already). The free-text fields below stay -- this is a faster way to
-// fill them, not a replacement for typing a not-yet-indexed id.
-function AP_ToolPicker({ toolsetId, toolName, onPick }) {
-  const { useResource, apiFetch } = window.primerApi;
-  const [q, setQ] = React.useState("");
-  const catalogue = useResource(
-    "approval-policy:tools-catalogue",
-    (signal) => apiFetch("GET", "/tools", null, { signal }),
-    { pollMs: null },
-  );
-  const groups = catalogue.data?.items ?? [];
-  const ql = q.trim().toLowerCase();
-  const rows = React.useMemo(() => {
-    const out = [];
-    for (const g of groups) {
-      if (!g.available) continue;
-      for (const t of g.tools || []) {
-        if (ql && !(
-          t.id.toLowerCase().includes(ql)
-          || g.id.toLowerCase().includes(ql)
-          || (t.description || "").toLowerCase().includes(ql)
-        )) continue;
-        out.push({ toolsetId: g.id, tool: t });
-      }
-    }
-    return out;
-  }, [groups, ql]);
-
-  return (
-    <div className="field">
-      <label className="field-label">
-        browse tool catalogue
-        <span className="hint">pick a tool to fill toolset + tool name below, with its y/w/r/n capabilities</span>
-      </label>
-      <div className="input-icon">
-        <Icon name="search" size={13} className="icon" />
-        <input
-          className="input"
-          placeholder="Filter by tool, toolset, or description…"
-          value={q}
-          onChange={(e) => setQ(e.target.value)}
-          data-testid="approval-policy-tool-picker-filter"
-          style={{ width: "100%" }}
-        />
-      </div>
-      <div
-        style={{
-          maxHeight: 220, overflowY: "auto", border: "1px solid var(--border)",
-          borderRadius: 6, marginTop: 6,
-        }}
-        data-testid="approval-policy-tool-picker-results"
-      >
-        {catalogue.loading && rows.length === 0 && (
-          <div className="muted text-sm" style={{ padding: 10 }}>Loading tool catalogue…</div>
-        )}
-        {!catalogue.loading && rows.length === 0 && (
-          <div className="muted text-sm" style={{ padding: 10 }}>No tools match.</div>
-        )}
-        {rows.map((r) => {
-          const rowKey = `${r.toolsetId}__${r.tool.id}`;
-          const selected = r.toolsetId === toolsetId && r.tool.id === toolName;
-          return (
-            <div
-              key={rowKey}
-              data-testid={`approval-policy-tool-picker-row-${rowKey}`}
-              onClick={() => onPick(r.toolsetId, r.tool.id)}
-              style={{
-                display: "flex", alignItems: "center", gap: 8,
-                padding: "6px 10px", cursor: "pointer",
-                background: selected ? "var(--bg-2)" : "transparent",
-                borderBottom: "1px solid var(--bg-1)",
-              }}
-            >
-              <span
-                className="mono"
-                style={{
-                  fontSize: 12, minWidth: 0, flex: 1, overflow: "hidden",
-                  textOverflow: "ellipsis", whiteSpace: "nowrap",
-                }}
-              >
-                {r.toolsetId} · {r.tool.id}
-              </span>
-              <CapabilityBadges tool={r.tool} testid={`approval-policy-tool-picker-badges-${rowKey}`} />
-            </div>
-          );
-        })}
-      </div>
-    </div>
-  );
-}
 
 function AP_NewPolicyModal({ onClose, pushToast, existing }) {
   // Same modal: create (no existing, or existing with empty id) and
@@ -719,6 +632,24 @@ function AP_NewPolicyModal({ onClose, pushToast, existing }) {
     const arr = spec.kind === "roles" ? spec.roles : spec.users;
     return (arr || []).join(", ");
   });
+  // uiv2 Wave 3 (approved judgment call): roles are a fixed, small enum
+  // (primer/model/user.py's Literal["admin","user","restricted"]), so
+  // "role(s)" renders as toggleable chip tokens per the mockup ("admin
+  // ✓" green-tinted / "user" neutral) instead of typed free text.
+  // "specific users" has no such bounded set (real usernames, not an
+  // enum) and the mockup doesn't show that variant, so it keeps the
+  // existing comma-separated input unchanged.
+  const AP_ROLE_OPTIONS = ["admin", "user", "restricted"];
+  const apprRoleSet = React.useMemo(
+    () => new Set(apprList.split(",").map((s) => s.trim()).filter(Boolean)),
+    [apprList],
+  );
+  const toggleApprRole = (role) => {
+    const next = new Set(apprRoleSet);
+    if (next.has(role)) next.delete(role);
+    else next.add(role);
+    setApprList([...next].join(", "));
+  };
   const [fieldErrors, setFieldErrors] = React.useState({});
 
   // Provider dropdown source — keyed separately from the page-level
@@ -901,49 +832,27 @@ function AP_NewPolicyModal({ onClose, pushToast, existing }) {
         {fieldErr("body.id")}
       </div>
 
-      <AP_ToolPicker
-        toolsetId={toolsetId}
-        toolName={toolName}
-        onPick={(pickedToolsetId, pickedToolName) => {
-          setToolsetId(pickedToolsetId);
-          setToolName(pickedToolName);
-        }}
-      />
-
       <div className="field">
-        <label className="field-label">toolset</label>
-        <select
-          className="select mono"
-          value={toolsetId}
-          onChange={(e) => setToolsetId(e.target.value)}
-          style={{ width: "100%" }}
-          data-testid="approval-policy-toolset"
-        >
-          {AP_INTERNAL_TOOLSETS.map((t) => <option key={t} value={t}>{t}</option>)}
-        </select>
-        <div className="field-help">
-          Pick a built-in toolset, or type a user-defined toolset id below.
-        </div>
-        <input
-          className="input mono"
-          value={toolsetId}
-          onChange={(e) => setToolsetId(e.target.value)}
-          style={{ width: "100%", marginTop: 4 }}
-          placeholder="or type a toolset id…"
+        <label className="field-label">
+          Tool
+          <span className="hint">the shared toolset__tool picker</span>
+        </label>
+        <window.ToolPicker
+          mode="single"
+          pageSize={6}
+          selected={toolsetId && toolName ? new Set([`${toolsetId}__${toolName}`]) : new Set()}
+          onChange={(next) => {
+            const picked = [...next][0] || "";
+            // Toolset ids never contain "__" themselves (builtins are
+            // `_system`/`_workspaces`/`_misc`/`_search`/`web`; the same
+            // assumption the agent-tools scoped id already relies on),
+            // so splitting on the first occurrence recovers both parts.
+            const sep = picked.indexOf("__");
+            setToolsetId(sep < 0 ? "" : picked.slice(0, sep));
+            setToolName(sep < 0 ? "" : picked.slice(sep + 2));
+          }}
         />
         {fieldErr("body.toolset_id")}
-      </div>
-
-      <div className="field">
-        <label className="field-label">tool name</label>
-        <input
-          className="input mono"
-          value={toolName}
-          onChange={(e) => setToolName(e.target.value)}
-          style={{ width: "100%" }}
-          placeholder="fs.delete"
-          data-testid="approval-policy-tool"
-        />
         {fieldErr("body.tool_name")}
       </div>
 
@@ -983,13 +892,31 @@ function AP_NewPolicyModal({ onClose, pushToast, existing }) {
             </span>
           ))}
         </div>
-        {apprKind !== "anyone" && (
+        {apprKind === "roles" && (
+          <div className="chip-group" style={{ marginTop: 6 }} data-testid="approval-policy-approvers-role-chips">
+            {AP_ROLE_OPTIONS.map((role) => {
+              const on = apprRoleSet.has(role);
+              return (
+                <span
+                  key={role}
+                  className={`chip${on ? " active" : ""}`}
+                  style={on ? { color: "var(--green)", borderColor: "var(--green)" } : undefined}
+                  onClick={() => toggleApprRole(role)}
+                  data-testid={`approval-policy-approvers-role-${role}`}
+                >
+                  {role}{on ? " ✓" : ""}
+                </span>
+              );
+            })}
+          </div>
+        )}
+        {apprKind === "users" && (
           <input
             className="input mono"
             style={{ width: "100%", marginTop: 6 }}
             value={apprList}
             onChange={(e) => setApprList(e.target.value)}
-            placeholder={apprKind === "roles" ? "user, admin" : "alice, bob"}
+            placeholder="alice, bob"
             data-testid="approval-policy-approvers-list"
           />
         )}
@@ -1076,6 +1003,38 @@ function AP_NewPolicyModal({ onClose, pushToast, existing }) {
       )}
     </Modal>
   );
+}
+
+// =============================================================
+// AP_PolicyDetail - uiv2 Wave 3 routing fix (item 0): the "Open" card
+// action now addresses this overlay WITH the policy's id
+// (nv-platform.jsx's approvals.open), landing here instead of the
+// generic records sheet. Fetches the one row and hands it to
+// AP_NewPolicyModal's existing edit-mode support - the modal itself
+// already had everything it needed, only the entry point was missing.
+// =============================================================
+
+function AP_PolicyDetail({ policyId, pushToast, onClose }) {
+  const { useResource, apiFetch } = window.primerApi;
+  const policy = useResource(
+    "approvals:policy:" + policyId,
+    (signal) => apiFetch("GET", "/tool_approval_policies/" + encodeURIComponent(policyId), null, { signal }),
+    { pollMs: null },
+  );
+  if (policy.loading && !policy.data) {
+    return <div className="muted text-sm" style={{ padding: 40, textAlign: "center" }}>Loading…</div>;
+  }
+  if (policy.error && !policy.data) {
+    return (
+      <Banner
+        kind="error"
+        title={policy.error.title || "Couldn't load policy"}
+        detail={policy.error.detail || policy.error.message}
+        actions={<Btn size="sm" icon="chevron-left" onClick={onClose}>Back to list</Btn>}
+      />
+    );
+  }
+  return <AP_NewPolicyModal existing={policy.data} pushToast={pushToast} onClose={onClose} />;
 }
 
 // =============================================================
@@ -1194,4 +1153,5 @@ function ApprovalBanner({ data, scope, id, pushToast }) {
 }
 
 window.ApprovalsPage = ApprovalsPage;
+window.AP_PolicyDetail = AP_PolicyDetail;
 window.ApprovalBanner = ApprovalBanner;

--- a/ui/components/console/nv-overlays.jsx
+++ b/ui/components/console/nv-overlays.jsx
@@ -705,11 +705,24 @@ var NV_OVERLAY_MOUNTS = {
       return <window.WorkersPage pushToast={window.primerApi.toastPush} />;
     },
   },
+  // List/records and the policy editor are ONE overlay: the id slot
+  // decides which renders (same "list and record are ONE overlay"
+  // convention as `agents` above) - uiv2 Wave 3 routing fix (item 0).
   approvals: {
     render: function (state, shell) {
+      if (state.id) {
+        return (
+          <window.AP_PolicyDetail
+            policyId={state.id}
+            pushToast={window.primerApi.toastPush}
+            onClose={function () { shell.openOverlay("approvals", null, null); }}
+          />
+        );
+      }
       return (
         <window.ApprovalsPage
           pushToast={window.primerApi.toastPush}
+          startCreate={state.section === "new"}
           onNavigate={function (page, sid) {
             if (sid) {
               shell.openDoc({ kind: "session", ref: sid, preview: false });

--- a/ui/components/console/nv-platform.jsx
+++ b/ui/components/console/nv-platform.jsx
@@ -366,21 +366,173 @@ var NV_PLAT_PAGES = {
     },
     card: function (row) {
       return {
-        name: row.id, sub: row.description || row.tool_pattern || "",
-        chip: row.mode ? { label: row.mode, color: "var(--text-3)" } : null,
-        facts: [
-          NV_fact("tool", row.tool_pattern || row.tool_id),
-          NV_fact("action", row.action || row.decision),
-        ],
+        // rev-2 synthesis Wave 3 item 48/49: title is the mono TOOL
+        // PATTERN (toolset_id__tool_name), not the policy's own
+        // entity id - the id still addresses Open/Delete, it just
+        // isn't the thing an operator scans the grid for.
+        name: NV_approvalToolPattern(row),
+        sub: "strategy: " + NV_approvalStrategyLabel(row),
+        // .nv-pcard-chip (bare mono, no pill border) is the mockup's
+        // "active" treatment - .nv-pcard-status (bordered pill) is a
+        // DIFFERENT, unrelated affordance used by other entities.
+        chip: {
+          label: row.enabled ? "active" : "disabled",
+          color: row.enabled ? "var(--green)" : "var(--text-3)",
+        },
+        facts: NV_approvalFacts(row),
       };
     },
-    open: function (con) { con.openOverlay("approvals", null, null); },
-    create: function (con) { con.openOverlay("approvals", null, null); },
+    // uiv2 Wave 3 routing fix (item 0, approved): thread row.id through
+    // like every sibling entity (services et al.) - the "approvals"
+    // overlay now dispatches on the id slot itself (nv-overlays.jsx),
+    // landing on AP_PolicyDetail's edit-mode AP_NewPolicyModal instead
+    // of the generic records sheet. "new" mirrors AgentsPage's own
+    // startCreate convention for an immediate create modal.
+    open: function (con, row) { con.openOverlay("approvals", null, row.id); },
+    create: function (con) { con.openOverlay("approvals", "new", null); },
     delPath: function (row) {
       return "/tool_approval_policies/" + encodeURIComponent(row.id);
     },
   },
 };
+
+// Approval-policy card helpers (rev-2 synthesis Wave 3 item 49) - kept
+// module-local since only the approvals card() above uses them. Real
+// ToolApprovalPolicy fields (primer/model/tool_approval.py): toolset_id,
+// tool_name, enabled, approval.{type,policy,provider_id,model},
+// timeout_seconds, approvers.{kind,roles,users}.
+
+function NV_approvalToolPattern(row) {
+  return (row.toolset_id || "?") + "__" + (row.tool_name || "?");
+}
+
+function NV_approvalStrategyLabel(row) {
+  var t = row.approval && row.approval.type;
+  if (t === "policy") return "Rego";
+  if (t === "llm") return "LLM judge";
+  return "always require";
+}
+
+// "anyone" | "role: x, y" | "user: x, y" - admins are always admitted
+// regardless (ApproverSpec.allows), so that's not spelled out here.
+function NV_approvalWhoDecides(row) {
+  var spec = row.approvers;
+  if (!spec || spec.kind === "anyone") return "anyone";
+  var names = (spec.kind === "roles" ? spec.roles : spec.users) || [];
+  var noun = spec.kind === "roles" ? "role" : "user";
+  return names.length ? noun + ": " + names.join(", ") : noun + ": (none set)";
+}
+
+// timeout_seconds is a float; render whole minutes when it divides
+// evenly (the common case), falling back to seconds for odd values
+// rather than showing a decimal.
+function NV_approvalTimeoutLabel(row) {
+  var secs = row.timeout_seconds;
+  if (secs == null) return "60m (default) → reject";
+  var mins = secs / 60;
+  var text = Number.isInteger(mins) ? mins + "m" : Math.round(secs) + "s";
+  return text + " → reject";
+}
+
+function NV_approvalFacts(row) {
+  var t = row.approval && row.approval.type;
+  if (t === "policy") {
+    // No separate human-readable description field on
+    // PolicyApprovalConfig (only the raw Rego source) - show its
+    // first non-blank line rather than inventing summary prose.
+    var firstLine = ((row.approval && row.approval.policy) || "")
+      .split("\n").map(function (l) { return l.trim(); })
+      .filter(function (l) { return l && l[0] !== "#"; })[0] || "(empty policy)";
+    return [
+      NV_fact("who decides", "returned per call"),
+      NV_fact("policy", firstLine),
+    ];
+  }
+  if (t === "llm") {
+    var judge = row.approval
+      ? (row.approval.provider_id || "?") + " · " + (row.approval.model || "?")
+      : "?";
+    return [
+      NV_fact("judge", judge),
+      NV_fact("who decides", NV_approvalWhoDecides(row) + " (judge may escalate)"),
+    ];
+  }
+  return [
+    NV_fact("who decides", NV_approvalWhoDecides(row)),
+    NV_fact("timeout", NV_approvalTimeoutLabel(row)),
+  ];
+}
+
+// Decisions-audit row helpers (Phase-2c: platform-approvals-staged).
+// ToolApprovalRecord (primer/model/tool_approval.py) is the real
+// shape - `decided_by` is null for SYNTHESIZED verdicts (timeout/
+// cancel), and classify_approval_payload (primer/worker/yield_runtime.
+// py) always collapses both to decision="rejected", distinguishing
+// them only by the literal reason string "timed-out" (timeout) vs
+// whatever the cancel payload gave, defaulting to "cancelled". The
+// literal decision values "timeout"/"cancelled" are separately
+// reachable via the chat-abandon flow and are honoured as-is.
+function NV_approvalDerivedStatus(r) {
+  if (r.decision === "timeout" || r.decision === "cancelled") return r.decision;
+  if (r.decision === "rejected" && !r.decided_by) {
+    if (r.reason === "timed-out") return "timeout";
+    // A synthesized reject with SOME reason but no timeout marker is
+    // the cancel path. No mockup slot for this state exists (its 4
+    // rows are pending/approved/rejected/timeout only) - rendering it
+    // as its own "cancelled" token rather than silently folding back
+    // into "rejected" is a judgment call, flagged for the PR body.
+    if (r.reason) return "cancelled";
+  }
+  return r.decision || "";
+}
+
+function NV_approvalStatusColor(status) {
+  if (status === "approved") return "var(--green)";
+  if (status === "rejected" || status === "timeout" || status === "cancelled") return "var(--red)";
+  return "var(--text-3)";
+}
+
+function NV_ellipsize(s, max) {
+  if (!s || s.length <= max) return s || "";
+  return s.slice(0, max) + "…";
+}
+
+// "{N}m elapsed → rejected" derives from the RECORD's own requested_at/
+// decided_at span, not the policy's configured timeout_seconds - the
+// staged fixture that surfaced this fired on the 60-minute GLOBAL yield
+// cap (policy timeout_seconds was null), where reconstructing a
+// hardcoded "30m" from the mockup's own example would have been wrong.
+// The record always carries both timestamps, so this is exact
+// regardless of which timeout (policy or global cap) actually fired.
+function NV_approvalDecidedBy(r, status) {
+  if (status === "timeout") {
+    if (r.requested_at && r.decided_at) {
+      const mins = Math.round((new Date(r.decided_at) - new Date(r.requested_at)) / 60000);
+      return `${mins}m elapsed → rejected`;
+    }
+    return "elapsed → rejected";
+  }
+  if (status === "cancelled") {
+    return r.reason && r.reason !== "cancelled" ? `cancelled — "${NV_ellipsize(r.reason, 40)}"` : "cancelled";
+  }
+  if (r.decided_by) {
+    return r.reason ? `${r.decided_by} — "${NV_ellipsize(r.reason, 40)}"` : r.decided_by;
+  }
+  return "—";
+}
+
+function NV_approvalAt(iso) {
+  if (!iso) return "";
+  const d = new Date(iso);
+  const now = new Date();
+  const sameDay = d.getFullYear() === now.getFullYear()
+    && d.getMonth() === now.getMonth() && d.getDate() === now.getDate();
+  const hh = String(d.getHours()).padStart(2, "0");
+  const mm = String(d.getMinutes()).padStart(2, "0");
+  if (sameDay) return `${hh}:${mm}`;
+  const months = ["Jan", "Feb", "Mar", "Apr", "May", "Jun", "Jul", "Aug", "Sep", "Oct", "Nov", "Dec"];
+  return `${months[d.getMonth()]} ${d.getDate()} · ${hh}:${mm}`;
+}
 
 // notes 3.1: "pager (range + prev/next appears past 6 entities)".
 var NV_PLAT_PAGE_SIZE = 6;
@@ -618,19 +770,21 @@ function NV_ApprovalsAudit() {
           <span>Decided by</span><span>At</span>
         </div>
         {rows.map(function (r, i) {
-          var status = r.status || r.decision || "";
+          // Phase-2c (platform-approvals-staged): TOOL was reading
+          // r.tool_id/r.tool, neither of which exist on
+          // ToolApprovalRecord (real fields: toolset_id/tool_name) -
+          // confirmed live bug, not a data gap. Reuses the same mono
+          // tool-pattern helper the policy cards use.
+          var status = NV_approvalDerivedStatus(r);
           return (
             <div key={r.id || i} className="nv-audit-row">
               <span>{r.session_id || ""}</span>
-              <span className="nv-audit-mono">{r.tool_id || r.tool || ""}</span>
-              <span className="nv-audit-mono" style={{
-                color: status === "approved" ? "var(--green)"
-                  : status === "rejected" ? "var(--red)" : "var(--text-3)",
-              }}>{status}</span>
-              <span>{r.decided_by || r.responded_by || "—"}</span>
-              <span className="nv-audit-mono">
-                {(r.decided_at || r.updated_at || "").slice(0, 16)}
+              <span className="nv-audit-mono">{NV_approvalToolPattern(r)}</span>
+              <span className="nv-audit-mono" style={{ color: NV_approvalStatusColor(status) }}>
+                {status}
               </span>
+              <span>{NV_approvalDecidedBy(r, status)}</span>
+              <span className="nv-audit-mono">{NV_approvalAt(r.decided_at)}</span>
             </div>
           );
         })}

--- a/ui/components/console/nv-platform.jsx
+++ b/ui/components/console/nv-platform.jsx
@@ -476,11 +476,16 @@ function NV_approvalDerivedStatus(r) {
   if (r.decision === "timeout" || r.decision === "cancelled") return r.decision;
   if (r.decision === "rejected" && !r.decided_by) {
     if (r.reason === "timed-out") return "timeout";
-    // A synthesized reject with SOME reason but no timeout marker is
-    // the cancel path. No mockup slot for this state exists (its 4
-    // rows are pending/approved/rejected/timeout only) - rendering it
-    // as its own "cancelled" token rather than silently folding back
-    // into "rejected" is a judgment call, flagged for the PR body.
+    // HEURISTIC, not spec (approved as a judgment call, not derived
+    // from any documented contract): classify_approval_payload's only
+    // OTHER synthesized-reject path is YieldCancelled, whose reason is
+    // always non-null (either the given cancel reason or the literal
+    // fallback "cancelled") - so "no decided_by (synthesized) + a
+    // reason that isn't the timeout marker" is, by elimination, the
+    // cancel path. No mockup slot for this state exists (its 4 rows
+    // are pending/approved/rejected/timeout only), so surfacing it as
+    // its own "cancelled" token instead of silently folding back into
+    // "rejected" is this file's own call - flag it in the PR body.
     if (r.reason) return "cancelled";
   }
   return r.decision || "";

--- a/ui/components/console/nv-session-doc.jsx
+++ b/ui/components/console/nv-session-doc.jsx
@@ -686,6 +686,46 @@ function NV_DecisionCard(props) {
   );
 }
 
+// uiv2 Wave 3 (Phase-2c missing-feature: "resolved decision cards do
+// not exist" - nv-session-doc.jsx used to build gate cards with
+// records:[] hardcoded, so an approved/rejected call just vanished
+// from the transcript). Static, no actions - a resolved record is
+// already terminal. Reuses the SAME derivation the DECISIONS - AUDIT
+// table uses (nv-platform.jsx's NV_approval* helpers, plain function
+// declarations sharing this file's top-level scope) so the one place
+// that can tell a session-bound timeout from a cancel (both collapse
+// to decision=rejected, only `reason` differs - primer/worker/
+// yield_runtime.py's classify_approval_payload) renders it the same
+// way in both surfaces.
+function NV_ResolvedDecisionCard(props) {
+  var item = props.item;
+  var rec = {
+    decision: item.decision, decided_by: item.decidedBy, reason: item.reason,
+    requested_at: item.requestedAt, decided_at: item.decidedAt,
+  };
+  var status = NV_approvalDerivedStatus(rec);
+  var color = NV_approvalStatusColor(status);
+  return (
+    <div className="nv-card" data-kind="approval-resolved"
+      data-testid={"nv-decision-resolved:" + item.toolCallId}>
+      <div className="nv-card-head">
+        <span className="nv-dot-resolved" style={{ color: color }} />
+        <span className="nv-card-title" style={{ color: color }}>
+          {status === "approved" ? "Approved" : "Rejected"}
+        </span>
+        <span className="nv-card-tool">{item.gatedTool}</span>
+        <span style={{ flex: 1 }} />
+        <span className="nv-card-routing">{NV_approvalAt(item.decidedAt)}</span>
+      </div>
+      <div className="nv-card-body">
+        <span className="nv-card-note" data-testid="nv-decision-resolved-line">
+          {NV_approvalDecidedBy(rec, status)}
+        </span>
+      </div>
+    </div>
+  );
+}
+
 function NV_AskCard(props) {
   var con = NV_useConsole();
   var item = props.item;
@@ -1612,6 +1652,20 @@ function NV_SessionDoc(props) {
     },
     { pollMs: 5000, deps: [con.wid, sid] }
   );
+  // uiv2 Wave 3 (resolved-card renderer): this session's own resolved
+  // approval history - a park's pending yield disappears the moment a
+  // human decides it, so without this the card just vanishes instead
+  // of leaving the notes §2.4 resolved line. No poll: a resolved
+  // record can't change again, and the tap-listener refetch below
+  // covers the moment a NEW one lands (a decide always fires a
+  // "resumed" workspace-tap event).
+  var resolvedRecords = window.primerApi.useResource(
+    SH_api.keys.sessionRecords(sid),
+    function (signal) {
+      return SH_api.sessionApprovalRecords(sid, signal);
+    },
+    { pollMs: 0, deps: [sid] }
+  );
   // Top-level hook call (it is a hook: useRef+useEffect inside); the hook
   // keeps the latest closure in a ref, so gates.refetch stays current.
   window.useWorkspaceTapListener(con.wid, function (ev) {
@@ -1620,6 +1674,10 @@ function NV_SessionDoc(props) {
             || ev["class"] === "resumed"
             || ev["class"] === "done")) {
       gates.refetch();
+      // A decide fires "resumed" the same tick the pending yield
+      // clears - refetch here too, or the resolved card wouldn't
+      // appear until the operator reloads the page.
+      resolvedRecords.refetch();
     }
   });
   // Seed the store from the REST history resource so the first paint is
@@ -2069,7 +2127,8 @@ function NV_SessionDoc(props) {
   }, [flat.length, voiceOn, ttsOk]);
   var pending = (session && session.pending_messages) || [];
   var gateItems = window.SH_toAttentionItems({
-    pending: (gates.data && gates.data.items) || [], records: [],
+    pending: (gates.data && gates.data.items) || [],
+    records: (resolvedRecords.data && resolvedRecords.data.items) || [],
   });
   var agentId = session && session.binding
     ? (session.binding.agent_id || session.binding.graph_id)
@@ -2481,6 +2540,13 @@ function NV_SessionDoc(props) {
               // the card for historical context, but it can no longer be
               // actionable.
               var ended = NV_sessionIsOver(session);
+              // uiv2 Wave 3: a resolved record (item.resolved) is
+              // already terminal - it gets the static digest-tier
+              // card regardless of `ended`, never the pending
+              // approve/reject/ask actions.
+              if (item.resolved) {
+                return <NV_ResolvedDecisionCard key={item.id} item={item} />;
+              }
               return item.kind === "approval" ? (
                 <NV_DecisionCard key={item.id} item={item} ended={ended}
                   onResolved={refetchAll} />

--- a/ui/components/shared/tool-picker.jsx
+++ b/ui/components/shared/tool-picker.jsx
@@ -23,6 +23,14 @@
 // Controlled component: `selected` is a Set<scoped_id>, `onChange(next)`
 // receives the new Set on every toggle - the caller owns persistence
 // (agent.tools, a graph node's tool list, ...).
+//
+// `mode="single"` (uiv2 Wave 3, approved for the approval-policy Tool
+// row - a policy gates exactly one tool): rows become radio-styled and
+// picking one REPLACES the selection instead of adding to it, the
+// toolset group header's bulk-select checkbox and the "selected · N"
+// filter chip are hidden (neither makes sense with at most one pick).
+// Default (no `mode`, or "multi") is byte-identical to before this was
+// added - every existing multi-select consumer is unaffected.
 
 function TP_toggleSet(set, id) {
   const next = new Set(set);
@@ -31,7 +39,7 @@ function TP_toggleSet(set, id) {
   return next;
 }
 
-function TP_Row({ tool, checked, onToggle, open, onToggleOpen }) {
+function TP_Row({ tool, checked, onToggle, open, onToggleOpen, single }) {
   const hl = window.primerVendor?.highlightJson;
   return (
     <div style={{ borderTop: "1px solid var(--bg-1)" }}>
@@ -44,7 +52,7 @@ function TP_Row({ tool, checked, onToggle, open, onToggleOpen }) {
         data-testid={`tool-picker-row-${tool.scoped_id}`}
       >
         <input
-          type="checkbox"
+          type={single ? "radio" : "checkbox"}
           checked={checked}
           onChange={() => onToggle(tool.scoped_id)}
           style={{ marginTop: 3 }}
@@ -85,8 +93,9 @@ function TP_Row({ tool, checked, onToggle, open, onToggleOpen }) {
   );
 }
 
-function ToolPicker({ selected, onChange, pageSize }) {
+function ToolPicker({ selected, onChange, pageSize, mode }) {
   const { useResource, apiFetch } = window.primerApi;
+  const single = mode === "single";
   const size = pageSize || 6;
   const catalogue = useResource(
     "tool-picker:catalogue",
@@ -165,7 +174,8 @@ function ToolPicker({ selected, onChange, pageSize }) {
   const pageEnd = Math.min(pageStart + size, flatTools.length);
   const pageTools = flatTools.slice(pageStart, pageEnd);
 
-  const toggleId = (scopedId) => onChange(TP_toggleSet(selected, scopedId));
+  const toggleId = (scopedId) =>
+    onChange(single ? new Set([scopedId]) : TP_toggleSet(selected, scopedId));
   const toggleGroup = (entry, allSelected) => {
     let next = new Set(selected);
     for (const t of entry.tools) {
@@ -191,17 +201,19 @@ function ToolPicker({ selected, onChange, pageSize }) {
             style={{ width: "100%" }}
           />
         </div>
-        <button
-          type="button"
-          data-testid="tool-picker-filter-selected"
-          className={"chip" + (selectedOnly ? " active" : "")}
-          aria-pressed={selectedOnly}
-          onClick={() => setSelectedOnly((v) => !v)}
-          title={selectedOnly ? "Show all tools" : "Show only selected tools"}
-          style={{ whiteSpace: "nowrap" }}
-        >
-          selected · {selectedCount}
-        </button>
+        {!single && (
+          <button
+            type="button"
+            data-testid="tool-picker-filter-selected"
+            className={"chip" + (selectedOnly ? " active" : "")}
+            aria-pressed={selectedOnly}
+            onClick={() => setSelectedOnly((v) => !v)}
+            title={selectedOnly ? "Show all tools" : "Show only selected tools"}
+            style={{ whiteSpace: "nowrap" }}
+          >
+            selected · {selectedCount}
+          </button>
+        )}
       </div>
       {staleIds.length > 0 && (
         <div className="field-help" style={{ color: "var(--amber)", marginBottom: 6 }} data-testid="tool-picker-stale">
@@ -255,11 +267,13 @@ function ToolPicker({ selected, onChange, pageSize }) {
                       borderTop: lastToolsetId === null ? "none" : "1px solid var(--border)",
                       borderBottom: "1px solid var(--border)", position: "sticky", top: 0, zIndex: 1,
                     }}>
-                    <input type="checkbox" checked={allSelected}
-                      ref={(el) => { if (el) el.indeterminate = !allSelected && someSelected; }}
-                      onChange={() => toggleGroup(entry, allSelected)}
-                      disabled={entry.tools.length === 0}
-                      data-testid={`tool-picker-group-${entry.id}`} />
+                    {!single && (
+                      <input type="checkbox" checked={allSelected}
+                        ref={(el) => { if (el) el.indeterminate = !allSelected && someSelected; }}
+                        onChange={() => toggleGroup(entry, allSelected)}
+                        disabled={entry.tools.length === 0}
+                        data-testid={`tool-picker-group-${entry.id}`} />
+                    )}
                     <span className="mono" style={{ fontSize: 12.5, fontWeight: 600 }}>{entry.id}</span>
                     {entry.builtin && <span className="muted text-sm" style={{ fontSize: 10.5 }}>· built-in</span>}
                     <span className="muted text-sm" style={{ marginLeft: "auto" }}>
@@ -274,7 +288,8 @@ function ToolPicker({ selected, onChange, pageSize }) {
                   checked={selected.has(t.scoped_id)}
                   onToggle={toggleId}
                   open={openId === t.scoped_id}
-                  onToggleOpen={(id) => setOpenId((cur) => (cur === id ? null : id))} />
+                  onToggleOpen={(id) => setOpenId((cur) => (cur === id ? null : id))}
+                  single={single} />
               );
             }
             return rows;

--- a/ui/components/shell/sh-api.jsx
+++ b/ui/components/shell/sh-api.jsx
@@ -276,6 +276,17 @@ var SH_api = {
       null, { signal: signal });
   },
 
+  // uiv2 Wave 3: the session-detail transcript's resolved-decision
+  // cards need exactly this session's history - the server-side
+  // session_id filter (added alongside this) avoids fetching + client-
+  // filtering a page of the whole instance's records per open session.
+  sessionApprovalRecords: function (sid, signal) {
+    return window.primerApi.apiFetch(
+      "GET", "/tool_approval/records?session_id=" + encodeURIComponent(sid)
+        + "&status=all&offset=0&length=50",
+      null, { signal: signal });
+  },
+
   // S7 spec section 5. The Trace tab derives its tree from this read.
   timeline: function (sid, turnNo, signal) {
     return window.primerApi.apiFetch(
@@ -428,6 +439,7 @@ var SH_api = {
     log: function (wid) { return "shell-log:" + wid; },
     commit: function (wid, sha) { return "shell-commit:" + wid + ":" + sha; },
     records: function () { return "shell-approval-records"; },
+    sessionRecords: function (sid) { return "shell-session-records:" + sid; },
     eventSubscriptions: function () { return "shell-event-subscriptions"; },
     timeline: function (sid, turnNo) {
       return "shell-timeline:" + sid + ":" + turnNo;

--- a/ui/foundation/shell-attention.js
+++ b/ui/foundation/shell-attention.js
@@ -204,6 +204,7 @@ function SH_toAttentionItems(input) {
       toolCallId: rec.tool_call_id,
       toolName: rec.tool_name,
       gatedTool: rec.tool_name,
+      toolsetId: rec.toolset_id,
       kind: "approval",
       // The records endpoint's field is `decision` (approved/rejected);
       // `status` never existed on ToolApprovalRecord (live-pass finding,
@@ -213,6 +214,16 @@ function SH_toAttentionItems(input) {
       at: rec.decided_at,
       resolved: true,
       workspaceId: rec.workspace_id || null,
+      // uiv2 Wave 3 (resolved-card renderer): explicit, undecorated
+      // fields for NV_ResolvedDecisionCard to derive the notes §2.4
+      // "approved/rejected by {user} · time — reason" line from - raw
+      // ToolApprovalRecord shape, same fields the DECISIONS - AUDIT
+      // table's derivation helpers already key off of.
+      decision: rec.decision,
+      decidedBy: rec.decided_by || null,
+      reason: rec.reason || null,
+      requestedAt: rec.requested_at || null,
+      decidedAt: rec.decided_at || null,
     };
     done.tier = SH_tierFor(done);
     out.push(done);

--- a/ui/styles.css
+++ b/ui/styles.css
@@ -3607,6 +3607,16 @@ input, textarea, select { font: inherit; color: inherit; }
   background: var(--attention);
   flex-shrink: 0;
 }
+/* Resolved decision cards (digest tier, uiv2 Wave 3): color comes from
+   an inline `color` matching NV_approvalStatusColor's palette (green
+   approved / red rejected-family) - one class, no per-outcome variants. */
+.nv-dot-resolved {
+  width: 7px;
+  height: 7px;
+  border-radius: 50%;
+  background: currentColor;
+  flex-shrink: 0;
+}
 
 /* Files rows, history, context menu */
 .nv-file-row {


### PR DESCRIPTION
Wave 3 of the uiv2 reconciliation programme (approvals cluster), two commits:

**1ef7c629 — approval policies are editable and the audit table tells the truth.** Routing fix threading `row.id` (the policy editor existed but was unreachable), tool-picker migrated to the shared single-select `ToolPicker`, who-decides role chips, and audit-row derivation producing the "Nm elapsed → rejected" line from record timestamps. 13 MiniRacer derivation tests.

**05861eea — resolved approval decisions stay in the transcript.** The Phase-2c missing feature: gate cards were built with `records:[]` hardcoded, so a decided approval vanished instead of collapsing to the notes-§2.4 resolved line. Adds a purely-additive `session_id` filter on `GET /tool_approval/records`, explicit record fields through shell-attention, and `NV_ResolvedDecisionCard` reusing the exact audit-table derivation helpers — so timeout-vs-cancel (both `decision=rejected`, only `reason` differs) renders identically in both surfaces. Cancel classification is a documented heuristic-by-elimination (no mockup slot exists for it) — flagged per the comment in `NV_approvalDerivedStatus`.

**Verification:** 54 UI tests (8 new wiring) + 9 records-route (3 new) + 5 approver-routing, all green under the resource-policy wrapper; live e2e pass confirmed all three resolved variants (timeout / explicit reject / approved) render with audit-table cross-consistency. This batch is a faithful reconstruction of the pre-restart work (same +266/-16 diff) after the /tmp worktree wipe.

Remaining Wave-3 tail (separate PRs): a-14 records-sheet fold, answered-ask cards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)