### PR TITLE
fix(graph): resumed agent nodes forward their continuation events (01a06933)

### DIFF
--- a/primer/graph/_agent_node.py
+++ b/primer/graph/_agent_node.py
@@ -22,6 +22,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+from collections.abc import AsyncIterator
 from typing import TYPE_CHECKING, Any
 
 from primer.agent.loop import run_agent_turn
@@ -228,15 +229,35 @@ class _AgentNodeMixin:
         self,
         pending: "_PendingAgentYield",
         tool_result_msg: Message,
-    ) -> NodeOutput:
+        out_holder: dict,
+    ) -> AsyncIterator[StreamEvent]:
         """Continue a parked agent node's turn with the injected tool result.
 
         Rebuilds the prompt from: system + persisted node history +
         re-rendered input_template (deterministic against the restored
         context) + the rehydrated in-progress assistant turn + the
         ``tool_result_msg`` (the human's ask_user answer / approval
-        verdict), then continues ``run_agent_turn`` to completion and
-        returns the node's NodeOutput.
+        verdict), then continues ``run_agent_turn`` to completion.
+
+        01a06933: an async GENERATOR, not an awaited coroutine — forwards
+        every event the continued ``run_agent_turn`` call produces
+        (``_wrap_event``-tagged with ``pending.node_id``, the SAME node-
+        tagging the live ``_stream_agent_node`` path's own queue-forwarding
+        applies) instead of discarding them. Before this fix, a resumed
+        node's OWN continuing turn — e.g. an ask_user answer triggering
+        more tool calls before the node finishes — never reached
+        ``resume_from_checkpoint``'s generator at all (an awaited call
+        can't yield through its caller), so 01a0690a's resume-drain tap
+        had nothing to see: those tool calls vanished from the durable
+        record even after that fix landed.
+
+        An async generator's own ``return`` cannot carry a value back to
+        the caller the way a coroutine's can, so the final ``NodeOutput``
+        goes into ``out_holder["output"]`` instead, set once the generator
+        is fully drained — mirrors ``run_agent_turn``'s own
+        ``messages_out`` out-parameter idiom (a caller-owned mutable
+        container the callee fills as a side effect) rather than
+        inventing a second convention for the same problem.
         """
         node = self._resolve_node_def(pending.node_id)
         assert isinstance(node, _AgentNodeRef)
@@ -272,7 +293,7 @@ class _AgentNodeMixin:
         prompt.append(tool_result_msg)
 
         produced_messages: list[Message] = []
-        async for _event in run_agent_turn(
+        async for event in run_agent_turn(
             agent=agent,
             llm=llm,
             llm_model=llm_model,
@@ -283,12 +304,12 @@ class _AgentNodeMixin:
             messages_out=produced_messages,
             artifact_storage=self._artifact_storage,
         ):
-            pass
+            yield self._wrap_event(event, pending.node_id, pending.iteration)
 
         all_new = [new_user_msg, *rehydrated_assistant, tool_result_msg, *produced_messages]
         await self._persist_node_turn(pending.node_id, pending.iteration, all_new)
 
-        return self._agent_node_output(
+        out_holder["output"] = self._agent_node_output(
             produced_messages, node.response_format,
             history + all_new, pending.iteration,
         )

--- a/primer/graph/_agent_node.py
+++ b/primer/graph/_agent_node.py
@@ -293,18 +293,41 @@ class _AgentNodeMixin:
         prompt.append(tool_result_msg)
 
         produced_messages: list[Message] = []
-        async for event in run_agent_turn(
-            agent=agent,
-            llm=llm,
-            llm_model=llm_model,
-            tool_manager=tool_manager,
-            prompt=prompt,
-            response_format=node.response_format,
-            principal=self._principal,
-            messages_out=produced_messages,
-            artifact_storage=self._artifact_storage,
-        ):
-            yield self._wrap_event(event, pending.node_id, pending.iteration)
+        try:
+            async for event in run_agent_turn(
+                agent=agent,
+                llm=llm,
+                llm_model=llm_model,
+                tool_manager=tool_manager,
+                prompt=prompt,
+                response_format=node.response_format,
+                principal=self._principal,
+                messages_out=produced_messages,
+                artifact_storage=self._artifact_storage,
+            ):
+                yield self._wrap_event(event, pending.node_id, pending.iteration)
+        except YieldToWorker as yld:
+            # 01a06ca4: the resumed turn's OWN continuation yielded again
+            # (e.g. a second ask_user, or a fresh approval gate) before
+            # finishing - mirrors _stream_agent_node's own "stamp the in-
+            # progress turn onto the exception" handling, so
+            # graph/base.py's caller can rebuild a correct
+            # _PendingAgentYield for a THIRD resume. Unlike
+            # _stream_agent_node's first-ever dispatch (where
+            # produced_messages alone IS the whole in-progress turn), a
+            # resume's prompt already carries a PREFIX -- new_user_msg +
+            # the PRIOR park's rehydrated_assistant + THIS resume's own
+            # tool_result_msg -- that must be included too, or a third
+            # resume would silently lose everything before this
+            # continuation's own new messages.
+            if not yld.llm_messages:
+                yld.llm_messages = [
+                    m.model_dump(mode="json") for m in (
+                        [new_user_msg, *rehydrated_assistant, tool_result_msg]
+                        + produced_messages
+                    )
+                ]
+            raise
 
         all_new = [new_user_msg, *rehydrated_assistant, tool_result_msg, *produced_messages]
         await self._persist_node_turn(pending.node_id, pending.iteration, all_new)

--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -707,6 +707,20 @@ class _BaseGraphExecutor(
                     # when this yield's ToolCallStart streamed past the tap
                     # a moment ago, above (01a0690a's stash-don't-recompute
                     # doctrine, unchanged by this fix).
+                    #
+                    # frames/leaf: mirrors _node_dispatch.py's first-park
+                    # constructor byte-for-byte. The resumed outer turn can
+                    # make a FRESH nested invoke_agent call that itself
+                    # yields - the tool engine attaches yld.frames the same
+                    # way regardless of dispatch-vs-resume - so dropping
+                    # them here would silently truncate the subagent chain
+                    # on the NEXT resume: the worker would skip the
+                    # continuation walk and splice the answer straight into
+                    # the outer turn as the invoke_agent result. Empty
+                    # frames (the node's own ask_user / approval gate) keep
+                    # this identical to the pre-fix park.
+                    from primer.worker.frames import frames_to_jsonable
+                    nested_frames = list(getattr(yld, "frames", None) or [])
                     self._pending_agent_yields.append(
                         _PendingAgentYield(
                             node_id=ay.node_id,
@@ -716,6 +730,8 @@ class _BaseGraphExecutor(
                             resume_metadata=dict(yld.yielded.resume_metadata or {}),
                             llm_messages=list(yld.llm_messages or []),
                             iteration=ay.iteration,
+                            frames=frames_to_jsonable(nested_frames) if nested_frames else [],
+                            leaf=yld.yielded.to_jsonable() if nested_frames else None,
                         )
                     )
                     continue

--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -682,6 +682,43 @@ class _BaseGraphExecutor(
                     ):
                         yield _ev
                     out = out_holder["output"]
+                except YieldToWorker as yld:
+                    # 01a06ca4: two-phase park, agent-node flavor (mirrors
+                    # the tc_pending branch above for _ToolCallNode) - the
+                    # resumed node's OWN continuation yielded AGAIN (e.g. a
+                    # second ask_user, or a fresh approval gate) before
+                    # finishing. Re-record it as a pending agent yield on
+                    # the NEW event key so the drain-until-empty check
+                    # below re-parks via _build_pending_park_yield() - built
+                    # from THIS executor's live _pending_agent_yields, not
+                    # the checkpoint this resume started from (already
+                    # consumed by restore_state() at the top of this
+                    # method; the live in-memory lists are the source of
+                    # truth for the rest of this drain). Must come before
+                    # `except Exception` below - YieldToWorker IS an
+                    # Exception subclass, and without this branch it fell
+                    # into that one, silently turning a legitimate re-park
+                    # into a node FAILURE.
+                    #
+                    # scoped_tool_call_id is left unset here deliberately:
+                    # worker/graph_resume.py's own repark catch
+                    # (stash_graph_scoped_ids) backfills it from the SAME
+                    # resume-drain _CoalesceState that already minted it
+                    # when this yield's ToolCallStart streamed past the tap
+                    # a moment ago, above (01a0690a's stash-don't-recompute
+                    # doctrine, unchanged by this fix).
+                    self._pending_agent_yields.append(
+                        _PendingAgentYield(
+                            node_id=ay.node_id,
+                            tool_call_id=yld.tool_call_id,
+                            event_key=yld.yielded.event_key,
+                            tool_name=yld.yielded.tool_name,
+                            resume_metadata=dict(yld.yielded.resume_metadata or {}),
+                            llm_messages=list(yld.llm_messages or []),
+                            iteration=ay.iteration,
+                        )
+                    )
+                    continue
                 except Exception as exc:  # noqa: BLE001 -- map to node failure
                     fail_out = NodeOutput(
                         text="", parsed=None, history=[],

--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -665,11 +665,23 @@ class _BaseGraphExecutor(
             token = set_current_graph_node_id(ay.node_id)
             try:
                 try:
-                    out = await self._resume_agent_node(
+                    # 01a06933: _resume_agent_node is an async generator
+                    # (forwards the resumed turn's own events instead of
+                    # discarding them) -- its final NodeOutput can't ride
+                    # its own `return`, so it lands in out_holder once the
+                    # generator is fully drained. Forwarding each event on
+                    # via our own `yield` here is what lets 01a0690a's
+                    # resume-drain tap (worker/graph_resume.py) actually
+                    # see them; they were never reachable at all before.
+                    out_holder: dict = {}
+                    async for _ev in self._resume_agent_node(
                         ay, agent_tool_result if agent_tool_result is not None
                         else Message(role="tool", parts=[
                             ToolResultPart(id=ay.tool_call_id, output="")]),
-                    )
+                        out_holder,
+                    ):
+                        yield _ev
+                    out = out_holder["output"]
                 except Exception as exc:  # noqa: BLE001 -- map to node failure
                     fail_out = NodeOutput(
                         text="", parsed=None, history=[],

--- a/tests/graph/test_agent_node_fanout_history_isolation.py
+++ b/tests/graph/test_agent_node_fanout_history_isolation.py
@@ -145,7 +145,12 @@ async def test_resume_agent_node_persists_history_under_the_instance_id() -> Non
         role="tool", parts=[ToolResultPart(id="tc-1", output="yes")],
     )
 
-    await executor._resume_agent_node(pending, tool_result_msg)
+    # 01a06933: _resume_agent_node is an async generator now (forwards the
+    # resumed turn's own events instead of discarding them) - drain it;
+    # the final NodeOutput isn't this test's concern (out_holder unused).
+    out_holder: dict = {}
+    async for _ev in executor._resume_agent_node(pending, tool_result_msg, out_holder):
+        pass
 
     persisted_node_ids = {m.node_id for m in message_storage._data.values()}
     assert persisted_node_ids == {"worker[0]", "worker[1]"}, (

--- a/tests/graph/test_agent_node_resume.py
+++ b/tests/graph/test_agent_node_resume.py
@@ -48,6 +48,23 @@ class _ContinuationLLM:
         return _g()
 
 
+class _ReAskingContinuationLLM:
+    """01a06ca4: the resumed turn's OWN continuation yields AGAIN (a
+    second ask_user) instead of finishing - e.g. the agent needs one more
+    piece of information before it can answer."""
+    async def list_models(self): return ["m"]
+    def stream(self, **kw) -> AsyncIterator[StreamEvent]:
+        async def _g():
+            raise YieldToWorker(
+                Yielded(tool_name="ask_user", event_key="ask_user:t:tc2",
+                        resume_metadata={"prompt": "and what shade?"}),
+                tool_call_id="tc2",
+                llm_messages=[Message(role="assistant",
+                                      parts=[TextPart(text="(calling ask_user again)")]).model_dump(mode="json")])
+            yield  # pragma: no cover
+        return _g()
+
+
 def _graph():
     return Graph(id="g", description="b->A->e", nodes=[
         _BeginNode(id="begin"), _AgentNodeRef(id="A", agent_id="x"),
@@ -136,6 +153,58 @@ async def test_resumed_node_continuation_events_reach_the_caller(tmp_path):
     inner_types = {ev.extended.inner_type for ev in node_a_events}
     assert "text_delta" in inner_types
     assert "done" in inner_types
+
+
+@pytest.mark.asyncio
+async def test_resume_agent_node_reyield_reparks_not_fails(tmp_path):
+    """01a06ca4: _resume_agent_node had no `except YieldToWorker` branch -
+    a nested re-yield during resume (the resumed turn asks a SECOND
+    ask_user before finishing) fell into the generic `except Exception`
+    handler in graph/base.py's ay_pending loop and was mapped to a node
+    FAILURE, discarding the in-progress turn entirely. Assert it instead
+    re-parks: resume_from_checkpoint raises YieldToWorker again, on the
+    NEW event key, carrying a fresh checkpoint built from live state."""
+    ex1 = await _build(tmp_path, _YieldingLLM(), "gsid-r5")
+    raised = await _drain_until_yield(ex1.invoke([]))
+    assert raised is not None and raised.graph_checkpoint is not None
+    checkpoint = raised.graph_checkpoint
+
+    ex2 = await _build(tmp_path, _ReAskingContinuationLLM(), "gsid-r5")
+    tool_result = Message(role="tool",
+                          parts=[ToolResultPart(id="tc1", output="blue")])
+    repark = await _drain_until_yield(ex2.resume_from_checkpoint(
+        checkpoint, resumed_tcid="tc1", agent_tool_result=tool_result))
+
+    assert repark is not None, (
+        "a mid-resume re-yield must re-park via YieldToWorker, not be "
+        "swallowed and mapped to a node failure"
+    )
+    assert repark.yielded.event_keys == ["ask_user:t:tc2"]
+    assert repark.graph_checkpoint is not None
+
+    state = await ex2.load_state()
+    assert state is not None
+    assert state["status"] == "waiting"
+    assert state["node_states"]["A"]["status"] != "failed"
+
+    # A third resume must see the FULL accumulated history (the original
+    # user turn + the first ask_user's rehydrated answer + this second
+    # ask_user's own in-progress assistant message), not just the second
+    # turn in isolation - proves _agent_node.py's except-branch stamped
+    # yld.llm_messages with the whole prefix, not produced_messages alone.
+    ex3 = await _build(tmp_path, _ContinuationLLM(), "gsid-r5")
+    tool_result_2 = Message(role="tool",
+                            parts=[ToolResultPart(id="tc2", output="navy")])
+    async for _ev in ex3.resume_from_checkpoint(
+        repark.graph_checkpoint, resumed_tcid="tc2",
+        agent_tool_result=tool_result_2):
+        pass
+
+    state3 = await ex3.load_state()
+    assert state3 is not None
+    assert state3["status"] == "ended"
+    assert state3["ended_reason"] == "completed"
+    assert state3["node_states"]["A"]["status"] == "ended"
 
 
 class _CountingYieldLLM:

--- a/tests/graph/test_agent_node_resume.py
+++ b/tests/graph/test_agent_node_resume.py
@@ -13,6 +13,9 @@ from primer.model.graph import (
     Graph, _AgentNodeRef, _BeginNode, _EndNode, _StaticEdge,
 )
 from primer.model.yield_ import Yielded, YieldToWorker
+from primer.worker.frames import (
+    AgentFrame, AgentResumeContext, frames_from_jsonable,
+)
 
 from tests.graph.test_workspace_executor import _make_state_repo
 from primer.model_profile import ResolvedModel
@@ -205,6 +208,88 @@ async def test_resume_agent_node_reyield_reparks_not_fails(tmp_path):
     assert state3["status"] == "ended"
     assert state3["ended_reason"] == "completed"
     assert state3["node_states"]["A"]["status"] == "ended"
+
+
+_NESTED_INVOKE_TCID = "invoke-tc2"
+_NESTED_LEAF_TCID = "leaf-tc2"
+
+
+def _subagent_frame() -> AgentFrame:
+    return AgentFrame(
+        agent_id="sub",
+        llm_messages=[{"role": "assistant", "parts": []}],
+        tool_call_id=_NESTED_INVOKE_TCID,
+        depth=0,
+        context=AgentResumeContext(
+            session_id="s", workspace_id="w", chat_id=None,
+            principal="p", tools=["misc__ask_user"],
+        ),
+    )
+
+
+class _NestedReAskingContinuationLLM:
+    """01a06ca4 follow-up: the resumed turn's continuation makes a FRESH
+    nested invoke_agent call whose subagent itself yields (mirrors
+    test_graph_node_subagent_yield.py's _NestedYieldLLM, applied to the
+    RESUME path instead of first dispatch) - the re-park must preserve
+    yld.frames/leaf, not just the leaf tool_call_id."""
+    async def list_models(self): return ["m"]
+    def stream(self, **kw) -> AsyncIterator[StreamEvent]:
+        async def _g():
+            yld = YieldToWorker(
+                Yielded(tool_name="ask_user",
+                        event_key=f"ask_user:s:{_NESTED_LEAF_TCID}",
+                        resume_metadata={"prompt": "nested?"}),
+                tool_call_id=_NESTED_LEAF_TCID,
+                llm_messages=[Message(role="assistant",
+                                      parts=[TextPart(text="(calling invoke_agent)")]).model_dump(mode="json")])
+            yld.frames = [_subagent_frame()]
+            raise yld
+            yield  # pragma: no cover
+        return _g()
+
+
+@pytest.mark.asyncio
+async def test_resume_agent_node_reyield_preserves_nested_frames(tmp_path):
+    """Lead-flagged gap on f1dc8b4: the re-park branch's _PendingAgentYield
+    must mirror _node_dispatch.py's first-park constructor's frames/leaf
+    handling byte-for-byte, or a resumed turn's fresh nested invoke_agent
+    yield gets its subagent chain silently dropped on re-park - the NEXT
+    resume would then skip the continuation walk and splice the answer
+    straight into the outer turn as the invoke_agent result."""
+    ex1 = await _build(tmp_path, _YieldingLLM(), "gsid-r6")
+    raised = await _drain_until_yield(ex1.invoke([]))
+    assert raised is not None and raised.graph_checkpoint is not None
+    checkpoint = raised.graph_checkpoint
+
+    ex2 = await _build(tmp_path, _NestedReAskingContinuationLLM(), "gsid-r6")
+    tool_result = Message(role="tool",
+                          parts=[ToolResultPart(id="tc1", output="blue")])
+    repark = await _drain_until_yield(ex2.resume_from_checkpoint(
+        checkpoint, resumed_tcid="tc1", agent_tool_result=tool_result))
+
+    assert repark is not None, "nested subagent yield must still re-park"
+    assert len(ex2._pending_agent_yields) == 1
+    p = ex2._pending_agent_yields[0]
+    assert p.tool_call_id == _NESTED_LEAF_TCID
+    assert p.event_key == f"ask_user:s:{_NESTED_LEAF_TCID}"
+    assert p.leaf is not None and p.leaf["tool_name"] == "ask_user"
+    assert len(p.frames) == 1
+    restored_frames = frames_from_jsonable(p.frames)
+    assert isinstance(restored_frames[0], AgentFrame)
+    assert restored_frames[0].agent_id == "sub"
+    assert restored_frames[0].tool_call_id == _NESTED_INVOKE_TCID
+
+    # Checkpoint round-trip: the fresh park this re-yield produced must
+    # carry the frames/leaf through snapshot_state/restore_state too.
+    ck = ex2.snapshot_state()
+    import json
+    json.dumps(ck)  # must be JSON-able
+    ex3 = await _build(tmp_path, _NestedReAskingContinuationLLM(), "gsid-r6")
+    ex3.restore_state(ck)
+    p2 = ex3._pending_agent_yields[0]
+    assert len(p2.frames) == 1
+    assert p2.leaf is not None and p2.leaf["tool_name"] == "ask_user"
 
 
 class _CountingYieldLLM:

--- a/tests/graph/test_agent_node_resume.py
+++ b/tests/graph/test_agent_node_resume.py
@@ -6,7 +6,8 @@ import pytest
 from primer.graph.workspace_executor import WorkspaceGraphExecutor
 from primer.model.agent import Agent, AgentModel
 from primer.model.chat import (
-    Done, Message, StreamEvent, TextDelta, TextPart, ToolResultPart,
+    Done, ExtendedEvent, Message, StreamEvent, TextDelta, TextPart,
+    ToolResultPart, _GraphNodeEvent,
 )
 from primer.model.graph import (
     Graph, _AgentNodeRef, _BeginNode, _EndNode, _StaticEdge,
@@ -96,6 +97,45 @@ async def test_agent_node_park_then_resume_completes(tmp_path):
     assert state["status"] == "ended"
     assert state["ended_reason"] == "completed"
     assert state["node_states"]["A"]["status"] == "ended"
+
+
+@pytest.mark.asyncio
+async def test_resumed_node_continuation_events_reach_the_caller(tmp_path):
+    """01a06933: _resume_agent_node's own `async for _event in
+    run_agent_turn(...): pass` used to discard everything the resumed
+    node's CONTINUING turn produced -- an awaited call has no way to
+    yield through resume_from_checkpoint's own generator, so 01a0690a's
+    resume-drain tap (which taps resume_from_checkpoint's yielded events
+    for the durable record) had nothing to see for this specific case,
+    even after that fix landed. Assert the events the continuation LLM
+    actually streams (TextDelta + Done, via _ContinuationLLM) now come
+    out of resume_from_checkpoint itself, wrapped for node "A" the same
+    way the live _stream_agent_node path tags its own forwarded events."""
+    ex1 = await _build(tmp_path, _YieldingLLM(), "gsid-r3")
+    raised = await _drain_until_yield(ex1.invoke([]))
+    assert raised is not None and raised.graph_checkpoint is not None
+    checkpoint = raised.graph_checkpoint
+
+    ex2 = await _build(tmp_path, _ContinuationLLM(), "gsid-r3")
+    tool_result = Message(role="tool",
+                          parts=[ToolResultPart(id="tc1", output="blue")])
+    events: list[StreamEvent] = []
+    async for ev in ex2.resume_from_checkpoint(
+        checkpoint, resumed_tcid="tc1", agent_tool_result=tool_result):
+        events.append(ev)
+
+    node_a_events = [
+        ev for ev in events
+        if isinstance(ev, ExtendedEvent) and isinstance(ev.extended, _GraphNodeEvent)
+        and ev.extended.node_id == "A"
+    ]
+    assert node_a_events, (
+        "the resumed node's own continuation produced no events at all - "
+        "pre-fix, _resume_agent_node discarded every one of them"
+    )
+    inner_types = {ev.extended.inner_type for ev in node_a_events}
+    assert "text_delta" in inner_types
+    assert "done" in inner_types
 
 
 class _CountingYieldLLM:


### PR DESCRIPTION
## Summary

01a06933. `_resume_agent_node` had its own `async for _event in run_agent_turn(...): pass` — a second, deeper drain-and-discard beyond the one [01a0690a](https://github.com/primerhq/primer/pull/233) already fixed. When a resumed agent node's turn *continues* (an ask_user answer triggering more tool calls before the node finishes, or just the plain text response that closes the turn), every event that continuation produced vanished: an awaited coroutine has no way to yield through its caller, so `resume_from_checkpoint`'s own generator — what 01a0690a's resume-drain tap actually taps — never saw any of it, even after that fix landed. The live path avoids this because fresh dispatch (`_stream_agent_node`) forwards its own events through a queue via `_wrap_event`; `_resume_agent_node` had no equivalent.

## Fix

Converts `_resume_agent_node` from an awaited coroutine returning `NodeOutput` to an async generator yielding `StreamEvent`s (each `_wrap_event`-tagged with `pending.node_id`, the same node-tagging the live path applies), forwarded on by its one call site (`graph/base.py`'s `ay_pending` loop, itself already an async generator) via a nested `async for ... yield`.

An async generator's own `return` can't carry a value back to the caller the way a coroutine's can, so the final `NodeOutput` goes into an `out_holder` dict the caller passes in and reads after the generator drains — mirrors `run_agent_turn`'s own `messages_out` out-parameter idiom rather than inventing a second convention for the same problem.

## Test plan

- [x] `tests/graph/test_agent_node_resume.py` — new regression: resume a parked agent node whose continuation streams real events (`TextDelta` + `Done`), collect `resume_from_checkpoint`'s own yielded events, assert they include the continuation's events wrapped for the resumed node (empty pre-fix, non-empty now).
- [x] `tests/graph/test_agent_node_fanout_history_isolation.py` — existing direct-call test updated to the new generator signature (drain via `async for`, pass the `out_holder`); no behavior change of its own.
- [x] Full enumerated sweep of every test file touching `resume_from_checkpoint`/`_resume_agent_node`/`ay_pending` (10 files) plus the worker-level graph-resume-coordinator suite (5 files, the call chain one layer up) — all green.
- [x] `ruff check` + `lint-imports` clean.

## Found but NOT fixed here (flagging for a follow-up)

`_resume_agent_node`'s exception handling has no `except YieldToWorker` branch the way the live path's own dispatch and the sibling `tc_pending` (`_ToolCallNode`) loop both do. If the resumed node's continuation itself yields **again** (e.g. the agent calls a second yielding tool, or hits another approval gate, right after this resume), `YieldToWorker` (`Exception`-derived) falls into `graph/base.py`'s existing generic `except Exception as exc:` in the `ay_pending` loop and gets mapped to a node **failure** (`ended_detail="tool_execution_failed"`) instead of a legitimate re-park.

This is pre-existing behavior, unchanged by this PR either way — the exception-handling structure itself isn't touched. It's a real gap, but a distinct control-flow question from "does a non-exceptional resume's events reach the caller," and deliberately left for its own task rather than folded in here unreviewed.
