### PR TITLE
feat(mcp): protocol-level inputSchema validation on tools/call

### DIFF
--- a/primer/mcp/server.py
+++ b/primer/mcp/server.py
@@ -32,6 +32,7 @@ from contextvars import ContextVar
 from typing import TYPE_CHECKING, Any
 from collections.abc import Callable
 
+import jsonschema
 from mcp.server.lowlevel import Server
 from mcp.shared.exceptions import MCPError
 from mcp.types import (
@@ -87,6 +88,51 @@ current_api_token_scopes: ContextVar["list[str] | None"] = ContextVar(
 )
 
 
+async def _input_validation_error(
+    deps: ExposureDeps, name: str, arguments: dict,
+) -> str | None:
+    """Check ``arguments`` against the exposed tool's ``inputSchema``.
+
+    mcp 1.x validated tool arguments against ``inputSchema`` inside the
+    SDK before dispatch; 2.x dropped that. Primer's pydantic layer still
+    rejects malformed arguments further down (no correctness/security
+    gap -- confirmed during the #226 migration review by both the lead
+    and Dev-Backend), but the error SHAPE regressed: a caller got a deep
+    tool-execution error instead of a protocol-level one, without the
+    tool ever running. This restores that shape as an optional DX
+    polish, re-checked here rather than cached: the schema is whatever
+    ``_list`` would currently advertise for this tool, so a caller who
+    just re-fetched ``tools/list`` sees a call rejected against the
+    exact same shape.
+
+    Returns the human-readable validation message, or ``None`` when the
+    arguments are valid, the tool declares no schema, or the tool is not
+    found here at all -- an unresolvable name is ``_call``'s job to
+    reject as not-exposed (JSON-RPC method-not-found), not this
+    function's, so a lookup miss is silently treated as "nothing to
+    validate against" rather than surfaced as a validation failure.
+    """
+    for tool, _provider in await list_exposed_tools(deps):
+        if tool_scoped_id(tool) != name:
+            continue
+        schema = tool.args_schema
+        if not schema:
+            return None
+        try:
+            jsonschema.validate(instance=arguments, schema=schema)
+        except jsonschema.exceptions.ValidationError as exc:
+            return exc.message
+        except jsonschema.exceptions.SchemaError:
+            # The tool's own advertised schema is malformed -- a
+            # provider bug, not the caller's fault. Do not block every
+            # call to this tool on it; proceed as if there were no
+            # schema to check (dispatch's own pydantic layer is still
+            # the real backstop either way).
+            return None
+        return None
+    return None
+
+
 def build_mcp_server(deps_factory: Callable[[], ExposureDeps]) -> Server:
     """Construct a :class:`Server` instance with primer's handlers attached.
 
@@ -129,6 +175,8 @@ def build_mcp_server(deps_factory: Callable[[], ExposureDeps]) -> Server:
         * :class:`NotExposed` → JSON-RPC ``method-not-found`` so the
           client treats the tool name as unknown. Operators see the
           rich ``reason`` only in the audit log.
+        * A malformed argument shape → protocol-level ``isError=True``
+          BEFORE dispatch (see :func:`_input_validation_error` below).
         * Any other exception from the dispatcher / provider → returned
           as an MCP-level ``isError=True`` result, which is the SDK's
           convention for tool-execution failures the client should
@@ -147,6 +195,16 @@ def build_mcp_server(deps_factory: Callable[[], ExposureDeps]) -> Server:
         ok = False
         try:
             try:
+                bad_input = await _input_validation_error(deps, name, arguments)
+                if bad_input is not None:
+                    error_code = "invalid_arguments"
+                    return CallToolResult(
+                        isError=True,
+                        content=[TextContent(
+                            type="text",
+                            text=f"Input validation error: {bad_input}",
+                        )],
+                    )
                 result = await invoke_exposed(
                     scoped_id=name,
                     arguments=arguments,

--- a/tests/mcp/conftest.py
+++ b/tests/mcp/conftest.py
@@ -108,12 +108,17 @@ class FakeProviderRegistry:
         return self._providers.get(toolset_id)
 
 
-def _make_tool(toolset_id: str, name: str, descr: str = "") -> Tool:
+def _make_tool(
+    toolset_id: str, name: str, descr: str = "", *, args_schema: dict | None = None,
+) -> Tool:
     return Tool(
         id=name,
         toolset_id=toolset_id,
         description=descr or f"{toolset_id}.{name}",
-        args_schema={"type": "object", "properties": {}},
+        args_schema=(
+            args_schema if args_schema is not None
+            else {"type": "object", "properties": {}}
+        ),
     )
 
 

--- a/tests/mcp/test_server_handlers.py
+++ b/tests/mcp/test_server_handlers.py
@@ -10,13 +10,16 @@ business-logic contract that those handlers depend on.
 from __future__ import annotations
 
 import logging
+from typing import Any
 
 import pytest
 
 from primer.mcp.dispatch import NotExposed, invoke_exposed, list_exposed_tools
 from primer.mcp.exposure import ExposureDeps, update_exposure
 from primer.mcp.server import (
+    _input_validation_error,
     build_mcp_server,
+    current_actor,
     current_api_token_id,
     current_api_token_scopes,
     current_principal,
@@ -460,6 +463,229 @@ async def test_invoke_no_policy_runs_with_resolver(
     )
     assert isinstance(result, ToolCallResult)
     assert result.is_error is False
+
+
+# ---- _input_validation_error (01a068d7) -------------------------------
+#
+# mcp 1.x validated tool arguments against inputSchema inside the SDK
+# before dispatch; 2.x dropped that. This restores a protocol-level
+# pre-check at the top of _call, before invoke_exposed ever runs.
+
+
+def _registry_with_schema(schema: dict) -> Any:
+    """A registry exposing one tool, ``misc__strict``, whose
+    ``args_schema`` is the caller-supplied ``schema`` -- the fixture
+    tools every other test in this file uses all carry the same
+    permissive empty schema, which cannot exercise a validation
+    FAILURE at all.
+    """
+    from tests.mcp.conftest import FakeProviderRegistry, FakeToolsetProvider, _make_tool
+
+    tool = _make_tool("misc", "strict", args_schema=schema)
+    provider = FakeToolsetProvider("misc", [tool])
+    return FakeProviderRegistry({"misc": provider})
+
+
+@pytest.mark.asyncio
+async def test_input_validation_error_none_for_valid_arguments(
+    fake_storage_provider,
+) -> None:
+    schema = {
+        "type": "object",
+        "properties": {"n": {"type": "integer"}},
+        "required": ["n"],
+    }
+    registry = _registry_with_schema(schema)
+    deps = _deps(fake_storage_provider, registry)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__strict"],
+        updated_by="alice", deps=deps,
+    )
+
+    msg = await _input_validation_error(deps, "misc__strict", {"n": 1})
+
+    assert msg is None
+
+
+@pytest.mark.asyncio
+async def test_input_validation_error_reports_missing_required_field(
+    fake_storage_provider,
+) -> None:
+    schema = {
+        "type": "object",
+        "properties": {"n": {"type": "integer"}},
+        "required": ["n"],
+    }
+    registry = _registry_with_schema(schema)
+    deps = _deps(fake_storage_provider, registry)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__strict"],
+        updated_by="alice", deps=deps,
+    )
+
+    msg = await _input_validation_error(deps, "misc__strict", {})
+
+    assert msg is not None
+    assert "n" in msg
+
+
+@pytest.mark.asyncio
+async def test_input_validation_error_reports_wrong_type(
+    fake_storage_provider,
+) -> None:
+    schema = {
+        "type": "object",
+        "properties": {"n": {"type": "integer"}},
+        "required": ["n"],
+    }
+    registry = _registry_with_schema(schema)
+    deps = _deps(fake_storage_provider, registry)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__strict"],
+        updated_by="alice", deps=deps,
+    )
+
+    msg = await _input_validation_error(deps, "misc__strict", {"n": "not-an-int"})
+
+    assert msg is not None
+
+
+@pytest.mark.asyncio
+async def test_input_validation_error_none_when_schema_is_empty(
+    fake_storage_provider, fake_provider_registry_with_tools,
+) -> None:
+    """The default fixture tools all carry the permissive empty schema
+    ({"type": "object", "properties": {}}) -- nothing to reject."""
+    deps = _deps(fake_storage_provider, fake_provider_registry_with_tools)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__uuid_v4"],
+        updated_by="alice", deps=deps,
+    )
+
+    msg = await _input_validation_error(
+        deps, "misc__uuid_v4", {"anything": "goes"},
+    )
+
+    assert msg is None
+
+
+@pytest.mark.asyncio
+async def test_input_validation_error_none_when_tool_not_found(
+    fake_storage_provider, fake_provider_registry_with_tools,
+) -> None:
+    """A name that resolves to nothing here is _call's NotExposed job to
+    reject, not this function's -- must not be mistaken for a
+    validation failure."""
+    deps = _deps(fake_storage_provider, fake_provider_registry_with_tools)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__uuid_v4"],
+        updated_by="alice", deps=deps,
+    )
+
+    msg = await _input_validation_error(deps, "misc__does_not_exist", {})
+
+    assert msg is None
+
+
+@pytest.mark.asyncio
+async def test_input_validation_error_none_when_schema_itself_is_malformed(
+    fake_storage_provider,
+) -> None:
+    """A provider bug (an invalid JSON Schema advertised as the tool's
+    own inputSchema) must not block every call to that tool -- dispatch
+    proceeds as if there were nothing to check."""
+    # "type": "not-a-real-type" is not a valid JSON Schema type keyword
+    # value, so jsonschema.validate raises SchemaError before it even
+    # gets to checking the instance.
+    schema = {"type": "not-a-real-type"}
+    registry = _registry_with_schema(schema)
+    deps = _deps(fake_storage_provider, registry)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__strict"],
+        updated_by="alice", deps=deps,
+    )
+
+    msg = await _input_validation_error(deps, "misc__strict", {})
+
+    assert msg is None
+
+
+@pytest.mark.asyncio
+async def test_call_returns_isError_for_invalid_arguments_before_dispatch(
+    fake_storage_provider,
+) -> None:
+    """Integration: _call itself (not just the helper) rejects malformed
+    arguments with a protocol-level isError result, and the tool never
+    runs."""
+    from mcp.types import CallToolRequestParams
+
+    schema = {
+        "type": "object",
+        "properties": {"n": {"type": "integer"}},
+        "required": ["n"],
+    }
+    registry = _registry_with_schema(schema)
+    deps = _deps(fake_storage_provider, registry)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__strict"],
+        updated_by="alice", deps=deps,
+    )
+    server = build_mcp_server(lambda: deps)
+    # get_request_handler returns a HandlerEntry wrapper (.handler is the
+    # bare on_call_tool callable passed to the Server constructor, i.e.
+    # _call itself), not something directly callable on its own.
+    handler = server.get_request_handler("tools/call").handler
+
+    result = await handler(
+        None,
+        CallToolRequestParams(name="misc__strict", arguments={}),
+    )
+
+    assert result.is_error is True
+    assert "Input validation error" in result.content[0].text
+    provider = await registry.get_toolset("misc")
+    assert provider.calls == [], "the tool must never have been dispatched"
+
+
+@pytest.mark.asyncio
+async def test_call_dispatches_normally_when_arguments_are_valid(
+    fake_storage_provider, system_actor,
+) -> None:
+    """The no-false-positive case: a tool WITH a real schema still runs
+    end to end when the arguments actually satisfy it -- pre-validation
+    must not become a second, stricter gate that blocks legitimate
+    calls."""
+    from mcp.types import CallToolRequestParams
+
+    schema = {
+        "type": "object",
+        "properties": {"n": {"type": "integer"}},
+        "required": ["n"],
+    }
+    registry = _registry_with_schema(schema)
+    deps = _deps(fake_storage_provider, registry)
+    await update_exposure(
+        enabled=True, allowed_tools=["misc__strict"],
+        updated_by="alice", deps=deps,
+    )
+    server = build_mcp_server(lambda: deps)
+    handler = server.get_request_handler("tools/call").handler
+
+    actor_tok = current_actor.set(system_actor)
+    try:
+        result = await handler(
+            None,
+            CallToolRequestParams(name="misc__strict", arguments={"n": 7}),
+        )
+    finally:
+        current_actor.reset(actor_tok)
+
+    assert result.is_error is False
+    provider = await registry.get_toolset("misc")
+    assert provider.calls == [{
+        "tool_name": "strict", "arguments": {"n": 7},
+        "principal": None, "ctx": None,
+    }], "the tool must have been dispatched exactly once with the real arguments"
 
 
 # ---- build_mcp_server smoke ------------------------------------------------


### PR DESCRIPTION
Board 01a068d7. Restores the mcp 1.x SDK behavior the 2.x migration dropped (noted as an accepted behavior change in #226): `tools/call` arguments are now jsonschema-validated against the exposed tool's `args_schema` before dispatch, returning the protocol-level `isError` result (`error_code="invalid_arguments"`) without running the tool — instead of a deep tool-layer error with a worse shape.

Self-contained at the `_call` handler per the task's placement ruling, reusing the same `list_exposed_tools` lookup `_list` already performs; `invoke_exposed` untouched. Validation sits inside the existing try/finally, so rejected calls still produce `log_invoke` and the `mcp.tool_called` event — observability parity with every other error path. Conservative fall-through: no schema, tool-not-found, or a malformed schema on the tool all mean "nothing to check", never a blocked call.

68/68 across the full tests/mcp/ suite; conftest's `_make_tool` gained an optional `args_schema` override with all existing call sites unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)