### PR TITLE
feat(ui): composer fold-split + answered-ask card (01a052d9 step 3, 01a06622)

### DIFF
--- a/tests/ui/test_composer_attachments.py
+++ b/tests/ui/test_composer_attachments.py
@@ -1,20 +1,32 @@
-"""01a052a5 item 5: real attachments flow, zero-backend default scope.
+"""01a052a5 item 5 + 01a052d9 step 3: composer attachments, plain-text
+convention plus the true-vision/document fold-split.
 
-The lead's ruling: wire the composer's attach button to the ALREADY
-WORKING upload primitive nv-files-sidebar.jsx uses (SH_api.fileUpload ->
-PUT .../files, base64 - binary-safe), show pending uploads as removable
-chips, and fold each finished upload's path into the sent instruction as
-a plain "Attached file: {path}" line - no message-schema change. True
-multimodal/vision attachments are a separate, explicitly-filed design
-task (SteerBody has no parts/attachments field today - only a bare
-`instruction: str | None`).
+01a052a5's original scope: wire the composer's attach button to the
+ALREADY WORKING upload primitive nv-files-sidebar.jsx uses
+(SH_api.fileUpload -> PUT .../files, base64 - binary-safe), show pending
+uploads as removable chips, and fold each finished upload's path into the
+sent instruction as a plain "Attached file: {path}" line - no message-
+schema change.
+
+01a052d9 step 3 (this file's newer half): SteerBody now HAS a real
+attachments field (list[AttachmentIn], each a bare {path}) that folds a
+workspace file into the turn as true vision/document input
+(ImagePart/DocumentPart via primer.channel.media.media_from_workspace_
+files), landed on main as part of the same design. send() now SPLITS
+readyAttachments by NV_isVisionDocAttachment(a.type): image/* and the
+handful of document mimes ride as steerAttachments (SteerBody.
+attachments); everything else (text/code/audio/video/unrecognised) keeps
+the original plain-text convention above, since the agent's existing
+file tools already handle those and there is no benefit to hydrating
+their bytes into the prompt.
 
 Static source checks (the ui/ suite convention) plus one MiniRacer test
-for send()'s text-folding logic, extracted and executed for real -
-mirrors test_trace_row_expand_toggle_via_mini_racer's "stub React, run
-the real snippet" technique, since the folding rule (empty text vs. text
-+ attachments vs. attachments-only, skipping non-"done" ones) is exactly
-the kind of conditional a source-grep alone could get subtly wrong.
+for send()'s text-folding + fold-split logic, extracted and executed for
+real - mirrors test_trace_row_expand_toggle_via_mini_racer's "stub React,
+run the real snippet" technique, since the folding/split rule (empty
+text vs. text + attachments vs. attachments-only, skipping non-"done"
+ones, routing by mime type) is exactly the kind of conditional a source-
+grep alone could get subtly wrong.
 """
 
 from __future__ import annotations
@@ -29,6 +41,16 @@ DOC = (UI / "components" / "console" / "nv-session-doc.jsx").read_text(encoding=
 def _composer() -> str:
     start = DOC.index("function NV_Composer")
     end = DOC.index("\n// ---", start)
+    return DOC[start:end]
+
+
+def _vision_doc_helper() -> str:
+    """NV_isVisionDocAttachment + its NV_VISION_DOC_EXACT_TYPES constant --
+    module-level, defined just above NV_Composer, which calls it. The
+    MiniRacer harness below needs this alongside the extracted composer
+    body since it isn't a closure-captured local."""
+    start = DOC.index("var NV_VISION_DOC_EXACT_TYPES")
+    end = DOC.index("\n\n// ---", start)
     return DOC[start:end]
 
 
@@ -112,10 +134,18 @@ def test_attachments_clear_only_on_successful_send():
     assert "setAttachments([])" not in failure_branch
 
 
-def test_send_folding_logic_via_mini_racer():
-    """Extracts send()'s guard + fullText computation (up to the point
-    it starts touching React state / the network) and runs it for real
-    against representative attachment lists."""
+def _send_fold_context():
+    """Build the MiniRacer context + `fold()` helper shared by the
+    folding and fold-split tests below. Extracts send()'s guard +
+    fullText/steerAttachments computation (up to the point it starts
+    touching React state / the network) and runs it for real against
+    representative attachment lists.
+
+    Returns ``fold(val, attachments, sending=False, pending=False)``,
+    which gives back ``{"fullText": ..., "steerAttachments": ...}`` (both
+    ``None`` when absent) or bare ``None`` when the guard's own early
+    ``return;`` fired (nothing to send).
+    """
     import json
 
     from py_mini_racer import MiniRacer
@@ -130,9 +160,14 @@ def test_send_folding_logic_via_mini_racer():
     end = composer.index("setSending(true);", start)
     body = composer[start:end]
     wrapped = (
+        _vision_doc_helper() + "\n"
         "function SEND_FOLD(val, attachments, sending, attachmentsPending) {\n"
         + body
-        + "\n  return fullText;\n}\n"
+        + "\n  return JSON.stringify({"
+        "fullText: (typeof fullText === \"undefined\" ? null : fullText), "
+        "steerAttachments: (typeof steerAttachments === \"undefined\" "
+        "? null : steerAttachments)"
+        "});\n}\n"
     )
     transpiled = bundler._transform(wrapped, "send_fold_test.jsx")
 
@@ -140,34 +175,94 @@ def test_send_folding_logic_via_mini_racer():
     ctx.eval(transpiled)
 
     def fold(val, attachments, sending=False, pending=False):
-        # A guard hit returns bare `undefined`, which py_mini_racer's
-        # JSON-marshalling ctx.call() cannot round-trip - coerce to null
-        # before crossing back into Python.
+        # A guard hit returns bare `undefined` for the whole function
+        # (SEND_FOLD's inlined `return;` never reaches the JSON.stringify
+        # tail below it) - coerce to None before crossing back into
+        # Python, same as the pre-fold-split version of this test did.
         ctx.eval(
             "var __r = SEND_FOLD(" + json.dumps(val) + ", "
             + json.dumps(attachments) + ", " + json.dumps(sending) + ", "
             + json.dumps(pending) + ");"
         )
-        return ctx.eval("__r === undefined ? null : __r")
+        raw = ctx.eval("__r === undefined ? null : __r")
+        return json.loads(raw) if raw is not None else None
 
-    assert fold("hello", []) == "hello"
+    return fold
+
+
+def test_send_folding_logic_via_mini_racer():
+    fold = _send_fold_context()
+
+    def text_of(val, attachments, **kw):
+        r = fold(val, attachments, **kw)
+        return r["fullText"] if r else None
+
+    assert text_of("hello", []) == "hello"
     assert fold("", []) is None, "nothing to send returns undefined (the guard's bare return)"
-    assert fold("", [{"path": "uploads/x-a.png", "status": "done"}]) == (
-        "Attached file: uploads/x-a.png"
+    assert text_of("", [{"path": "uploads/x-a.pdf", "status": "done", "type": "text/plain"}]) == (
+        "Attached file: uploads/x-a.pdf"
     )
-    assert fold("look at this", [{"path": "uploads/x-a.png", "status": "done"}]) == (
-        "look at this\n\nAttached file: uploads/x-a.png"
-    )
-    two = fold("", [
-        {"path": "uploads/x-a.png", "status": "done"},
-        {"path": "uploads/x-b.pdf", "status": "done"},
+    assert text_of(
+        "look at this",
+        [{"path": "uploads/x-a.pdf", "status": "done", "type": "text/plain"}],
+    ) == "look at this\n\nAttached file: uploads/x-a.pdf"
+    two = text_of("", [
+        {"path": "uploads/x-a.txt", "status": "done", "type": "text/plain"},
+        {"path": "uploads/x-b.csv", "status": "done", "type": "text/csv"},
     ])
-    assert two == "Attached file: uploads/x-a.png\nAttached file: uploads/x-b.pdf"
+    assert two == "Attached file: uploads/x-a.txt\nAttached file: uploads/x-b.csv"
     # An uploading/errored attachment is never folded into the sent text.
-    assert fold("hi", [{"path": "uploads/x-a.png", "status": "uploading"}]) == "hi"
-    assert fold("hi", [{"path": "uploads/x-a.png", "status": "error"}]) == "hi"
+    assert text_of("hi", [{"path": "uploads/x-a.txt", "status": "uploading", "type": "text/plain"}]) == "hi"
+    assert text_of("hi", [{"path": "uploads/x-a.txt", "status": "error", "type": "text/plain"}]) == "hi"
     # Only an uploading one blocks the guard when there is otherwise
     # nothing else to send yet.
-    assert fold("", [{"path": "uploads/x-a.png", "status": "uploading"}]) is None
+    assert fold("", [{"path": "uploads/x-a.txt", "status": "uploading", "type": "text/plain"}]) is None
     assert fold("hello", [], sending=True) is None
     assert fold("hello", [], pending=True) is None
+
+
+def test_send_fold_split_routes_images_and_documents_as_vision_attachments():
+    """01a052d9 step 3: image/* and document mimes ride as
+    steerAttachments (SteerBody.attachments -> true vision/document
+    input); everything else keeps the plain-text convention. Mixed lists
+    split correctly, and a vision-only attachment with no typed text
+    still has something to send (the guard does not block it)."""
+    fold = _send_fold_context()
+
+    image_only = fold("", [
+        {"path": "uploads/x-a.png", "status": "done", "type": "image/png"},
+    ])
+    assert image_only is not None, "a vision attachment alone must not hit the empty-send guard"
+    assert image_only["fullText"] == ""
+    assert image_only["steerAttachments"] == [{"path": "uploads/x-a.png"}]
+
+    pdf_only = fold("", [
+        {"path": "uploads/report.pdf", "status": "done", "type": "application/pdf"},
+    ])
+    assert pdf_only["steerAttachments"] == [{"path": "uploads/report.pdf"}]
+    assert pdf_only["fullText"] == ""
+
+    # A text/code file stays on the legacy convention, not steerAttachments.
+    text_only = fold("", [
+        {"path": "uploads/notes.txt", "status": "done", "type": "text/plain"},
+    ])
+    assert text_only["steerAttachments"] is None
+    assert text_only["fullText"] == "Attached file: uploads/notes.txt"
+
+    # A mixed list splits: the image goes to steerAttachments, the text
+    # file stays folded into fullText - and only the text file appears
+    # in fullText, not both.
+    mixed = fold("caption", [
+        {"path": "uploads/photo.jpg", "status": "done", "type": "image/jpeg"},
+        {"path": "uploads/readme.txt", "status": "done", "type": "text/plain"},
+    ])
+    assert mixed["steerAttachments"] == [{"path": "uploads/photo.jpg"}]
+    assert mixed["fullText"] == "caption\n\nAttached file: uploads/readme.txt"
+
+    # An uploading/errored image is not yet "done" - it must not appear
+    # in steerAttachments any more than it would in the old fullText fold.
+    still_uploading = fold("hi", [
+        {"path": "uploads/x-a.png", "status": "uploading", "type": "image/png"},
+    ])
+    assert still_uploading["steerAttachments"] is None
+    assert still_uploading["fullText"] == "hi"

--- a/tests/ui/test_console_session_doc.py
+++ b/tests/ui/test_console_session_doc.py
@@ -1513,3 +1513,107 @@ def test_records_endpoint_gained_a_session_filter_not_a_client_side_one():
     )
     assert "session_id" in api
     assert 'query = query.where("session_id", session_id)' in api
+
+
+# ---------------------------------------------------------------------------
+# 01a06622 (Phase-2c resolved-cards finding, second half): the answered
+# ask_user card. Same shape as the NV_ResolvedDecisionCard section above:
+# these pin the WIRING (real transcript rows reach the card, the right
+# component renders instead of the generic tool block, and it reuses the
+# EXISTING resultsByCallId/resultFor pairing rather than a new fetch -
+# unlike NV_ResolvedDecisionCard, there is no dedicated entity/endpoint
+# here to wire at all).
+# ---------------------------------------------------------------------------
+
+
+def test_answered_ask_routes_through_a_dedicated_dispatcher_at_every_call_site():
+    # All three tool_call render sites (main transcript, sectioned turns,
+    # subagent children) must go through NV_toolCallElement - a raw
+    # <NV_ToolBlock ...> at any of them would silently regress that one
+    # surface back to the bare generic block for an answered ask_user.
+    assert DOC.count("NV_toolCallElement(") >= 3
+    assert 'if (row.kind === "tool_call") {\n      return NV_toolCallElement(' in DOC
+    assert 'if (child.kind === "tool_call") {\n                return NV_toolCallElement(' in DOC
+    assert "{NV_toolCallElement(child, resultFor(child), shownActive)}" in DOC
+
+
+def test_dispatcher_only_diverts_answered_ask_user_everything_else_is_the_generic_block():
+    dispatcher = DOC[DOC.index("function NV_toolCallElement"):
+                      DOC.index("function NV_AskCard")]
+    assert 'row.payload.name === "system__ask_user"' in dispatcher
+    assert "result != null" in dispatcher
+    assert "<NV_AnsweredAskCard" in dispatcher
+    assert "<NV_ToolBlock" in dispatcher, (
+        "a still-pending ask_user (no result yet) or any other tool call "
+        "must still fall through to the generic block"
+    )
+
+
+def test_answered_ask_card_reuses_the_paired_result_not_a_new_fetch():
+    card = DOC[DOC.index("function NV_AnsweredAskCard"):
+               DOC.index("function NV_toolCallElement")]
+    # The answer comes in as props.result (resultFor(row), already fetched
+    # as part of the ordinary transcript pull) - no SH_api.* call of its
+    # own, unlike NV_ResolvedDecisionCard's dedicated records endpoint.
+    assert "props.result" in card
+    assert "SH_api." not in card
+    # Visual pattern copied from NV_ResolvedDecisionCard verbatim.
+    assert '<div className="nv-card"' in card
+    assert '<span className="nv-dot-resolved"' in card
+    assert '<div className="nv-card-head">' in card
+    assert '<div className="nv-card-body">' in card
+    assert "NV_approvalAt(result.createdAt)" in card
+    assert 'data-testid={"nv-ask-answered:"' in card
+
+
+def test_answered_ask_card_registers_no_new_css_debt():
+    card = DOC[DOC.index("function NV_AnsweredAskCard"):
+               DOC.index("function NV_toolCallElement")]
+    classes = set(re.findall(r'className="([^"{]+)"', card))
+    for cls_group in classes:
+        for cls in cls_group.split():
+            assert ("." + cls) in STYLES, cls
+
+
+def test_ask_answered_line_via_mini_racer():
+    """The three terminal shapes ask_user_resume can produce
+    (primer/toolset/_system_tools.py), plus the malformed/unrecognised
+    fallback - each must reach the transcript as an actual sentence, not
+    "no answer recorded" or a silent blank line."""
+    from py_mini_racer import MiniRacer
+
+    start = DOC.index("function NV_askAnsweredLine")
+    end = DOC.index("\n}\n", start) + len("\n}\n")
+    ctx = MiniRacer()
+    ctx.eval(DOC[start:end])
+
+    answered = ctx.call("NV_askAnsweredLine", '{"response": "yes, go ahead"}')
+    assert answered["status"] == "answered"
+    assert answered["text"] == "yes, go ahead"
+
+    timed_out = ctx.call(
+        "NV_askAnsweredLine", '{"timed_out": true, "elapsed_seconds": 125.4}',
+    )
+    assert timed_out["status"] == "timed_out"
+    assert "125" in timed_out["text"]
+
+    cancelled = ctx.call(
+        "NV_askAnsweredLine",
+        '{"cancelled": true, "reason": "operator dismissed", "elapsed_seconds": 3}',
+    )
+    assert cancelled["status"] == "cancelled"
+    assert cancelled["text"] == "operator dismissed"
+
+    cancelled_no_reason = ctx.call("NV_askAnsweredLine", '{"cancelled": true}')
+    assert cancelled_no_reason["status"] == "cancelled"
+    assert cancelled_no_reason["text"]
+
+    # Malformed / unrecognised output: still SOMETHING, not a silent blank
+    # (the exact regression this card exists to fix).
+    garbage = ctx.call("NV_askAnsweredLine", "not json at all")
+    assert garbage["status"] == "unknown"
+    assert garbage["text"]
+
+    empty = ctx.call("NV_askAnsweredLine", None)
+    assert empty["status"] == "unknown"
+    assert "no answer" in empty["text"].lower()

--- a/ui/components/console/nv-session-doc.jsx
+++ b/ui/components/console/nv-session-doc.jsx
@@ -732,6 +732,97 @@ function NV_ResolvedDecisionCard(props) {
   );
 }
 
+// 01a06622 (Phase-2c resolved-cards finding, second half): an answered
+// ask_user call used to render as a bare generic NV_ToolBlock (raw JSON
+// arguments/result behind a collapsed chevron) - the question and the
+// operator's own answer were both there, just never surfaced as a line
+// anyone would read. Same fix shape as NV_ResolvedDecisionCard above, but
+// simpler: no dedicated entity/endpoint exists for this (unlike an
+// approval decision) - the answer IS the ordinary TOOL_RESULT
+// SessionMessageRecord already paired to this call by resultsByCallId /
+// resultFor(row), so there is nothing new to fetch.
+//
+// TOOL_RESULT.output is a JSON STRING (ask_user_resume's own shape,
+// primer/toolset/_system_tools.py) parsing to exactly one of three
+// terminal forms: {response} | {timed_out, elapsed_seconds} |
+// {cancelled, reason, elapsed_seconds}.
+function NV_askAnsweredLine(output) {
+  var parsed;
+  try {
+    parsed = typeof output === "string" ? JSON.parse(output) : output;
+  } catch (_e) {
+    parsed = null;
+  }
+  if (parsed && typeof parsed === "object") {
+    if (parsed.response !== undefined) {
+      return { status: "answered", title: "Answered", text: String(parsed.response) };
+    }
+    if (parsed.timed_out) {
+      var secs = parsed.elapsed_seconds != null ? Math.round(parsed.elapsed_seconds) : null;
+      return {
+        status: "timed_out", title: "Timed out",
+        text: "No answer arrived" + (secs != null ? " (" + secs + "s)" : ""),
+      };
+    }
+    if (parsed.cancelled) {
+      return {
+        status: "cancelled", title: "Cancelled",
+        text: parsed.reason ? String(parsed.reason) : "Cancelled before it was answered",
+      };
+    }
+  }
+  // Malformed/unrecognised output shape - still show SOMETHING rather
+  // than silently falling back to the generic tool block, since that is
+  // exactly the "no answer" regression this card exists to fix.
+  return {
+    status: "unknown", title: "Resolved",
+    text: output != null ? String(output) : "(no answer recorded)",
+  };
+}
+
+function NV_AnsweredAskCard(props) {
+  var row = props.row;
+  var result = props.result;
+  var args = (row.payload && row.payload.arguments) || {};
+  var question = args.prompt || "";
+  var rp = (result && result.payload) || {};
+  var line = NV_askAnsweredLine(rp.output);
+  var idForTestid = (row.payload && (row.payload.id || row.payload.tool_call_id)) || row.seq;
+  return (
+    <div className="nv-card" data-kind="ask-answered" data-status={line.status}
+      data-testid={"nv-ask-answered:" + idForTestid}>
+      <div className="nv-card-head">
+        <span className="nv-dot-resolved" />
+        <span className="nv-card-title">{line.title}</span>
+        <span className="nv-card-tool">ask_user</span>
+        <span style={{ flex: 1 }} />
+        <span className="nv-card-routing">
+          {result && result.createdAt ? NV_approvalAt(result.createdAt) : ""}
+        </span>
+      </div>
+      <div className="nv-card-body">
+        {question ? <div className="nv-ask-prompt">{question}</div> : null}
+        <span className="nv-card-note" data-testid="nv-ask-answered-line">
+          {line.text}
+        </span>
+      </div>
+    </div>
+  );
+}
+
+// Shared by every tool_call render site (main transcript, sectioned
+// turns, subagent children): an answered ask_user call gets the card
+// above; everything else (including a STILL-PENDING ask_user, which has
+// no `result` yet - the live "attention" surface owns that state via
+// NV_AskCard/gateItems, not this row) keeps the generic tool block.
+function NV_toolCallElement(row, result, running) {
+  var isAnsweredAsk = !!(row.payload && row.payload.name === "system__ask_user")
+    && result != null;
+  return isAnsweredAsk
+    ? <NV_AnsweredAskCard key={row.seq} row={row} result={result} />
+    : <NV_ToolBlock key={row.seq} row={row} result={result} running={running} />;
+}
+
 function NV_AskCard(props) {
   var con = NV_useConsole();
   var item = props.item;
@@ -2245,10 +2336,7 @@ function NV_SessionDoc(props) {
           <div className="nv-turn-sections">
             {(row.rows || []).map(function (child) {
               if (child.kind === "tool_call") {
-                return (
-                  <NV_ToolBlock key={child.seq} row={child}
-                    result={resultFor(child)} running={shownActive} />
-                );
+                return NV_toolCallElement(child, resultFor(child), shownActive);
               }
               if (child.kind === "reasoning") {
                 return <NV_Thought key={child.seq} row={child} />;
@@ -2339,9 +2427,7 @@ function NV_SessionDoc(props) {
     // Tool traffic in the LIVE turn: same expandable block as folded
     // sections use, so a call reads identically mid-run and after.
     if (row.kind === "tool_call") {
-      return (
-        <NV_ToolBlock key={row.seq} row={row} result={resultFor(row)} running={shownActive} />
-      );
+      return NV_toolCallElement(row, resultFor(row), shownActive);
     }
     if (row.kind === "tool_result") return null;
     // Lifecycle markers: a slim muted line, not a full agent block. The
@@ -2469,7 +2555,7 @@ function NV_SessionDoc(props) {
                         || "subagent"}
                     </span>
                   </div>
-                  <NV_ToolBlock row={child} result={resultFor(child)} running={shownActive} />
+                  {NV_toolCallElement(child, resultFor(child), shownActive)}
                 </div>
               );
             }

--- a/ui/components/console/nv-session-doc.jsx
+++ b/ui/components/console/nv-session-doc.jsx
@@ -1187,6 +1187,29 @@ function NV_StatusStrip(props) {
   );
 }
 
+// 01a052d9: which uploaded files the composer folds as true vision/document
+// input (SteerBody.attachments -> ImagePart/DocumentPart, primer.channel.
+// media.media_from_workspace_files) rather than the legacy plain-text
+// "Attached file: {path}" line. Deliberately NARROWER than the server's own
+// MediaConfig.allowed_prefixes/allowed_exact (primer/channel/media.py),
+// which also takes audio/video/text/json for the ask_user/inform_user
+// outbound-file pipeline that same function serves - this composer only
+// ever offers "vision/document input" (per SteerBody.attachments' own
+// docstring), so audio/video/text/code stay on the existing convention the
+// agent's file tools already handle; there is no benefit to hydrating a
+// text file's bytes into the prompt when the agent can just read it.
+var NV_VISION_DOC_EXACT_TYPES = {
+  "application/pdf": true,
+  "application/msword": true,
+  "application/vnd.openxmlformats-officedocument.wordprocessingml.document": true,
+  "application/vnd.ms-excel": true,
+  "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": true,
+};
+function NV_isVisionDocAttachment(mimeType) {
+  var mt = (mimeType || "").toLowerCase();
+  return mt.indexOf("image/") === 0 || !!NV_VISION_DOC_EXACT_TYPES[mt];
+}
+
 // ---------------------------------------------------------------------------
 // Composer (status strip + input row + mic + stop + send)
 // ---------------------------------------------------------------------------
@@ -1275,7 +1298,9 @@ function NV_Composer(props) {
       var token = Date.now() + "-" + Math.random().toString(36).slice(2, 8);
       var dest = "uploads/" + token + "-" + f.name;
       setAttachments(function (prev) {
-        return prev.concat([{ id: token, name: f.name, path: dest, status: "uploading" }]);
+        return prev.concat([{
+          id: token, name: f.name, path: dest, status: "uploading", type: f.type,
+        }]);
       });
       function setStatus(status) {
         setAttachments(function (prev) {
@@ -1318,12 +1343,23 @@ function NV_Composer(props) {
     if ((!text && !readyAttachments.length) || sending || attachmentsPending) {
       return;
     }
-    // Attachment references are plain text, folded in here rather than
-    // a new message-part type - see the attachState comment above.
-    var attachLines = readyAttachments.map(function (a) {
+    // Fold-split (01a052d9): vision/document-eligible files ride as true
+    // multimodal input (steerAttachments, below); everything else keeps the
+    // legacy plain-text "Attached file: {path}" line folded into the
+    // message text - see NV_isVisionDocAttachment's comment above.
+    var visionAttachments = readyAttachments.filter(function (a) {
+      return NV_isVisionDocAttachment(a.type);
+    });
+    var textAttachments = readyAttachments.filter(function (a) {
+      return !NV_isVisionDocAttachment(a.type);
+    });
+    var attachLines = textAttachments.map(function (a) {
       return "Attached file: " + a.path;
     }).join("\n");
     var fullText = attachLines ? (text ? text + "\n\n" + attachLines : attachLines) : text;
+    var steerAttachments = visionAttachments.length
+      ? visionAttachments.map(function (a) { return { path: a.path }; })
+      : undefined;
     setSending(true);
     setSendErr(null);
     // The store owns the optimistic row and the steer POST; it removes the
@@ -1331,8 +1367,8 @@ function NV_Composer(props) {
     // text + shows the inline error (P0 send-failure behaviour).
     var clientId = "steer-" + Date.now() + "-" + Math.random().toString(36).slice(2, 8);
     var promise = typeof props.onSend === "function"
-      ? props.onSend(fullText, clientId)
-      : SH_api.steer(con.wid, props.sid, fullText);
+      ? props.onSend(fullText, clientId, steerAttachments)
+      : SH_api.steer(con.wid, props.sid, fullText, steerAttachments);
     promise.then(function () {
       setVal("");
       // Clear only on success - a failed send restores the typed text
@@ -2604,8 +2640,8 @@ function NV_SessionDoc(props) {
         onInterrupt={function () {
           NV_doInterrupt(con.wid, sid, refetchAll, con.toast);
         }}
-        onSend={function (text, clientId) {
-          return window.SS_sendUserMessage(store, text, clientId);
+        onSend={function (text, clientId, attachments) {
+          return window.SS_sendUserMessage(store, text, clientId, attachments);
         }}
         onSendStarted={function () {
           setOptimistic(Date.now());

--- a/ui/components/shell/sh-api.jsx
+++ b/ui/components/shell/sh-api.jsx
@@ -306,11 +306,16 @@ var SH_api = {
   // endpoint covers invoking, steering and resuming, and "content" was
   // not a field at all: every send from the composer 422'd, which is the
   // most important action in the console failing on every use.
-  steer: function (wid, sid, instruction) {
+  steer: function (wid, sid, instruction, attachments) {
+    var body = { instruction: instruction };
+    // 01a052d9: see SS_sendUserMessage's matching comment - omit the key
+    // rather than send [] when the composer's fold-split kept every
+    // upload on the legacy plain-text convention.
+    if (attachments && attachments.length) body.attachments = attachments;
     return window.primerApi.apiFetch(
       "POST", "/workspaces/" + encodeURIComponent(wid) + "/sessions/"
         + encodeURIComponent(sid) + "/steer",
-      { instruction: instruction });
+      body);
   },
 
   deleteSession: function (wid, sid) {

--- a/ui/foundation/session-store.js
+++ b/ui/foundation/session-store.js
@@ -566,7 +566,7 @@ function SS_isDegraded(store) {
 // server user_input record reconciles it (SS_apply / SS_reconcileOptimistic).
 // Returns the fetch promise; on failure the caller restores the composer text
 // and the optimistic row is removed here.
-function SS_sendUserMessage(store, text, clientId) {
+function SS_sendUserMessage(store, text, clientId, attachments) {
   store.optimistic[clientId] = {
     clientId: clientId,
     text: text,
@@ -584,11 +584,18 @@ function SS_sendUserMessage(store, text, clientId) {
   if (typeof apiFetch !== "function") {
     return Promise.reject(new Error("SS_sendUserMessage: apiFetch unavailable"));
   }
+  var body = { instruction: text };
+  // 01a052d9: only set when the composer's fold-split routed at least one
+  // upload as true vision/document input (NV_isVisionDocAttachment) -
+  // omit the key entirely rather than send [] so a pre-attachments
+  // SteerBody schema change never has to distinguish "no field" from
+  // "empty list".
+  if (attachments && attachments.length) body.attachments = attachments;
   return apiFetch(
     "POST",
     "/workspaces/" + encodeURIComponent(wid) + "/sessions/" +
       encodeURIComponent(sid) + "/steer",
-    { instruction: text }
+    body
   ).then(function () {
     // Success: the row stays pending until the server user_input record
     // arrives and reconciles it; the composer clears its text (Phase 0.2).


### PR DESCRIPTION
## Summary

Two independent, same-file features queued together per the lead's call ("same branch as step 3 if that's cleaner"), landed as two commits:

- **6c9e4b3** — 01a052d9 step 3 (final piece of the vision/multimodal attachments design): the composer's attach flow now fold-splits uploads by type. Images and documents (PDF/Word/Excel) route through the new `SteerBody.attachments` field as true vision/document input; everything else (text/code/audio/video) keeps the existing plain-text `"Attached file: {path}"` convention.
- **e984d32** — 01a06622 (Phase-2c resolved-cards finding, second half): an answered `ask_user` call now renders as a dedicated green resolved card (question + answer as real text) instead of a bare generic tool block with the answer buried in a collapsed JSON result nobody opens by default.

## Step 3 detail (composer fold-split)

`send()` splits `readyAttachments` by `NV_isVisionDocAttachment(a.type)` — `image/*` plus the document mimes `MediaConfig` already accepts server-side, deliberately narrower than that full allowed set (audio/video/text/json stay on the legacy convention; there's no benefit to hydrating a text file's bytes into the prompt when the agent can just read it via file tools). Threaded through both send paths (`SS_sendUserMessage`, `SH_api.steer`) with the `attachments` param optional and the key omitted (not `[]`) when nothing routed through it.

## 01a06622 detail (answered-ask card)

No new backend surface — the answer is the ordinary `TOOL_RESULT` already paired to the `ask_user` `TOOL_CALL` via the existing `resultsByCallId`/`resultFor(row)` lookup. `NV_askAnsweredLine` parses `TOOL_RESULT.output` (a JSON string) into one of three terminal shapes (`{response}` / `{timed_out, elapsed_seconds}` / `{cancelled, reason, elapsed_seconds}`), each with its own line, mirroring the approval card's own status fan-out. Visual pattern copied verbatim from `NV_ResolvedDecisionCard` (zero new CSS). `NV_toolCallElement` is the shared dispatcher every `tool_call` render site (main transcript, sectioned turns, subagent children) now goes through, so a still-pending ask (no result yet — that's `NV_AskCard`'s job) or any other tool call still falls through to the generic block unchanged.

This was blocked on 01a068ea-dc95 (now merged): the resume coordinator wrote `TOOL_RESULT` under the raw provider id, and `ask_user` is always a yield, so every coordinator-path answer would have failed the `resultsByCallId` pairing and rendered as "no answer" regardless of this card.

## Test plan

- [x] `tests/ui/test_composer_attachments.py` — MiniRacer-executed: images/documents route to `steerAttachments`, text/code stays on the legacy fold, mixed lists split correctly, in-flight uploads excluded from both paths.
- [x] `tests/ui/test_console_session_doc.py` — dispatcher wiring pinned at all three `tool_call` call sites; the card reuses `props.result` (no new fetch); MiniRacer coverage of `NV_askAnsweredLine`'s three terminal shapes plus the malformed/unrecognised fallback.
- [x] Full regression sweep: every other `tests/ui/` file that reads either touched source file as text (20 files, 310 tests) — all green.
- [x] `ruff check` clean.
