### PR TITLE
fix(ui_e2e): open_legacy_route sets location.hash in-page, not goto()

### DIFF
--- a/tests/ui_e2e/_shell_helpers.py
+++ b/tests/ui_e2e/_shell_helpers.py
@@ -233,7 +233,30 @@ def open_legacy_route(page: Page, console_url: str, route: str,
         target = f"{head}:{tab}:{record}" if record else f"{head}:{tab}"
     name = target.split(":")[0]
     prefix = f"#/w/{wid}" if wid else "#/"
-    page.goto(f"{console_url}{prefix}?overlay={target}")
+    fragment = f"{prefix}?overlay={target}"
+
+    # Every real caller reaches this with the console ALREADY loaded (the
+    # `page` fixture's own pre-navigation guarantees it), so a page.goto()
+    # to a URL differing from the current one only by hash is a same-
+    # document (fragment) navigation. Whether that reliably fires the
+    # hashchange event nv-shell.jsx's URL-sync listener depends on is not
+    # guaranteed across Playwright/browser navigation classification --
+    # the same trap class as the Phase-1 screenshot-rig lesson (fragment-
+    # only page.goto = same-document navigation, SPA router may not
+    # re-handle). Assign location.hash directly in-page instead: the
+    # browser's own native hash-assignment primitive, which unambiguously
+    # queues a hashchange task per spec regardless of how Playwright
+    # classifies the navigation. Falls back to a real goto() when the
+    # page isn't on this console origin yet (nothing to same-document-
+    # navigate from -- not exercised by the current suite, but a route
+    # helper shouldn't assume every future caller pre-navigates).
+    current_origin = page.url.split("#", 1)[0].rstrip("/")
+    console_origin = console_url.rstrip("/")
+    if current_origin == console_origin:
+        page.evaluate("(h) => { window.location.hash = h; }", fragment)
+    else:
+        page.goto(f"{console_url}{fragment}")
+
     body = page.get_by_test_id("nv-overlay-body")
     expect(body).to_be_visible(timeout=timeout)
     expect(page.get_by_test_id(f"nv-overlay:{name}")).to_be_visible(timeout=timeout)


### PR DESCRIPTION
## Summary
- `open_legacy_route` (tests/ui_e2e/_shell_helpers.py) fixes a rare, previously-unexplained routing-swallow flake: `#/toolsets/<id>?tab=config`-style deep links occasionally never mount, landing on the console's default "Nothing open" view instead — with zero network activity and zero console errors.
- Root cause: every `page` fixture pre-navigates to `console_url` before yielding, so `open_legacy_route`'s `page.goto()` to a URL differing only by hash is a same-document (fragment) navigation. Whether that reliably fires `hashchange` (which the app's URL-sync listener depends on) is not guaranteed across Playwright/browser navigation classification — a prior incident ("Phase-1 screenshot-rig lesson") already named this trap class; the fix applied then (20s→45s timeout) only thinned the flake, it didn't close it.
- Fix: assign `window.location.hash` directly in-page via `page.evaluate()` instead of relying on `page.goto()`'s fragment-navigation classification — the browser's own native hash-assignment primitive, unambiguous per spec. One change in the shared helper; all ~20 callers get it for free.

## Test plan
- [x] Local e2e smoke pass (auth-disabled bringup): `tests/ui_e2e/test_navigation_and_signals.py` (contains the primary repro, U0036), `tests/ui_e2e/test_python_builder.py` (contains the second repro), `tests/ui_e2e/test_knowledge_collection_journey.py` (heaviest other caller) — 9/9 passed.
- [x] `ruff check` clean.
- [ ] CI's larger sample size verifies the flake side over time — it reproduces too rarely (2 hits across CI history, both on branches with zero UI changes) for a local pass/fail to prove the fix on its own.

Fixes task 01a068de.