### PR TITLE
docs: _probe_llm_models fallback is a dispatch-completeness guard, not dead code

### DIFF
--- a/primer/api/routers/providers.py
+++ b/primer/api/routers/providers.py
@@ -768,6 +768,23 @@ async def _probe_llm_models(provider: str, config: dict[str, Any]) -> dict:
             ) from exc
         result = {"models": catalogue}
     else:
+        # 01a06918: unreachable today. _build_stub_provider above already
+        # validated `provider` against LLMProvider's own LLMProviderType
+        # field, so by this point it is one of the 6 current members --
+        # ollama/openresponses/openchat/openrouter/anthropic/gemini --
+        # every one of which has its own elif above. The old reachable
+        # case was "aggregated" (an LLMProviderType member with no live
+        # probe of its own); it moved off LLMProvider entirely onto
+        # ModelProfile (01a067c4) and no longer exists as a value this
+        # function can even receive.
+        #
+        # Kept anyway as a dispatch-completeness guard: a FUTURE
+        # LLMProviderType member added without a matching elif here would
+        # otherwise fall through to an UnboundLocalError on `result`
+        # below instead of a clean 400. setup.py's _live_llm_provider_check
+        # matches this exact message string for the same "provider type
+        # with no live probe" case -- if this branch is ever removed,
+        # that fallback needs revisiting too.
         raise BadRequestError(
             f"live model discovery is not supported for provider "
             f"{provider!r}; populate the models list manually or "

--- a/primer/api/routers/setup.py
+++ b/primer/api/routers/setup.py
@@ -229,9 +229,16 @@ async def _live_llm_provider_check(storage_provider) -> tuple[bool, str | None]:
         )
     except BadRequestError as exc:
         if "live model discovery is not supported" in str(exc):
-            # Not every provider type exposes a list-models probe (e.g.
-            # aggregated); no live signal either way, so this falls
-            # back to "configured" rather than reading as a failure.
+            # 01a06918: unreachable today -- every current LLMProviderType
+            # member has a live probe (_probe_llm_models' dispatch, see
+            # its own comment on the analogous else branch). The old
+            # reachable case was "aggregated" (a provider type with no
+            # probe of its own); it moved off LLMProvider entirely onto
+            # ModelProfile (01a067c4). Kept as a forward-looking fallback
+            # for the same reason _probe_llm_models keeps its match: a
+            # future provider type added without a live-probe path should
+            # read as "configured, no live signal either way" here rather
+            # than fail the setup gate outright.
             return True, None
         return False, str(exc)
     return True, None


### PR DESCRIPTION
Board 01a06918 (flagged during the aggregated-profile migration when the 'aggregated' kind — the only no-probe provider — left the enum). Verified: the else branch is unreachable today because `_build_stub_provider` validates against `LLMProviderType` before the dispatch chain runs, and all six current members have explicit branches. Kept and documented rather than removed: it guards a FUTURE enum member added without a matching elif, turning what would be an `UnboundLocalError` into a clean 400. Also fixed the coupled half — setup.py's `_live_llm_provider_check` catches this exact message string and still carried a stale "(e.g. aggregated)" comment; both sides of the one mechanism updated together. 58/58 across the four touched routers' test files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)