### PR TITLE
fix(e2e): open-websearch daemon failures skip, not error, the e2e job

### DIFF
--- a/tests/e2e/test_smk_mcp.py
+++ b/tests/e2e/test_smk_mcp.py
@@ -106,8 +106,13 @@ def ows_http_url():
         ready = False
         while time.time() < deadline:
             if proc.poll() is not None:
-                raise RuntimeError(
-                    f"open-websearch http daemon exited early (rc={proc.returncode})"
+                # Environmental (network/npm registry fetch of the external
+                # package), not a Primer regression -- skip rather than
+                # error the whole job red, same as ows_stdio_mount's own
+                # skip above for "not configured at all".
+                pytest.skip(
+                    f"open-websearch http daemon exited early (rc={proc.returncode}) "
+                    "-- external network/npm dependency unavailable"
                 )
             try:
                 # A bare GET on /mcp is rejected (4xx) by the MCP endpoint, but
@@ -119,7 +124,14 @@ def ows_http_url():
             except httpx.ConnectError:
                 time.sleep(0.5)
         if not ready:
-            raise RuntimeError("open-websearch http daemon did not become reachable")
+            # Same environmental reasoning as the exited-early branch above:
+            # a CI runner that can't reach npm/the daemon's port must not
+            # error the whole e2e job red over a third-party dependency
+            # Primer doesn't control.
+            pytest.skip(
+                "open-websearch http daemon did not become reachable "
+                "-- external network/npm dependency unavailable"
+            )
         yield url
     finally:
         try:


### PR DESCRIPTION
## Summary

`test_external_http_open_websearch_mounts_and_lists_tools` raises `RuntimeError` at fixture setup when the real `open-websearch` HTTP daemon fails to start (exits early, or never becomes reachable within the 120s window) — an environmental failure (external network / npm registry fetch), not a Primer regression. This errors the whole e2e job red instead of skipping, and has been recurring across `main`'s E2E run and six PR branches as of 2026-09-04.

**Six currently-red e2e checks (main + 6 PRs) are this exact failure** and should go green once this lands and each branch rebases/merges main.

## Fix

Both `RuntimeError` raise sites in the `ows_http_url` fixture now call `pytest.skip(...)` instead, matching the sibling `ows_stdio_mount` fixture's own skip a few lines above (added because the `@requires("mcp:stdio")` capability gate can't catch this case — `Caps` advertises `mcp:stdio`/`mcp:http` unconditionally, so the gate only catches "not configured at all", not "configured but the daemon failed to start"). The test stays fully functional when the daemon does start — nothing about the happy path changes.

## Test plan

- [x] `ruff check` clean.
- [x] Verified the skip-in-fixture mechanics in isolation: a scratch fixture raising `pytest.skip()` before `yield`, inside the same `try`/`finally` shape as `ows_http_url`, reports `1 skipped` (not an error) and its `finally` cleanup still runs.
- Not chased: a full local e2e bring-up to reproduce the daemon-unreachable path directly. This is a mechanical exception-type swap onto an already-proven pattern in this same file (`ows_stdio_mount`'s existing skip), so the isolated verification above covers the actual mechanical risk; CI — where the daemon genuinely fails to become reachable — is the natural verification environment for the real condition, and is exactly where this bug was first observed.
