### PR TITLE
fix(session): close the executor's event generator deterministically on every turn exit

### DIFF
--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -440,8 +440,20 @@ async def run_one_session_turn(
     if delta_buffer is not None:
         await delta_buffer.start()
 
+    # 01a0692f: held so the finally below can explicitly aclose() it on
+    # every exit path (break, exception, or normal exhaustion - aclose()
+    # on an already-finished generator is a no-op). A bare `break` alone
+    # leaves the generator suspended mid-yield; for a graph session that
+    # generator is `_run_superstep_loop`, whose own node-task-cancellation
+    # cleanup lives in ITS `finally`, reached only once this generator is
+    # actually closed. Without an explicit aclose(), Python still closes
+    # it eventually via the asyncgen finalizer hook when this local's
+    # refcount drops - but that runs on a LATER event-loop tick, not
+    # in-line, so a mid-turn cancel on a wide fan-out could leave sibling
+    # node tasks running in the background for a tick or few.
+    turn_events = executor.invoke([])
     try:
-        async for event in executor.invoke([]):
+        async for event in turn_events:
             # agent_phase (01a04d91-a7a0): inspect the RAW event, before
             # translate_stream_event's coalescing, so "responding"/
             # "executing" are true the instant the tokens/tool call start
@@ -779,6 +791,19 @@ async def run_one_session_turn(
         return ReleaseOutcome(success=False, drop_lease=True)
 
     finally:
+        # 01a0692f: close the turn's event stream explicitly and first -
+        # a graph session's generator chain (_run_superstep_loop) cancels
+        # any still-in-flight fan-out node tasks in ITS OWN finally, which
+        # only runs once this aclose() actually reaches it. See turn_events'
+        # own comment above for why relying on implicit GC-driven closure
+        # instead would only delay that cleanup, not skip it.
+        try:
+            await turn_events.aclose()
+        except Exception:  # noqa: BLE001 - best-effort, never blocks release
+            logger.exception(
+                "session %s: turn_events.aclose() raised during cleanup",
+                session_id,
+            )
         _metrics.sessions_active.labels(session.workspace_id).dec()
         reset_delegation_sink(_delegation_token)
         cancel_task.cancel()

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -281,6 +281,73 @@ async def test_cancel_mid_stream_writes_cancelled_and_breaks(
 
 
 @pytest.mark.asyncio
+async def test_cancel_mid_stream_closes_the_executor_generator(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """01a0692f: a mid-turn cancel's `break` must aclose() the executor's
+    generator explicitly and synchronously (by the time run_one_session_turn
+    returns), not rely on CPython's asyncgen finalizer to get to it on some
+    later event-loop tick. For a graph session, that generator's own
+    finally is what cancels any still-in-flight fan-out node tasks - a
+    bare break alone would leave that cleanup pending indefinitely (well
+    past this function's return), not skipped, but pending is still a
+    real gap on a wide fan-out.
+    """
+    gate = asyncio.Event()
+    closed = False
+
+    class _SlowExecutor:
+        async def invoke(self, messages: list[Any], **kwargs: Any):
+            nonlocal closed
+            try:
+                yield TextDelta(text="starting…", index=0)
+                await gate.wait()
+                yield TextDelta(text="should-not-persist", index=0)
+            finally:
+                closed = True
+
+    async def _build_executor(session: WorkspaceSession):
+        return _SlowExecutor()
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    lease = _make_lease(seeded_session.id)
+
+    turn_task = asyncio.create_task(run_one_session_turn(lease, deps))
+
+    # Let the executor emit the first TextDelta, then fire cancel - same
+    # choreography as test_cancel_mid_stream_writes_cancelled_and_breaks.
+    await asyncio.sleep(0.05)
+    await fake_event_bus.publish(f"session:{seeded_session.id}:cancel", {})
+    await asyncio.sleep(0.05)
+
+    # The generator is parked at `await gate.wait()`, cancel is flagged
+    # but not yet actable - the dispatch loop's own cancel-check only
+    # runs in the loop BODY, after an event is received, so it can't fire
+    # until the generator yields again. Not closed yet.
+    assert not closed
+    gate.set()
+    # Opening the gate lets the generator yield its second event; the
+    # loop body then sees cancel_event.is_set() and breaks - leaving the
+    # generator suspended mid-yield, exactly the case aclose() must cover.
+
+    outcome = await asyncio.wait_for(turn_task, timeout=2.0)
+    assert outcome.drop_lease is True
+    assert closed, (
+        "run_one_session_turn returned without closing the executor's "
+        "generator - its own cleanup (cancelling any in-flight fan-out "
+        "node tasks, for a graph session) never ran"
+    )
+
+
+@pytest.mark.asyncio
 async def test_turn_status_reads_running_for_the_whole_streaming_window(
     seeded_session: WorkspaceSession,
     fake_workspace_io: FakeWorkspaceIO,


### PR DESCRIPTION
Board 01a0692f (found by Dev-Backend while building the tool-dispatch barrier, verified empirically then): dispatch's cancel path broke out of `async for event in executor.invoke([])` with a bare `break` — no `aclose()` — so closing the inner generator chain relied on CPython's asyncgen finalizer hook firing on a later event-loop tick. On a wide fan-out, a mid-turn cancel left sibling node tasks running in the background until GC-driven cleanup caught them.

Fix: hold the generator in a local and `await turn_events.aclose()` in the function's existing universal `finally`, covering break, exception, and normal exhaustion uniformly — cleanup is now synchronous with turn exit instead of eventual. The new test pins exactly that property: a fake executor whose generator records whether its own `finally` ran — false while suspended mid-stream, true by the time `run_one_session_turn` returns.

513 passed / 1 pre-existing xfail across tests/session + tests/worker; ruff clean. Standalone branch off main — deliberately not bundled with the 7a work despite being discovered there (unrelated concern).

🤖 Generated with [Claude Code](https://claude.com/claude-code)