### PR TITLE
fix(worker): resumed TOOL_RESULT records pair by the scoped id

### DIFF
--- a/primer/api/routers/sessions.py
+++ b/primer/api/routers/sessions.py
@@ -1040,17 +1040,17 @@ def _dedupe_legacy_user_input(
     matching modern record for those during live streaming (confirmed:
     ToolCallEnd's TOOL_CALL record lands before dispatch, the
     ExtendedEvent(_ExecutorToolResult) that becomes TOOL_RESULT lands
-    right after), but a PARKED-then-resumed turn's rehydrated
-    tool-result does not - WorkspaceAgentExecutor.inject_resume_messages
-    -> _persist_turn writes only the legacy line for that content, and
-    nothing (not park time, not resume time) ever writes a matching
-    modern TOOL_RESULT record for it. That is a separate, not-yet-fixed
-    write-side gap (reported alongside this one); reconciling it here
-    without a real modern record to key off risks synthesizing the
-    wrong shape or, worse, silently deciding a line is "covered" when
-    it isn't and dropping real content the raw passthrough never lost.
-    Dev-Prime's UI-side legacy-line tolerance stays load-bearing for
-    that case.
+    right after). A PARKED-then-resumed turn's rehydrated tool-result
+    ALSO gets a matching modern record now -
+    session_resume_coordinator.py's _persist_resume_tool_result_record
+    (01a04e0a) writes it at resume time, correctly paired by the
+    display-record's scoped id since 01a068ea-dc95 fixed that write to
+    use it instead of the raw provider id. (An earlier revision of this
+    docstring claimed that write never happened at all - it was already
+    landed by the time that claim was written; corrected here rather
+    than left to mislead the next reader.) role="user" stays the only
+    shape this function reconciles regardless - that scoping is a
+    standalone choice, not a workaround for a missing write.
 
     For each role="user" legacy line: if a modern USER_INPUT record
     ANYWHERE in this file already carries the exact same text, drop the

--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -560,6 +560,23 @@ async def run_one_session_turn(
         timeout = yielded.timeout if yielded.timeout is not None else 3600.0
         parked_until = parked_at + timedelta(seconds=timeout)
 
+        # 01a068ea-dc95: the durable TOOL_CALL SessionMessageRecord this
+        # park will answer was minted with the SCOPED id (persistence.py's
+        # ToolCallStart handler), not park.tool_call_id (the raw provider
+        # id LLM-context reconstruction needs). coalesce_state processed
+        # this call's ToolCallEnd earlier in the same async-for loop above
+        # (streaming events arrive strictly before the tool dispatch that
+        # might yield), and no _ExecutorToolResult ever popped the mapping
+        # since this call yielded instead of returning -- so the scoped id
+        # is still sitting in scoped_call_ids right now. node_id is always
+        # None here: this turn driver (run_one_session_turn) never passes
+        # one to translate_stream_event. Stash it so the resume coordinator
+        # can pair the eventual TOOL_RESULT display record correctly
+        # instead of falling back to the raw id.
+        scoped_tool_call_id = coalesce_state.scoped_call_ids.get(
+            (None, park.tool_call_id)
+        )
+
         # Stamp parked_at_iso into resume_metadata so the resume hook can
         # compute elapsed without a separate read.
         resume_metadata = dict(yielded.resume_metadata)
@@ -648,6 +665,7 @@ async def run_one_session_turn(
             # executor began streaming.
             started_at=_turn_started_at,
             tool_call_id=park.tool_call_id,
+            scoped_tool_call_id=scoped_tool_call_id,
             graph_checkpoint=graph_checkpoint,
             frames=list(getattr(park, "frames", []) or []),
             # Frozen at park so a fenced resume rebuilds the SAME toolset

--- a/primer/worker/session_resume_coordinator.py
+++ b/primer/worker/session_resume_coordinator.py
@@ -317,7 +317,7 @@ async def inject_resume_and_continue(
         )
         return await pool._end_session(session, reason="failed")
 
-    await _persist_resume_tool_result_record(pool, session, tool_result_part)
+    await _persist_resume_tool_result_record(pool, session, parked, tool_result_part)
 
     # Continuation: clear park (on_release) + keep the lease so the next
     # claim runs the continuation LLM turn.
@@ -325,7 +325,7 @@ async def inject_resume_and_continue(
 
 
 async def _persist_resume_tool_result_record(
-    pool: "WorkerPool", session, tool_result_part,
+    pool: "WorkerPool", session, parked, tool_result_part,
 ) -> None:
     """Write the modern TOOL_RESULT counterpart for a resumed tool call.
 
@@ -342,6 +342,15 @@ async def _persist_resume_tool_result_record(
     after ``primer.session.timeline`` was found unable to pair its old
     ``id``/``name``/``result`` shape back to a TOOL_CALL (it keys the
     lookup by ``call_id``).
+
+    01a068ea-dc95: ``call_id`` uses ``parked.scoped_tool_call_id`` (the
+    id the paired TOOL_CALL record actually carries -
+    ``primer.session.persistence``'s ``ToolCallStart`` mint), falling
+    back to ``tool_result_part.id`` (the raw provider id) only for a
+    park written before this field existed. Using the raw id
+    unconditionally (the pre-fix behaviour) left every resumed yield's
+    TOOL_RESULT unpaired from its TOOL_CALL in the transcript/trace UI,
+    since the durable pair never shared an id.
 
     Best-effort and best-effort ONLY: this is a secondary, display-side
     record. The turn's continuation already stands on the legacy write
@@ -368,7 +377,7 @@ async def _persist_resume_tool_result_record(
             seq=1,  # overwritten by the writer's monotonic counter
             kind=SessionMessageKind.TOOL_RESULT,
             payload={
-                "call_id": tool_result_part.id,
+                "call_id": parked.scoped_tool_call_id or tool_result_part.id,
                 "output": tool_result_part.output,
                 "error": tool_result_part.error,
             },
@@ -377,6 +386,21 @@ async def _persist_resume_tool_result_record(
         await writer.flush()
         storage = pool._storage.get_storage(WorkspaceSession)
         await storage.update(session.model_copy(update={"last_seq": new_seq}))
+        # 01a068ea-dc95 (sibling finding, same shape as
+        # claim/adapters/sessions.py's terminal-ERROR writer): a durable-
+        # but-unticked write is invisible to a live client until its next
+        # poll. Best-effort/advisory, same as every other tick publish in
+        # this module - never lets a bus hiccup fail an otherwise-
+        # successful write.
+        if pool._event_bus is not None:
+            try:
+                await pool._event_bus.publish(
+                    f"session:{session.id}:tick", {"seq": new_seq},
+                )
+            except Exception:  # noqa: BLE001 - advisory
+                logger.exception(
+                    "resume: tick publish failed for session %s", session.id,
+                )
     except Exception:  # noqa: BLE001 - best-effort, see docstring
         logger.exception(
             "resume: failed to persist modern TOOL_RESULT record for "
@@ -485,6 +509,12 @@ def repark_continuation(pool: "WorkerPool", session, parked, outcome):
         turn_no=session.turn_no,
         started_at=now,
         tool_call_id=parked.tool_call_id,
+        # 01a068ea-dc95: the leaf re-yielded, but the DURABLE TOOL_CALL
+        # record this eventual TOOL_RESULT answers is still the outer
+        # session-level call (parked.tool_call_id above) - carry its
+        # scoped id forward unchanged, same reasoning as tool_call_id
+        # itself.
+        scoped_tool_call_id=parked.scoped_tool_call_id,
         frames=list(outcome.frames),
     )
     return ReleaseOutcome(
@@ -538,6 +568,12 @@ def repark_resumed_yield_outcome(pool: "WorkerPool", session, parked, yld):
         turn_no=session.turn_no,
         started_at=now,
         tool_call_id=yld.tool_call_id,
+        # 01a068ea-dc95: phase 2 re-dispatches the SAME tool call directly
+        # (bypass_approval=True), outside the LLM-streaming pipeline that
+        # mints scoped ids - there is no new one to look up, so carry the
+        # phase-1 park's forward unchanged. It answers the same durable
+        # TOOL_CALL record either way.
+        scoped_tool_call_id=parked.scoped_tool_call_id,
         graph_checkpoint=getattr(yld, "graph_checkpoint", None),
     )
     return ReleaseOutcome(

--- a/primer/worker/yield_runtime.py
+++ b/primer/worker/yield_runtime.py
@@ -123,6 +123,21 @@ class ParkedState:
     binding_epoch: int | None = None
     frames: list = field(default_factory=list)
     schema_version: int = PARKED_STATE_SCHEMA_VERSION
+    # 01a068ea-dc95: the DURABLE TOOL_CALL SessionMessageRecord this park
+    # answers was minted with the SCOPED id (primer.session.persistence's
+    # ToolCallStart handler, node:tool:turn_no:seq) -- not this ParkedState's
+    # own tool_call_id, which is the raw provider id (correct for LLM-
+    # context reconstruction, but never the id the display-record pairing
+    # keys off). Stashed at park time, when the minting _CoalesceState is
+    # still in scope (primer.session.dispatch's except YieldToWorker
+    # handler); every repark path carries it forward unchanged, since a
+    # phase-2 re-dispatch (post-approval bypass) re-enters the SAME tool
+    # call outside the LLM-streaming pipeline and mints no new id. ``None``
+    # for a park written before this field existed, or if the scoped-id
+    # lookup somehow missed (defensive) -- the resume write falls back to
+    # the raw id in that case, exactly today's behaviour. Optional so
+    # pre-existing blobs load without a schema-version bump.
+    scoped_tool_call_id: str | None = None
 
     def to_jsonable(self) -> dict[str, Any]:
         """Render to a JSON-safe dict for persistence in sessions.data."""
@@ -132,6 +147,7 @@ class ParkedState:
         return {
             "schema_version": self.schema_version,
             "tool_call_id": self.tool_call_id,
+            "scoped_tool_call_id": self.scoped_tool_call_id,
             "yielded": self.yielded.to_jsonable(),
             "llm_messages": list(self.llm_messages),
             "turn_no": self.turn_no,
@@ -231,6 +247,7 @@ class ParkedState:
             graph_checkpoint=graph_checkpoint,
             frames=frames,
             schema_version=version,
+            scoped_tool_call_id=data.get("scoped_tool_call_id"),
         )
 
 

--- a/tests/worker/test_approval_yield_repark.py
+++ b/tests/worker/test_approval_yield_repark.py
@@ -103,6 +103,7 @@ def _make_approval_parked_session(
     real_arguments: dict,
     resume_event_payload: dict,
     llm_messages: list,
+    scoped_tool_call_id: str | None = None,
 ) -> WorkspaceSession:
     """A session parked (phase 1) on an approval gate guarding a yielding
     tool. resume_metadata carries the original_call so the approved resume
@@ -128,6 +129,7 @@ def _make_approval_parked_session(
         started_at=parked_at,
         tool_call_id=tool_call_id,
         resume_event_payload=resume_event_payload,
+        scoped_tool_call_id=scoped_tool_call_id,
     )
     return WorkspaceSession(
         id=sid,
@@ -241,6 +243,80 @@ async def test_approved_yielding_tool_reparks_then_resumes(monkeypatch):
     assert row.parked_state["yielded"]["tool_name"] == real_tool_name
     # The in-progress turn messages were preserved across the re-park.
     assert row.parked_state["llm_messages"]
+
+
+@pytest.mark.asyncio
+async def test_repark_carries_scoped_tool_call_id_through_phase_2(monkeypatch):
+    """01a068ea-dc95: phase 2 re-dispatches the SAME tool call directly
+    (bypass_approval=True), outside the LLM-streaming pipeline that
+    mints scoped ids at ToolCallStart - there is no new one to look up
+    for the fresh yield, so repark_resumed_yield_outcome must carry the
+    phase-1 park's scoped_tool_call_id forward unchanged. Without this,
+    the eventual TOOL_RESULT (once the real event fires) would fall back
+    to the raw id and stay unpaired from the durable TOOL_CALL record,
+    same failure mode as the primary bug this task fixes."""
+    sid = "sess-approval-yield-scoped-id"
+    tool_call_id = "tc-sleep-scoped"
+    real_tool_name = "_test_yield_repark_tool_scoped"
+    scoped_id = "x:tool:0:1"
+
+    from primer.worker.yield_resume_registry import register_resume_hook
+
+    class _HookResult:
+        def __init__(self, output, is_error=False):
+            self.output = output
+            self.is_error = is_error
+
+    register_resume_hook(
+        real_tool_name,
+        lambda resume_metadata, payload, ctx: _HookResult(
+            json.dumps({"woke": True}),
+        ),
+    )
+
+    storage_provider = _FakeStorageProvider()
+    session_storage = storage_provider.get_storage(WorkspaceSession)
+    engine = _build_engine(session_storage)
+    pool = _build_pool(storage_provider, engine)
+
+    real_event = Yielded(
+        tool_name=real_tool_name,
+        event_key=f"timer:{tool_call_id}",
+        timeout=120.0,
+        resume_metadata={"seconds": 30},
+    )
+    tm = _YieldingToolManager(yielded=real_event, tool_call_id=tool_call_id)
+    fake_executor = _RecordingExecutor(tool_manager=tm)
+
+    sess = _make_approval_parked_session(
+        sid,
+        tool_call_id=tool_call_id,
+        real_tool_name=real_tool_name,
+        real_arguments={"seconds": 30},
+        resume_event_payload={"decision": "approved"},
+        llm_messages=[_assistant_msg(tool_call_id, real_tool_name).model_dump(mode="json")],
+        scoped_tool_call_id=scoped_id,
+    )
+    await session_storage.create(sess)
+
+    monkeypatch.setattr(
+        pool, "_load_workspace_for_persist",
+        lambda _ws_id: _async_return(_NoopPersist()),
+    )
+    monkeypatch.setattr(
+        pool, "_build_agent_executor",
+        lambda _s, _w: _async_return(fake_executor),
+    )
+
+    lease = await _claim_session(engine, sid)
+    await pool._run_engine_session(lease)
+
+    row = await session_storage.get(sid)
+    assert row is not None
+    assert row.parked_status == "parked"
+    # The re-parked (phase 2) blob still carries the ORIGINAL scoped id,
+    # not None and not something re-derived.
+    assert row.parked_state["scoped_tool_call_id"] == scoped_id
 
     # ---- Phase 2 resume: the real (timer) event fires -> resume to done. ----
     # Re-stamp the row as resumable carrying the real event payload, mirroring

--- a/tests/worker/test_engine_session_resume.py
+++ b/tests/worker/test_engine_session_resume.py
@@ -71,6 +71,14 @@ class _NoopPersist:
     pass
 
 
+class _FakeEventBus:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict]] = []
+
+    async def publish(self, key: str, payload: dict) -> None:
+        self.published.append((key, payload))
+
+
 class _FakeWorkspaceIO:
     """Records ``append_message_line`` calls (the modern-record write
     path); ``_NoopPersist`` above deliberately lacks this method so tests
@@ -91,7 +99,7 @@ def _build_engine(session_storage) -> InMemoryClaimEngine:
     )
 
 
-def _build_pool(storage, engine) -> WorkerPool:
+def _build_pool(storage, engine, *, event_bus=None) -> WorkerPool:
     pool = WorkerPool(
         config=WorkerConfig(concurrency=1),
         scheduler=None,                  # type: ignore[arg-type]
@@ -99,6 +107,7 @@ def _build_pool(storage, engine) -> WorkerPool:
         workspace_registry=None,         # type: ignore[arg-type]
         provider_registry=None,          # type: ignore[arg-type]
         engine=engine,
+        event_bus=event_bus,             # type: ignore[arg-type]
     )
     pool._worker_id = "wrk-engine-resume"
     return pool
@@ -113,6 +122,7 @@ def _make_resumable_session(
     parked_state_blob: dict | None = None,
     llm_messages: list | None = None,
     turn_no: int = 0,
+    scoped_tool_call_id: str | None = None,
 ) -> WorkspaceSession:
     """Build a WorkspaceSession row pre-stamped with a resumable park,
     mirroring what the listener + mark_resumable leave behind."""
@@ -132,6 +142,7 @@ def _make_resumable_session(
             started_at=parked_at,
             tool_call_id=tool_call_id,
             resume_event_payload=resume_event_payload,
+            scoped_tool_call_id=scoped_tool_call_id,
         )
         parked_state_blob = parked_state.to_jsonable()
 
@@ -317,6 +328,135 @@ async def test_resume_agent_persists_modern_tool_result_record(monkeypatch):
     row = await session_storage.get(sid)
     assert row is not None
     assert row.last_seq == 4
+
+
+@pytest.mark.asyncio
+async def test_resume_agent_modern_tool_result_uses_scoped_id_when_present(
+    monkeypatch,
+):
+    """01a068ea-dc95: the durable TOOL_CALL record this TOOL_RESULT
+    answers was minted with the SCOPED id (primer.session.persistence's
+    ToolCallStart handler), not the raw provider tool_call_id every id
+    in this test file otherwise uses. When the park carries a
+    scoped_tool_call_id (stashed at park time - dispatch.py's
+    except YieldToWorker handler), the modern record must key off THAT,
+    not the raw id, or the display/trace UI can never pair the two."""
+    sid = "sess-engine-resume-scoped-id"
+    tool_call_id = "tc-ask-3"
+    scoped_id = "x:tool:0:1"
+
+    assistant_msg = Message(
+        role="assistant",
+        parts=[
+            ToolCallPart(
+                id=tool_call_id,
+                name="_misc__ask_user",
+                arguments={"prompt": "What is your name?"},
+            ),
+        ],
+    )
+
+    storage_provider = _FakeStorageProvider()
+    session_storage = storage_provider.get_storage(WorkspaceSession)
+    engine = _build_engine(session_storage)
+    pool = _build_pool(storage_provider, engine)
+
+    sess = _make_resumable_session(
+        sid,
+        tool_name="ask_user",
+        tool_call_id=tool_call_id,
+        resume_event_payload={"response": "Alice"},
+        llm_messages=[assistant_msg.model_dump(mode="json")],
+        scoped_tool_call_id=scoped_id,
+    )
+    sess.last_seq = 3
+    await session_storage.create(sess)
+
+    fake_executor = _RecordingExecutor()
+    fake_ws = _FakeWorkspaceIO()
+    monkeypatch.setattr(
+        pool, "_load_workspace_for_persist",
+        lambda _ws_id: _async_return(fake_ws),
+    )
+    monkeypatch.setattr(
+        pool, "_build_agent_executor",
+        lambda _s, _w: _async_return(fake_executor),
+    )
+
+    lease = await _claim_session(engine, sid)
+    await pool._run_engine_session(lease)
+
+    # The legacy inject still carries the RAW id -- correct for LLM
+    # context reconstruction, unrelated to this fix.
+    injected = fake_executor.injected[0]
+    tool_part = next(
+        p for p in injected[-1].parts if isinstance(p, ToolResultPart)
+    )
+    assert tool_part.id == tool_call_id
+
+    # The modern display record uses the SCOPED id instead.
+    written_sid, blob = fake_ws.lines[0]
+    record = json.loads(blob.decode().splitlines()[0])
+    assert record["payload"]["call_id"] == scoped_id
+    assert record["payload"]["call_id"] != tool_call_id
+
+
+@pytest.mark.asyncio
+async def test_resume_agent_modern_tool_result_publishes_tick(monkeypatch):
+    """01a068ea-dc95 (sibling finding): a durable-but-unticked write is
+    invisible to a live client until its next poll. The resume branch's
+    modern-record append must publish session:{sid}:tick, same as every
+    other durable append in this codebase."""
+    sid = "sess-engine-resume-tick"
+    tool_call_id = "tc-ask-4"
+
+    assistant_msg = Message(
+        role="assistant",
+        parts=[
+            ToolCallPart(
+                id=tool_call_id,
+                name="_misc__ask_user",
+                arguments={"prompt": "What is your name?"},
+            ),
+        ],
+    )
+
+    storage_provider = _FakeStorageProvider()
+    session_storage = storage_provider.get_storage(WorkspaceSession)
+    engine = _build_engine(session_storage)
+    event_bus = _FakeEventBus()
+    pool = _build_pool(storage_provider, engine, event_bus=event_bus)
+
+    sess = _make_resumable_session(
+        sid,
+        tool_name="ask_user",
+        tool_call_id=tool_call_id,
+        resume_event_payload={"response": "Alice"},
+        llm_messages=[assistant_msg.model_dump(mode="json")],
+    )
+    sess.last_seq = 3
+    await session_storage.create(sess)
+
+    fake_executor = _RecordingExecutor()
+    fake_ws = _FakeWorkspaceIO()
+    monkeypatch.setattr(
+        pool, "_load_workspace_for_persist",
+        lambda _ws_id: _async_return(fake_ws),
+    )
+    monkeypatch.setattr(
+        pool, "_build_agent_executor",
+        lambda _s, _w: _async_return(fake_executor),
+    )
+
+    lease = await _claim_session(engine, sid)
+    await pool._run_engine_session(lease)
+
+    tick_events = [
+        (key, payload) for key, payload in event_bus.published
+        if key == f"session:{sid}:tick"
+    ]
+    assert len(tick_events) == 1
+    assert tick_events[0][1] == {"seq": 4}  # start_seq (3) + 1
 
 
 @pytest.mark.asyncio

--- a/tests/worker/test_yield_runtime.py
+++ b/tests/worker/test_yield_runtime.py
@@ -100,6 +100,33 @@ class TestParkedStateRoundTrip:
         assert round_tripped.started_at == resumed.started_at
         assert round_tripped.frames == []
 
+    def test_roundtrip_with_scoped_tool_call_id(self, parked_state: ParkedState):
+        # 01a068ea-dc95: the id the paired durable TOOL_CALL record was
+        # minted with (persistence.py's ToolCallStart), distinct from
+        # ParkedState.tool_call_id (the raw provider id).
+        scoped = ParkedState(
+            yielded=parked_state.yielded,
+            llm_messages=parked_state.llm_messages,
+            turn_no=parked_state.turn_no,
+            started_at=parked_state.started_at,
+            tool_call_id="tc-1",
+            scoped_tool_call_id="x:tool:3:1",
+        )
+        round_tripped = ParkedState.from_jsonable(scoped.to_jsonable())
+        assert round_tripped.scoped_tool_call_id == "x:tool:3:1"
+        assert round_tripped.tool_call_id == "tc-1"
+
+    def test_legacy_blob_without_scoped_tool_call_id_loads_as_none(
+        self, parked_state: ParkedState,
+    ):
+        # A park written before this field existed has no such key at
+        # all -- from_jsonable must not KeyError, and the resume write
+        # falls back to the raw id (today's pre-fix behaviour).
+        blob = parked_state.to_jsonable()
+        del blob["scoped_tool_call_id"]
+        round_tripped = ParkedState.from_jsonable(blob)
+        assert round_tripped.scoped_tool_call_id is None
+
     def test_unknown_schema_version_raises_loudly(self, parked_state: ParkedState):
         blob = parked_state.to_jsonable()
         blob["schema_version"] = 9999


### PR DESCRIPTION
## Summary
- Every resumed yield's (ask_user, tool_approval, ...) durable TOOL_RESULT record was written with the raw provider `tool_call_id`, never the SCOPED id (`node:tool:turn_no:seq`) the paired TOOL_CALL record actually carries — so the transcript/trace UI could never pair them for a resumed turn.
- `ParkedState` grows an optional `scoped_tool_call_id`, stashed at park time (where the minting `_CoalesceState` is still in scope) and carried forward unchanged through both re-park paths (two-phase approval-then-yield, nested continuation re-yield).
- `session_resume_coordinator.py`'s `_persist_resume_tool_result_record` now keys `call_id` off it, falling back to the raw id only for a park written before this field existed.
- Adds the missing post-append tick publish on that same write (a durable-but-unticked write was invisible to a live client until its next poll).
- Corrects a stale docstring in `primer/api/routers/sessions.py` that asserted the modern TOOL_RESULT write "never" happens for a resumed tool-result — that was already fixed by c83f3a9e a day before the docstring was last touched.
- Graph-bound sessions checked (read-only): confirmed **not** to have the identical gap — `graph_resume_coordinator.py` writes no modern TOOL_RESULT record at all, for any resume shape. Structurally different (per-node `messages.jsonl`, not the session-level writer this fix touches) and out of scope here; tracked separately.

## Test plan
- [x] New tests: `ParkedState` round-trip with/without the new field (legacy-blob tolerance), the primary resume path using the scoped id when present, the tick-publish assertion, and a two-phase repark test proving the scoped id survives a phase-1→phase-2 transition.
- [x] Existing tests unaffected (the fallback preserves pre-fix behavior for parks without the new field): `512 passed, 1 xfailed` across `tests/worker/` + `tests/session/`.
- [x] `ruff check` clean.

Fixes task 01a068ea-dc95.