### PR TITLE
feat(approval): audit record written at respond-time with an indexed gate key

### DIFF
--- a/primer/agent/approval_record.py
+++ b/primer/agent/approval_record.py
@@ -43,6 +43,7 @@ def record_from_parked_blob(
     requested_at: datetime | None = None,
     decided_at: datetime | None = None,
     decided_by: str | None = None,
+    gate_event_key: str | None = None,
 ) -> ToolApprovalRecord:
     """Build a record from a session/graph ``parked_state`` blob.
 
@@ -50,6 +51,12 @@ def record_from_parked_blob(
     gated ``id``/``name``/``arguments``) plus ``policy_id`` /
     ``approval_type`` / ``gate_reason`` and, for ``call_tool`` meta-dispatch,
     ``via_call_tool`` (inner toolset id + principal).
+
+    ``gate_event_key`` defaults to None (backward/forward compatible with
+    every existing caller); a caller with a real ``ParkedState.yielded.
+    event_key`` in hand should pass it explicitly (01a068da) so the
+    respond-time and resume-time write sites can dedupe against the same
+    gate via ``ToolApprovalRecord``'s unique index.
     """
     yielded: dict = blob.get("yielded") or {}
     metadata: dict = yielded.get("resume_metadata") or {}
@@ -60,6 +67,7 @@ def record_from_parked_blob(
         tool_name=original.get("name") or "",
         arguments=original.get("arguments") or {},
         tool_call_id=original.get("id") or blob.get("tool_call_id"),
+        gate_event_key=gate_event_key,
         agent_id=agent_id,
         session_id=session_id,
         chat_id=chat_id,
@@ -119,13 +127,31 @@ async def write_approval_record(
 ) -> None:
     """Persist a record best-effort. Never raises.
 
-    A failure here must not block or fail an in-progress resume, so any
-    exception (including a missing storage) is logged and swallowed.
+    A failure here must not block or fail an in-progress resume (or a
+    respond request), so any exception (including a missing storage) is
+    logged and swallowed.
+
+    01a068da: a record with a non-None ``gate_event_key`` can legitimately
+    lose a race against the OTHER write site for the same gate (respond-
+    time vs. the resume-time fallback) - ``ToolApprovalRecord``'s unique
+    index on that field turns the loser's insert into a
+    :class:`~primer.model.except_.ConflictError`. That is the mechanism
+    working as intended, not a failure: log it at DEBUG (still visible if
+    someone is looking, not noise on the normal path) rather than the
+    ERROR-level ``logger.exception`` a genuine write failure gets.
     """
     if storage is None:
         return
+    from primer.model.except_ import ConflictError
+
     try:
         await storage.create(record)
+    except ConflictError:
+        logger.debug(
+            "approval-record: gate_event_key=%r already has a record "
+            "(the other write site won the race) - skipping",
+            record.gate_event_key,
+        )
     except Exception:  # noqa: BLE001 - best-effort; resume must not fail
         logger.exception(
             "approval-record: failed to persist record for tool %r",

--- a/primer/api/routers/tool_approval.py
+++ b/primer/api/routers/tool_approval.py
@@ -332,6 +332,43 @@ async def _publish_decision(
         engine=engine,
     )
     if storage_provider is not None:
+        # 01a068da: write the durable ToolApprovalRecord HERE, at the
+        # moment the decision actually arrives, rather than waiting for
+        # the resume coordinator to get around to it (session_resume_
+        # coordinator.py's write_approval_record_for_session, which used
+        # to be the ONLY write site - a crash between this respond and
+        # that eventual resume lost the audit record entirely). Attempted
+        # unconditionally, not gated on `did`: a retry after a half-
+        # applied first attempt (row already resumable, but that earlier
+        # call's record write itself failed for some unrelated reason)
+        # still gets a fresh try, and gate_event_key's unique index makes
+        # a genuine duplicate attempt a safe no-op either way (see
+        # write_approval_record's own docstring). classify_approval_
+        # payload is the SAME classifier the resume path uses on this
+        # SAME payload shape, so the record's verdict cannot drift from
+        # whatever the eventual resume computes.
+        from primer.agent.approval_record import (
+            record_from_parked_blob,
+            write_approval_record,
+        )
+        from primer.model.tool_approval import ToolApprovalRecord
+        from primer.worker.yield_runtime import classify_approval_payload
+
+        decision, reason = classify_approval_payload(payload)
+        record = record_from_parked_blob(
+            blob=blob,
+            decision=decision,
+            reason=reason,
+            agent_id=getattr(sess.binding, "agent_id", None),
+            session_id=id_str,
+            requested_at=sess.parked_at,
+            decided_by=decided_by,
+            gate_event_key=event_key,
+        )
+        await write_approval_record(
+            storage_provider.get_storage(ToolApprovalRecord), record,
+        )
+
         from primer.events.wake import emit_session_wake
 
         await emit_session_wake(storage_provider, event_bus, event_key, payload)
@@ -489,25 +526,42 @@ def make_tool_approval_ops_router() -> APIRouter:
                 ),
             ),
         ] = None,
+        gate_event_key: Annotated[
+            str | None,
+            Query(
+                description=(
+                    "Look up the record for one specific gate "
+                    "(ParkedState.yielded.event_key). 01a068da: the field "
+                    "carries a unique index, so this narrows to at most "
+                    "one record - useful for a caller that has the event "
+                    "key in hand (e.g. confirming a just-submitted "
+                    "decision landed) and does not want to page through "
+                    "session_id history to find it."
+                ),
+            ),
+        ] = None,
         offset: Annotated[int, Query(ge=0)] = 0,
         length: Annotated[int, Query(ge=1, le=200)] = 50,
     ) -> OffsetPageResponse[ToolApprovalRecord]:
         """List resolved approval decisions, newest first.
 
         ``status`` filters by decision (``all`` = no filter). ``session_id``
-        optionally scopes to one session. Ordered by ``decided_at``
-        descending so the most recent decisions lead, mirroring the
-        records view's default sort.
+        optionally scopes to one session; ``gate_event_key`` optionally
+        narrows to one gate. Ordered by ``decided_at`` descending so the
+        most recent decisions lead, mirroring the records view's default
+        sort.
         """
         sp = get_storage_provider(request)
         storage = sp.get_storage(ToolApprovalRecord)
         page = OffsetPage(offset=offset, length=length)
         order = [OrderBy(field="decided_at", direction="desc")]
-        if status == "all" and session_id is None:
+        if status == "all" and session_id is None and gate_event_key is None:
             return await storage.list(page, order_by=order)
         query = Q(ToolApprovalRecord)
         if session_id is not None:
             query = query.where("session_id", session_id)
+        if gate_event_key is not None:
+            query = query.where("gate_event_key", gate_event_key)
         if status != "all":
             query = query.where("decision", status)
         return await storage.find(query.build(), page, order_by=order)

--- a/primer/model/tool_approval.py
+++ b/primer/model/tool_approval.py
@@ -173,11 +173,32 @@ ApprovalDecision = Literal["approved", "rejected", "timeout", "cancelled"]
 class ToolApprovalRecord(Identifiable):
     """One durable, resolved tool-approval decision.
 
-    Written exactly once at the moment an approval gate is finalized
-    (operator approved/rejected, or a yield timeout/cancel synthesised a
-    decision) by every resume path: agent sessions, graph sessions, and
-    chats. The Approvals records view reads these back to show resolved
-    history alongside the live (still-parked) pending calls.
+    01a068da: written at RESPOND-TIME (the moment the operator's decision
+    actually arrives - ``tool_approval.py``'s ``_publish_decision``, the
+    single-park agent-session respond path) for approved/rejected
+    verdicts, with a resume-time write as a FALLBACK for verdicts that
+    never go through respond at all (a synthesised timeout/cancel) and as
+    crash recovery (a process that dies between the respond-time write
+    attempt and its confirmation still gets the record written when the
+    session is eventually resumed). ``gate_event_key`` carries a UNIQUE
+    index (see ``primer.storage.postgres._HOT_FIELD_INDEXES`` /
+    ``primer.storage.sqlite._SQLITE_HOT_FIELD_INDEXES``, NULL-tolerant so
+    pre-migration rows are unaffected) so the two write sites cannot both
+    land a row for the SAME gate: whichever writes second hits the unique
+    constraint and is treated as an expected no-op, not a failure. Before
+    this fix the ONLY write happened at resume-time, best-effort, so a
+    crash between respond and resume lost the audit record entirely - see
+    the git history on this docstring for the prior, less accurate,
+    claim ("written exactly once... by every resume path").
+
+    This durability upgrade covers the single-park agent-session respond
+    path specifically (``/sessions/{id}/tool_approval/respond``). The
+    graph engine's multi-concurrent-node approval resolution
+    (``primer.worker.graph_resume_coordinator.write_approval_record_for_
+    graph``, matched by ``tool_call_id`` rather than a single
+    session-level ``event_key``) is a distinct mechanism this change does
+    NOT extend to a respond-time write - it keeps its existing
+    resume-time-only, best-effort behaviour and its own analogous gap.
 
     Fields are captured from the parked ``resume_metadata`` blob being
     resolved: ``original_call`` carries the gated ``(id, name, arguments)``
@@ -202,6 +223,16 @@ class ToolApprovalRecord(Identifiable):
     tool_call_id: str | None = Field(
         default=None,
         description="Id of the gated tool call this decision resolves.",
+    )
+    gate_event_key: str | None = Field(
+        default=None,
+        description=(
+            "The park's own event_key (ParkedState.yielded.event_key) - "
+            "None for records written before this field existed. Carries "
+            "a NULL-tolerant unique index, so a record is queryable by "
+            "gate and the respond-time + resume-time write sites cannot "
+            "both land a row for the same gate."
+        ),
     )
     agent_id: str | None = Field(
         default=None,

--- a/primer/storage/postgres.py
+++ b/primer/storage/postgres.py
@@ -564,6 +564,19 @@ _HOT_FIELD_INDEXES: dict[str, list[tuple[str, bool, str]]] = {
         # scan, but a retention/prune policy is still owed as a follow-up.
         ("status", False, "((data->>'status'))"),
     ],
+    "toolapprovalrecord": [
+        # 01a068da: makes a decision queryable by the gate that produced
+        # it, and -- the reason this is UNIQUE, not a plain lookup index --
+        # is the mechanism that lets the respond-time write and the
+        # resume-time fallback write both target the same gate without
+        # ever landing two rows for it: whichever insert loses the race
+        # hits this constraint and is treated as an expected no-op (see
+        # ToolApprovalRecord's own docstring). Postgres treats NULL as
+        # distinct from every other NULL under a unique index, so the
+        # many pre-migration records with no gate_event_key at all do not
+        # collide with each other or with anything else.
+        ("gate_event_key_uniq", True, "((data->>'gate_event_key'))"),
+    ],
 }
 
 

--- a/primer/storage/sqlite.py
+++ b/primer/storage/sqlite.py
@@ -92,6 +92,17 @@ _SQLITE_HOT_FIELD_INDEXES: dict[str, list[tuple[str, bool, str]]] = {
             "(json_extract(data,'$.provider_id'), json_extract(data,'$.subject'))",
         ),
     ],
+    "toolapprovalrecord": [
+        # Mirrors postgres._HOT_FIELD_INDEXES' toolapprovalrecord entry --
+        # see its comment. SQLite's UNIQUE index treats NULL the same way
+        # (distinct from every other NULL), so pre-migration rows with no
+        # gate_event_key do not collide.
+        (
+            "gate_event_key_uniq",
+            True,
+            "(json_extract(data,'$.gate_event_key'))",
+        ),
+    ],
 }
 
 

--- a/primer/worker/session_resume_coordinator.py
+++ b/primer/worker/session_resume_coordinator.py
@@ -56,9 +56,20 @@ async def write_approval_record_for_session(
 ) -> None:
     """Persist the resolved approval decision for a session park.
 
+    01a068da: this used to be the ONLY write site (a crash between an
+    operator's respond and this eventual resume lost the audit record
+    entirely). The respond route (tool_approval.py's _publish_decision)
+    now writes the SAME record durably at the moment the decision
+    arrives, keyed by gate_event_key, so this call is a FALLBACK: it
+    still fires unconditionally on every resume (a synthesised timeout/
+    cancel verdict never goes through respond at all, so this remains
+    the ONLY write site for those), but when the respond-time write
+    already landed, gate_event_key's unique index turns this insert into
+    an expected no-op rather than a duplicate row (see
+    write_approval_record's own docstring).
+
     Best-effort: a write failure is logged and swallowed so the resume
-    proceeds. Shared by the agent and graph resume paths via the same
-    parked-state blob shape.
+    proceeds.
     """
     from primer.agent.approval_record import (
         record_from_parked_blob,
@@ -67,6 +78,7 @@ async def write_approval_record_for_session(
     from primer.model.tool_approval import ToolApprovalRecord
 
     decision, reason = classify_approval_payload(payload)
+    yielded: dict = blob.get("yielded") or {}
     record = record_from_parked_blob(
         blob=blob,
         decision=decision,
@@ -79,6 +91,7 @@ async def write_approval_record_for_session(
         decided_by=(
             payload.get("decided_by") if isinstance(payload, dict) else None
         ),
+        gate_event_key=yielded.get("event_key"),
     )
     storage = (
         pool._storage.get_storage(ToolApprovalRecord)

--- a/tests/agent/test_approval_record.py
+++ b/tests/agent/test_approval_record.py
@@ -11,6 +11,7 @@ from primer.agent.approval_record import (
     record_from_parked_blob,
     write_approval_record,
 )
+from primer.model.except_ import ConflictError
 from primer.model.tool_approval import ToolApprovalRecord
 
 
@@ -57,6 +58,21 @@ def test_record_from_parked_blob_captures_fields():
     assert rec.requested_at == now
     assert rec.decided_at is not None
     assert rec.id.startswith("tool-approval-record-")
+
+
+def test_record_from_parked_blob_gate_event_key_defaults_to_none():
+    """01a068da: every pre-existing caller omits the new kwarg -- must
+    not become required and must not silently invent a value."""
+    rec = record_from_parked_blob(blob=_blob(), decision="approved", reason=None)
+    assert rec.gate_event_key is None
+
+
+def test_record_from_parked_blob_carries_gate_event_key_through():
+    rec = record_from_parked_blob(
+        blob=_blob(), decision="approved", reason=None,
+        gate_event_key="approval:sess-1:c1",
+    )
+    assert rec.gate_event_key == "approval:sess-1:c1"
 
 
 def test_record_from_parked_blob_via_call_tool_principal():
@@ -138,3 +154,48 @@ async def test_write_approval_record_persists_once():
     await write_approval_record(_Storage(), rec)
     assert len(created) == 1
     assert created[0] is rec
+
+
+@pytest.mark.asyncio
+async def test_write_approval_record_swallows_a_gate_key_conflict(caplog):
+    """01a068da: a ConflictError means the OTHER write site (respond-time
+    vs. the resume-time fallback) already won the race for this
+    gate_event_key -- ToolApprovalRecord's unique index working exactly
+    as intended, not a failure. Must not raise, and should log quietly
+    (DEBUG) rather than as an error."""
+    import logging
+
+    class _AlreadyThere:
+        async def create(self, _entity):
+            raise ConflictError("ToolApprovalRecord with id 'x' already exists")
+
+    rec = ToolApprovalRecord(
+        tool_name="x", decided_at=datetime.now(UTC), decision="approved",
+        gate_event_key="approval:sess-1:c1",
+    )
+    with caplog.at_level(logging.DEBUG, logger="primer.agent.approval_record"):
+        await write_approval_record(_AlreadyThere(), rec)
+    assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+    assert any(
+        "gate_event_key" in r.getMessage() and "approval:sess-1:c1" in r.getMessage()
+        for r in caplog.records
+    )
+
+
+@pytest.mark.asyncio
+async def test_write_approval_record_still_logs_a_real_failure_as_an_error(caplog):
+    """A non-conflict exception is a genuine write failure and must stay
+    at ERROR level (via logger.exception) -- only the specific,
+    known-benign duplicate-gate race gets the quieter treatment."""
+    import logging
+
+    class _Boom:
+        async def create(self, _entity):
+            raise RuntimeError("backend down")
+
+    rec = ToolApprovalRecord(
+        tool_name="x", decided_at=datetime.now(UTC), decision="approved",
+    )
+    with caplog.at_level(logging.DEBUG, logger="primer.agent.approval_record"):
+        await write_approval_record(_Boom(), rec)
+    assert any(r.levelno >= logging.ERROR for r in caplog.records)

--- a/tests/api/test_tool_approval_records.py
+++ b/tests/api/test_tool_approval_records.py
@@ -10,7 +10,12 @@ from primer.model.tool_approval import ToolApprovalRecord
 
 
 def _rec(
-    *, id_: str, decision: str, decided_at: datetime, session_id: str = "sess-1",
+    *,
+    id_: str,
+    decision: str,
+    decided_at: datetime,
+    session_id: str = "sess-1",
+    gate_event_key: str | None = None,
 ) -> ToolApprovalRecord:
     return ToolApprovalRecord(
         id=id_,
@@ -23,6 +28,7 @@ def _rec(
         decision=decision,  # type: ignore[arg-type]
         policy_id="p1",
         approval_type="required",
+        gate_event_key=gate_event_key,
     )
 
 
@@ -135,5 +141,51 @@ async def test_records_list_filter_by_session_id_and_status(client, app):
 async def test_records_list_filter_by_session_id_no_match(client, app):
     await _seed(app)
     r = await client.get("/v1/tool_approval/records?session_id=sess-nope")
+    assert r.status_code == 200, r.text
+    assert r.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_records_list_filter_by_gate_event_key(client, app):
+    """01a068da: a caller that has the event key in hand (e.g.
+    confirming a just-submitted decision landed) can look it up directly
+    rather than paging through session_id history to find it."""
+    await _seed(app)
+    storage = app.state.storage_provider.get_storage(ToolApprovalRecord)
+    await storage.create(_rec(
+        id_="r5", decision="approved",
+        decided_at=datetime(2026, 6, 14, 9, 20, tzinfo=UTC),
+        gate_event_key="tool_approval:sess-1:call-r5",
+    ))
+    r = await client.get(
+        "/v1/tool_approval/records?gate_event_key=tool_approval:sess-1:call-r5",
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    assert [it["id"] for it in body["items"]] == ["r5"]
+    assert body["items"][0]["gate_event_key"] == "tool_approval:sess-1:call-r5"
+
+
+@pytest.mark.asyncio
+async def test_records_list_filter_by_gate_event_key_no_match(client, app):
+    await _seed(app)
+    r = await client.get("/v1/tool_approval/records?gate_event_key=does-not-exist")
+    assert r.status_code == 200, r.text
+    assert r.json()["items"] == []
+
+
+@pytest.mark.asyncio
+async def test_records_list_filter_by_gate_event_key_and_status(client, app):
+    await _seed(app)
+    storage = app.state.storage_provider.get_storage(ToolApprovalRecord)
+    await storage.create(_rec(
+        id_="r5", decision="rejected",
+        decided_at=datetime(2026, 6, 14, 9, 20, tzinfo=UTC),
+        gate_event_key="tool_approval:sess-1:call-r5",
+    ))
+    r = await client.get(
+        "/v1/tool_approval/records"
+        "?gate_event_key=tool_approval:sess-1:call-r5&status=approved",
+    )
     assert r.status_code == 200, r.text
     assert r.json()["items"] == []

--- a/tests/api/test_yields_durable_flip.py
+++ b/tests/api/test_yields_durable_flip.py
@@ -202,6 +202,77 @@ async def test_tool_approval_respond_flips_row_without_listener(app, client):
 
 
 @pytest.mark.asyncio
+async def test_tool_approval_respond_writes_a_durable_record_immediately(
+    app, client,
+):
+    """01a068da: the ONE write site used to be the eventual resume
+    (session_resume_coordinator.py, best-effort) - a crash between this
+    respond and that resume lost the audit record entirely. Now the
+    respond route itself writes it durably, before this test's session
+    has been resumed at all (nothing here drives a resume)."""
+    from primer.model.storage import OffsetPage
+    from primer.model.tool_approval import ToolApprovalRecord
+
+    sess = _make_approval_parked_session(
+        session_id="d-rec1", tool_call_id="call-rec1",
+    )
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.post(
+        "/v1/sessions/d-rec1/tool_approval/respond",
+        json={"tool_call_id": "call-rec1", "decision": "approved"},
+    )
+    assert resp.status_code == 202
+
+    records = app.state.storage_provider.get_storage(ToolApprovalRecord)
+    page = await records.list(OffsetPage(offset=0, length=50))
+    matches = [r for r in page.items if r.session_id == "d-rec1"]
+    assert len(matches) == 1
+    rec = matches[0]
+    assert rec.decision == "approved"
+    assert rec.tool_name == "delete_workspace"
+    assert rec.tool_call_id == "call-rec1"
+    assert rec.session_id == "d-rec1"
+    assert rec.agent_id == "agt"
+    # Stamped by the respond route's approver-routing (fixture client's
+    # auto-registered first user is the admin, same as the payload
+    # assertion above).
+    assert rec.decided_by == "testuser"
+    assert rec.gate_event_key == "tool_approval:d-rec1:call-rec1"
+
+
+@pytest.mark.asyncio
+async def test_tool_approval_respond_reject_writes_a_record_with_the_reason(
+    app, client,
+):
+    from primer.model.storage import OffsetPage
+    from primer.model.tool_approval import ToolApprovalRecord
+
+    sess = _make_approval_parked_session(
+        session_id="d-rec2", tool_call_id="call-rec2",
+    )
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.post(
+        "/v1/sessions/d-rec2/tool_approval/respond",
+        json={
+            "tool_call_id": "call-rec2", "decision": "rejected",
+            "reason": "too risky",
+        },
+    )
+    assert resp.status_code == 202
+
+    records = app.state.storage_provider.get_storage(ToolApprovalRecord)
+    page = await records.list(OffsetPage(offset=0, length=50))
+    matches = [r for r in page.items if r.session_id == "d-rec2"]
+    assert len(matches) == 1
+    assert matches[0].decision == "rejected"
+    assert matches[0].reason == "too risky"
+
+
+@pytest.mark.asyncio
 async def test_second_listener_style_flip_is_idempotent(app, client):
     """After the handler's durable flip, a second (listener-style) flip of
     the same single-event park is a guard-rejected no-op - it must not

--- a/tests/storage/test_postgres_hot_indexes.py
+++ b/tests/storage/test_postgres_hot_indexes.py
@@ -32,10 +32,11 @@ from primer.storage.postgres import (
 
 def test_registry_declares_the_hot_tables():
     """token_hash / session status / channel routing / useridentity
-    uniqueness / webhook recovery are all registered."""
+    uniqueness / webhook recovery / tool-approval-record gate key are
+    all registered."""
     assert set(_HOT_FIELD_INDEXES) == {
         "apitoken", "sessions", "channel", "useridentity",
-        "webhookdelivery",
+        "webhookdelivery", "toolapprovalrecord",
     }
 
 

--- a/tests/worker/test_approval_record_resume.py
+++ b/tests/worker/test_approval_record_resume.py
@@ -154,6 +154,10 @@ async def test_resume_approved_writes_record(monkeypatch):
     assert rec.approval_type == "required"
     assert rec.gate_reason == "always-on"
     assert rec.requested_at is not None
+    # 01a068da: threaded from ParkedState.yielded.event_key so a respond-
+    # time write and this resume-time fallback dedupe against the same
+    # gate via the field's unique index.
+    assert rec.gate_event_key == "tool_approval:sess-rec-approve:tc1"
 
 
 @pytest.mark.asyncio
@@ -189,3 +193,98 @@ async def test_resume_writes_record_exactly_once(monkeypatch):
     )
     items = await _drive(monkeypatch, sess)
     assert len(items) == 1
+
+
+async def _drive_with_preseeded_storage(monkeypatch, sess, storage_provider):
+    """Variant of ``_drive`` that takes an already-built storage provider
+    (so the caller can pre-seed a record before the resume runs) rather
+    than building a fresh one."""
+    session_storage = storage_provider.get_storage(WorkspaceSession)
+    engine = InMemoryClaimEngine(
+        adapters={ClaimKind.SESSION: SessionClaimAdapter(session_storage=session_storage)},
+    )
+    pool = WorkerPool(
+        config=WorkerConfig(concurrency=1),
+        scheduler=None,                  # type: ignore[arg-type]
+        storage=storage_provider,
+        workspace_registry=None,         # type: ignore[arg-type]
+        provider_registry=None,          # type: ignore[arg-type]
+        engine=engine,
+    )
+    pool._worker_id = "wrk-approval-record"
+    await session_storage.create(sess)
+    fake_executor = _RecordingExecutor(tool_manager=_FakeToolManager())
+    monkeypatch.setattr(
+        pool, "_load_workspace_for_persist",
+        lambda _ws_id: _async_return(_NoopPersist()),
+    )
+    monkeypatch.setattr(
+        pool, "_build_agent_executor",
+        lambda _s, _w: _async_return(fake_executor),
+    )
+    await engine.mark_resumable(ClaimKind.SESSION, sess.id)
+    leases = await engine.claim_due("wrk-approval-record", max_count=10)
+    lease = next(
+        ln for ln in leases
+        if ln.kind == ClaimKind.SESSION and ln.entity_id == sess.id
+    )
+    await pool._run_engine_session(lease)
+    records = await storage_provider.get_storage(ToolApprovalRecord).list(
+        OffsetPage(offset=0, length=50)
+    )
+    return records.items
+
+
+@pytest.mark.asyncio
+async def test_resume_skips_the_write_when_respond_time_already_recorded_it(
+    monkeypatch, tmp_path,
+):
+    """01a068da's core idempotency guarantee: if the respond route
+    already wrote the durable record for this gate (the normal case now
+    -- this resume-time write is a FALLBACK, not the primary write site
+    any more), the resume must not add a second row for the same
+    decision. gate_event_key's unique index is what makes this provably
+    true rather than merely likely: a duplicate insert attempt raises
+    ConflictError, which write_approval_record swallows as an expected
+    no-op (see tests/agent/test_approval_record.py).
+
+    Uses a REAL SqliteStorageProvider, not the shared _FakeStorageProvider
+    every other test in this file uses: the fake only enforces uniqueness
+    on the primary key (a plain id-keyed dict), it has no concept of a
+    hot-field unique index at all, so it would silently let a second
+    gate_event_key through and this test would prove nothing.
+    """
+    from primer.model.provider import SqliteConfig
+    from primer.storage.sqlite import SqliteStorageProvider
+
+    sid, tcid = "sess-rec-dedupe", "tc5"
+    gate_key = f"tool_approval:{sid}:{tcid}"
+    sess = _approval_session(sid, tcid=tcid, resume_payload={"decision": "approved"})
+
+    storage_provider = SqliteStorageProvider(
+        SqliteConfig(path=str(tmp_path / "dedupe.sqlite"))
+    )
+    await storage_provider.initialize()
+    try:
+        # Simulate the respond-time write having already landed, BEFORE
+        # the resume runs at all.
+        preseeded = ToolApprovalRecord(
+            tool_name="delete_workspace",
+            arguments={"id": "ws-1"},
+            tool_call_id=tcid,
+            session_id=sid,
+            agent_id="ag-1",
+            decided_at=datetime.now(timezone.utc),
+            decision="approved",
+            gate_event_key=gate_key,
+        )
+        await storage_provider.get_storage(ToolApprovalRecord).create(preseeded)
+
+        items = await _drive_with_preseeded_storage(
+            monkeypatch, sess, storage_provider,
+        )
+        assert len(items) == 1
+        assert items[0].id == preseeded.id
+        assert items[0].gate_event_key == gate_key
+    finally:
+        await storage_provider.aclose()


### PR DESCRIPTION
Board 01a068da (Option A from the 7a ruling-3 ground-truth remap). Closes the audit-integrity gap Dev-Backend's trace exposed: `ToolApprovalRecord` was written only by the resume coordinator, late and best-effort — a crash between respond and resume lost the audit record entirely, and the records surfaces (resolved cards, DECISIONS-AUDIT) showed decisions only after a successful resume.

**Design**: the respond endpoint's `_publish_decision` now writes the record at real arrival time (primary, for operator decisions); the resume-time write stays as the unconditional site for **synthesized timeout/cancel verdicts**, which never pass through respond at all. The two writes are idempotent against each other via a new `gate_event_key` field with a NULL-tolerant unique hot-field index (both storage backends) — either order, exactly one record survives (ConflictError absorbed). `GET /tool_approval/records` gains a `gate_event_key` query param, making decisions queryable by gate.

**Verification**: 125 tests green (47 direct + 78 blast-radius incl. approver routing, audit derivation, console session doc). The idempotency test runs against a real SqliteStorageProvider deliberately — the shared fake only enforces primary-key uniqueness, not hot-field indexes, and would have vacuously passed.

**Known analogous gap, filed separately** (board 01a06b82): the graph path's `write_approval_record_for_graph` remains resume-time-only — multi-concurrent-node parks have no natural single gate key, so it needs its own design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)