### PR TITLE
fix(claim): terminal-error session write no longer corrupts history, and actually runs

### DIFF
--- a/primer/api/_app_lifespan.py
+++ b/primer/api/_app_lifespan.py
@@ -455,6 +455,7 @@ def _make_lifespan(config: AppConfig):
             claim_engine = _ClaimEngineFactory.create(
                 storage_provider=storage_provider,
                 event_bus=event_bus,
+                workspace_registry=workspace_registry,
             )
             logger.info("lifespan: claim engine constructed (%s)", type(claim_engine).__name__)
             await provider_registry.bind_invalidation_bus(coordinator.invalidation_bus)

--- a/primer/api/app.py
+++ b/primer/api/app.py
@@ -367,6 +367,7 @@ def create_test_app(
         _claim_engine = _CEF.create(
             storage_provider=storage_provider,
             event_bus=_test_event_bus,
+            workspace_registry=workspace_registry,
         )
         _pool = _WorkerPool(
             config=_pool_config,

--- a/primer/claim/adapters/sessions.py
+++ b/primer/claim/adapters/sessions.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import logging
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
@@ -7,7 +8,11 @@ from primer.int.claim import ClaimAdapter, ClaimKind, ReleaseOutcome
 from primer.int.storage import Storage
 
 if TYPE_CHECKING:
-    from primer.session.persistence import WorkspaceIO
+    from primer.api.registries.workspace_registry import WorkspaceRegistry
+    from primer.int.event_bus import EventBus
+    from primer.model.workspace_session import WorkspaceSession
+
+logger = logging.getLogger(__name__)
 
 
 class SessionClaimAdapter(ClaimAdapter):
@@ -18,10 +23,18 @@ class SessionClaimAdapter(ClaimAdapter):
         self,
         *,
         session_storage: Storage | None,
-        workspace_io: "WorkspaceIO | None" = None,
+        workspace_registry: "WorkspaceRegistry | None" = None,
+        event_bus: "EventBus | None" = None,
     ) -> None:
         self._storage = session_storage
-        self._workspace_io = workspace_io
+        # 01a068ea: a workspace's I/O handle is resolved per-session (each
+        # session belongs to its own workspace), so this adapter -- a
+        # process-wide singleton spanning every workspace -- needs the
+        # REGISTRY, not one fixed WorkspaceIO. Resolved lazily in
+        # _write_terminal_record, mirroring
+        # WorkerPool._load_workspace_for_persist's own per-call resolution.
+        self._workspace_registry = workspace_registry
+        self._event_bus = event_bus
 
     def eligibility_sql(self) -> str:
         # parked_status lives inside the entity's JSONB ``data`` column, not as
@@ -132,15 +145,24 @@ class SessionClaimAdapter(ClaimAdapter):
 
         # Write a terminal error record to messages.jsonl when the release
         # is a failure (reclaim, worker crash, or any other engine error).
-        if not outcome.success and self._workspace_io is not None:
-            await self._write_terminal_record(entity_id, outcome)
+        # This is the ONLY durable error record for a crash/reclaim failure
+        # mode: dispatch.py's own except-block write can't run if the
+        # worker process that would run it is the thing that died.
+        if not outcome.success and self._workspace_registry is not None:
+            await self._write_terminal_record(sess, outcome)
 
     async def _write_terminal_record(
-        self, session_id: str, outcome: ReleaseOutcome
+        self, session: "WorkspaceSession", outcome: ReleaseOutcome,
     ) -> None:
         """Append a synthetic error-kind SessionMessageRecord to messages.jsonl."""
         from primer.model.workspace_session import SessionMessageKind, SessionMessageRecord
         from primer.session.persistence import WorkspaceMessageWriter
+
+        workspace_io = await self._workspace_registry.get_workspace(
+            session.workspace_id,
+        )
+        if workspace_io is None:
+            return
 
         reason = outcome.last_error or "unknown"
         record = SessionMessageRecord(
@@ -150,8 +172,27 @@ class SessionClaimAdapter(ClaimAdapter):
             created_at=datetime.now(timezone.utc),
         )
         writer = WorkspaceMessageWriter(
-            workspace_io=self._workspace_io,
-            session_id=session_id,
+            workspace_io=workspace_io,
+            session_id=session.id,
+            # 01a068ea: seed past the row's existing history. The default
+            # start_seq=0 landed this record at seq=1, silently OVERWRITING
+            # whatever real message already held that seq on any session
+            # that errors out after messages exist (pool.py:596's pattern).
+            start_seq=session.last_seq,
         )
-        await writer.append(record)
+        new_seq = await writer.append(record)
         await writer.flush()
+        # 01a068ea: a durable-but-unticked write is invisible to a live
+        # client until its next poll -- same advisory doctrine as every
+        # other tick publish in this codebase (best-effort, never fails
+        # the write it's reporting on).
+        if self._event_bus is not None:
+            try:
+                await self._event_bus.publish(
+                    f"session:{session.id}:tick", {"seq": new_seq},
+                )
+            except Exception:  # noqa: BLE001 - advisory
+                logger.exception(
+                    "on_release: tick publish failed for session %s",
+                    session.id,
+                )

--- a/primer/claim/factory.py
+++ b/primer/claim/factory.py
@@ -21,6 +21,7 @@ from primer.int.claim import ClaimKind
 from primer.int.event_bus import EventBus
 
 if TYPE_CHECKING:
+    from primer.api.registries.workspace_registry import WorkspaceRegistry
     from primer.int.claim import ClaimEngine
     from primer.int.storage_provider import StorageProvider
 
@@ -31,6 +32,7 @@ class ClaimEngineFactory:
         *,
         storage_provider: "StorageProvider",
         event_bus: EventBus,
+        workspace_registry: "WorkspaceRegistry | None" = None,
     ) -> "ClaimEngine":
         """Build a ClaimEngine + the three standard adapters.
 
@@ -43,6 +45,14 @@ class ClaimEngineFactory:
         Adapters are constructed here so callers do not need to know about the
         individual adapter constructors.  Each adapter receives the
         ``Storage[T]`` handle from *storage_provider*.
+
+        ``workspace_registry`` (01a068ea) activates
+        :class:`SessionClaimAdapter`'s terminal-error write: every real
+        caller already builds a registry for its own turn-execution path,
+        so this is always the SAME registry, not a second one. Optional
+        (``None`` degrades exactly like the pre-01a068ea default: no
+        terminal-error write) so callers that only exercise the
+        harness/trigger adapters don't need one.
         """
         from primer.model.workspace_session import WorkspaceSession
         from primer.model.harness import Harness
@@ -52,6 +62,8 @@ class ClaimEngineFactory:
         adapters = {
             ClaimKind.SESSION: SessionClaimAdapter(
                 session_storage=storage_provider.get_storage(WorkspaceSession),
+                workspace_registry=workspace_registry,
+                event_bus=event_bus,
             ),
             ClaimKind.HARNESS: HarnessClaimAdapter(
                 harness_storage=storage_provider.get_storage(Harness),

--- a/tests/claim/test_factory.py
+++ b/tests/claim/test_factory.py
@@ -2,13 +2,16 @@
 
 from __future__ import annotations
 
+import json
+from collections import defaultdict
+
 import pytest
 
 from primer.bus.in_memory import InMemoryEventBus
 from primer.claim.factory import ClaimEngineFactory
 from primer.claim.in_memory import InMemoryClaimEngine
 from primer.claim.postgres import PostgresClaimEngine
-from primer.int.claim import ClaimKind
+from primer.int.claim import ClaimKind, ReleaseOutcome
 
 
 # ---------------------------------------------------------------------------
@@ -43,6 +46,26 @@ class _FakePostgresEventBus:
     """Non-InMemory bus — factory should choose PostgresClaimEngine."""
 
     pass
+
+
+class _FakeWorkspaceIO:
+    def __init__(self) -> None:
+        self._data: dict[tuple[str, str], bytes] = defaultdict(bytes)
+
+    async def append_message_line(self, session_id: str, line: bytes) -> None:
+        self._data[(session_id, "messages.jsonl")] += line
+
+    def read_lines(self, session_id: str) -> list[str]:
+        raw = self._data.get((session_id, "messages.jsonl"), b"")
+        return [ln for ln in raw.decode().splitlines() if ln.strip()]
+
+
+class _FakeWorkspaceRegistry:
+    def __init__(self) -> None:
+        self.workspaces: dict[str, _FakeWorkspaceIO] = {}
+
+    async def get_workspace(self, workspace_id: str) -> _FakeWorkspaceIO:
+        return self.workspaces.setdefault(workspace_id, _FakeWorkspaceIO())
 
 
 # ---------------------------------------------------------------------------
@@ -91,3 +114,84 @@ def test_factory_postgres_engine_has_all_four_adapters():
     assert ClaimKind.HARNESS in engine._adapters
     assert ClaimKind.TRIGGER in engine._adapters
     assert ClaimKind.TOOL_CALL in engine._adapters
+
+
+# ---------------------------------------------------------------------------
+# 01a068ea: activation — the factory-constructed SESSION adapter must
+# actually WRITE a terminal error record, not just have workspace_registry/
+# event_bus threaded through as unused params. Drives the same construction
+# path production startup uses (ClaimEngineFactory.create), then exercises
+# the built adapter's on_release exactly like the claim engine would on a
+# worker crash / reclaim.
+# ---------------------------------------------------------------------------
+
+
+class _FakeSessionStorage:
+    def __init__(self, session) -> None:
+        self._session = session
+        self.updated = []
+
+    async def get(self, id: str, *, conn=None):
+        return self._session if self._session.id == id else None
+
+    async def update(self, entity, *, conn=None):
+        self.updated.append(entity)
+        self._session = entity
+        return entity
+
+
+class _StorageProviderWithSessions(_FakeStorageProvider):
+    """Routes WorkspaceSession lookups to a real fake Storage; everything
+    else (harness/trigger) still gets None, matching _FakeStorageProvider —
+    this test only cares about the SESSION adapter's activation."""
+
+    def __init__(self, session_storage) -> None:
+        self._session_storage = session_storage
+
+    def get_storage(self, model_class):
+        from primer.model.workspace_session import WorkspaceSession
+
+        if model_class is WorkspaceSession:
+            return self._session_storage
+        return None
+
+
+@pytest.mark.asyncio
+async def test_factory_wired_session_adapter_writes_terminal_error_record():
+    from datetime import datetime, timezone
+    from primer.model.workspace_session import (
+        AgentSessionBinding, SessionStatus, WorkspaceSession,
+    )
+
+    session = WorkspaceSession(
+        id="s-activation",
+        workspace_id="ws-activation",
+        binding=AgentSessionBinding(agent_id="ag1"),
+        status=SessionStatus.RUNNING,
+        created_at=datetime.now(timezone.utc),
+        turn_no=0,
+    )
+    session_storage = _FakeSessionStorage(session)
+    registry = _FakeWorkspaceRegistry()
+
+    engine = ClaimEngineFactory.create(
+        storage_provider=_StorageProviderWithSessions(session_storage),
+        event_bus=InMemoryEventBus(),
+        workspace_registry=registry,
+    )
+    adapter = engine._adapters[ClaimKind.SESSION]
+
+    await adapter.on_release(
+        conn=None,
+        entity_id="s-activation",
+        outcome=ReleaseOutcome(success=False, last_error="worker_crash"),
+    )
+
+    lines = registry.workspaces["ws-activation"].read_lines("s-activation")
+    assert lines, (
+        "the factory-wired adapter must actually write a terminal error "
+        "record, not just accept the params unused"
+    )
+    record = json.loads(lines[0])
+    assert record["kind"] == "error"
+    assert record["payload"]["reason"] == "worker_crash"

--- a/tests/claim/test_session_adapter.py
+++ b/tests/claim/test_session_adapter.py
@@ -60,7 +60,7 @@ def _now() -> datetime:
     return datetime.now(timezone.utc)
 
 
-def _make_session(session_id: str) -> WorkspaceSession:
+def _make_session(session_id: str, *, last_seq: int = 0) -> WorkspaceSession:
     return WorkspaceSession(
         id=session_id,
         workspace_id="w1",
@@ -68,6 +68,7 @@ def _make_session(session_id: str) -> WorkspaceSession:
         status=SessionStatus.RUNNING,
         created_at=_now(),
         turn_no=0,
+        last_seq=last_seq,
     )
 
 
@@ -97,6 +98,27 @@ class FakeWorkspaceIO:
         return [ln for ln in raw.decode().splitlines() if ln.strip()]
 
 
+class FakeWorkspaceRegistry:
+    """01a068ea: the adapter resolves I/O per-session via a registry (a
+    workspace's I/O is not a single process-wide value) -- this fake mirrors
+    WorkspaceRegistry.get_workspace's shape (one FakeWorkspaceIO per
+    workspace_id, lazily created)."""
+
+    def __init__(self) -> None:
+        self.workspaces: dict[str, FakeWorkspaceIO] = {}
+
+    async def get_workspace(self, workspace_id: str) -> FakeWorkspaceIO:
+        return self.workspaces.setdefault(workspace_id, FakeWorkspaceIO())
+
+
+class FakeEventBus:
+    def __init__(self) -> None:
+        self.published: list[tuple[str, dict]] = []
+
+    async def publish(self, key: str, payload: dict) -> None:
+        self.published.append((key, payload))
+
+
 # ---------------------------------------------------------------------------
 # on_release tests
 # ---------------------------------------------------------------------------
@@ -107,16 +129,16 @@ async def test_on_release_writes_terminal_record_on_reclaim() -> None:
     """A reclaim failure writes an error-kind record to messages.jsonl."""
     sess = _make_session("s1")
     fake_storage = FakeStorage(sess)
-    fake_io = FakeWorkspaceIO()
+    registry = FakeWorkspaceRegistry()
 
-    adapter = SessionClaimAdapter(session_storage=fake_storage, workspace_io=fake_io)
+    adapter = SessionClaimAdapter(session_storage=fake_storage, workspace_registry=registry)
     await adapter.on_release(
         conn=None,
         entity_id="s1",
         outcome=ReleaseOutcome(success=False, last_error="reclaim", drop_lease=True),
     )
 
-    lines = fake_io.read_lines("s1", "messages.jsonl")
+    lines = registry.workspaces[sess.workspace_id].read_lines("s1", "messages.jsonl")
     assert lines, "Expected at least one record in messages.jsonl"
     assert any(json.loads(ln)["kind"] == "error" for ln in lines)
 
@@ -126,16 +148,16 @@ async def test_on_release_writes_error_record_on_generic_failure() -> None:
     """Any failure outcome writes an error-kind record."""
     sess = _make_session("s2")
     fake_storage = FakeStorage(sess)
-    fake_io = FakeWorkspaceIO()
+    registry = FakeWorkspaceRegistry()
 
-    adapter = SessionClaimAdapter(session_storage=fake_storage, workspace_io=fake_io)
+    adapter = SessionClaimAdapter(session_storage=fake_storage, workspace_registry=registry)
     await adapter.on_release(
         conn=None,
         entity_id="s2",
         outcome=ReleaseOutcome(success=False, last_error="worker_crash"),
     )
 
-    lines = fake_io.read_lines("s2", "messages.jsonl")
+    lines = registry.workspaces[sess.workspace_id].read_lines("s2", "messages.jsonl")
     assert lines, "Expected at least one record in messages.jsonl"
     record = json.loads(lines[0])
     assert record["kind"] == "error"
@@ -147,27 +169,26 @@ async def test_on_release_no_record_on_success() -> None:
     """A successful release does NOT write any message record."""
     sess = _make_session("s3")
     fake_storage = FakeStorage(sess)
-    fake_io = FakeWorkspaceIO()
+    registry = FakeWorkspaceRegistry()
 
-    adapter = SessionClaimAdapter(session_storage=fake_storage, workspace_io=fake_io)
+    adapter = SessionClaimAdapter(session_storage=fake_storage, workspace_registry=registry)
     await adapter.on_release(
         conn=None,
         entity_id="s3",
         outcome=ReleaseOutcome(success=True),
     )
 
-    lines = fake_io.read_lines("s3", "messages.jsonl")
-    assert lines == [], "No records expected on successful release"
+    assert registry.workspaces == {}, "No workspace should even be resolved on success"
 
 
 @pytest.mark.asyncio
-async def test_on_release_no_workspace_io_still_updates_storage() -> None:
-    """When workspace_io is None, storage is still updated (graceful degradation)."""
+async def test_on_release_no_workspace_registry_still_updates_storage() -> None:
+    """When workspace_registry is None, storage is still updated (graceful degradation)."""
     sess = _make_session("s4")
     fake_storage = FakeStorage(sess)
 
-    adapter = SessionClaimAdapter(session_storage=fake_storage, workspace_io=None)
-    # Should NOT raise even without workspace_io
+    adapter = SessionClaimAdapter(session_storage=fake_storage, workspace_registry=None)
+    # Should NOT raise even without workspace_registry
     await adapter.on_release(
         conn=None,
         entity_id="s4",
@@ -217,3 +238,78 @@ async def test_on_release_failure_does_not_bump_turn_no() -> None:
     assert updated.last_turn_at is None, "last_turn_at must NOT be stamped on failure"
     # Park / worker fields still cleared — that's bookkeeping, not turn accounting.
     assert updated.last_worker_id is None
+
+
+@pytest.mark.asyncio
+async def test_terminal_record_seeds_past_existing_history() -> None:
+    """01a068ea: the default start_seq=0 landed the terminal error record at
+    seq=1, silently overwriting whatever real message already held that seq
+    on a session that errors out after messages exist. Pre-seed a real
+    seq-1 line, then trigger a failure release and assert the error record
+    landed at seq=2 -- the pre-existing line is untouched."""
+    sess = _make_session("s7", last_seq=1)
+    fake_storage = FakeStorage(sess)
+    registry = FakeWorkspaceRegistry()
+    fake_io = await registry.get_workspace(sess.workspace_id)
+    await fake_io.append_message_line(
+        "s7", (json.dumps({"seq": 1, "kind": "user_input"}) + "\n").encode(),
+    )
+
+    adapter = SessionClaimAdapter(session_storage=fake_storage, workspace_registry=registry)
+    await adapter.on_release(
+        conn=None,
+        entity_id="s7",
+        outcome=ReleaseOutcome(success=False, last_error="worker_crash"),
+    )
+
+    lines = [json.loads(ln) for ln in fake_io.read_lines("s7", "messages.jsonl")]
+    assert len(lines) == 2, "the pre-existing seq-1 line must survive, not be overwritten"
+    assert lines[0] == {"seq": 1, "kind": "user_input"}
+    assert lines[1]["seq"] == 2
+    assert lines[1]["kind"] == "error"
+
+
+@pytest.mark.asyncio
+async def test_terminal_record_publishes_tick() -> None:
+    """01a068ea: a durable-but-unticked write is invisible to a live client
+    until its next poll -- the terminal-error write needs the same tick
+    publish every other durable append in this codebase gets."""
+    sess = _make_session("s8")
+    fake_storage = FakeStorage(sess)
+    registry = FakeWorkspaceRegistry()
+    event_bus = FakeEventBus()
+
+    adapter = SessionClaimAdapter(
+        session_storage=fake_storage, workspace_registry=registry, event_bus=event_bus,
+    )
+    await adapter.on_release(
+        conn=None,
+        entity_id="s8",
+        outcome=ReleaseOutcome(success=False, last_error="worker_crash"),
+    )
+
+    assert len(event_bus.published) == 1
+    key, payload = event_bus.published[0]
+    assert key == "session:s8:tick"
+    assert "seq" in payload
+
+
+@pytest.mark.asyncio
+async def test_terminal_record_no_event_bus_still_writes() -> None:
+    """A None event_bus (graceful degradation, mirrors the no-registry
+    case) must not block the write itself."""
+    sess = _make_session("s9")
+    fake_storage = FakeStorage(sess)
+    registry = FakeWorkspaceRegistry()
+
+    adapter = SessionClaimAdapter(
+        session_storage=fake_storage, workspace_registry=registry, event_bus=None,
+    )
+    await adapter.on_release(
+        conn=None,
+        entity_id="s9",
+        outcome=ReleaseOutcome(success=False, last_error="worker_crash"),
+    )
+
+    lines = registry.workspaces[sess.workspace_id].read_lines("s9", "messages.jsonl")
+    assert lines, "the write must still land even without an event bus"


### PR DESCRIPTION
## Summary

01a068ea. `SessionClaimAdapter._write_terminal_record` (the durable ERROR record written on a failed claim release — reclaim, worker crash, or any other engine error) had two independent bugs, fixed as two commits per the review conditions:

- **42e8c898** — the internal correctness fix. The writer was constructed with the default `start_seq=0`, so the error record always landed at `seq=1`, silently overwriting whatever real message already held that seq on any session that errors out after messages exist. Now seeds from `session.last_seq`, the same pattern every other correct writer in this codebase uses. Also adds the missing tick publish. Along the way, replaces the adapter's single fixed `workspace_io` with a `workspace_registry`, resolved per-session — the adapter is a process-wide singleton spanning every workspace, so a single fixed I/O handle was never a coherent shape once you look past whichever one session happened to be tested.
- **f3eba64d** — the activation fix. `SessionClaimAdapter`'s only construction site, `ClaimEngineFactory.create`, never passed `workspace_io`/`workspace_registry` at all, so the write above has been **dead code in every real deployment** — it never ran. This wires the already-available `workspace_registry` through both of production's real call sites (`primer/api/_app_lifespan.py`'s startup path and `primer/api/app.py`'s shared test/dev app factory), reusing the same registry instance each already builds for its own turn-execution wiring.

## Behavior change (read before merging)

As of the second commit, **every session that ends via a claim reclaim or worker crash will start gaining a durable terminal ERROR record in its transcript, where before it silently got nothing.** This is the fix, not a regression — flagging loudly since it's the kind of change that can look surprising in a diff review without this context. It's arguably the more significant half of the fix: this is the *only* durable error record for a crash/reclaim failure mode (`dispatch.py`'s own except-block write can't run if the worker process that would run it is the thing that died), so sessions that looked "stuck" with no error trace may be explained by this gap.

## Test plan

- [x] `tests/claim/test_session_adapter.py` — start_seq seeding (a pre-seeded seq-1 line survives, the error record lands at seq-2, not seq-1), tick publish, graceful degradation with no registry/no event bus.
- [x] `tests/claim/test_factory.py::test_factory_wired_session_adapter_writes_terminal_error_record` — the activation test: drives the exact same construction path production startup uses (`ClaimEngineFactory.create`) and asserts the resulting adapter actually writes a terminal ERROR record on a failure release, proving the wiring is live rather than just threaded-and-unused.
- [x] `tests/claim/` full directory: 82 passed, 22 skipped (unrelated Postgres-only tests).
- [x] `tests/trigger/test_claim_adapter.py`, `tests/worker/test_harness_claim_loop.py`, `tests/worker/test_pool_trigger.py` — unaffected by the now-optional `workspace_registry` param.
- [x] `tests/api/test_yields.py` — exercises `app.py`'s test-wiring path end to end, confirming `workspace_registry` is correctly in scope at the `ClaimEngineFactory.create` call site there.
- [x] `ruff check` and `lint-imports` clean on every touched file.

A broader `tests/worker/ tests/claim/ tests/api/` sweep was attempted for extra confidence but got OOM-killed by the local resource cap (contending with a concurrent teammate run) before completing — no failures were visible in the ~59% of it that ran. Not re-attempted locally per this repo's test-resource policy; CI covers the rest.