### PR TITLE
feat(agent): vision attachments — artifact hydration + SteerBody.attachments

### DIFF
--- a/primer/agent/base.py
+++ b/primer/agent/base.py
@@ -71,6 +71,7 @@ from primer.model.graph import build_execution_context
 
 
 if TYPE_CHECKING:
+    from primer.int.artifact_storage import ArtifactStorage
     from primer.int.llm import LLM
     from primer.model.agent import Agent
     from primer.model_profile import ResolvedModel
@@ -115,6 +116,7 @@ class _BaseAgentExecutor(ABC):
         tool_manager: ToolExecutionManager,
         compaction: CompactionStrategy | None = None,
         principal: str | None = None,
+        artifact_storage: "ArtifactStorage | None" = None,
     ) -> None:
         self._agent = agent
         self._llm = llm
@@ -122,6 +124,10 @@ class _BaseAgentExecutor(ABC):
         self._tool_manager = tool_manager
         self._compaction = compaction or CompactionStrategy()
         self._principal = principal
+        # Forwarded to run_agent_turn so artifact-backed parts (image/
+        # document attachments) resolve to inline bytes before the LLM
+        # sees them. None is a no-op -- see hydrate_prompt_parts.
+        self._artifact_storage = artifact_storage
         # Ambient run context exposed to the system prompt as ``ctx``. Base is
         # surface-agnostic -> memory default; subclasses override with the real
         # surface (AgentExecutor -> "chat", WorkspaceAgentExecutor -> "workspace").
@@ -330,6 +336,7 @@ class _BaseAgentExecutor(ABC):
                 principal=self._principal,
                 messages_out=full_turn_messages,
                 last_input_tokens_out=last_input_tokens_holder,
+                artifact_storage=self._artifact_storage,
             ):
                 await self._emit(event)
                 yield event

--- a/primer/agent/invoke.py
+++ b/primer/agent/invoke.py
@@ -270,6 +270,10 @@ async def run_subagent(
         from primer.session.delegation import current_delegation_sink
 
         _sink = current_delegation_sink()
+        # No artifact_storage: this subagent path is scope-cut from the
+        # vision-attachments hydration seam (01a052d9) -- it's a third,
+        # nested-invocation surface, text-in/text-out today, that nobody
+        # has asked to carry vision attachments yet.
         async for _ev in run_agent_turn(
             agent=agent, llm=llm, llm_model=llm_model, tool_manager=tool_manager,
             prompt=prompt_msgs, principal=principal, messages_out=produced,
@@ -395,6 +399,8 @@ async def resume_subagent(
             from primer.session.delegation import current_delegation_sink
 
             _sink = current_delegation_sink()
+            # No artifact_storage -- see the invoke_agent call site above;
+            # same scope-cut applies to this resume path.
             async for _ev in run_agent_turn(
                 agent=agent, llm=llm, llm_model=llm_model,
                 tool_manager=tool_manager, prompt=resume_prompt,

--- a/primer/agent/loop.py
+++ b/primer/agent/loop.py
@@ -49,6 +49,7 @@ from primer.model.except_ import AuthRequiredError, PrimerError
 
 
 if TYPE_CHECKING:
+    from primer.int.artifact_storage import ArtifactStorage
     from primer.int.llm import LLM
     from primer.model.agent import Agent
     from primer.model_profile import ResolvedModel
@@ -130,6 +131,7 @@ async def run_agent_turn(
     principal: str | None = None,
     messages_out: list[Message] | None = None,
     last_input_tokens_out: list[int | None] | None = None,
+    artifact_storage: "ArtifactStorage | None" = None,
 ) -> AsyncIterator[StreamEvent]:
     """Run one full agent turn with tool dispatch; stream events live.
 
@@ -161,6 +163,15 @@ async def run_agent_turn(
         sets ``[0]`` to the most recent ``Usage.input_tokens`` value
         observed during the turn (or leaves it as-is if the LLM
         never emitted Usage).
+    artifact_storage
+        When given, every part with an ``artifact_id`` (image/document
+        attachments, MCP tool-result media) is resolved to inline
+        ``data`` immediately before each ``llm.stream`` call -- an
+        adapter only ever reads ``data``/``url``/``file_id``, never
+        ``artifact_id``. Re-run every tool round so media a tool
+        produces mid-turn is hydrated too, not just the turn's
+        starting prompt. ``None`` (the default) is a no-op: callers
+        that never resolve a store keep today's behaviour exactly.
 
     Raises
     ------
@@ -173,6 +184,10 @@ async def run_agent_turn(
 
     tool_round = 0
     while True:
+        if artifact_storage is not None:
+            from primer.channel.media import hydrate_prompt_parts
+
+            prompt = await hydrate_prompt_parts(artifact_storage, prompt)
         buffered: list[StreamEvent] = []
         held_done: StreamEvent | None = None
         call_t0 = time.monotonic()

--- a/primer/agent/loop.py
+++ b/primer/agent/loop.py
@@ -31,6 +31,7 @@ from typing import TYPE_CHECKING, Any
 import primer.observability.metrics as _metrics
 
 from primer.agent.tool_manager import ToolExecutionManager
+from primer.media.hydrate import hydrate_prompt_parts
 from primer.model.chat import (
     Done,
     Error,
@@ -185,8 +186,6 @@ async def run_agent_turn(
     tool_round = 0
     while True:
         if artifact_storage is not None:
-            from primer.channel.media import hydrate_prompt_parts
-
             prompt = await hydrate_prompt_parts(artifact_storage, prompt)
         buffered: list[StreamEvent] = []
         held_done: StreamEvent | None = None

--- a/primer/agent/workspace_executor.py
+++ b/primer/agent/workspace_executor.py
@@ -36,6 +36,7 @@ from primer.model.yield_ import YieldToWorker
 
 
 if TYPE_CHECKING:
+    from primer.int.artifact_storage import ArtifactStorage
     from primer.int.llm import LLM
     from primer.model.agent import Agent
     from primer.model.principal import PrincipalRef
@@ -66,6 +67,7 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
         compaction: CompactionStrategy | None = None,
         principal: str | None = None,
         identity: "PrincipalRef | None" = None,
+        artifact_storage: "ArtifactStorage | None" = None,
     ) -> None:
         # Extend the agent's system prompt with the workspace fragment
         # so the LLM sees workspace-tool documentation in its system
@@ -93,6 +95,7 @@ class WorkspaceAgentExecutor(_BaseAgentExecutor):
             tool_manager=tool_manager,
             compaction=compaction,
             principal=principal,
+            artifact_storage=artifact_storage,
         )
         self._session = session
         self._execution_context = build_execution_context(

--- a/primer/api/deps.py
+++ b/primer/api/deps.py
@@ -125,6 +125,18 @@ def get_artifact_storage_registry(request: Request):
     return reg
 
 
+def get_optional_artifact_storage_registry(request: Request):
+    """Same as :func:`get_artifact_storage_registry`, but ``None`` instead
+    of a 503 when unconfigured.
+
+    For routes where artifact storage is only used conditionally (e.g. a
+    steer body's optional ``attachments`` field): a request that carries
+    no attachments must not 503 just because the deployment never
+    configured artifact storage at all.
+    """
+    return getattr(request.app.state, "artifact_storage_registry", None)
+
+
 def get_artifact_storage_provider_storage(
     storage_provider=Depends(get_storage_provider),
 ) -> "Storage":

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -40,6 +40,7 @@ from primer.api.deps import (
     get_claim_engine,
     get_collection_storage,
     get_event_bus,
+    get_optional_artifact_storage_registry,
     get_provider_registry,
     get_scheduler,
     get_session_storage,
@@ -199,6 +200,57 @@ _DIAGNOSTIC_COMMAND_WHITELIST: frozenset[str] = frozenset(
 )
 
 
+def _reject_path_escape(value: str) -> str:
+    """Reject an absolute path or any ``..`` segment.
+
+    Same check as :meth:`WorkspaceTemplate._validate_workspace_relative_path`
+    (``primer/model/workspace.py``) -- kept as a standalone function here
+    rather than importing that bound classmethod, since it validates an
+    unrelated model. This is the WIRE-LAYER half of the traversal defence:
+    it turns an escape attempt into a clean 422 before the request reaches
+    ``media_from_workspace_files``, which independently re-derives the same
+    guarantee at the filesystem layer via ``Workspace._resolve_path``
+    (``candidate.relative_to(root)``) -- belt and suspenders, not a
+    substitute for each other.
+    """
+    from pathlib import PurePosixPath, PureWindowsPath
+
+    if PurePosixPath(value).is_absolute() or PureWindowsPath(value).is_absolute():
+        raise ValueError(
+            f"attachment path {value!r} must be relative to the workspace "
+            f"root, not absolute"
+        )
+    parts = value.replace("\\", "/").split("/")
+    if any(p == ".." for p in parts):
+        raise ValueError(
+            f"attachment path {value!r} must not contain '..' segments "
+            f"(would escape the workspace root)"
+        )
+    return value
+
+
+class AttachmentIn(BaseModel):
+    """One workspace file to fold into a steer as vision/document input.
+
+    The file must already exist in the workspace -- upload it first via
+    the existing ``PUT /v1/workspaces/{id}/files`` (unchanged). Resolved
+    server-side through :func:`primer.channel.media.media_from_workspace_files`,
+    the same artifact-backed-Part pipeline ``ask_user``/``inform_user``
+    already use for outbound files.
+    """
+
+    path: str = Field(
+        ...,
+        min_length=1,
+        description="Workspace-relative path to an already-uploaded file.",
+    )
+
+    @model_validator(mode="after")
+    def _safe_path(self) -> "AttachmentIn":
+        _reject_path_escape(self.path)
+        return self
+
+
 class SteerBody(BaseModel):
     """Body of ``POST /v1/workspaces/{id}/sessions/{sid}/steer``.
 
@@ -208,7 +260,10 @@ class SteerBody(BaseModel):
     pending calls, then the instruction steers the resumed turn.
     ``external_tools`` registers invoker-supplied tool defs for the
     turn this message triggers (gated by the agent's
-    ``allow_external_tools``).
+    ``allow_external_tools``). ``attachments`` folds already-uploaded
+    workspace files into the turn as true vision/document input,
+    alongside the existing plain-text ``"Attached file: {path}"``
+    convention the composer also supports.
     """
 
     response_format: dict[str, Any] | None = Field(
@@ -244,6 +299,17 @@ class SteerBody(BaseModel):
             "any state changes."
         ),
     )
+    attachments: list[AttachmentIn] | None = Field(
+        default=None,
+        description=(
+            "Workspace files to fold into this turn's user message as "
+            "true vision/document input. Requires 'instruction' -- an "
+            "attachment needs a user turn to ride in on. A missing/"
+            "oversized/disallowed-type file is dropped with a log rather "
+            "than failing the whole steer (matches the ask_user/"
+            "inform_user files= convention)."
+        ),
+    )
 
     @model_validator(mode="after")
     def _at_least_one(self) -> "SteerBody":
@@ -253,6 +319,11 @@ class SteerBody(BaseModel):
             )
         if self.tool_results is not None and len(self.tool_results) == 0:
             raise ValueError("'tool_results' must be non-empty when present")
+        if self.attachments and not self.instruction:
+            raise ValueError(
+                "'attachments' requires 'instruction' -- an attachment "
+                "needs a user turn to ride in on"
+            )
         if self.external_tools:
             validate_external_tool_defs(self.external_tools)
         return self
@@ -1564,6 +1635,7 @@ async def steer_session(
     engine=Depends(get_claim_engine),
     storage_provider=Depends(get_storage_provider),
     event_bus=Depends(get_event_bus),
+    artifact_registry=Depends(get_optional_artifact_storage_registry),
 ) -> WorkspaceSession:
     """Send a user message to a session and auto-wake it.
 
@@ -1615,6 +1687,7 @@ async def steer_session(
         payload={
             "has_instruction": bool(body.instruction),
             "has_tool_results": bool(body.tool_results),
+            "has_attachments": bool(body.attachments),
         },
     )
 
@@ -1666,11 +1739,17 @@ async def steer_session(
         # Bodies carrying tool defs are exempt alongside results: a
         # pending row has nowhere to hold external_tools, so deferring
         # one would silently drop the registration for the turn it was
-        # meant to arm.
+        # meant to arm. Bodies carrying attachments are exempt for the
+        # same reason: PendingSessionMessage.parts is a plain text-only
+        # projection today (realize_next_pending only ever extracts
+        # type=="text"), so a deferred attachment would silently vanish
+        # rather than reach the model. append_instruction's own message
+        # FIFO (used below via wake_session) already carries parts.
         if (
             row is not None
             and not body.tool_results
             and not body.external_tools
+            and not body.attachments
             and route_steer(row) == ROUTE_PENDING
         ):
             await store_pending_steer(
@@ -1690,6 +1769,36 @@ async def steer_session(
             row = row.model_copy(update={"metadata": meta})
             await sessions.update(row)
 
+        # Resolve attachments to artifact-backed Parts through the SAME
+        # pipeline ask_user/inform_user already use for outbound files
+        # (primer.channel.media.media_from_workspace_files). Best-effort,
+        # matching that pipeline's own tolerance: a missing/oversized/
+        # disallowed file or an unconfigured artifact store drops the
+        # attachment with a log rather than failing the whole steer.
+        extra_parts = None
+        extra_payload = None
+        if body.attachments:
+            from primer.channel.media import media_from_workspace_files
+
+            if artifact_registry is None:
+                logger.warning(
+                    "steer_session: attachments given but no artifact "
+                    "storage registry is configured; dropping %d "
+                    "attachment(s) for session %r",
+                    len(body.attachments), session_id,
+                )
+            else:
+                workspace = await registry.get_workspace(workspace_id)
+                artifact_store = await artifact_registry.get_default()
+                extra_parts = await media_from_workspace_files(
+                    workspace, artifact_store,
+                    [a.path for a in body.attachments],
+                )
+                if extra_parts:
+                    extra_payload = {
+                        "attachments": [a.path for a in body.attachments],
+                    }
+
         deps = SessionWakeDeps(
             storage_provider=storage_provider,
             scheduler=scheduler,
@@ -1702,6 +1811,8 @@ async def steer_session(
             session_id=session_id,
             instruction=body.instruction,
             external_tools=body.external_tools,
+            extra_parts=extra_parts,
+            extra_payload=extra_payload,
             deps=deps,
         )
 

--- a/primer/channel/media.py
+++ b/primer/channel/media.py
@@ -7,8 +7,12 @@ No platform SDKs here. This module:
 * enforces size + type limits,
 * stores inbound bytes as an artifact and builds the referencing part,
 * collects media parts from a turn's output (outbound), and
-* hydrates an artifact-referencing part back to inline ``data`` (for the LLM
-  at turn time and for a channel upload at relay time).
+* parses ``PromptEnvelope.media`` dicts and hydrates them for channel upload.
+
+``hydrate_part``/``hydrate_prompt_parts`` (resolving an artifact-referencing
+part back to inline ``data``) live in :mod:`primer.media.hydrate` and are
+re-exported here for backward compatibility -- the agent turn loop needs
+them too and may not import ``primer.channel``.
 
 Bytes live in the :class:`primer.int.artifact_storage.ArtifactStorage` backend;
 persisted parts carry only an ``artifact_id`` reference.
@@ -21,6 +25,7 @@ import logging
 from dataclasses import dataclass, field
 
 from primer.int.artifact_storage import ArtifactStorage
+from primer.media.hydrate import hydrate_part, hydrate_prompt_parts
 from primer.model.chat import (
     AudioPart, DocumentPart, ImagePart, Message, Part, VideoPart,
 )
@@ -269,52 +274,6 @@ async def hydrate_media_dicts(artifact_registry, media: list[dict] | None) -> li
             out.append(await hydrate_part(store, part))
         except Exception:
             logger.warning("hydrate_media_dicts: hydrate failed; skipping")
-    return out
-
-
-async def hydrate_part(artifact_storage: ArtifactStorage, part: Part) -> Part:
-    """Return a copy of ``part`` with inline ``data`` populated from its
-    ``artifact_id`` (when set and ``data`` is empty). Clears ``artifact_id`` on
-    the copy so downstream consumers see only ``data``. Parts without an
-    ``artifact_id`` (or that already carry ``data``) pass through unchanged."""
-    aid = getattr(part, "artifact_id", None)
-    if not aid or getattr(part, "data", None):
-        return part
-    blob = await artifact_storage.get(aid)
-    if blob is None:
-        logger.warning("hydrate_part: artifact %s not found", aid)
-        return part
-    update: dict = {"data": blob.data, "artifact_id": None}
-    if getattr(part, "mime_type", None) is None:
-        update["mime_type"] = blob.mime_type
-    return part.model_copy(update=update)
-
-
-async def hydrate_prompt_parts(
-    artifact_storage: ArtifactStorage | None, messages: list[Message],
-) -> list[Message]:
-    """Resolve every part's ``artifact_id`` to inline ``data`` across a
-    whole prompt, so an LLM adapter (which only reads ``data``/``url``/
-    ``file_id``, never ``artifact_id``) sees real bytes for any
-    artifact-backed part in history or the turn's new messages.
-
-    ``artifact_storage=None`` returns ``messages`` unchanged (no-op) --
-    callers that never resolve a store (tests, surfaces with no
-    ArtifactStorage wired) keep today's behaviour exactly. Messages with
-    no binary parts are returned as the SAME object (no copy), so this is
-    cheap to call unconditionally on every turn.
-    """
-    if artifact_storage is None:
-        return messages
-    out: list[Message] = []
-    for msg in messages:
-        if not any(getattr(p, "artifact_id", None) for p in msg.parts):
-            out.append(msg)
-            continue
-        hydrated_parts = [
-            await hydrate_part(artifact_storage, p) for p in msg.parts
-        ]
-        out.append(msg.model_copy(update={"parts": hydrated_parts}))
     return out
 
 

--- a/primer/channel/media.py
+++ b/primer/channel/media.py
@@ -22,7 +22,7 @@ from dataclasses import dataclass, field
 
 from primer.int.artifact_storage import ArtifactStorage
 from primer.model.chat import (
-    AudioPart, DocumentPart, ImagePart, Part, VideoPart,
+    AudioPart, DocumentPart, ImagePart, Message, Part, VideoPart,
 )
 
 
@@ -290,6 +290,34 @@ async def hydrate_part(artifact_storage: ArtifactStorage, part: Part) -> Part:
     return part.model_copy(update=update)
 
 
+async def hydrate_prompt_parts(
+    artifact_storage: ArtifactStorage | None, messages: list[Message],
+) -> list[Message]:
+    """Resolve every part's ``artifact_id`` to inline ``data`` across a
+    whole prompt, so an LLM adapter (which only reads ``data``/``url``/
+    ``file_id``, never ``artifact_id``) sees real bytes for any
+    artifact-backed part in history or the turn's new messages.
+
+    ``artifact_storage=None`` returns ``messages`` unchanged (no-op) --
+    callers that never resolve a store (tests, surfaces with no
+    ArtifactStorage wired) keep today's behaviour exactly. Messages with
+    no binary parts are returned as the SAME object (no copy), so this is
+    cheap to call unconditionally on every turn.
+    """
+    if artifact_storage is None:
+        return messages
+    out: list[Message] = []
+    for msg in messages:
+        if not any(getattr(p, "artifact_id", None) for p in msg.parts):
+            out.append(msg)
+            continue
+        hydrated_parts = [
+            await hydrate_part(artifact_storage, p) for p in msg.parts
+        ]
+        out.append(msg.model_copy(update={"parts": hydrated_parts}))
+    return out
+
+
 __all__ = [
     "MediaConfig",
     "MediaError",
@@ -300,6 +328,7 @@ __all__ = [
     "enforce_limits",
     "hydrate_media_dicts",
     "hydrate_part",
+    "hydrate_prompt_parts",
     "is_allowed",
     "media_from_workspace_files",
     "part_cls_for_mime",

--- a/primer/graph/_agent_node.py
+++ b/primer/graph/_agent_node.py
@@ -188,6 +188,7 @@ class _AgentNodeMixin:
                 response_format=node.response_format,
                 principal=self._principal,
                 messages_out=produced_messages,
+                artifact_storage=self._artifact_storage,
             ):
                 # 01a0518f: current_graph_node_id() is the fan-out-
                 # instance-qualified id (_stream_node sets it before
@@ -280,6 +281,7 @@ class _AgentNodeMixin:
             response_format=node.response_format,
             principal=self._principal,
             messages_out=produced_messages,
+            artifact_storage=self._artifact_storage,
         ):
             pass
 

--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -95,6 +95,7 @@ from primer.observability.turn_log_writer import (
 
 
 if TYPE_CHECKING:
+    from primer.int.artifact_storage import ArtifactStorage
     from primer.int.llm import LLM
     from primer.model.agent import Agent
     from primer.model.chat import ToolResultPart
@@ -183,6 +184,7 @@ class _BaseGraphExecutor(
         router_registry: RouterRegistry | None = None,
         principal: str | None = None,
         max_parallel_nodes: int = DEFAULT_MAX_PARALLEL_NODES,
+        artifact_storage: "ArtifactStorage | None" = None,
     ) -> None:
         self._graph = graph
         self._agent_resolver = agent_resolver
@@ -194,6 +196,10 @@ class _BaseGraphExecutor(
         self._graph_resolver = graph_resolver
         self._router_registry = router_registry or RouterRegistry()
         self._principal = principal
+        # Forwarded to run_agent_turn by _AgentNodeMixin so artifact-backed
+        # parts resolve to inline bytes before the LLM sees them. None is a
+        # no-op -- see hydrate_prompt_parts.
+        self._artifact_storage = artifact_storage
         # Ambient run context exposed to node templates as ``ctx``. The base
         # executor is surface-agnostic, so default to an in-memory context;
         # WorkspaceGraphExecutor overrides this with real workspace ids.

--- a/primer/graph/workspace_executor.py
+++ b/primer/graph/workspace_executor.py
@@ -61,6 +61,7 @@ from primer.observability.turn_log_writer import (
 
 
 if TYPE_CHECKING:
+    from primer.int.artifact_storage import ArtifactStorage
     from primer.int.llm import LLM
     from primer.model.agent import Agent
     from primer.model_profile import ResolvedModel
@@ -114,6 +115,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
         toolset_resolver: Callable[[str], Awaitable[Any]] | None = None,
         approval_resolver: Any | None = None,
         max_parallel_nodes: int = DEFAULT_MAX_PARALLEL_NODES,
+        artifact_storage: "ArtifactStorage | None" = None,
     ) -> None:
         wrapped_agent_resolver = self._wrap_agent_resolver(
             agent_resolver, workspace_session
@@ -130,6 +132,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             router_registry=router_registry,
             principal=principal,
             max_parallel_nodes=max_parallel_nodes,
+            artifact_storage=artifact_storage,
         )
         self._state_repo = state_repo
         self._graph_session_id = graph_session_id
@@ -658,6 +661,7 @@ class WorkspaceGraphExecutor(_BaseGraphExecutor):
             approval_resolver=self._approval_resolver,
             # Inherit the parent's per-superstep fan-out cap (BE5).
             max_parallel_nodes=self._max_parallel_nodes,
+            artifact_storage=self._artifact_storage,
         )
 
     # ---- Public helpers --------------------------------------------------

--- a/primer/media/__init__.py
+++ b/primer/media/__init__.py
@@ -1,0 +1,11 @@
+"""Layer-pure media helpers shared by channel adapters and the agent turn loop.
+
+Nothing platform- or channel-specific lives here -- only behaviour over
+:class:`primer.model.chat.Part`/``Message`` and the
+:class:`primer.int.artifact_storage.ArtifactStorage` interface, so both
+``primer.channel`` (inbound uploads, outbound relay) and ``primer.agent``
+(prompt-time hydration) can depend on it directly instead of one reaching
+into the other.
+"""
+
+from __future__ import annotations

--- a/primer/media/hydrate.py
+++ b/primer/media/hydrate.py
@@ -1,0 +1,69 @@
+"""Resolve artifact-backed chat parts to inline bytes.
+
+Split out of ``primer.channel.media`` (which re-exports these two names for
+backward compatibility): the logic here touches only ``Message``/``Part``
+and the ``ArtifactStorage`` interface, so it belongs below ``primer.channel``
+in the dependency graph rather than behind it -- the agent turn loop needs
+it too, and agent/worker may not import primer.channel (see the
+"agent/worker reach channel only through sanctioned dispatch seams"
+import-linter contract).
+"""
+
+from __future__ import annotations
+
+import logging
+
+from primer.int.artifact_storage import ArtifactStorage
+from primer.model.chat import Message, Part
+
+
+logger = logging.getLogger(__name__)
+
+
+async def hydrate_part(artifact_storage: ArtifactStorage, part: Part) -> Part:
+    """Return a copy of ``part`` with inline ``data`` populated from its
+    ``artifact_id`` (when set and ``data`` is empty). Clears ``artifact_id`` on
+    the copy so downstream consumers see only ``data``. Parts without an
+    ``artifact_id`` (or that already carry ``data``) pass through unchanged."""
+    aid = getattr(part, "artifact_id", None)
+    if not aid or getattr(part, "data", None):
+        return part
+    blob = await artifact_storage.get(aid)
+    if blob is None:
+        logger.warning("hydrate_part: artifact %s not found", aid)
+        return part
+    update: dict = {"data": blob.data, "artifact_id": None}
+    if getattr(part, "mime_type", None) is None:
+        update["mime_type"] = blob.mime_type
+    return part.model_copy(update=update)
+
+
+async def hydrate_prompt_parts(
+    artifact_storage: ArtifactStorage | None, messages: list[Message],
+) -> list[Message]:
+    """Resolve every part's ``artifact_id`` to inline ``data`` across a
+    whole prompt, so an LLM adapter (which only reads ``data``/``url``/
+    ``file_id``, never ``artifact_id``) sees real bytes for any
+    artifact-backed part in history or the turn's new messages.
+
+    ``artifact_storage=None`` returns ``messages`` unchanged (no-op) --
+    callers that never resolve a store (tests, surfaces with no
+    ArtifactStorage wired) keep today's behaviour exactly. Messages with
+    no binary parts are returned as the SAME object (no copy), so this is
+    cheap to call unconditionally on every turn.
+    """
+    if artifact_storage is None:
+        return messages
+    out: list[Message] = []
+    for msg in messages:
+        if not any(getattr(p, "artifact_id", None) for p in msg.parts):
+            out.append(msg)
+            continue
+        hydrated_parts = [
+            await hydrate_part(artifact_storage, p) for p in msg.parts
+        ]
+        out.append(msg.model_copy(update={"parts": hydrated_parts}))
+    return out
+
+
+__all__ = ["hydrate_part", "hydrate_prompt_parts"]

--- a/primer/session/enqueue.py
+++ b/primer/session/enqueue.py
@@ -74,8 +74,20 @@ async def wake_session(
     instruction: str | None,
     deps: SessionWakeDeps,
     external_tools: "list | None" = None,
+    extra_parts: "list | None" = None,
+    extra_payload: "dict | None" = None,
 ) -> WorkspaceSession:
     """Append ``instruction`` (if any) and re-arm the session's claim.
+
+    ``extra_parts`` (vision/document attachments, already resolved to
+    artifact-backed :class:`~primer.model.chat.Part` objects) rides the
+    same :class:`~primer.model.chat.Message` the instruction's
+    :class:`~primer.model.chat.TextPart` does -- forwarded to
+    :meth:`AgentSession.append_instruction`. ``extra_payload`` merges into
+    the USER_INPUT display record's ``payload`` dict (e.g. attachment
+    paths) so the transcript surface can show what was attached without
+    reconstructing it from the full Message. Both ``None`` (every
+    existing caller) is unchanged behaviour.
 
     Raises NotFoundError (missing / workspace mismatch). An ENDED session is
     reopened in place (reopen slot + invocation divider + ENDED->CREATED)
@@ -150,14 +162,16 @@ async def wake_session(
             try:
                 slot = await ws.get_session(session_id)
                 if slot is not None:
-                    await slot.append_instruction(instruction)
+                    await slot.append_instruction(
+                        instruction, extra_parts=extra_parts,
+                    )
                 writer = WorkspaceMessageWriter(
                     workspace_io=ws, session_id=session_id, start_seq=row.last_seq,
                 )
                 user_input_seq = await writer.append(SessionMessageRecord(
                     seq=1,  # overwritten by the writer's monotonic counter
                     kind=SessionMessageKind.USER_INPUT,
-                    payload={"text": instruction},
+                    payload={"text": instruction, **(extra_payload or {})},
                     created_at=datetime.now(timezone.utc),
                 ))
                 await writer.flush()

--- a/primer/worker/executor_builders.py
+++ b/primer/worker/executor_builders.py
@@ -16,11 +16,15 @@ dependency tree at startup.
 
 from __future__ import annotations
 
+import logging
 from typing import TYPE_CHECKING
 
 from primer.model.principal import PrincipalRef
 from primer.model.workspace_session import WorkspaceSession, SessionStatus
 from primer.worker.pool import _toolset_ids_from_scoped
+
+
+logger = logging.getLogger(__name__)
 
 
 def _pool_event_recorder(pool):
@@ -88,6 +92,27 @@ async def client_toolset_for(pool: "WorkerPool", session_row) -> dict:
     from primer.toolset.client import CLIENT_TOOLSET_ID, ClientToolsetProvider
 
     return {CLIENT_TOOLSET_ID: ClientToolsetProvider()}
+
+
+async def _resolve_default_artifact_storage(pool: "WorkerPool"):
+    """The deployment's default ArtifactStorage, or ``None``.
+
+    ``pool._artifact_storage_registry`` is optional (unset in some
+    pool test configurations, same tolerance as ``pool._storage`` /
+    ``pool._channel_dispatcher`` elsewhere in this module) -- None
+    here means the turn's prompt is built without hydration, an
+    explicit no-op (see ``hydrate_prompt_parts``), not a hard failure.
+    """
+    if pool._artifact_storage_registry is None:
+        return None
+    try:
+        return await pool._artifact_storage_registry.get_default()
+    except Exception:  # noqa: BLE001 -- degrade to no hydration
+        logger.warning(
+            "executor_builders: default artifact storage resolve failed",
+            exc_info=True,
+        )
+        return None
 
 
 async def build_executor(pool: "WorkerPool", session: WorkspaceSession, workspace):
@@ -348,6 +373,7 @@ async def build_agent_executor(pool: "WorkerPool", session: WorkspaceSession, wo
         tool_manager=tool_manager,
         session=agent_session,
         identity=initiated_by,
+        artifact_storage=await _resolve_default_artifact_storage(pool),
     )
     return _TurnDriver(executor)
 
@@ -542,6 +568,7 @@ async def build_graph_executor(pool: "WorkerPool", session: WorkspaceSession, wo
         toolset_resolver=toolset_resolver,
         approval_resolver=pool._approval_resolver,
         max_parallel_nodes=pool.config.max_parallel_nodes,
+        artifact_storage=await _resolve_default_artifact_storage(pool),
     )
     return _GraphTurnDriver(executor)
 

--- a/primer/workspace/session.py
+++ b/primer/workspace/session.py
@@ -33,7 +33,7 @@ from typing import TYPE_CHECKING, Literal
 
 from pydantic import TypeAdapter
 
-from primer.model.chat import Message, TextPart
+from primer.model.chat import Message, Part, TextPart
 from primer.model.except_ import ConflictError
 from primer.model.workspace_session import (
     AgentBinding,
@@ -483,13 +483,20 @@ class AgentSession:
                 if self._info.status != SessionStatus.ENDED:
                     self._info = disk
 
-    async def append_instruction(self, content: str) -> Instruction:
+    async def append_instruction(
+        self, content: str, *, extra_parts: list[Part] | None = None,
+    ) -> Instruction:
         """Queue a user instruction for delivery to the next turn.
 
         Allowed in any non-ENDED status. In WAITING, the runtime
         typically observes the new message and transitions back to
         RUNNING (clearing ``waiting.json``); the transition itself is
         the runtime's responsibility, not this method's.
+
+        ``extra_parts`` (vision/document attachments) are appended after
+        the instruction's own :class:`TextPart` in the stored
+        :class:`Message`. ``None`` (every existing caller) is unchanged
+        behaviour: a single-TextPart message exactly as before.
 
         Returns the :class:`Instruction` record (id + timestamps) for
         caller bookkeeping.
@@ -509,7 +516,10 @@ class AgentSession:
                 content=content,
                 queued_at=now,
             )
-            message = Message(role="user", parts=[TextPart(text=content)])
+            parts: list[Part] = [TextPart(text=content)]
+            if extra_parts:
+                parts.extend(extra_parts)
+            message = Message(role="user", parts=parts)
 
             # Updated session metadata: last_activity_at moves forward.
             updated_info = self._info.model_copy(

--- a/tests/agent/test_run_agent_turn_hydration.py
+++ b/tests/agent/test_run_agent_turn_hydration.py
@@ -1,0 +1,152 @@
+"""run_agent_turn(artifact_storage=...) hydrates artifact-backed parts
+(image/document attachments) to inline data before each llm.stream() call.
+
+This is the one shared choke point every executor funnels through
+(the base agent executor, the graph agent node, and the subagent runner
+all call run_agent_turn) -- see _observe_llm_call's docstring in
+primer.agent.loop. artifact_storage=None (the default) must be a total
+no-op so every existing caller that doesn't pass one keeps today's
+behaviour byte-for-byte.
+"""
+
+from __future__ import annotations
+
+from collections.abc import AsyncIterator
+from typing import Any
+
+import pytest
+
+from primer.int.artifact_storage import ArtifactBlob
+from primer.model.model_profile import ModelProfileConfig
+from primer.model_profile import ResolvedModel
+
+from primer.agent.loop import run_agent_turn
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import (
+    Done,
+    ImagePart,
+    Message,
+    StreamEvent,
+    TextPart,
+)
+
+
+class _MemArtifacts:
+    def __init__(self) -> None:
+        self.blobs: dict[str, ArtifactBlob] = {}
+
+    async def put(self, *, data, mime_type, filename=None):
+        aid = f"art-{len(self.blobs) + 1}"
+        self.blobs[aid] = ArtifactBlob(data=data, mime_type=mime_type, filename=filename)
+        return aid
+
+    async def get(self, artifact_id):
+        return self.blobs.get(artifact_id)
+
+
+class _CapturingLLM:
+    """Records every messages= list it was called with, then stops."""
+
+    def __init__(self) -> None:
+        self.calls: list[list[Message]] = []
+
+    async def list_models(self):
+        return ["m"]
+
+    def stream(self, *, model, messages, **kwargs) -> AsyncIterator[StreamEvent]:
+        del model, kwargs
+        self.calls.append(list(messages))
+        return self._gen()
+
+    async def _gen(self) -> AsyncIterator[StreamEvent]:
+        yield Done(stop_reason="stop", raw_reason="stop")
+
+
+class _NoToolManager:
+    def is_notifying(self, tool_name: str) -> bool:
+        del tool_name
+        return False
+
+    async def list_tools(self, *, principal=None):
+        return []
+
+
+def _agent() -> Agent:
+    return Agent(id="ag", description="x", model=AgentModel(profile_id="p--m"))
+
+
+def _model() -> ResolvedModel:
+    return ResolvedModel(
+        profile_id="test-profile", provider_id="test-provider",
+        model_name="m", context_length=4096, config=ModelProfileConfig(),
+    )
+
+
+async def _drain(agen) -> None:
+    async for _ in agen:
+        pass
+
+
+@pytest.mark.asyncio
+async def test_artifact_backed_part_is_hydrated_before_stream() -> None:
+    arts = _MemArtifacts()
+    aid = await arts.put(data=b"PNGBYTES", mime_type="image/png")
+    llm = _CapturingLLM()
+    prompt = [
+        Message(role="user", parts=[
+            TextPart(text="look at this"),
+            ImagePart(artifact_id=aid, mime_type="image/png"),
+        ]),
+    ]
+
+    await _drain(run_agent_turn(
+        agent=_agent(), llm=llm, llm_model=_model(),
+        tool_manager=_NoToolManager(), prompt=prompt,
+        artifact_storage=arts,
+    ))
+
+    assert len(llm.calls) == 1
+    sent_image = llm.calls[0][0].parts[1]
+    assert isinstance(sent_image, ImagePart)
+    assert sent_image.data == b"PNGBYTES"
+    assert sent_image.artifact_id is None
+    # The caller's own prompt list is untouched -- hydrate_prompt_parts
+    # returns a new list/messages, never mutates in place.
+    assert prompt[0].parts[1].data is None
+    assert prompt[0].parts[1].artifact_id == aid
+
+
+@pytest.mark.asyncio
+async def test_no_artifact_storage_is_a_total_noop() -> None:
+    """Every existing caller omits artifact_storage. It must behave exactly
+    as before: the artifact-backed part rides through unresolved."""
+    llm = _CapturingLLM()
+    prompt = [
+        Message(role="user", parts=[
+            ImagePart(artifact_id="art-1", mime_type="image/png"),
+        ]),
+    ]
+
+    await _drain(run_agent_turn(
+        agent=_agent(), llm=llm, llm_model=_model(),
+        tool_manager=_NoToolManager(), prompt=prompt,
+    ))
+
+    sent_image = llm.calls[0][0].parts[0]
+    assert sent_image.artifact_id == "art-1"
+    assert sent_image.data is None
+
+
+@pytest.mark.asyncio
+async def test_text_only_prompt_unaffected_by_artifact_storage() -> None:
+    arts = _MemArtifacts()
+    llm = _CapturingLLM()
+    prompt = [Message(role="user", parts=[TextPart(text="hello")])]
+
+    await _drain(run_agent_turn(
+        agent=_agent(), llm=llm, llm_model=_model(),
+        tool_manager=_NoToolManager(), prompt=prompt,
+        artifact_storage=arts,
+    ))
+
+    assert llm.calls[0][0].parts[0].text == "hello"

--- a/tests/agent/test_workspace_executor.py
+++ b/tests/agent/test_workspace_executor.py
@@ -19,6 +19,7 @@ from primer.agent.workspace_executor import WorkspaceAgentExecutor
 from primer.model.agent import Agent, AgentModel
 from primer.model.chat import (
     Done,
+    ImagePart,
     Message,
     StreamEvent,
     TextDelta,
@@ -222,6 +223,111 @@ class TestPersistence:
             # Initial instruction "hello" + new user msg + assistant msg.
             assert len(lines) >= 3
             assert "hello!" in lines[-1]  # assistant text in last line
+        finally:
+            await session.aclose()
+            await backend.aclose()
+
+
+# ===========================================================================
+# Attachment hydration (session path -- see tests/agent/test_run_agent_turn_hydration.py
+# for the shared-seam unit tests; this proves the session's own DI wiring
+# reaches run_agent_turn end to end)
+# ===========================================================================
+
+
+class _MemArtifacts:
+    def __init__(self) -> None:
+        self.blobs: dict[str, "Any"] = {}
+
+    async def put(self, *, data, mime_type, filename=None):
+        from primer.int.artifact_storage import ArtifactBlob
+        aid = f"art-{len(self.blobs) + 1}"
+        self.blobs[aid] = ArtifactBlob(data=data, mime_type=mime_type, filename=filename)
+        return aid
+
+    async def get(self, artifact_id):
+        return self.blobs.get(artifact_id)
+
+
+class TestAttachmentHydration:
+    @pytest.mark.asyncio
+    async def test_artifact_backed_part_hydrated_before_llm_sees_it(
+        self, tmp_path: Path
+    ) -> None:
+        backend, _, session = await _build_session(tmp_path)
+        try:
+            arts = _MemArtifacts()
+            aid = await arts.put(data=b"PNGBYTES", mime_type="image/png")
+            llm = _FakeLLM(
+                scripts=[
+                    [
+                        TextDelta(text="I see it", index=0),
+                        Done(stop_reason="stop", raw_reason="stop"),
+                    ]
+                ]
+            )
+            mgr = ToolExecutionManager.for_workspace(
+                toolset_providers={}, session=session
+            )
+            executor = WorkspaceAgentExecutor(
+                agent=_agent(),
+                llm=llm,  # type: ignore[arg-type]
+                llm_model=_model(),
+                tool_manager=mgr,
+                session=session,
+                artifact_storage=arts,  # type: ignore[arg-type]
+            )
+            await _drain(executor.invoke([
+                Message(role="user", parts=[
+                    TextPart(text="what is this"),
+                    ImagePart(artifact_id=aid, mime_type="image/png"),
+                ]),
+            ]))
+            sent_messages = llm.calls[0]["messages"]
+            new_user_msg = sent_messages[-1]
+            sent_image = new_user_msg.parts[1]
+            assert isinstance(sent_image, ImagePart)
+            assert sent_image.data == b"PNGBYTES"
+            assert sent_image.artifact_id is None
+        finally:
+            await session.aclose()
+            await backend.aclose()
+
+    @pytest.mark.asyncio
+    async def test_no_artifact_storage_leaves_part_unhydrated(
+        self, tmp_path: Path
+    ) -> None:
+        """Every executor constructed without artifact_storage (today's
+        default for every non-vision-attachment call site) keeps behaving
+        exactly as before: an artifact-backed part rides through as-is."""
+        backend, _, session = await _build_session(tmp_path)
+        try:
+            llm = _FakeLLM(
+                scripts=[
+                    [
+                        TextDelta(text="ok", index=0),
+                        Done(stop_reason="stop", raw_reason="stop"),
+                    ]
+                ]
+            )
+            mgr = ToolExecutionManager.for_workspace(
+                toolset_providers={}, session=session
+            )
+            executor = WorkspaceAgentExecutor(
+                agent=_agent(),
+                llm=llm,  # type: ignore[arg-type]
+                llm_model=_model(),
+                tool_manager=mgr,
+                session=session,
+            )
+            await _drain(executor.invoke([
+                Message(role="user", parts=[
+                    ImagePart(artifact_id="art-orphan", mime_type="image/png"),
+                ]),
+            ]))
+            sent_image = llm.calls[0]["messages"][-1].parts[0]
+            assert sent_image.artifact_id == "art-orphan"
+            assert sent_image.data is None
         finally:
             await session.aclose()
             await backend.aclose()

--- a/tests/api/test_session_messages_route.py
+++ b/tests/api/test_session_messages_route.py
@@ -41,7 +41,9 @@ class _FakeWorkspace:
 
 
 class _FakeSlot:
-    async def append_instruction(self, content: str) -> None:
+    async def append_instruction(
+        self, content: str, *, extra_parts=None,
+    ) -> None:
         pass
 
 

--- a/tests/api/test_session_restart.py
+++ b/tests/api/test_session_restart.py
@@ -29,7 +29,9 @@ class _FakeSlot:
     async def reopen(self) -> None:
         self.reopened = True
 
-    async def append_instruction(self, instruction: str) -> None:
+    async def append_instruction(
+        self, instruction: str, *, extra_parts=None,
+    ) -> None:
         self.instructions.append(instruction)
 
 

--- a/tests/api/test_steer_attachments.py
+++ b/tests/api/test_steer_attachments.py
@@ -1,0 +1,271 @@
+"""SteerBody.attachments -- workspace-file vision/document attachments.
+
+Resolution path: steer_session -> media_from_workspace_files (same
+artifact-backed-Part pipeline ask_user/inform_user already use for
+outbound files) -> wake_session(extra_parts=...) ->
+AgentSession.append_instruction(extra_parts=...). This module proves the
+wire-layer validation (traversal/absolute-path rejection, attachments-
+without-instruction rejection) and the resolve-and-fold behaviour through
+the real HTTP endpoint, using the same _FakeBackend harness
+test_external_tools_steer.py established.
+"""
+
+from __future__ import annotations
+
+import base64
+from datetime import UTC, datetime
+
+import httpx
+import pytest
+from httpx import ASGITransport
+
+from primer.api.app import create_test_app
+from primer.api.registries import ProviderRegistry, WorkspaceRegistry
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import DocumentPart, ImagePart
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+from tests.api.test_workspaces import _FakeBackend, _SP, _provider, _template
+
+
+@pytest.fixture
+def sp() -> _SP:
+    return _SP()
+
+
+@pytest.fixture
+def pr(sp) -> ProviderRegistry:
+    return ProviderRegistry(
+        sp,  # type: ignore[arg-type]
+        llm_factory=lambda p: object(),
+        embedder_factory=lambda p: object(),
+        cross_encoder_factory=lambda p: object(),
+        toolset_factory=lambda t: object(),
+    )
+
+
+@pytest.fixture
+def wsr(sp) -> WorkspaceRegistry:
+    return WorkspaceRegistry(sp, factory=_FakeBackend)
+
+
+@pytest.fixture
+async def app(sp, pr, wsr):
+    _app = create_test_app(
+        storage_provider=sp,  # type: ignore[arg-type]
+        provider_registry=pr,
+        workspace_registry=wsr,
+    )
+    # Seed the reserved default artifact provider (parity with the
+    # lifespan / tests/api/conftest.py's shared app fixture) -- without
+    # this, ArtifactStorageRegistry.get_default() has no row to resolve
+    # and media_from_workspace_files can never be reached.
+    if getattr(_app.state, "seed_artifact_default", None) is not None:
+        await _app.state.seed_artifact_default()
+    return _app
+
+
+@pytest.fixture
+async def client(app):
+    async with httpx.AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        try:
+            await c.post(
+                "/v1/auth/register",
+                json={"username": "testuser", "password": "testpassword"},
+            )
+        except Exception:
+            pass
+        yield c
+
+
+async def _setup_ws(client, wsr) -> str:
+    await client.post(
+        "/v1/workspace_providers", json=_provider().model_dump(mode="json")
+    )
+    await client.post(
+        "/v1/workspace_templates", json=_template().model_dump(mode="json")
+    )
+    post = await client.post("/v1/workspaces", json={"template_id": "tpl-1"})
+    wid = post.json()["id"]
+    backend = await wsr.get_backend("local-1")
+    ws = await backend.get(wid)
+    ws.add_session("sess-1", "agent-att")
+    return wid
+
+
+async def _seed_agent(sp) -> None:
+    await sp.get_storage(Agent).create(
+        Agent(id="agent-att", description="d", model=AgentModel(profile_id="prof-1"))
+    )
+
+
+async def _seed_session(sp, wid: str) -> WorkspaceSession:
+    now = datetime.now(UTC)
+    row = WorkspaceSession(
+        id="sess-1",
+        workspace_id=wid,
+        binding=AgentSessionBinding(agent_id="agent-att"),
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        started_at=now,
+    )
+    await sp.get_storage(WorkspaceSession).create(row)
+    return row
+
+
+async def _upload(client, wid: str, path: str, data: bytes) -> None:
+    r = await client.put(
+        f"/v1/workspaces/{wid}/files",
+        params={"path": path},
+        json={
+            "content": base64.b64encode(data).decode(),
+            "encoding": "base64",
+        },
+    )
+    assert r.status_code == 204, r.text
+
+
+@pytest.mark.asyncio
+async def test_attachment_resolves_and_folds_into_message(client, wsr, sp):
+    wid = await _setup_ws(client, wsr)
+    await _seed_agent(sp)
+    await _seed_session(sp, wid)
+    await _upload(client, wid, "uploads/pic.png", b"PNGBYTES")
+
+    r = await client.post(
+        f"/v1/workspaces/{wid}/sessions/sess-1/steer",
+        json={"instruction": "look at this", "attachments": [{"path": "uploads/pic.png"}]},
+    )
+    assert r.status_code == 200, r.text
+
+    backend = await wsr.get_backend("local-1")
+    ws = await backend.get(wid)
+    slot = await ws.get_session("sess-1")
+    assert slot.appended == ["look at this"]
+    parts = slot.appended_extra_parts
+    assert parts is not None and len(parts) == 1
+    assert isinstance(parts[0], ImagePart)
+    # media_from_workspace_files returns artifact-referenced parts (no
+    # inline data): see test_attachment_is_artifact_referenced_not_inline
+    # for the dedicated assertion on that shape.
+
+
+@pytest.mark.asyncio
+async def test_attachment_is_artifact_referenced_not_inline(client, wsr, sp):
+    """media_from_workspace_files stores bytes and returns an
+    artifact_id-only Part (no inline data) -- messages.jsonl / the
+    session's Message must never carry raw attachment bytes."""
+    wid = await _setup_ws(client, wsr)
+    await _seed_agent(sp)
+    await _seed_session(sp, wid)
+    await _upload(client, wid, "uploads/pic.png", b"PNGBYTES")
+
+    r = await client.post(
+        f"/v1/workspaces/{wid}/sessions/sess-1/steer",
+        json={"instruction": "look", "attachments": [{"path": "uploads/pic.png"}]},
+    )
+    assert r.status_code == 200, r.text
+
+    backend = await wsr.get_backend("local-1")
+    ws = await backend.get(wid)
+    slot = await ws.get_session("sess-1")
+    part = slot.appended_extra_parts[0]
+    assert part.artifact_id is not None
+    assert part.data is None
+
+
+@pytest.mark.asyncio
+async def test_document_mime_maps_to_document_part(client, wsr, sp):
+    wid = await _setup_ws(client, wsr)
+    await _seed_agent(sp)
+    await _seed_session(sp, wid)
+    await _upload(client, wid, "uploads/report.pdf", b"%PDF-1.4")
+
+    r = await client.post(
+        f"/v1/workspaces/{wid}/sessions/sess-1/steer",
+        json={"instruction": "read this", "attachments": [{"path": "uploads/report.pdf"}]},
+    )
+    assert r.status_code == 200, r.text
+
+    backend = await wsr.get_backend("local-1")
+    ws = await backend.get(wid)
+    slot = await ws.get_session("sess-1")
+    assert isinstance(slot.appended_extra_parts[0], DocumentPart)
+
+
+@pytest.mark.asyncio
+async def test_attachment_traversal_escape_is_422(client, wsr, sp):
+    wid = await _setup_ws(client, wsr)
+    await _seed_agent(sp)
+    await _seed_session(sp, wid)
+
+    r = await client.post(
+        f"/v1/workspaces/{wid}/sessions/sess-1/steer",
+        json={
+            "instruction": "go",
+            "attachments": [{"path": "../../../etc/passwd"}],
+        },
+    )
+    assert r.status_code == 422, r.text
+    assert ".." in r.text or "escape" in r.text.lower()
+
+    # Never resolved outside the workspace root: the fake session's
+    # append_instruction (which would only run past validation) was
+    # never reached.
+    backend = await wsr.get_backend("local-1")
+    ws = await backend.get(wid)
+    slot = await ws.get_session("sess-1")
+    assert slot.appended == []
+
+
+@pytest.mark.asyncio
+async def test_attachment_absolute_path_is_422(client, wsr, sp):
+    wid = await _setup_ws(client, wsr)
+    await _seed_agent(sp)
+    await _seed_session(sp, wid)
+
+    r = await client.post(
+        f"/v1/workspaces/{wid}/sessions/sess-1/steer",
+        json={"instruction": "go", "attachments": [{"path": "/etc/passwd"}]},
+    )
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_attachments_without_instruction_is_422(client, wsr, sp):
+    wid = await _setup_ws(client, wsr)
+    await _seed_agent(sp)
+    await _seed_session(sp, wid)
+
+    r = await client.post(
+        f"/v1/workspaces/{wid}/sessions/sess-1/steer",
+        json={"attachments": [{"path": "uploads/pic.png"}]},
+    )
+    assert r.status_code == 422, r.text
+
+
+@pytest.mark.asyncio
+async def test_missing_attachment_file_is_dropped_not_failed(client, wsr, sp):
+    """Best-effort, matching media_from_workspace_files' own tolerance:
+    a nonexistent workspace file drops the attachment with a log rather
+    than failing the whole steer."""
+    wid = await _setup_ws(client, wsr)
+    await _seed_agent(sp)
+    await _seed_session(sp, wid)
+
+    r = await client.post(
+        f"/v1/workspaces/{wid}/sessions/sess-1/steer",
+        json={"instruction": "go", "attachments": [{"path": "uploads/nope.png"}]},
+    )
+    assert r.status_code == 200, r.text
+
+    backend = await wsr.get_backend("local-1")
+    ws = await backend.get(wid)
+    slot = await ws.get_session("sess-1")
+    assert slot.appended == ["go"]
+    assert not slot.appended_extra_parts

--- a/tests/api/test_workspaces.py
+++ b/tests/api/test_workspaces.py
@@ -157,8 +157,9 @@ class _FakeAgentSession:
     async def request_resume(self) -> None:
         self._status = SessionStatus.RUNNING
 
-    async def append_instruction(self, content: str):
+    async def append_instruction(self, content: str, *, extra_parts=None):
         self.appended.append(content)
+        self.appended_extra_parts = extra_parts
         from primer.model.workspace_session import Instruction
 
         return Instruction(

--- a/tests/channel/test_media.py
+++ b/tests/channel/test_media.py
@@ -8,11 +8,11 @@ import pytest
 
 from primer.channel.media import (
     MediaConfig, MediaTooLarge, MediaTypeNotAllowed, collect_media_parts,
-    compress_image, enforce_limits, hydrate_part, part_cls_for_mime,
-    store_inbound_media,
+    compress_image, enforce_limits, hydrate_part, hydrate_prompt_parts,
+    part_cls_for_mime, store_inbound_media,
 )
 from primer.int.artifact_storage import ArtifactBlob
-from primer.model.chat import AudioPart, DocumentPart, ImagePart, TextPart
+from primer.model.chat import AudioPart, DocumentPart, ImagePart, Message, TextPart
 
 
 class _MemArtifacts:
@@ -99,3 +99,44 @@ def test_collect_media_parts():
     media = collect_media_parts(parts)
     assert len(media) == 1
     assert isinstance(media[0], ImagePart)
+
+
+@pytest.mark.asyncio
+async def test_hydrate_prompt_parts_fills_artifact_backed_parts():
+    arts = _MemArtifacts()
+    aid = await arts.put(data=b"PNGBYTES", mime_type="image/png")
+    messages = [
+        Message(role="system", parts=[TextPart(text="sys")]),
+        Message(role="user", parts=[
+            TextPart(text="look at this"),
+            ImagePart(artifact_id=aid, mime_type="image/png"),
+        ]),
+    ]
+    out = await hydrate_prompt_parts(arts, messages)
+    assert out[0] is messages[0]  # no binary parts -> same object, no copy
+    hydrated_image = out[1].parts[1]
+    assert hydrated_image.data == b"PNGBYTES"
+    assert hydrated_image.artifact_id is None
+    # Original messages/parts are untouched (hydrate_part copies).
+    assert messages[1].parts[1].data is None
+    assert messages[1].parts[1].artifact_id == aid
+
+
+@pytest.mark.asyncio
+async def test_hydrate_prompt_parts_noop_when_storage_is_none():
+    messages = [Message(role="user", parts=[
+        ImagePart(artifact_id="art-1", mime_type="image/png"),
+    ])]
+    out = await hydrate_prompt_parts(None, messages)
+    assert out is messages
+
+
+@pytest.mark.asyncio
+async def test_hydrate_prompt_parts_missing_artifact_leaves_part_unhydrated():
+    arts = _MemArtifacts()
+    messages = [Message(role="user", parts=[
+        ImagePart(artifact_id="does-not-exist", mime_type="image/png"),
+    ])]
+    out = await hydrate_prompt_parts(arts, messages)
+    assert out[0].parts[0].artifact_id == "does-not-exist"
+    assert out[0].parts[0].data is None

--- a/tests/events/test_session_lifecycle_events.py
+++ b/tests/events/test_session_lifecycle_events.py
@@ -109,4 +109,5 @@ async def test_create_and_steer_land_on_the_event_log(client, app) -> None:
     assert steered.session_id == sid
     assert steered.payload == {
         "has_instruction": True, "has_tool_results": False,
+        "has_attachments": False,
     }

--- a/tests/graph/test_agent_node_hydration.py
+++ b/tests/graph/test_agent_node_hydration.py
@@ -1,0 +1,159 @@
+"""A graph agent-node's run_agent_turn call gets artifact_storage from the
+executor, so an artifact-backed part in the node's history is hydrated to
+inline data before the LLM sees it -- same seam as the session path
+(tests/agent/test_workspace_executor.py::TestAttachmentHydration), one
+level deeper than _build_prompt: graph nodes build their own prompt list
+and call run_agent_turn directly (primer/graph/_agent_node.py), never going
+through AgentExecutor._build_prompt at all.
+
+Reuses the capturing _FakeLLM + _make_state_repo + _build_executor from
+tests.graph.test_workspace_executor, same pattern as
+test_agent_node_system_prompt_ctx.py. History is seeded via
+state_repo.commit_arbitrary directly (not _persist_node_turn, which only
+buffers -- _load_node_history reads the committed repo state, so a
+buffered-but-uncommitted write would be invisible to the node's own turn).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import Done, ImagePart, Message, StreamEvent, TextDelta, TextPart
+from primer.model.graph import (
+    Graph,
+    _AgentNodeRef,
+    _BeginNode,
+    _EndNode,
+    _StaticEdge,
+)
+from tests.graph.test_workspace_executor import (
+    _FakeLLM,
+    _build_executor,
+    _make_state_repo,
+)
+
+
+class _MemArtifacts:
+    def __init__(self) -> None:
+        self.blobs: dict = {}
+
+    async def put(self, *, data, mime_type, filename=None):
+        from primer.int.artifact_storage import ArtifactBlob
+        aid = f"art-{len(self.blobs) + 1}"
+        self.blobs[aid] = ArtifactBlob(data=data, mime_type=mime_type, filename=filename)
+        return aid
+
+    async def get(self, artifact_id):
+        return self.blobs.get(artifact_id)
+
+
+async def _drain(it) -> list[StreamEvent]:
+    return [ev async for ev in it]
+
+
+def _graph() -> Graph:
+    return Graph(
+        id="g-hydration",
+        description="Begin -> Agent -> End",
+        nodes=[
+            _BeginNode(id="begin"),
+            _AgentNodeRef(id="A", agent_id="x", input_template="go"),
+            _EndNode(id="end", output_template="{{ nodes.A.text }}"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="A"),
+            _StaticEdge(from_node="A", to_node="end"),
+        ],
+    )
+
+
+async def _seed_node_history(executor, node_id: str, messages: list[Message]) -> None:
+    """Write + commit a node's messages.jsonl directly, bypassing the
+    buffered _persist_node_turn/_save_state pair so the history is visible
+    to _load_node_history (which reads committed repo state) before the
+    executor's own invoke() runs."""
+    rel_path = executor._state_rel(f"nodes/{node_id}/messages.jsonl")
+    body = "\n".join(m.model_dump_json() for m in messages) + "\n"
+    await executor._state_repo.commit_arbitrary(
+        summary="test: seed node history", files={rel_path: body},
+    )
+
+
+@pytest.mark.asyncio
+async def test_graph_agent_node_hydrates_artifact_backed_history(
+    tmp_path: Path,
+) -> None:
+    arts = _MemArtifacts()
+    aid = await arts.put(data=b"PNGBYTES", mime_type="image/png")
+    repo = await _make_state_repo(tmp_path, workspace_id="ws-hydration")
+    llm = _FakeLLM(
+        scripts=[[
+            TextDelta(text="ok", index=0),
+            Done(stop_reason="stop", raw_reason="stop"),
+        ]]
+    )
+    executor = await _build_executor(
+        graph=_graph(),
+        llm=llm,
+        state_repo=repo,
+        graph_session_id="gsid-hydration",
+        agents={"x": Agent(id="x", description="x", model=AgentModel(profile_id="p--m"))},
+        artifact_storage=arts,
+    )
+    await _seed_node_history(executor, "A", [
+        Message(role="user", parts=[
+            TextPart(text="earlier"),
+            ImagePart(artifact_id=aid, mime_type="image/png"),
+        ]),
+    ])
+
+    await _drain(executor.invoke([]))
+
+    sent_parts = [
+        p for call in llm.calls for m in call["messages"] for p in m.parts
+        if isinstance(p, ImagePart)
+    ]
+    assert len(sent_parts) == 1
+    assert sent_parts[0].data == b"PNGBYTES"
+    assert sent_parts[0].artifact_id is None
+
+
+@pytest.mark.asyncio
+async def test_graph_agent_node_without_artifact_storage_is_unaffected(
+    tmp_path: Path,
+) -> None:
+    """Every existing graph executor (no artifact_storage passed) keeps
+    behaving exactly as before."""
+    repo = await _make_state_repo(tmp_path, workspace_id="ws-hydration-2")
+    llm = _FakeLLM(
+        scripts=[[
+            TextDelta(text="ok", index=0),
+            Done(stop_reason="stop", raw_reason="stop"),
+        ]]
+    )
+    executor = await _build_executor(
+        graph=_graph(),
+        llm=llm,
+        state_repo=repo,
+        graph_session_id="gsid-hydration-2",
+        agents={"x": Agent(id="x", description="x", model=AgentModel(profile_id="p--m"))},
+    )
+    await _seed_node_history(executor, "A", [
+        Message(role="user", parts=[
+            TextPart(text="earlier"),
+            ImagePart(artifact_id="art-orphan", mime_type="image/png"),
+        ]),
+    ])
+
+    await _drain(executor.invoke([]))
+
+    sent_parts = [
+        p for call in llm.calls for m in call["messages"] for p in m.parts
+        if isinstance(p, ImagePart)
+    ]
+    assert len(sent_parts) == 1
+    assert sent_parts[0].artifact_id == "art-orphan"
+    assert sent_parts[0].data is None

--- a/tests/graph/test_workspace_executor.py
+++ b/tests/graph/test_workspace_executor.py
@@ -149,6 +149,7 @@ async def _build_executor(
     agents: dict[str, Agent] | None = None,
     tool_manager_resolver=None,
     graph_resolver=None,
+    artifact_storage=None,
 ) -> WorkspaceGraphExecutor:
     if agents is None:
         agents = {}
@@ -167,6 +168,7 @@ async def _build_executor(
         graph_session_id=graph_session_id,
         tool_manager_resolver=tool_manager_resolver,
         graph_resolver=graph_resolver,
+        artifact_storage=artifact_storage,
     )
 
 

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -1155,7 +1155,9 @@ class _SeqFakeSlot:
         self.appended: list[str] = []
         self.reopened = 0
 
-    async def append_instruction(self, content: str) -> None:
+    async def append_instruction(
+        self, content: str, *, extra_parts=None,
+    ) -> None:
         self.appended.append(content)
 
     async def reopen(self) -> None:

--- a/tests/session/test_enqueue.py
+++ b/tests/session/test_enqueue.py
@@ -40,10 +40,12 @@ class _FakeSP:
 class _FakeSlot:
     def __init__(self):
         self.appended = []
+        self.appended_extra_parts = []
         self.reopened = False
 
-    async def append_instruction(self, content):
+    async def append_instruction(self, content, *, extra_parts=None):
         self.appended.append(content)
+        self.appended_extra_parts.append(extra_parts)
 
     async def reopen(self):
         self.reopened = True
@@ -157,6 +159,59 @@ async def test_running_session_is_steered_without_status_change():
     assert out.turn_status == "claimable"
     assert slot.appended == ["steer me"]
     assert sched.enqueued == ["sess-1"]
+
+
+@pytest.mark.asyncio
+async def test_extra_parts_forwarded_to_append_instruction():
+    from primer.model.chat import ImagePart
+
+    row = _row(SessionStatus.CREATED)
+    deps, slot, sched, eng = _deps(row)
+    image = ImagePart(artifact_id="art-1", mime_type="image/png")
+    await wake_session(
+        workspace_id="ws-1",
+        session_id="sess-1",
+        instruction="look",
+        extra_parts=[image],
+        deps=deps,
+    )
+    assert slot.appended == ["look"]
+    assert slot.appended_extra_parts == [[image]]
+
+
+@pytest.mark.asyncio
+async def test_extra_payload_merges_into_user_input_record():
+    row = _row(SessionStatus.CREATED)
+    deps, slot, sched, eng = _deps(row)
+    ws = deps.workspace_registry._ws
+    await wake_session(
+        workspace_id="ws-1",
+        session_id="sess-1",
+        instruction="look",
+        extra_parts=["unused-marker"],  # only extra_payload is asserted here
+        extra_payload={"attachments": ["uploads/pic.png"]},
+        deps=deps,
+    )
+    records = _decode_records(ws)
+    user_input = next(r for r in records if r["kind"] == "user_input")
+    assert user_input["payload"]["text"] == "look"
+    assert user_input["payload"]["attachments"] == ["uploads/pic.png"]
+
+
+@pytest.mark.asyncio
+async def test_no_extra_parts_or_payload_is_unchanged():
+    """Every pre-existing caller (external_tools tests, restart, pending
+    realize) omits both kwargs -- must behave exactly as before."""
+    row = _row(SessionStatus.CREATED)
+    deps, slot, sched, eng = _deps(row)
+    ws = deps.workspace_registry._ws
+    await wake_session(
+        workspace_id="ws-1", session_id="sess-1", instruction="hello", deps=deps,
+    )
+    assert slot.appended_extra_parts == [None]
+    records = _decode_records(ws)
+    user_input = next(r for r in records if r["kind"] == "user_input")
+    assert user_input["payload"] == {"text": "hello"}
 
 
 @pytest.mark.asyncio

--- a/tests/toolset/test_restart_workspace_session.py
+++ b/tests/toolset/test_restart_workspace_session.py
@@ -29,7 +29,9 @@ class _FakeSlot:
     async def reopen(self) -> None:
         self.reopened = True
 
-    async def append_instruction(self, instruction: str) -> None:
+    async def append_instruction(
+        self, instruction: str, *, extra_parts=None,
+    ) -> None:
         self.instructions.append(instruction)
 
 

--- a/tests/toolset/test_workspaces.py
+++ b/tests/toolset/test_workspaces.py
@@ -148,7 +148,7 @@ class _LiveSession:
 
         self._status = SessionStatus.RUNNING
 
-    async def append_instruction(self, content):
+    async def append_instruction(self, content, *, extra_parts=None):
         from datetime import datetime, timezone
         from primer.model.workspace_session import Instruction
 

--- a/tests/workspace/test_session.py
+++ b/tests/workspace/test_session.py
@@ -171,6 +171,29 @@ class TestAppendInstruction:
         content = msgs_path.read_text(encoding="utf-8")
         assert "do the thing" in content
 
+    async def test_extra_parts_ride_the_same_message(
+        self, state_repo: StateRepo, truncation_store: TruncationStore
+    ) -> None:
+        from primer.model.chat import ImagePart
+
+        session = await _start_session(state_repo, truncation_store)
+        image = ImagePart(artifact_id="art-1", mime_type="image/png")
+        await session.append_instruction("look at this", extra_parts=[image])
+        pending = await session.take_pending_messages()
+        msg = pending[-1]
+        assert msg.parts[0].text == "look at this"
+        # take_pending_messages() reads back through storage, so this is
+        # value equality, not the same Python object.
+        assert msg.parts[1] == image
+
+    async def test_no_extra_parts_is_unchanged_single_text_part(
+        self, state_repo: StateRepo, truncation_store: TruncationStore
+    ) -> None:
+        session = await _start_session(state_repo, truncation_store)
+        await session.append_instruction("plain")
+        pending = await session.take_pending_messages()
+        assert len(pending[-1].parts) == 1
+
     async def test_returns_unique_instruction_ids(
         self, state_repo: StateRepo, truncation_store: TruncationStore
     ) -> None:


### PR DESCRIPTION
Backend half of the approved vision-attachments design (01a052d9, rev2 design doc), authored by Dev-Aux, both commits lead-reviewed. The composer UI (step 3) lands separately after the Wave-3 PRs merge — this PR is fully functional server-side via the API.

**4d440d30 — hydrate artifact-backed parts before every LLM call.** `run_agent_turn` gains an optional `artifact_storage` param that resolves artifact-backed Parts to inline bytes at the top of every tool-round-trip iteration (covers mid-turn tool-result media, not just the starting prompt), threaded through both session and graph executor paths including subgraph recursion, DI'd from the pool's registry with the standard tolerance pattern. `None` default is a provable no-op at every existing call site; hydration is idempotent across iterations and hydrated bytes never leak into durable history (verified in review). The subagent runner is deliberately unwired (scope cut, marked in-code by 1be5ef16).

**ceeb60da — `SteerBody.attachments`: workspace-file vision input.** `attachments: list[AttachmentIn]` (workspace-relative paths — no new endpoint, no inline base64; reuses the existing upload + `media_from_workspace_files` pipeline), folded into the turn via `wake_session(extra_parts=...)` → `append_instruction(extra_parts=...)`. Wire-layer traversal safety: absolute and `..` paths 422 before the resolver's own backstop is ever reached, each pinned by its own test (including one proving the session's `append_instruction` is never called for a rejected path). `attachments` requires `instruction` (422) and is exempt from the pending-steer queue for the same reason `external_tools` is (deferral would silently drop it). Deployments with no artifact storage configured best-effort-drop attachments with a log instead of 503ing every steer. All four LLM adapters were re-audited: each already raises `UnsupportedContentError` correctly for unsupported media — no gap-filling needed.

**Verification:** commit 1: 1055 tests across agent/graph/channel/worker, zero regressions. Commit 2: 65/65 on the targeted files; plus a 2855-test sweep across api/session/toolset/workspace validating the `extra_parts` signature change against every test fake (4 pre-existing venv-extras failures unrelated). All under the resource-policy wrapper.

🤖 Generated with [Claude Code](https://claude.com/claude-code)