### PR TITLE
fix(ui): useResource honors a null cacheKey as disabled — fixes u0107 save-draft stuck-enabled

### DIFF
--- a/tests/ui_e2e/conftest.py
+++ b/tests/ui_e2e/conftest.py
@@ -339,10 +339,19 @@ def page(
 
     def _on_pageerror(err: BaseException) -> None:
         # pageerror events fire on uncaught exceptions; treat as error.
+        # Playwright's Error carries the JS stack on .stack — without it,
+        # a bare "Cannot read properties of null" message is nearly
+        # useless for tracking down the throw site (every pageerror
+        # investigation used to re-derive this the hard way via static
+        # grepping across the whole ui/ tree). Truncated defensively:
+        # a pathological stack (recursion, minified bundle) should not
+        # blow up the artifact.
+        stack = getattr(err, "stack", None)
         console_messages.append({
             "level": "pageerror",
             "text": str(err),
             "location": None,
+            "stack": stack[:4000] if isinstance(stack, str) else None,
         })
 
     def _on_requestfailed(req) -> None:
@@ -448,7 +457,11 @@ def pytest_runtest_makereport(
         pass
     if console is not None:
         (artifacts / "console.log").write_text(
-            "\n".join(f"[{m['level']}] {m['text']}" for m in console),
+            "\n".join(
+                f"[{m['level']}] {m['text']}"
+                + (f"\n{m['stack']}" if m.get("stack") else "")
+                for m in console
+            ),
             encoding="utf-8",
         )
     failed = getattr(item, "_primer_failed_requests", None)

--- a/ui/foundation/use-resource.js
+++ b/ui/foundation/use-resource.js
@@ -179,6 +179,7 @@
     const effectiveKey = composeKey(cacheKey, deps);
 
     const [snap, setSnap] = useState(() => {
+      if (!effectiveKey) return { data: undefined, error: null, loading: false, degraded: false };
       const entry = cache.get(effectiveKey);
       return entry
         ? snapshotOf(entry)
@@ -193,6 +194,16 @@
     ignoreIdleRef.current = ignoreIdle;
 
     useEffect(() => {
+      // A falsy cacheKey (the `cond ? key : null` pattern every caller
+      // uses to gate an optional resource) means "disabled" -- fetching
+      // anyway would poll a bogus URL built from the caller's own
+      // "not ready yet" value (e.g. graph-builder.jsx's runStates firing
+      // GB_api.nodeStates with an undefined runId, landing a 404 on
+      // .../runs/undefined/node_states), AND it registers a `null`-keyed
+      // cache entry that a LATER invalidation's findKeys (called from
+      // useMutation's `invalidates` handling) would crash on:
+      // `null.startsWith(...)` when it iterates cache.keys(). U0107.
+      if (!effectiveKey) return;
       ensureVisibility();
       const entry = getOrCreate(effectiveKey);
       // Latest-wins: every render refreshes the entry's behaviour hooks


### PR DESCRIPTION
## Summary

01a06b5b (split from 01a068f7, one of dependabot #210's two loose ends). `test_u0107_graph_builder_persistence_journey` failed with "Save draft button expected disabled, got enabled" — `expect(save).to_be_disabled(timeout=15_000)` polled 34x over the full window right after clicking Save and never flipped. Not a slow-refetch race; the dirty-clear genuinely never happened.

## Root cause

Every `useResource` caller uses the `cond ? key : null` pattern to gate an optional resource (e.g. `graph-builder.jsx`'s `runStates: runId ? \`graph:runstates:${graphId}:${runId}\` : null`). But `useResource`'s mount effect called `getOrCreate(effectiveKey)` and fetched **unconditionally**, regardless of whether the key was `null`:

1. The fetcher closure still captured the caller's own gating value directly (`runId`, undefined precisely when the key was gated to `null`) and called it for real — `GB_api.nodeStates(graphId, undefined, signal)`, landing a 404 on `.../runs/undefined/node_states` on every mount.
2. A `null`-keyed entry got registered in the shared cache `Map`. When a save later ran `useMutation`'s `invalidates` handling, `findKeys(target)` iterated `cache.keys()` and hit `null.startsWith(prefix)` — an uncaught `TypeError` that broke the render cycle mid-invalidation, so the draft never resynced to the just-saved server response and the Save button stuck enabled forever.

Confirmed via a captured JS stack trace (`Object.findKeys` ← `Object.mutate`, see commit 1) after a local repro — static grepping for `.startsWith(` across the UI tree didn't converge on its own since the throw site is only reachable through the bundled/minified stack, not obvious from source inspection alone.

**Both symptoms trace to the same missing guard** — the 404 was filed as a separate board task (01a06b62) before this connection was found; that task is now resolved by this same fix and closed as a duplicate root cause.

## Fix

Two commits:
- **14053a69** — `tests/ui_e2e/conftest.py`'s `pageerror` handler now captures `err.stack` (truncated to 4KB) alongside the message, and the artifact writer includes it in `console.log`. Permanent, not a throwaway diagnostic — every future pageerror investigation gets the throw site for free instead of re-deriving it via a blind grep hunt (which is what this investigation initially had to do).
- **93c9a433** — the actual fix. `useResource`'s mount effect returns early when `effectiveKey` is falsy (no cache registration, no fetch); the initial snapshot for a null key reports `loading: false` (idle) instead of the permanent "loading forever" a disabled resource used to show.

## Test plan

- [x] `tests/ui_e2e/test_graph_builder_persistence_journey.py::test_u0107_graph_builder_persistence_journey` — the repro, now passes (reproduced against the unfixed image first, confirmed the failure + captured the stack trace, then fixed and reran green).
- [x] `test_graph_builder_feedback_loop.py`, `test_graph_run_view_journey.py`, `test_session_graph_liveness_pill.py` — the `runId`-driven polling paths this change touches most directly; all still pass (3 passed, 1 pre-existing skip, unrelated).
- [x] No JS linter is configured for `ui/` in this repo; verification is via the e2e suite above.