### PR TITLE
fix(worker): graph resume writes no durable TOOL_RESULT record

### DIFF
--- a/primer/graph/_checkpoint.py
+++ b/primer/graph/_checkpoint.py
@@ -177,6 +177,9 @@ class _CheckpointMixin:
                     # reply (resume hook on the operator payload).
                     "tool_name": p.tool_name,
                     "resume_metadata": dict(p.resume_metadata or {}),
+                    # 01a0690a: the scoped id the paired durable TOOL_CALL
+                    # record carries -- see _PendingToolCall's docstring.
+                    "scoped_tool_call_id": p.scoped_tool_call_id,
                 }
                 for p in self._pending_toolcalls
             ],
@@ -194,6 +197,8 @@ class _CheckpointMixin:
                     # nested invoke_agent. Empty / None for an ordinary park.
                     "frames": list(p.frames),
                     "leaf": dict(p.leaf) if p.leaf is not None else None,
+                    # 01a0690a: see _PendingAgentYield's docstring.
+                    "scoped_tool_call_id": p.scoped_tool_call_id,
                 }
                 for p in self._pending_agent_yields
             ],
@@ -320,6 +325,9 @@ class _CheckpointMixin:
                 # ``{}`` keep the approval-gate (bypass re-dispatch) path.
                 tool_name=raw.get("tool_name"),
                 resume_metadata=dict(raw.get("resume_metadata") or {}),
+                # 01a0690a: None for a checkpoint written before this field
+                # existed -- the resume write falls back to the raw id.
+                scoped_tool_call_id=raw.get("scoped_tool_call_id"),
             )
             for raw in (payload.get("pending_toolcalls") or [])
         ]
@@ -334,6 +342,7 @@ class _CheckpointMixin:
                 iteration=raw["iteration"],
                 frames=list(raw.get("frames") or []),
                 leaf=dict(raw["leaf"]) if raw.get("leaf") is not None else None,
+                scoped_tool_call_id=raw.get("scoped_tool_call_id"),
             )
             for raw in (payload.get("pending_agent_yields") or [])
         ]

--- a/primer/graph/_node_refs.py
+++ b/primer/graph/_node_refs.py
@@ -760,6 +760,18 @@ class _PendingToolCall:
         ask_user's ``prompt`` / ``response_schema`` / ``tool_call_id``).
         Surfaced to the channel/REST ask_user prompt + handed to the
         resume hook. Empty for an approval gate.
+    scoped_tool_call_id
+        01a0690a: the SCOPED id (``node:tool:turn_no:seq``) the durable
+        TOOL_CALL record this park will eventually be answered by was
+        minted with (dispatch.py's coalesce_state, via the live path's
+        ``_GraphNodeEvent`` unwrap) -- distinct from ``tool_call_id``
+        above, the raw provider id. Stashed once, at the original park
+        (dispatch.py's ``except YieldToWorker`` catch); every repark
+        carries it forward unchanged (mirrors ``ParkedState.
+        scoped_tool_call_id`` for the agent path, 0b4e8bfc). ``None``
+        for a checkpoint written before this field existed, or if the
+        mint lookup missed (defensive) -- the resume write falls back
+        to the raw id in that case.
     """
 
     node_id: str
@@ -768,6 +780,7 @@ class _PendingToolCall:
     arguments: dict[str, Any]
     tool_name: str | None = None
     resume_metadata: dict[str, Any] = field(default_factory=dict)
+    scoped_tool_call_id: str | None = None
 
 
 @dataclass
@@ -799,4 +812,7 @@ class _PendingAgentYield:
     iteration: int
     frames: list[dict[str, Any]] = field(default_factory=list)
     leaf: dict[str, Any] | None = None
+    # 01a0690a: same doctrine as _PendingToolCall.scoped_tool_call_id above
+    # -- the id the paired durable TOOL_CALL record actually carries.
+    scoped_tool_call_id: str | None = None
 

--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -63,6 +63,7 @@ from primer.session.persistence import (
     WorkspaceMessageWriter,
     _CoalesceState,
     infer_agent_phase,
+    stash_graph_scoped_ids,
     translate_stream_event,
 )
 from primer.observability.turn_log_writer import (
@@ -645,6 +646,14 @@ async def run_one_session_turn(
         # resume dispatch can route to the graph resume adapter.
         graph_checkpoint = getattr(park, "graph_checkpoint", None)
 
+        # 01a0690a: stash each pending entry's scoped tool-call id (the id
+        # the durable TOOL_CALL record actually carries, minted by THIS
+        # turn's coalesce_state via the live path's _GraphNodeEvent unwrap)
+        # into graph_checkpoint, plus the per-node mint-seq snapshot the
+        # eventual resume drain needs to avoid re-minting colliding ids.
+        # {}/None for an agent-bound park (graph_checkpoint is None).
+        node_tool_call_seq = stash_graph_scoped_ids(graph_checkpoint, coalesce_state)
+
         # A yield raised inside a NESTED invoke_agent invocation arrives with
         # ``park.frames`` already populated (run_subagent/resume_subagent
         # prepended one AgentFrame per in-flight caller). Persist that stack so
@@ -666,6 +675,7 @@ async def run_one_session_turn(
             started_at=_turn_started_at,
             tool_call_id=park.tool_call_id,
             scoped_tool_call_id=scoped_tool_call_id,
+            node_tool_call_seq=node_tool_call_seq or None,
             graph_checkpoint=graph_checkpoint,
             frames=list(getattr(park, "frames", []) or []),
             # Frozen at park so a fenced resume rebuilds the SAME toolset

--- a/primer/session/persistence.py
+++ b/primer/session/persistence.py
@@ -752,6 +752,47 @@ def translate_stream_event(
     return None
 
 
+def stash_graph_scoped_ids(
+    graph_checkpoint: dict[str, Any] | None, coalesce_state: "_CoalesceState",
+) -> dict[str, int]:
+    """Stash node-qualified scoped tool-call ids into a graph checkpoint's
+    pending entries, at the moment a ``_CoalesceState`` that minted them is
+    still in scope (01a0690a — the graph-path sibling of 0b4e8bfc's
+    ``ParkedState.scoped_tool_call_id`` for the agent path).
+
+    Two call sites share this: dispatch.py's top-level ``except
+    YieldToWorker`` catch (a fresh park, ``coalesce_state`` populated by the
+    live turn's own ``translate_stream_event`` calls via the
+    ``_GraphNodeEvent`` unwrap), and the graph-resume drain's own repark
+    catch (worker/graph_resume.py — a FRESH ``_CoalesceState`` seeded from
+    the checkpoint's prior mints, see ``ParkedState.node_tool_call_seq``).
+
+    Mutates ``pending_toolcalls``/``pending_agent_yields`` entries IN PLACE,
+    setting ``scoped_tool_call_id`` from ``coalesce_state.scoped_call_ids``
+    keyed by ``(entry["node_id"], entry["tool_call_id"])`` — but only when
+    the entry doesn't already carry one: an entry stashed by an EARLIER park
+    in this same checkpoint's history (carried forward through a repark)
+    keeps its original id rather than being re-derived (there is nothing to
+    re-derive from a resume-time ``coalesce_state`` that never minted it).
+
+    Returns a snapshot of ``coalesce_state.tool_call_seq`` (the per-node
+    monotonic mint counters) for ``ParkedState.node_tool_call_seq`` — {} for
+    an agent-bound park (``graph_checkpoint is None``, nothing to stash).
+    """
+    if graph_checkpoint is None:
+        return {}
+    for entries_key in ("pending_toolcalls", "pending_agent_yields"):
+        for entry in graph_checkpoint.get(entries_key) or []:
+            if entry.get("scoped_tool_call_id") is not None:
+                continue
+            sid = coalesce_state.scoped_call_ids.get(
+                (entry.get("node_id"), entry.get("tool_call_id"))
+            )
+            if sid is not None:
+                entry["scoped_tool_call_id"] = sid
+    return dict(coalesce_state.tool_call_seq)
+
+
 def infer_agent_phase(event: StreamEvent) -> str | None:
     """Map a raw StreamEvent to the agent_phase (01a04d91-a7a0) it
     implies, or ``None`` if this event kind carries no phase information
@@ -791,4 +832,7 @@ def infer_agent_phase(event: StreamEvent) -> str | None:
     return None
 
 
-__all__ = ["WorkspaceMessageWriter", "WorkspaceIO", "_CoalesceState", "translate_stream_event"]
+__all__ = [
+    "WorkspaceMessageWriter", "WorkspaceIO", "_CoalesceState",
+    "translate_stream_event", "stash_graph_scoped_ids",
+]

--- a/primer/worker/graph_resume.py
+++ b/primer/worker/graph_resume.py
@@ -36,6 +36,7 @@ from primer.worker.yield_runtime import (
 
 if TYPE_CHECKING:
     from primer.graph.workspace_executor import WorkspaceGraphExecutor
+    from primer.worker.pool import WorkerPool
 
 
 logger = logging.getLogger(__name__)
@@ -48,7 +49,10 @@ async def resume_graph_from_checkpoint(
     payload: "dict[str, Any] | YieldTimeout | YieldCancelled | Any",
     resumed_tcid: str | None = None,
     agent_tool_result: "Any | None" = None,
-) -> "tuple[str, Any | None]":
+    pool: "WorkerPool | None" = None,
+    session: "Any | None" = None,
+    node_tool_call_seq: dict[str, int] | None = None,
+) -> "tuple[str, Any | None, dict[str, int]]":
     """Drive a graph executor's resume stream to completion.
 
     Parameters
@@ -71,6 +75,27 @@ async def resume_graph_from_checkpoint(
         ``_dispatch_toolcall_with_bypass`` to raise
         :class:`_ToolApprovalRejected` so the resume drain emits the
         ``tool_execution_failed`` terminal event per spec §4.8.
+    pool, session
+        01a0690a piece 3/3 (Gap 2). When both are given, every event the
+        resumed drain yields is tapped through the SAME persistence
+        vocabulary the live turn uses (translate_stream_event ->
+        WorkspaceMessageWriter, see graph/base.py's own "flows through
+        translate_stream_event -> WorkspaceMessageWriter.append" comment)
+        instead of being silently discarded — a graph that keeps running
+        past the resumed node (the node's own LLM continuing, or
+        downstream nodes) previously left everything it did, post-resume,
+        missing from the durable record. ``None`` (the default) skips
+        tapping entirely — existing direct callers that only care about
+        the drain's control flow, not its persistence, are unaffected.
+    node_tool_call_seq
+        Per-node scoped-id mint-seq high-water mark from
+        :attr:`ParkedState.node_tool_call_seq` (piece 1) — seeds the tap's
+        fresh ``_CoalesceState`` so it continues minting past whatever
+        this turn_no already used pre-park, instead of restarting every
+        node's counter at 0 and re-minting colliding ids (turn_no does
+        not bump until on_release, so the resume drain observes the
+        SAME turn_no the pre-park turn did). ``None`` starts empty (a
+        checkpoint written before piece 1, or a park with no prior mints).
 
     ``resumed_tcid`` (multi-event park) selects which pending node the
     human replied to; ``agent_tool_result`` is the tool-result Message for
@@ -81,10 +106,15 @@ async def resume_graph_from_checkpoint(
 
     Returns
     -------
-    tuple[str, YieldToWorker | None]
-        ``(decision, repark)``. ``decision`` is ``"approved"`` /
-        ``"rejected"``. ``repark`` is the re-park ``YieldToWorker`` when
-        nodes remain pending, else ``None`` (graph drained to completion).
+    tuple[str, YieldToWorker | None, dict[str, int]]
+        ``(decision, repark, node_tool_call_seq)``. ``decision`` is
+        ``"approved"`` / ``"rejected"``. ``repark`` is the re-park
+        ``YieldToWorker`` when nodes remain pending, else ``None`` (graph
+        drained to completion). ``node_tool_call_seq`` is the tap's
+        (possibly advanced, if pool/session were given) per-node mint-seq
+        snapshot — the caller threads it into the repark's own
+        ``ParkedState.node_tool_call_seq`` so a park -> resume -> repark ->
+        resume chain never resets ({} when tapping was skipped).
     """
     # Local import to keep this module's import surface tiny — the
     # worker pool imports it lazily inside _handle_resume.
@@ -122,19 +152,145 @@ async def resume_graph_from_checkpoint(
 
         executor._dispatch_toolcall_with_bypass = _rejecting_dispatch  # type: ignore[assignment]
 
+    tap = None
+    if pool is not None and session is not None:
+        tap = await _ResumeDrainTap.create(
+            pool, session, node_tool_call_seq=node_tool_call_seq,
+        )
+
     repark: YieldToWorker | None = None
     try:
-        async for _ev in executor.resume_from_checkpoint(
+        async for ev in executor.resume_from_checkpoint(
             checkpoint,
             resumed_tcid=resumed_tcid,
             agent_tool_result=agent_tool_result,
             toolcall_payload=payload if value_yield_toolcall else None,
         ):
-            pass
+            if tap is not None:
+                await tap.observe(ev)
     except YieldToWorker as yld:
         repark = yld
+        if tap is not None and yld.graph_checkpoint is not None:
+            # 01a0690a: the SAME stash the original park uses
+            # (dispatch.py's catch) -- this repark never goes through
+            # dispatch.py, so any NEW pending entry this drain just
+            # produced gets its scoped id stashed here instead.
+            from primer.session.persistence import stash_graph_scoped_ids
+            stash_graph_scoped_ids(yld.graph_checkpoint, tap.coalesce_state)
 
-    return decision, repark
+    out_node_tool_call_seq = (
+        dict(tap.coalesce_state.tool_call_seq) if tap is not None else {}
+    )
+    if tap is not None:
+        await tap.finish()
+
+    return decision, repark, out_node_tool_call_seq
+
+
+class _ResumeDrainTap:
+    """Persists a graph resume drain's StreamEvents via the live path's own
+    persistence vocabulary (01a0690a piece 3/3 — Gap 2).
+
+    Best-effort throughout: any setup or per-event failure is logged and
+    the tap disables itself for the rest of the drain rather than raising
+    — a persistence hiccup must never fail an otherwise-successful resume
+    (same doctrine as ``persist_resume_tool_result_record_for_graph``,
+    piece 2).
+    """
+
+    def __init__(self, *, pool, session, writer, coalesce_state, turn_no) -> None:
+        self._pool = pool
+        self._session = session
+        self._writer = writer
+        self.coalesce_state = coalesce_state
+        self._turn_no = turn_no
+
+    @classmethod
+    async def create(
+        cls, pool: "WorkerPool", session, *, node_tool_call_seq: dict[str, int] | None,
+    ) -> "_ResumeDrainTap":
+        from primer.session.persistence import _CoalesceState, WorkspaceMessageWriter
+
+        state = _CoalesceState()
+        # Seed past whatever this turn_no already minted pre-park (see this
+        # module's docstring on node_tool_call_seq) instead of restarting
+        # every node's counter at 0 and re-minting colliding ids.
+        state.tool_call_seq = dict(node_tool_call_seq or {})
+        writer = None
+        try:
+            # Fresh read rather than trusting the session object threaded
+            # down the call chain: piece 2's write (resume_graph_engine
+            # calls it immediately before this) may already have bumped
+            # last_seq in storage, and starting this writer from a stale
+            # count would collide with piece 2's just-written seq.
+            from primer.model.workspace_session import WorkspaceSession
+
+            last_seq = session.last_seq
+            if pool._storage is not None:
+                fresh = await pool._storage.get_storage(WorkspaceSession).get(
+                    session.id,
+                )
+                if fresh is not None:
+                    last_seq = fresh.last_seq
+            ws = await pool._load_workspace_for_persist(session.workspace_id)
+            writer = WorkspaceMessageWriter(
+                workspace_io=ws, session_id=session.id, start_seq=last_seq,
+            )
+        except Exception:  # noqa: BLE001 - best-effort, see class docstring
+            logger.exception(
+                "resume: failed to set up graph resume-drain tap for "
+                "session %s",
+                session.id,
+            )
+        return cls(
+            pool=pool, session=session, writer=writer, coalesce_state=state,
+            turn_no=session.turn_no,
+        )
+
+    async def observe(self, event: Any) -> None:
+        if self._writer is None:
+            return
+        from primer.session.persistence import translate_stream_event
+
+        try:
+            result = translate_stream_event(
+                event, self.coalesce_state, turn_no=self._turn_no,
+            )
+            if result is None:
+                return
+            records = result if isinstance(result, list) else [result]
+            for rec in records:
+                seq = await self._writer.append(rec)
+                if self._pool._event_bus is not None:
+                    await self._pool._event_bus.publish(
+                        f"session:{self._session.id}:tick", {"seq": seq},
+                    )
+        except Exception:  # noqa: BLE001 - best-effort, see class docstring
+            logger.exception(
+                "resume: graph resume-drain tap failed for session %s -"
+                " disabling for the rest of this drain",
+                self._session.id,
+            )
+            self._writer = None
+
+    async def finish(self) -> None:
+        if self._writer is None:
+            return
+        try:
+            from primer.model.workspace_session import WorkspaceSession
+
+            await self._writer.flush()
+            if self._pool._storage is not None:
+                storage = self._pool._storage.get_storage(WorkspaceSession)
+                await storage.update(self._session.model_copy(
+                    update={"last_seq": self._writer.last_seq},
+                ))
+        except Exception:  # noqa: BLE001 - best-effort, see class docstring
+            logger.exception(
+                "resume: failed to flush graph resume-drain tap for "
+                "session %s",
+                self._session.id,
+            )
 
 
 def _pending_toolcalls_from(checkpoint: dict[str, Any]) -> "list[Any]":

--- a/primer/worker/graph_resume_coordinator.py
+++ b/primer/worker/graph_resume_coordinator.py
@@ -217,6 +217,15 @@ async def resume_graph_engine(pool: "WorkerPool", session, parked):
                 await pool._write_approval_record_for_graph(
                     session=session, checkpoint=ck, tcid=tcid, payload=payload,
                 )
+        # 01a0690a piece 2: agent_tool_result is a synthesized delivery
+        # (ask_user answer / unwound nested continuation) with no
+        # StreamEvent of its own -- the only way it gets a durable display
+        # record is an explicit write here.
+        if agent_tool_result is not None:
+            await pool._persist_resume_tool_result_record_for_graph(
+                session=session, checkpoint=ck, tcid=tcid,
+                agent_tool_result=agent_tool_result,
+            )
         try:
             _decision, repark = await resume_graph_from_checkpoint(
                 executor=executor,
@@ -443,6 +452,95 @@ async def graph_agent_tool_result(pool: "WorkerPool", checkpoint, tcid, payload)
         return Message(role="tool", parts=[ToolResultPart(
             id=tcid or ay["tool_call_id"], output="resume failed",
             error=True)])
+
+
+async def persist_resume_tool_result_record_for_graph(
+    pool: "WorkerPool", *, session, checkpoint, tcid, agent_tool_result,
+) -> None:
+    """Write the modern TOOL_RESULT counterpart for a resumed graph yield.
+
+    01a0690a piece 2/3. ``agent_tool_result`` (built by
+    :func:`graph_agent_tool_result` or the nested-continuation walk) is a
+    pure in-memory ``Message`` fed into the resumed node's LLM history for
+    continuation -- it has no corresponding StreamEvent, so no amount of
+    tapping the resume drain (piece 3) ever catches it. Mirrors
+    ``session_resume_coordinator._persist_resume_tool_result_record``
+    (0b4e8bfc / 01a068ea-dc95) for the agent path, node-tagged since graph
+    records carry a ``node_id`` the agent path has none of. ``call_id`` uses
+    the matched pending entry's ``scoped_tool_call_id`` (piece 1's stash),
+    falling back to the raw ``tcid`` for a checkpoint written before that
+    field existed.
+
+    A value-yielding tool_call's resume (ask_user answered via a
+    _PendingToolCall, not a _PendingAgentYield) has no durable record gap
+    to begin with: the node re-runs for real through _dispatch_toolcall_
+    with_bypass, so its ToolCallStart/End/Result flow through the live
+    _GraphNodeEvent-tapped pipeline exactly like any other execution --
+    that's why this only searches pending_agent_yields.
+
+    Best-effort, same doctrine as the agent-path sibling: a write failure
+    here must not fail an otherwise-successful resume.
+    """
+    if pool._storage is None or agent_tool_result is None:
+        return
+    from primer.model.chat import ToolResultPart
+    from primer.model.workspace_session import (
+        SessionMessageKind,
+        SessionMessageRecord,
+        WorkspaceSession,
+    )
+    from primer.session.persistence import WorkspaceMessageWriter
+
+    tool_result_part = next(
+        (p for p in agent_tool_result.parts if isinstance(p, ToolResultPart)),
+        None,
+    )
+    if tool_result_part is None:
+        return
+
+    node_id = None
+    scoped_call_id = None
+    for e in (checkpoint.get("pending_agent_yields") or []):
+        if e.get("tool_call_id") == tcid:
+            node_id = e.get("node_id")
+            scoped_call_id = e.get("scoped_tool_call_id")
+            break
+
+    try:
+        ws = await pool._load_workspace_for_persist(session.workspace_id)
+        writer = WorkspaceMessageWriter(
+            workspace_io=ws, session_id=session.id, start_seq=session.last_seq,
+        )
+        new_seq = await writer.append(SessionMessageRecord(
+            seq=1,  # overwritten by the writer's monotonic counter
+            kind=SessionMessageKind.TOOL_RESULT,
+            payload={
+                "call_id": scoped_call_id or tcid or tool_result_part.id,
+                "output": tool_result_part.output,
+                "error": tool_result_part.error,
+            },
+            node_id=node_id,
+            created_at=datetime.now(timezone.utc),
+        ))
+        await writer.flush()
+        storage = pool._storage.get_storage(WorkspaceSession)
+        await storage.update(session.model_copy(update={"last_seq": new_seq}))
+        if pool._event_bus is not None:
+            try:
+                await pool._event_bus.publish(
+                    f"session:{session.id}:tick", {"seq": new_seq},
+                )
+            except Exception:  # noqa: BLE001 - advisory
+                logger.exception(
+                    "resume: tick publish failed for graph session %s",
+                    session.id,
+                )
+    except Exception:  # noqa: BLE001 - best-effort, see docstring
+        logger.exception(
+            "resume: failed to persist modern TOOL_RESULT record for "
+            "graph session %s",
+            session.id,
+        )
 
 
 def repark_graph_outcome(pool: "WorkerPool", session, repark):

--- a/primer/worker/graph_resume_coordinator.py
+++ b/primer/worker/graph_resume_coordinator.py
@@ -185,6 +185,11 @@ async def resume_graph_engine(pool: "WorkerPool", session, parked):
         replies = [(resumed_tcid, resume_payload.payload)]
 
     repark = None
+    # 01a0690a piece 3: per-node mint-seq high-water mark, seeded from the
+    # original park and advanced after each drain below -- threaded into
+    # any repark this loop produces so a chain of resumes never re-mints a
+    # colliding scoped id.
+    node_tool_call_seq = dict(getattr(parked, "node_tool_call_seq", None) or {})
     for tcid, payload in replies:
         # Unified nested-yield: when the parked agent-node yielded from
         # INSIDE a nested invoke_agent invocation, its pending entry carries
@@ -227,12 +232,19 @@ async def resume_graph_engine(pool: "WorkerPool", session, parked):
                 agent_tool_result=agent_tool_result,
             )
         try:
-            _decision, repark = await resume_graph_from_checkpoint(
+            _decision, repark, node_tool_call_seq = await resume_graph_from_checkpoint(
                 executor=executor,
                 checkpoint=ck,
                 payload=payload,
                 resumed_tcid=tcid,
                 agent_tool_result=agent_tool_result,
+                pool=pool,
+                session=session,
+                # 01a0690a piece 3: seed from wherever the LAST drain left
+                # off, not the original park -- a multi-event park's later
+                # replies resume through this same loop, and each drain's
+                # own mints must not collide with the ones before it.
+                node_tool_call_seq=node_tool_call_seq,
             )
         except Exception:
             logger.exception(
@@ -247,7 +259,9 @@ async def resume_graph_engine(pool: "WorkerPool", session, parked):
     if repark is not None:
         # Human-interaction nodes still pending (not yet replied to) ->
         # re-park on the remaining keys (no re-dispatch).
-        return pool._repark_graph_outcome(session, repark)
+        return pool._repark_graph_outcome(
+            session, repark, node_tool_call_seq=node_tool_call_seq,
+        )
 
     # Drained to completion (the graph's own state.json carries the
     # real ended_reason; the session row mirrors _GraphTurnDriver).
@@ -404,6 +418,11 @@ def repark_graph_continuation(pool: "WorkerPool", session, parked, checkpoint, a
         started_at=now,
         tool_call_id=parked.tool_call_id,
         graph_checkpoint=new_ck,
+        # 01a0690a: the continuation walk mints no new tool-call events
+        # (it operates purely on the frames/leaf stack) -- nothing to
+        # seed with, so carry the original park's snapshot forward
+        # unchanged, same doctrine as 0b4e8bfc's repark_continuation.
+        node_tool_call_seq=getattr(parked, "node_tool_call_seq", None),
     )
     return ReleaseOutcome(
         success=True,
@@ -543,9 +562,17 @@ async def persist_resume_tool_result_record_for_graph(
         )
 
 
-def repark_graph_outcome(pool: "WorkerPool", session, repark):
+def repark_graph_outcome(
+    pool: "WorkerPool", session, repark, *, node_tool_call_seq=None,
+):
     """Build a ReleaseOutcome that re-parks a graph session on the
-    remaining human-interaction keys after one reply was resumed."""
+    remaining human-interaction keys after one reply was resumed.
+
+    ``node_tool_call_seq`` (01a0690a piece 3): the resume drain's own
+    per-node mint-seq snapshot -- carried into the new park so a further
+    resume of THIS repark seeds past whatever THIS drain just minted,
+    instead of the stale pre-park snapshot the checkpoint started with.
+    """
     from datetime import timedelta
     from primer.int.claim import ParkRequest, ReleaseOutcome
 
@@ -558,6 +585,7 @@ def repark_graph_outcome(pool: "WorkerPool", session, repark):
         started_at=now,
         tool_call_id=repark.tool_call_id,
         graph_checkpoint=repark.graph_checkpoint,
+        node_tool_call_seq=node_tool_call_seq or None,
     )
     return ReleaseOutcome(
         success=True,

--- a/primer/worker/pool.py
+++ b/primer/worker/pool.py
@@ -784,8 +784,10 @@ class WorkerPool:
             agent_tool_result=agent_tool_result,
         )
 
-    def _repark_graph_outcome(self, session, repark):
-        return graph_resume_coordinator.repark_graph_outcome(self, session, repark)
+    def _repark_graph_outcome(self, session, repark, *, node_tool_call_seq=None):
+        return graph_resume_coordinator.repark_graph_outcome(
+            self, session, repark, node_tool_call_seq=node_tool_call_seq,
+        )
 
     def _repark_resumed_yield_outcome(self, session, parked, yld):
         return session_resume_coordinator.repark_resumed_yield_outcome(

--- a/primer/worker/pool.py
+++ b/primer/worker/pool.py
@@ -776,6 +776,14 @@ class WorkerPool:
             self, checkpoint, tcid, payload,
         )
 
+    async def _persist_resume_tool_result_record_for_graph(
+        self, *, session, checkpoint, tcid, agent_tool_result,
+    ) -> None:
+        return await graph_resume_coordinator.persist_resume_tool_result_record_for_graph(
+            self, session=session, checkpoint=checkpoint, tcid=tcid,
+            agent_tool_result=agent_tool_result,
+        )
+
     def _repark_graph_outcome(self, session, repark):
         return graph_resume_coordinator.repark_graph_outcome(self, session, repark)
 

--- a/primer/worker/yield_runtime.py
+++ b/primer/worker/yield_runtime.py
@@ -122,6 +122,18 @@ class ParkedState:
     client_tools_attached: bool = False
     binding_epoch: int | None = None
     frames: list = field(default_factory=list)
+    # 01a0690a: per-node monotonic tool-call-seq high-water mark, snapshotted
+    # from dispatch.py's coalesce_state.tool_call_seq at park time -- ONLY
+    # meaningful for a graph park (None for an agent-bound park, which has
+    # no node_id keying to begin with). A resumed graph drain that mints
+    # MORE scoped ids (Gap 2: tool calls after the resumed node continues)
+    # must seed its own fresh _CoalesceState.tool_call_seq from this instead
+    # of restarting every node's counter at 0 -- a fresh counter would
+    # re-mint node:tool:turn_no:1.. and collide with ids this SAME turn_no
+    # already minted before the park (turn_no does not bump until
+    # on_release, so the resume drain observes the identical turn_no).
+    # None for a checkpoint written before this field existed.
+    node_tool_call_seq: dict[str, int] | None = None
     schema_version: int = PARKED_STATE_SCHEMA_VERSION
     # 01a068ea-dc95: the DURABLE TOOL_CALL SessionMessageRecord this park
     # answers was minted with the SCOPED id (primer.session.persistence's
@@ -165,6 +177,11 @@ class ParkedState:
                 else None
             ),
             "frames": frames_to_jsonable(self.frames),
+            "node_tool_call_seq": (
+                dict(self.node_tool_call_seq)
+                if self.node_tool_call_seq is not None
+                else None
+            ),
         }
 
     @classmethod
@@ -248,6 +265,11 @@ class ParkedState:
             frames=frames,
             schema_version=version,
             scoped_tool_call_id=data.get("scoped_tool_call_id"),
+            node_tool_call_seq=(
+                dict(data["node_tool_call_seq"])
+                if data.get("node_tool_call_seq") is not None
+                else None
+            ),
         )
 
 

--- a/tests/graph/test_graph_checkpoint_roundtrip.py
+++ b/tests/graph/test_graph_checkpoint_roundtrip.py
@@ -149,6 +149,10 @@ async def test_snapshot_and_restore_preserves_state() -> None:
             tool_call_id="tc-abc",
             parked_event_key="tool_approval:gsid-1:tc-abc",
             arguments={"q": "x", "limit": 10},
+            # 01a0690a: the scoped id the paired durable TOOL_CALL record
+            # carries — must survive the snapshot/restore round-trip so a
+            # repark carries it forward unchanged.
+            scoped_tool_call_id="worker[1]:tool:3:1",
         ),
     ]
 
@@ -207,3 +211,4 @@ async def test_snapshot_and_restore_preserves_state() -> None:
     assert p.tool_call_id == "tc-abc"
     assert p.parked_event_key == "tool_approval:gsid-1:tc-abc"
     assert p.arguments == {"q": "x", "limit": 10}
+    assert p.scoped_tool_call_id == "worker[1]:tool:3:1"

--- a/tests/session/test_persistence.py
+++ b/tests/session/test_persistence.py
@@ -633,6 +633,57 @@ def test_stash_graph_scoped_ids_preserves_existing_value() -> None:
     assert checkpoint["pending_toolcalls"][0]["scoped_tool_call_id"] == "worker[0]:tool:3:1"
 
 
+def test_seeded_coalesce_state_avoids_scoped_id_collision_after_resume() -> None:
+    """01a0690a piece 3 collision guard: turn_no does not bump across a
+    park/resume (on_release only bumps it on a non-park release), so a
+    resumed drain's fresh _CoalesceState observes the SAME turn_no the
+    pre-park mints used. Without seeding tool_call_seq from the park's
+    node_tool_call_seq snapshot, a node that made 2 calls before parking
+    would mint seq 1, 2 again after resume -- a silent, unpaired id
+    collision in the durable record.
+
+    Simulates: node worker[0] makes 2 tool calls (minted live, pre-park),
+    parks; on resume a FRESH _CoalesceState is seeded from the snapshot
+    (mirroring _ResumeDrainTap.create) and the SAME node makes 2 more
+    calls. All 4 scoped ids must be distinct.
+    """
+    from primer.model.chat import ToolCallStart
+    from primer.session.persistence import _CoalesceState, translate_stream_event
+
+    turn_no = 3
+    node_id = "worker[0]"
+
+    # --- pre-park: 2 tool calls on the live coalesce_state ---
+    live_state = _CoalesceState()
+    for i in range(2):
+        translate_stream_event(
+            ToolCallStart(id=f"raw-{i}", name="t", index=i), live_state,
+            node_id=node_id, turn_no=turn_no,
+        )
+    pre_park_ids = {
+        live_state.scoped_call_ids[(node_id, f"raw-{i}")] for i in range(2)
+    }
+    assert len(pre_park_ids) == 2  # sanity: the two pre-park mints differ
+
+    # --- park: snapshot the mint-seq high-water mark (ParkedState.node_tool_call_seq) ---
+    node_tool_call_seq = dict(live_state.tool_call_seq)
+
+    # --- resume: a FRESH _CoalesceState, seeded per _ResumeDrainTap.create ---
+    resume_state = _CoalesceState()
+    resume_state.tool_call_seq = dict(node_tool_call_seq)
+    for i in range(2, 4):
+        translate_stream_event(
+            ToolCallStart(id=f"raw-{i}", name="t", index=i - 2), resume_state,
+            node_id=node_id, turn_no=turn_no,  # SAME turn_no as pre-park
+        )
+    post_resume_ids = {
+        resume_state.scoped_call_ids[(node_id, f"raw-{i}")] for i in range(2, 4)
+    }
+
+    all_ids = pre_park_ids | post_resume_ids
+    assert len(all_ids) == 4, f"expected 4 distinct scoped ids, got {all_ids}"
+
+
 # ---------------------------------------------------------------------------
 # F1a: per-graph-node agent events flow into the session log, attributed by
 # node_id (the wrapped _GraphNodeEvent un-drop + per-node coalescing).

--- a/tests/session/test_persistence.py
+++ b/tests/session/test_persistence.py
@@ -572,6 +572,68 @@ def test_translate_done_usage_with_optional_fields() -> None:
 
 
 # ---------------------------------------------------------------------------
+# 01a0690a: stash_graph_scoped_ids — graph-park scoped-id/seq stashing
+# ---------------------------------------------------------------------------
+
+
+def test_stash_graph_scoped_ids_none_checkpoint_is_noop() -> None:
+    """An agent-bound park (no graph_checkpoint) has nothing to stash."""
+    from primer.session.persistence import _CoalesceState, stash_graph_scoped_ids
+
+    state = _CoalesceState()
+    assert stash_graph_scoped_ids(None, state) == {}
+
+
+def test_stash_graph_scoped_ids_sets_matching_entries() -> None:
+    """Each pending entry's scoped_tool_call_id is set from coalesce_state,
+    keyed by (node_id, tool_call_id); the per-node seq snapshot is returned
+    for ParkedState.node_tool_call_seq."""
+    from primer.session.persistence import _CoalesceState, stash_graph_scoped_ids
+
+    state = _CoalesceState()
+    state.scoped_call_ids[("worker[0]", "tc-1")] = "worker[0]:tool:5:1"
+    state.scoped_call_ids[("asker", "tc-2")] = "asker:tool:5:1"
+    state.tool_call_seq["worker[0]"] = 1
+    state.tool_call_seq["asker"] = 1
+    checkpoint = {
+        "pending_toolcalls": [
+            {"node_id": "worker[0]", "tool_call_id": "tc-1", "scoped_tool_call_id": None},
+        ],
+        "pending_agent_yields": [
+            {"node_id": "asker", "tool_call_id": "tc-2", "scoped_tool_call_id": None},
+        ],
+    }
+
+    node_tool_call_seq = stash_graph_scoped_ids(checkpoint, state)
+
+    assert checkpoint["pending_toolcalls"][0]["scoped_tool_call_id"] == "worker[0]:tool:5:1"
+    assert checkpoint["pending_agent_yields"][0]["scoped_tool_call_id"] == "asker:tool:5:1"
+    assert node_tool_call_seq == {"worker[0]": 1, "asker": 1}
+
+
+def test_stash_graph_scoped_ids_preserves_existing_value() -> None:
+    """An entry carried forward from an earlier park (repark) already has a
+    scoped_tool_call_id; a resume-time coalesce_state that never minted it
+    must not overwrite it with a (missing) lookup."""
+    from primer.session.persistence import _CoalesceState, stash_graph_scoped_ids
+
+    state = _CoalesceState()  # fresh -- mints nothing for tc-1
+    checkpoint = {
+        "pending_toolcalls": [
+            {
+                "node_id": "worker[0]", "tool_call_id": "tc-1",
+                "scoped_tool_call_id": "worker[0]:tool:3:1",
+            },
+        ],
+        "pending_agent_yields": [],
+    }
+
+    stash_graph_scoped_ids(checkpoint, state)
+
+    assert checkpoint["pending_toolcalls"][0]["scoped_tool_call_id"] == "worker[0]:tool:3:1"
+
+
+# ---------------------------------------------------------------------------
 # F1a: per-graph-node agent events flow into the session log, attributed by
 # node_id (the wrapped _GraphNodeEvent un-drop + per-node coalescing).
 # ---------------------------------------------------------------------------

--- a/tests/worker/test_graph_resume_coordinator.py
+++ b/tests/worker/test_graph_resume_coordinator.py
@@ -1,0 +1,190 @@
+"""01a0690a piece 2 — persist_resume_tool_result_record_for_graph.
+
+A resumed graph yield's ``agent_tool_result`` (ask_user answer / unwound
+nested continuation) is a pure in-memory Message built purely for LLM
+continuation — it has no corresponding StreamEvent, so nothing in the live
+tap pipeline ever records it. These tests drive
+``persist_resume_tool_result_record_for_graph`` directly (a standalone
+module function, not a full ``resume_graph_engine`` orchestration) against
+lightweight fakes for the pool's storage/workspace/event-bus deps, mirroring
+the direct-call style ``session_resume_coordinator``'s sibling function
+(``_persist_resume_tool_result_record``, 0b4e8bfc) is already unit-tested
+with in ``test_engine_session_resume.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime, timezone
+
+import pytest
+
+from primer.model.chat import Message, ToolResultPart
+from primer.model.workspace_session import (
+    GraphSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+from primer.worker import graph_resume_coordinator
+
+
+async def _async_return(value):
+    return value
+
+
+class _FakeEventBus:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict]] = []
+
+    async def publish(self, key: str, payload: dict) -> None:
+        self.published.append((key, payload))
+
+
+class _FakeWorkspaceIO:
+    def __init__(self) -> None:
+        self.lines: list[tuple[str, bytes]] = []
+
+    async def append_message_line(self, session_id: str, line: bytes) -> None:
+        self.lines.append((session_id, line))
+
+
+class _FakeSessionStorage:
+    def __init__(self) -> None:
+        self.updated: list[WorkspaceSession] = []
+
+    async def update(self, session: WorkspaceSession) -> None:
+        self.updated.append(session)
+
+
+class _FakeStorage:
+    def __init__(self, session_storage: _FakeSessionStorage) -> None:
+        self._session_storage = session_storage
+
+    def get_storage(self, model_cls):
+        assert model_cls is WorkspaceSession
+        return self._session_storage
+
+
+class _FakePool:
+    def __init__(self, *, workspace_io, storage, event_bus=None) -> None:
+        self._storage = storage
+        self._event_bus = event_bus
+        self._workspace_io = workspace_io
+
+    async def _load_workspace_for_persist(self, workspace_id: str):
+        return self._workspace_io
+
+
+def _make_graph_session(*, last_seq: int = 5) -> WorkspaceSession:
+    return WorkspaceSession(
+        id="gs-1",
+        workspace_id="ws-1",
+        binding=GraphSessionBinding(graph_id="g-1"),
+        status=SessionStatus.RUNNING,
+        created_at=datetime.now(timezone.utc),
+        last_seq=last_seq,
+    )
+
+
+def _make_agent_tool_result(tcid: str = "tc-raw") -> Message:
+    return Message(
+        role="tool",
+        parts=[ToolResultPart(id=tcid, output="Alice", error=False)],
+    )
+
+
+@pytest.mark.asyncio
+async def test_writes_tool_result_with_scoped_call_id_and_node_tag():
+    ws = _FakeWorkspaceIO()
+    session_storage = _FakeSessionStorage()
+    pool = _FakePool(workspace_io=ws, storage=_FakeStorage(session_storage))
+    session = _make_graph_session()
+    checkpoint = {
+        "pending_agent_yields": [
+            {
+                "node_id": "asker",
+                "tool_call_id": "tc-raw",
+                "scoped_tool_call_id": "asker:tool:0:1",
+            },
+        ],
+    }
+
+    await graph_resume_coordinator.persist_resume_tool_result_record_for_graph(
+        pool, session=session, checkpoint=checkpoint, tcid="tc-raw",
+        agent_tool_result=_make_agent_tool_result("tc-raw"),
+    )
+
+    assert len(ws.lines) == 1
+    _sid, blob = ws.lines[0]
+    record = json.loads(blob.decode().splitlines()[0])
+    assert record["kind"] == "tool_result"
+    assert record["payload"]["call_id"] == "asker:tool:0:1"
+    assert record["payload"]["output"] == "Alice"
+    assert record["node_id"] == "asker"
+    assert session_storage.updated
+    assert session_storage.updated[-1].last_seq > session.last_seq
+
+
+@pytest.mark.asyncio
+async def test_falls_back_to_raw_tcid_without_scoped_id():
+    """A checkpoint written before piece 1 has no scoped_tool_call_id."""
+    ws = _FakeWorkspaceIO()
+    session_storage = _FakeSessionStorage()
+    pool = _FakePool(workspace_io=ws, storage=_FakeStorage(session_storage))
+    session = _make_graph_session()
+    checkpoint = {
+        "pending_agent_yields": [
+            {"node_id": "asker", "tool_call_id": "tc-raw"},
+        ],
+    }
+
+    await graph_resume_coordinator.persist_resume_tool_result_record_for_graph(
+        pool, session=session, checkpoint=checkpoint, tcid="tc-raw",
+        agent_tool_result=_make_agent_tool_result("tc-raw"),
+    )
+
+    record = json.loads(ws.lines[0][1].decode().splitlines()[0])
+    assert record["payload"]["call_id"] == "tc-raw"
+
+
+@pytest.mark.asyncio
+async def test_publishes_tick():
+    ws = _FakeWorkspaceIO()
+    session_storage = _FakeSessionStorage()
+    event_bus = _FakeEventBus()
+    pool = _FakePool(
+        workspace_io=ws, storage=_FakeStorage(session_storage), event_bus=event_bus,
+    )
+    session = _make_graph_session()
+    checkpoint = {
+        "pending_agent_yields": [
+            {"node_id": "asker", "tool_call_id": "tc-raw", "scoped_tool_call_id": "x"},
+        ],
+    }
+
+    await graph_resume_coordinator.persist_resume_tool_result_record_for_graph(
+        pool, session=session, checkpoint=checkpoint, tcid="tc-raw",
+        agent_tool_result=_make_agent_tool_result("tc-raw"),
+    )
+
+    assert len(event_bus.published) == 1
+    key, payload = event_bus.published[0]
+    assert key == f"session:{session.id}:tick"
+    assert "seq" in payload
+
+
+@pytest.mark.asyncio
+async def test_none_agent_tool_result_is_noop():
+    """No agent_tool_result -> nothing to write (approval-gate resumes,
+    which re-run for real and get tapped by piece 3 instead)."""
+    ws = _FakeWorkspaceIO()
+    session_storage = _FakeSessionStorage()
+    pool = _FakePool(workspace_io=ws, storage=_FakeStorage(session_storage))
+    session = _make_graph_session()
+
+    await graph_resume_coordinator.persist_resume_tool_result_record_for_graph(
+        pool, session=session, checkpoint={}, tcid="tc-raw", agent_tool_result=None,
+    )
+
+    assert ws.lines == []
+    assert session_storage.updated == []

--- a/tests/worker/test_pool_graph_resume.py
+++ b/tests/worker/test_pool_graph_resume.py
@@ -21,6 +21,7 @@ turn loop while still pinning the load-bearing contract:
 
 from __future__ import annotations
 
+import json
 from collections.abc import AsyncIterator
 from datetime import datetime, timezone
 
@@ -284,7 +285,7 @@ async def test_resume_graph_from_checkpoint_approved_drains() -> None:
 
     resume_executor.resume_from_checkpoint = _tap  # type: ignore[assignment]
 
-    decision, _repark = await resume_graph_from_checkpoint(
+    decision, _repark, _node_tool_call_seq = await resume_graph_from_checkpoint(
         executor=resume_executor,
         checkpoint=restored.graph_checkpoint,  # type: ignore[arg-type]
         payload={"decision": "approved"},
@@ -301,6 +302,140 @@ async def test_resume_graph_from_checkpoint_approved_drains() -> None:
     loaded = await thread_storage.get(thread.id)
     assert loaded is not None
     assert loaded.ended_reason == "completed"
+
+
+# ===========================================================================
+# 01a0690a piece 3: the resume drain's events are durably tapped, not
+# discarded (Gap 2 -- worker/graph_resume.py's _ResumeDrainTap)
+# ===========================================================================
+
+
+class _FakeWorkspaceIO:
+    def __init__(self) -> None:
+        self.lines: list[tuple[str, bytes]] = []
+
+    async def append_message_line(self, session_id: str, line: bytes) -> None:
+        self.lines.append((session_id, line))
+
+
+class _FakeSessionRow:
+    def __init__(self, *, sid: str, workspace_id: str, turn_no: int, last_seq: int) -> None:
+        self.id = sid
+        self.workspace_id = workspace_id
+        self.turn_no = turn_no
+        self.last_seq = last_seq
+
+    def model_copy(self, *, update: dict):
+        merged = {**self.__dict__, **update}
+        return _FakeSessionRow(
+            sid=merged["id"], workspace_id=merged["workspace_id"],
+            turn_no=merged["turn_no"], last_seq=merged["last_seq"],
+        )
+
+
+class _FakeSessionStorage:
+    def __init__(self, row) -> None:
+        self._row = row
+
+    async def get(self, sid: str):
+        return self._row if self._row.id == sid else None
+
+    async def update(self, row) -> None:
+        self._row = row
+
+
+class _FakeStorage:
+    def __init__(self, session_storage) -> None:
+        self._session_storage = session_storage
+
+    def get_storage(self, _model_cls):
+        return self._session_storage
+
+
+class _FakePool:
+    def __init__(self, *, workspace_io, storage) -> None:
+        self._storage = storage
+        self._event_bus = None
+        self._workspace_io = workspace_io
+
+    async def _load_workspace_for_persist(self, _workspace_id: str):
+        return self._workspace_io
+
+
+@pytest.mark.asyncio
+async def test_resume_graph_from_checkpoint_taps_drain_into_durable_records() -> None:
+    """Gap 2: previously ``async for _ev in ...: pass`` -- the resumed
+    drain's own StreamEvents (node exit transitions, the End output) were
+    silently discarded. With pool/session passed, they land as durable
+    SessionMessageRecords via the same WorkspaceMessageWriter vocabulary
+    the live turn uses."""
+    graph = _make_simple_graph("g-resume-tapped")
+    yielded_obj = Yielded(tool_name="_approval", event_key="tool_approval:sid:tc-1")
+
+    async def first_dispatcher(node, arguments):
+        raise YieldToWorker(yielded_obj, tool_call_id="tc-1")
+
+    async def resume_dispatcher(node, arguments, bypass_approval=False):
+        return ToolResultPart(id="tc-1", output="ok")
+
+    thread_storage = _InMemoryStorage(GraphThread)
+    message_storage = _InMemoryStorage(GraphNodeMessage)
+    thread = await GraphExecutor.open_thread(
+        graph=graph, thread_storage=thread_storage,  # type: ignore[arg-type]
+    )
+    park_executor = GraphExecutor(
+        graph=graph,
+        agent_resolver=_agent_resolver,
+        llm_resolver=_llm_resolver,  # type: ignore[arg-type]
+        thread_storage=thread_storage,  # type: ignore[arg-type]
+        message_storage=message_storage,  # type: ignore[arg-type]
+        graph_thread_id=thread.id,
+        tool_dispatcher=first_dispatcher,
+    )
+    _events, raised = await _drain_until_yield(park_executor.invoke([]))
+    assert raised is not None
+    checkpoint = park_executor.snapshot_state()
+
+    resume_executor = GraphExecutor(
+        graph=graph,
+        agent_resolver=_agent_resolver,
+        llm_resolver=_llm_resolver,  # type: ignore[arg-type]
+        thread_storage=thread_storage,  # type: ignore[arg-type]
+        message_storage=message_storage,  # type: ignore[arg-type]
+        graph_thread_id=thread.id,
+        tool_dispatcher=resume_dispatcher,
+    )
+
+    ws = _FakeWorkspaceIO()
+    session_row = _FakeSessionRow(
+        sid="gs-tapped", workspace_id="ws-1", turn_no=1, last_seq=0,
+    )
+    pool = _FakePool(workspace_io=ws, storage=_FakeStorage(_FakeSessionStorage(session_row)))
+
+    decision, repark, node_tool_call_seq = await resume_graph_from_checkpoint(
+        executor=resume_executor,
+        checkpoint=checkpoint,
+        payload={"decision": "approved"},
+        pool=pool,  # type: ignore[arg-type]
+        session=session_row,
+    )
+    assert decision == "approved"
+    assert repark is None
+    assert node_tool_call_seq == {}  # no ToolCallStart events on this path
+
+    # The graph's own lifecycle events (node exit transition, End output)
+    # landed as durable records instead of being discarded. The writer
+    # buffers multiple records per append_message_line call, newline-
+    # separated, so flatten before parsing.
+    assert ws.lines, "resume drain produced no durable records"
+    kinds = [
+        json.loads(raw)["kind"]
+        for _sid, line in ws.lines
+        for raw in line.decode().splitlines()
+        if raw.strip()
+    ]
+    assert "graph_transition" in kinds
+    assert "assistant_token" in kinds  # the End node's output_template
 
 
 # ===========================================================================
@@ -363,7 +498,7 @@ async def test_resume_graph_from_checkpoint_rejected_terminates_failed() -> None
 
     resume_executor.resume_from_checkpoint = _tap  # type: ignore[assignment]
 
-    decision, _repark = await resume_graph_from_checkpoint(
+    decision, _repark, _node_tool_call_seq = await resume_graph_from_checkpoint(
         executor=resume_executor,
         checkpoint=checkpoint,
         payload={"decision": "rejected", "reason": "no thanks"},
@@ -423,7 +558,7 @@ async def test_resume_graph_from_checkpoint_timeout_terminates_failed() -> None:
         tool_dispatcher=never_called,
     )
 
-    decision, _repark = await resume_graph_from_checkpoint(
+    decision, _repark, _node_tool_call_seq = await resume_graph_from_checkpoint(
         executor=resume_executor,
         checkpoint=checkpoint,
         payload=YieldTimeout(elapsed_seconds=3600.0),


### PR DESCRIPTION
## Summary

01a0690a. Graph-bound session resumes wrote no durable TOOL_RESULT display record for a resumed yield, and anything the graph did after resuming (until its next park) was silently dropped from the record too. The bug had two independent causes, fixed as three commits:

- **e7b0314f** — stashes the node-qualified scoped tool-call id (the id the live-written TOOL_CALL record actually carries) into the graph checkpoint's pending entries at park time, plus a `ParkedState.node_tool_call_seq` snapshot needed by commit 3.
- **8e2c0571** (Gap 1) — the resumed yield's own answer (ask_user reply / unwound nested continuation) is a synthesized in-memory `Message` with no corresponding StreamEvent. Writes it explicitly via the same `WorkspaceMessageWriter` vocabulary the live path uses, node-tagged, paired by the scoped id from commit 1.
- **ae63a92d** (Gap 2) — `resume_graph_from_checkpoint`'s drain loop was `async for _ev in ...: pass`, discarding every event the resumed graph produced afterward (node transitions, new tool calls, the End output). Taps it into durable records instead, with a seq-collision hazard fixed along the way (see below).

## Base branch

Based on `fix/resume-tool-result-scoped-id` (#232, not yet merged) rather than `main`: commit 1 extends `ParkedState.scoped_tool_call_id`, which #232 introduces, and re-implementing that field here would fork the pattern. **Once #232 rebase-merges to main, this branch will be rebased onto main and its base retargeted** — ancestor SHAs will be rewritten by that rebase (rebase-only repo), so the diff here is expected to shift at that point, not a sign of drift.

## Seq-collision hazard (piece 3)

`session.turn_no` does not bump across a park/resume — `on_release` (primer/claim/adapters/sessions.py) only bumps it on a non-park release; a park explicitly skips it. So a resumed drain observes the *same* `turn_no` the pre-park turn used. A fresh `_CoalesceState` for the drain would restart every node's tool-call mint counter at 0 and re-mint ids that collide with (and silently overwrite the pairing of) ids already minted and displayed pre-park. Fixed by seeding the resume drain's counter from `ParkedState.node_tool_call_seq` (commit 1), re-derived through any further repark via a shared stash helper.

## Test plan

- [x] `tests/session/test_persistence.py::test_seeded_coalesce_state_avoids_scoped_id_collision_after_resume` — park after 2 tool calls, resume, 2 more calls on the same node, asserts 4 distinct scoped ids (fails without the seeding fix).
- [x] `tests/worker/test_pool_graph_resume.py::test_resume_graph_from_checkpoint_taps_drain_into_durable_records` — drives a real `GraphExecutor` through `resume_graph_from_checkpoint` with `pool`/`session` wired, asserts `graph_transition`/`assistant_token` records actually land (would have caught the original discard bug directly).
- [x] `tests/worker/test_graph_resume_coordinator.py` — new file, direct unit coverage of the Gap 1 write (scoped-id pairing, node tagging, tick publish, raw-id fallback, no-op on `agent_tool_result=None`).
- [x] `tests/graph/test_graph_checkpoint_roundtrip.py`, `tests/session/test_persistence.py` — checkpoint field round-trip + `stash_graph_scoped_ids` unit coverage.
- [x] Full `tests/worker/` + `tests/graph/` + `tests/session/` regression run: 883 passed, 1 pre-existing unrelated xfail.
- [x] `ruff check` clean on every touched file.

## Known follow-up (filed separately, not in this PR)

`primer/graph/_agent_node.py`'s `_resume_agent_node` has its own internal `async for _event in run_agent_turn(...): pass` — a second, deeper drain-and-discard for when a resumed agent node's own turn continues (e.g. the ask_user answer triggers more tool calls before that node finishes). It never reaches `resume_from_checkpoint`'s own generator, so this PR's tap can't see it. Fixing it means converting `_resume_agent_node` from an awaited call to an async generator and updating its call site — a control-flow shape change to a core executor method, a different risk class from this PR's caller-side persistence tap. Filed as task 01a06933.