### PR TITLE
fix(approval): non-primary graph approval gates are answerable, with a durable audit trail

### DIFF
--- a/primer/agent/approval_record.py
+++ b/primer/agent/approval_record.py
@@ -124,6 +124,8 @@ def record_from_chat_pending(
 async def write_approval_record(
     storage: Any | None,
     record: ToolApprovalRecord,
+    *,
+    warn_on_decision_mismatch: bool = False,
 ) -> None:
     """Persist a record best-effort. Never raises.
 
@@ -139,6 +141,22 @@ async def write_approval_record(
     working as intended, not a failure: log it at DEBUG (still visible if
     someone is looking, not noise on the normal path) rather than the
     ERROR-level ``logger.exception`` a genuine write failure gets.
+
+    ``warn_on_decision_mismatch`` (01a06b82 gate-review R1): set this when
+    ``record`` is a resume-time synthesised timeout/cancel verdict -- the
+    ONE case where a losing ConflictError is NOT automatically benign. A
+    channel reply can legitimately write "approved" and then have its
+    publish never actually land (the bus listener down, or the publish
+    call itself raising); the gate then genuinely times out, and this
+    synthesis computes the TRUE terminal outcome ("rejected"/"timed-out").
+    Silently dropping that as an ordinary dedup no-op would leave the
+    audit trail claiming a decision that never actually happened, forever
+    -- append-only means the wrong row is never corrected. When set, a
+    ConflictError triggers an extra read of the record that won the race;
+    if its decision disagrees with this one, that disagreement is logged
+    at ERROR with both values so it is loud rather than silently
+    swallowed. The wrong row is still never overwritten (append-only
+    holds) -- this only makes the suppression visible.
     """
     if storage is None:
         return
@@ -147,15 +165,63 @@ async def write_approval_record(
     try:
         await storage.create(record)
     except ConflictError:
-        logger.debug(
-            "approval-record: gate_event_key=%r already has a record "
-            "(the other write site won the race) - skipping",
-            record.gate_event_key,
-        )
+        if warn_on_decision_mismatch:
+            await _warn_if_decision_disagrees(storage, record)
+        else:
+            logger.debug(
+                "approval-record: gate_event_key=%r already has a record "
+                "(the other write site won the race) - skipping",
+                record.gate_event_key,
+            )
     except Exception:  # noqa: BLE001 - best-effort; resume must not fail
         logger.exception(
             "approval-record: failed to persist record for tool %r",
             record.tool_name,
+        )
+
+
+async def _warn_if_decision_disagrees(
+    storage: Any, record: ToolApprovalRecord,
+) -> None:
+    """Read the record that won the ``gate_event_key`` race and compare.
+
+    Best-effort and diagnostic only: never raises, never writes anything.
+    A read failure degrades to the ordinary DEBUG no-op log (it cannot
+    prove a disagreement, so it must not claim one).
+    """
+    from primer.model.storage import OffsetPage
+    from primer.model.tool_approval import ToolApprovalRecord
+    from primer.storage.q import Q
+
+    try:
+        page = await storage.find(
+            Q(ToolApprovalRecord)
+            .where("gate_event_key", record.gate_event_key)
+            .build(),
+            OffsetPage(offset=0, length=1),
+        )
+        existing = page.items[0] if page.items else None
+    except Exception:  # noqa: BLE001 - diagnostic only
+        logger.exception(
+            "approval-record: gate_event_key=%r conflict but reading the "
+            "winning record for the disagreement check itself failed",
+            record.gate_event_key,
+        )
+        return
+    if existing is not None and existing.decision != record.decision:
+        logger.error(
+            "approval-record audit disagreement: gate_event_key=%r already "
+            "recorded decision=%r, but the terminal outcome computed here "
+            "is decision=%r (reason=%r) - the persisted record does not "
+            "reflect what actually happened to this gate",
+            record.gate_event_key, existing.decision,
+            record.decision, record.reason,
+        )
+    else:
+        logger.debug(
+            "approval-record: gate_event_key=%r already has a record "
+            "(the other write site won the race) - skipping",
+            record.gate_event_key,
         )
 
 

--- a/primer/api/routers/tool_approval.py
+++ b/primer/api/routers/tool_approval.py
@@ -25,6 +25,7 @@ from primer.api.routers._crud import make_crud_router
 from primer.int.claim import ClaimEngine
 from primer.int.event_bus import EventBus
 from primer.model.except_ import ConflictError, NotFoundError
+from primer.session.pending_gates import enumerate_pending_gates, resolve_pending_gate
 from primer.session.yields import durably_wake_session
 from primer.model.workspace_session import WorkspaceSession
 from primer.model.storage import OffsetPage, OffsetPageResponse, OrderBy
@@ -201,8 +202,15 @@ class ToolApprovalRespondBody(BaseModel):
     reason: str | None = Field(default=None, max_length=1024)
 
 
-def _enforce_approvers(blob: dict, user: Any) -> None:
-    """403 ``approver_mismatch`` unless the caller may decide this park.
+def _enforce_approvers(metadata: dict, user: Any) -> None:
+    """403 ``approver_mismatch`` unless the caller may decide this gate.
+
+    ``metadata`` is the SPECIFIC pending gate's ``resume_metadata``
+    (from :func:`~primer.session.pending_gates.resolve_pending_gate`),
+    not necessarily the session's primary/top-level one -- a graph park
+    can have several pending approval gates at once, each with its own
+    resolved spec, so enforcement must check the gate actually being
+    decided rather than whichever one happens to be projected first.
 
     The spec was resolved and stamped at park time (policy row default,
     or the evaluator's per-call override). No spec means anyone.
@@ -211,9 +219,6 @@ def _enforce_approvers(blob: dict, user: Any) -> None:
     """
     if user is None:  # WS scope / auth-disabled synthetic admin absent
         return
-    metadata: dict = (
-        (blob.get("yielded") or {}).get("resume_metadata") or {}
-    )
     raw = metadata.get("approvers")
     if not raw:
         return
@@ -233,20 +238,31 @@ def _enforce_approvers(blob: dict, user: Any) -> None:
 
 
 def _approval_blob_or_404(sess: Any, id_str: str) -> dict:
-    """Return parked_state blob when the row is parked on _approval.
+    """Return parked_state blob when the row has a pending _approval gate.
 
     Raises :class:`NotFoundError` if:
     * the row is None (doesn't exist),
     * it isn't in a parked/resumable state, or
-    * it's parked on a different tool.
+    * none of its pending entries is an approval gate.
+
+    Checks every pending entry via
+    :func:`~primer.session.pending_gates.enumerate_pending_gates`, not
+    just the top-level ``yielded`` projection: a graph park's outer
+    ``yielded.tool_name`` is hardcoded ``"_approval"`` for ANY graph
+    park regardless of what's actually primary (see
+    ``_CheckpointMixin._build_pending_park_yield``), so the old
+    top-level-only check could both false-positive (primary is really an
+    ask_user agent yield) and false-negative (an _approval gate is
+    pending but isn't the primary entry).
     """
     if sess is None:
         raise NotFoundError(f"{id_str!r} does not exist")
     if sess.parked_status not in ("parked", "resumable"):
         raise NotFoundError(f"{id_str!r} has no pending tool_approval")
     blob: dict = sess.parked_state or {}
-    yielded: dict = blob.get("yielded") or {}
-    if yielded.get("tool_name") != "_approval":
+    if not any(
+        gate["kind"] == "_approval" for gate in enumerate_pending_gates(blob)
+    ):
         raise NotFoundError(f"{id_str!r} is parked on a different tool")
     return blob
 
@@ -254,10 +270,24 @@ def _approval_blob_or_404(sess: Any, id_str: str) -> dict:
 def _build_pending_response(
     blob: dict, sess: Any
 ) -> ToolApprovalPendingResponse:
-    """Construct the pending-response envelope from parked_state."""
-    yielded: dict = blob.get("yielded") or {}
-    metadata: dict = yielded.get("resume_metadata") or {}
+    """Construct the pending-response envelope for ONE approval gate.
+
+    This endpoint's response shape is singular (predates multi-gate
+    graph parks), so a session with several pending approval gates at
+    once surfaces only the first found here -- callers that need every
+    pending gate use ``GET .../yields/pending`` (workspaces.py) instead,
+    which returns all of them via the same shared resolver.
+    """
+    gate = next(
+        (g for g in enumerate_pending_gates(blob) if g["kind"] == "_approval"),
+        None,
+    )
+    metadata: dict = (gate or {}).get("resume_metadata") or {}
     original: dict = metadata.get("original_call") or {}
+    # Graph pending-toolcall entries never carry a timeout (the checkpoint's
+    # _PendingToolCall has no such field); this stays None for every graph
+    # park, same as before this fix.
+    yielded: dict = blob.get("yielded") or {}
     timeout = yielded.get("timeout")
     timeout_at_iso: str | None = None
     if timeout is not None and sess.parked_at is not None:
@@ -265,7 +295,7 @@ def _build_pending_response(
             sess.parked_at + timedelta(seconds=float(timeout))
         ).isoformat()
     return ToolApprovalPendingResponse(
-        tool_call_id=original.get("id") or blob.get("tool_call_id", ""),
+        tool_call_id=original.get("id") or (gate or {}).get("tool_call_id") or "",
         tool_name=original.get("name", ""),
         arguments=original.get("arguments") or {},
         policy_id=metadata.get("policy_id"),
@@ -286,13 +316,21 @@ async def _publish_decision(
     sess: Any,
     id_str: str,
     body: ToolApprovalRespondBody,
+    gate: dict[str, Any],
     event_bus: EventBus,
     session_storage,
     engine: ClaimEngine | None,
     storage_provider=None,
     decided_by: str | None = None,
 ) -> bool:
-    """Validate the decision, durably flip the row, then wake the bus.
+    """Durably flip the row on ``gate``'s own event_key, then wake the bus.
+
+    ``gate`` is the SPECIFIC pending entry ``body.tool_call_id`` resolved
+    to (see :func:`~primer.session.pending_gates.resolve_pending_gate`),
+    not necessarily the session's primary one -- a graph park can have
+    several pending approval gates open at once, each waking on its own
+    event_key, so publishing the top-level/primary key here would answer
+    the wrong gate (or 404) for every non-primary one.
 
     D-C2 fix: the operator decision is stamped onto the session row
     (``resume_event_payload`` + ``parked_status='resumable'`` + the claim
@@ -307,16 +345,7 @@ async def _publish_decision(
     repairs the row rather than accepting a decision the claim loop can never
     act on. Returns True when this call advanced the row.
     """
-    blob = _approval_blob_or_404(sess, id_str)
-    yielded: dict = blob.get("yielded") or {}
-    original: dict = (yielded.get("resume_metadata") or {}).get("original_call") or {}
-    expected = original.get("id") or blob.get("tool_call_id")
-    if expected != body.tool_call_id:
-        raise NotFoundError(
-            f"No pending tool_approval with tool_call_id "
-            f"{body.tool_call_id!r} on {id_str!r}"
-        )
-    event_key: str | None = yielded.get("event_key")
+    event_key: str | None = gate.get("event_key")
     if not event_key:
         raise NotFoundError(f"{id_str!r} park is missing event_key")
     payload = {
@@ -355,8 +384,15 @@ async def _publish_decision(
         from primer.worker.yield_runtime import classify_approval_payload
 
         decision, reason = classify_approval_payload(payload)
+        # record_from_parked_blob reads a ``{"yielded": {"resume_metadata":
+        # ...}}``-shaped blob; project the resolved gate into that shape
+        # rather than passing the session's raw parked_state, which would
+        # describe the PRIMARY entry, not necessarily this one.
         record = record_from_parked_blob(
-            blob=blob,
+            blob={
+                "tool_call_id": gate.get("tool_call_id"),
+                "yielded": {"resume_metadata": gate.get("resume_metadata") or {}},
+            },
             decision=decision,
             reason=reason,
             agent_id=getattr(sess.binding, "agent_id", None),
@@ -471,15 +507,27 @@ def make_tool_approval_ops_router() -> APIRouter:
         user=Depends(require_user),
     ) -> dict[str, str]:
         sess = await session_storage.get(session_id)
+        blob = _approval_blob_or_404(sess, session_id)
+        # Resolve the SPECIFIC gate body.tool_call_id names -- a graph park
+        # can have several pending approval gates open at once, and only
+        # the primary one is projected onto the top-level `yielded` blob
+        # (see primer.session.pending_gates). Mirrors yields.py's
+        # _graph_ask_user_dispatch pattern for the ask_user case.
+        gate = resolve_pending_gate(blob, tool_call_id=body.tool_call_id, kind="_approval")
+        if gate is None:
+            raise NotFoundError(
+                f"No pending tool_approval with tool_call_id "
+                f"{body.tool_call_id!r} on {session_id!r}"
+            )
         # Approver routing (P6): 403 approver_mismatch before any state
         # moves; decided_by rides the wake payload into the durable
         # record the resume coordinator writes.
-        blob = _approval_blob_or_404(sess, session_id)
-        _enforce_approvers(blob, user)
+        _enforce_approvers(gate.get("resume_metadata") or {}, user)
         await _publish_decision(
             sess=sess,
             id_str=session_id,
             body=body,
+            gate=gate,
             event_bus=event_bus,
             session_storage=session_storage,
             engine=engine,

--- a/primer/api/routers/workspaces.py
+++ b/primer/api/routers/workspaces.py
@@ -90,6 +90,7 @@ from primer.model.workspace import (
 )
 from primer.model.workspace_session import SessionStatus, WorkspaceSession
 from primer.session.mutation_lock import session_lifecycle_lock
+from primer.session.pending_gates import enumerate_pending_gates
 
 
 logger = logging.getLogger(__name__)
@@ -2769,6 +2770,14 @@ async def list_session_pending_yields(
     but scoped to one session, so the run-view can render Approve/Deny /
     respond affordances inline in the stream while the right sidebar keeps
     the global Action-Required list (studio-agents-interact §5.4 / §4.5).
+
+    01a06c94: a graph superstep can park on SEVERAL nodes at once (e.g. a
+    fan-out with concurrent approval gates) - this is the console's actual
+    DecisionCard data source (nv-session-doc.jsx's `gates` resource), so
+    every pending entry is returned now via the shared
+    ``primer.session.pending_gates`` resolver, not just the primary one
+    the old single-``yielded``-blob read projected. Non-primary gates were
+    previously invisible here and therefore unanswerable in the console.
     """
     sess = await session_storage.get(session_id)
     if sess is None or sess.workspace_id != workspace_id:
@@ -2779,27 +2788,27 @@ async def list_session_pending_yields(
     items: list[dict] = []
     if sess.parked_status == "parked":
         blob: dict = sess.parked_state or {}
-        yielded_blob: dict = blob.get("yielded") or {}
-        tool_name: str = yielded_blob.get("tool_name") or ""
-        metadata: dict = yielded_blob.get("resume_metadata") or {}
-        items.append({
-            "session_id": sess.id,
-            "kind": _extract_yield_kind(tool_name),
-            "prompt": _extract_yield_prompt(tool_name, metadata),
-            "tool_call_id": _tool_call_id_from_blob(blob),
-            "parked_at": (
-                sess.parked_at.isoformat()
-                if sess.parked_at is not None else None
-            ),
-            # Who may decide (P6 approver routing); None = anyone.
-            "approvers": metadata.get("approvers"),
-            # The literal gated call (see the aggregated route above).
-            "resume_metadata": {
-                "original_call": metadata.get("original_call"),
-                # UX reconcile wave 5 - see the aggregated route above.
-                "response_schema": metadata.get("response_schema"),
-            },
-        })
+        for gate in enumerate_pending_gates(blob):
+            tool_name = gate["kind"]
+            metadata: dict = gate["resume_metadata"]
+            items.append({
+                "session_id": sess.id,
+                "kind": _extract_yield_kind(tool_name),
+                "prompt": _extract_yield_prompt(tool_name, metadata),
+                "tool_call_id": gate["tool_call_id"],
+                "parked_at": (
+                    sess.parked_at.isoformat()
+                    if sess.parked_at is not None else None
+                ),
+                # Who may decide (P6 approver routing); None = anyone.
+                "approvers": metadata.get("approvers"),
+                # The literal gated call (see the aggregated route above).
+                "resume_metadata": {
+                    "original_call": metadata.get("original_call"),
+                    # UX reconcile wave 5 - see the aggregated route above.
+                    "response_schema": metadata.get("response_schema"),
+                },
+            })
     return {"items": items}
 
 

--- a/primer/channel/inbox.py
+++ b/primer/channel/inbox.py
@@ -126,7 +126,82 @@ class ChannelInbox:
             "event_key=%s",
             env.kind, env.session_id, env.tool_call_id, event_key,
         )
+        if env.kind == "tool_approval":
+            await self._record_decision_best_effort(env, event_key=event_key)
         await self._event_bus.publish(event_key, payload)
+
+    async def _record_decision_best_effort(
+        self, env: ResponseEnvelope, *, event_key: str,
+    ) -> None:
+        """Persist a durable ToolApprovalRecord for a channel-answered gate.
+
+        01a06b82: the REST respond route (tool_approval.py's
+        _publish_decision) has written this record at decision time since
+        01a068da; the channel surface never did, so a decision answered
+        through Slack/Discord/etc. had no durable record unless the
+        session later happened to resume (the resume-time fallback,
+        write_approval_record_for_graph / the agent-path equivalent).
+
+        This is advisory ONLY, unlike the REST route's write: that route
+        stamps parked_status durably (the guarded parked -> resumable
+        flip) BEFORE writing the record, so it always has a confirmed-real
+        park to describe. handle_response has no equivalent durable step
+        of its own -- it publishes straight onto the event bus, and the
+        durable flip happens elsewhere (the bus listener / durable event
+        dispatcher). So there is no natural place to hang a hard failure
+        off: ANY problem here (no storage_provider wired, the session
+        lookup failing, the gate not resolving, or the write itself
+        failing) is logged and swallowed, and must NEVER block or delay
+        the wake publish that follows this call. A missed record here is
+        recoverable (the resume-time write is still a backstop); a missed
+        or delayed wake is not.
+        """
+        if self._storage_provider is None:
+            return
+        try:
+            from primer.agent.approval_record import (
+                record_from_parked_blob,
+                write_approval_record,
+            )
+            from primer.model.tool_approval import ToolApprovalRecord
+            from primer.model.workspace_session import WorkspaceSession
+            from primer.session.pending_gates import resolve_pending_gate
+            from primer.worker.yield_runtime import classify_approval_payload
+
+            row = await self._storage_provider.get_storage(
+                WorkspaceSession,
+            ).get(env.session_id)
+            if row is None:
+                return
+            blob = getattr(row, "parked_state", None) or {}
+            gate = resolve_pending_gate(
+                blob, tool_call_id=env.tool_call_id, kind="_approval",
+            )
+            if gate is None:
+                return
+            decision, reason = classify_approval_payload(
+                {"decision": env.decision, "reason": env.reason},
+            )
+            record = record_from_parked_blob(
+                blob={
+                    "tool_call_id": env.tool_call_id,
+                    "yielded": {"resume_metadata": gate.get("resume_metadata") or {}},
+                },
+                decision=decision,
+                reason=reason,
+                agent_id=getattr(row.binding, "agent_id", None),
+                session_id=env.session_id,
+                requested_at=getattr(row, "parked_at", None),
+                gate_event_key=gate.get("event_key") or event_key,
+            )
+            await write_approval_record(
+                self._storage_provider.get_storage(ToolApprovalRecord), record,
+            )
+        except Exception:  # noqa: BLE001 -- advisory; must never block the wake publish
+            logger.exception(
+                "channel inbox: best-effort approval record write failed "
+                "for session=%s tool_call=%s", env.session_id, env.tool_call_id,
+            )
 
     async def _resolve_event_key(self, env: ResponseEnvelope) -> str:
         """The event_key to publish for ``env``.

--- a/primer/channel/inbox.py
+++ b/primer/channel/inbox.py
@@ -126,9 +126,23 @@ class ChannelInbox:
             "event_key=%s",
             env.kind, env.session_id, env.tool_call_id, event_key,
         )
+        # 01a06b82 gate-review R1: publish FIRST, record AFTER. Writing
+        # the record before the publish landed meant a publish that
+        # raised (or a listener that never actually advanced the park)
+        # left a permanently WRONG "decided" record on the books: the
+        # gate then genuinely times out, the resume-time synthesis tries
+        # to write the TRUE ("rejected", "timed-out") verdict, loses the
+        # gate_event_key race to this earlier wrong write, and that
+        # ConflictError used to be swallowed as an ordinary benign dedup
+        # no-op. Publishing first means a raise here skips the record
+        # entirely (no decision reached the system, nothing to record);
+        # write_approval_record's warn_on_decision_mismatch on the
+        # resume-time write is the remaining safety net for the case
+        # where publish() itself succeeds but the listener still never
+        # advances the park.
+        await self._event_bus.publish(event_key, payload)
         if env.kind == "tool_approval":
             await self._record_decision_best_effort(env, event_key=event_key)
-        await self._event_bus.publish(event_key, payload)
 
     async def _record_decision_best_effort(
         self, env: ResponseEnvelope, *, event_key: str,
@@ -151,10 +165,15 @@ class ChannelInbox:
         dispatcher). So there is no natural place to hang a hard failure
         off: ANY problem here (no storage_provider wired, the session
         lookup failing, the gate not resolving, or the write itself
-        failing) is logged and swallowed, and must NEVER block or delay
-        the wake publish that follows this call. A missed record here is
-        recoverable (the resume-time write is still a backstop); a missed
-        or delayed wake is not.
+        failing) is logged and swallowed. Called AFTER the publish
+        (R1): writing this BEFORE the publish used to mean a publish
+        that raised (or a listener that never actually advanced the
+        park) left a permanently wrong "decided" record on the books
+        with nothing to correct it. A missed record here is recoverable
+        (the resume-time write is still a backstop, now with its own
+        disagreement check for exactly this residual race - see
+        write_approval_record's warn_on_decision_mismatch); a missed or
+        delayed wake would not have been.
         """
         if self._storage_provider is None:
             return

--- a/primer/session/pending_gates.py
+++ b/primer/session/pending_gates.py
@@ -33,6 +33,14 @@ the ability to reconstruct the unscoped key by convention). REST needs
 the real stored event_key (a graph fan-out gate's key may be
 node-scoped) plus the full metadata for approver enforcement and the
 audit record, so this module goes straight to the source fields instead.
+
+Known, accepted gap: a checkpoint written before 575c9b1d can carry a
+``pending_toolcalls``/``pending_agent_yields`` entry whose own
+``resume_metadata`` lacks ``original_call`` (main's top-level
+``yielded``-projection read had its own reconstruction for that legacy
+shape, which this module does not reproduce) -- verified real but not
+worth a fallback here: that pre-575c9b1d window was brief and no park
+from it survived into this deployment.
 """
 
 from __future__ import annotations

--- a/primer/session/pending_gates.py
+++ b/primer/session/pending_gates.py
@@ -1,0 +1,138 @@
+"""Enumerate + resolve pending human-decision gates on a parked session.
+
+A parked ``WorkspaceSession`` carries exactly one pending item in the
+common (non-graph) case: ``parked_state['yielded']``. A graph park is
+different -- a single superstep can suspend on SEVERAL nodes at once (a
+fan-out with concurrent approval gates, or a mix of tool-call approvals
+and agent-node ``ask_user`` yields), and only the FIRST of those is
+projected onto the top-level ``yielded`` blob
+(:meth:`primer.graph._checkpoint._CheckpointMixin._build_pending_park_yield`).
+The rest live only in ``parked_state['graph_checkpoint']``'s
+``pending_toolcalls`` / ``pending_agent_yields`` lists.
+
+Before this module, every REST consumer read ``yielded`` alone, so a
+reply aimed at any gate but the primary one had nothing to match against
+and 404'd -- even though :mod:`primer.channel.inbox` already resolves any
+entry correctly for channel replies. :func:`enumerate_pending_gates` and
+:func:`resolve_pending_gate` are the ONE shared implementation for both
+directions (list everything pending / find one by tool_call_id), used by
+``workspaces.py``'s session yields lister and both
+``tool_approval.py`` pending/respond routes, so the three call sites
+can't drift the way the primary-only projection and the inbox's own
+matcher already have.
+
+Deliberately reads the checkpoint's raw ``pending_toolcalls`` /
+``pending_agent_yields`` -- NOT
+:func:`primer.worker.yield_runtime.merge_pending_dispatch`'s
+``pending_dispatch``-based view. That view is purpose-built for channel
+prompts and denormalises tool-call approval entries down to
+``{"original_call": ...}``, dropping ``policy_id`` / ``approval_type`` /
+``gate_reason`` / ``approvers`` and the entry's own ``parked_event_key``
+entirely (channel dispatch only ever needs a human-readable prompt +
+the ability to reconstruct the unscoped key by convention). REST needs
+the real stored event_key (a graph fan-out gate's key may be
+node-scoped) plus the full metadata for approver enforcement and the
+audit record, so this module goes straight to the source fields instead.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from primer.session.yields import _tool_call_id_for
+
+
+logger = logging.getLogger(__name__)
+
+
+def enumerate_pending_gates(blob: dict[str, Any]) -> list[dict[str, Any]]:
+    """Every pending human-decision entry on a parked_state blob.
+
+    Each entry is normalised to::
+
+        {
+            "kind": str,               # tool_name: "_approval", "ask_user", ...
+            "node_id": str | None,     # graph node/instance id; None for a
+                                        # non-graph (agent-session/chat) park
+            "tool_call_id": str | None,
+            "event_key": str | None,
+            "resume_metadata": dict,
+        }
+
+    A non-graph park yields at most one entry, built from
+    ``blob['yielded']``. A graph park yields one entry per pending
+    tool-call approval (``graph_checkpoint['pending_toolcalls']``) followed
+    by one per pending agent yield (``graph_checkpoint['pending_agent_yields']``)
+    -- toolcalls first, matching
+    :meth:`_CheckpointMixin._build_pending_park_yield`'s own primary-pick
+    order, so callers that only look at ``[0]`` see the same "primary"
+    entry that endpoint already projects today.
+
+    Returns ``[]`` for an unparked/empty blob.
+    """
+    checkpoint = blob.get("graph_checkpoint")
+    if checkpoint:
+        entries: list[dict[str, Any]] = []
+        for p in checkpoint.get("pending_toolcalls") or []:
+            entries.append({
+                "kind": p.get("tool_name") or "_approval",
+                "node_id": p.get("node_id"),
+                "tool_call_id": p.get("tool_call_id"),
+                "event_key": p.get("parked_event_key"),
+                "resume_metadata": dict(p.get("resume_metadata") or {}),
+            })
+        for p in checkpoint.get("pending_agent_yields") or []:
+            entries.append({
+                "kind": p.get("tool_name") or "",
+                "node_id": p.get("node_id"),
+                "tool_call_id": p.get("tool_call_id"),
+                "event_key": p.get("event_key"),
+                "resume_metadata": dict(p.get("resume_metadata") or {}),
+            })
+        return entries
+
+    yielded: dict[str, Any] = blob.get("yielded") or {}
+    tool_name = yielded.get("tool_name")
+    if not tool_name:
+        return []
+    return [{
+        "kind": tool_name,
+        "node_id": None,
+        "tool_call_id": _tool_call_id_for(blob),
+        "event_key": yielded.get("event_key"),
+        "resume_metadata": dict(yielded.get("resume_metadata") or {}),
+    }]
+
+
+def resolve_pending_gate(
+    blob: dict[str, Any],
+    *,
+    tool_call_id: str,
+    kind: str | None = None,
+) -> dict[str, Any] | None:
+    """The one pending entry matching ``tool_call_id`` (and ``kind`` if given).
+
+    ``kind`` narrows to one tool_name (e.g. ``"_approval"``) when a caller
+    knows only entries of that kind can answer the request. Mirrors
+    :func:`primer.api.routers.yields._graph_ask_user_dispatch`'s collision
+    handling: two concurrent fan-out siblings can share a raw provider
+    tool_call_id, which the REST wire contract has no field to
+    disambiguate, so a collision resolves to the first match and logs a
+    warning rather than raising.
+    """
+    matches = [
+        entry for entry in enumerate_pending_gates(blob)
+        if entry.get("tool_call_id") == tool_call_id
+        and (kind is None or entry.get("kind") == kind)
+    ]
+    if len(matches) > 1:
+        logger.warning(
+            "resolve_pending_gate: %d pending entries share "
+            "tool_call_id=%r (kind=%r); resolving the first",
+            len(matches), tool_call_id, kind,
+        )
+    return matches[0] if matches else None
+
+
+__all__ = ["enumerate_pending_gates", "resolve_pending_gate"]

--- a/primer/storage/sqlite.py
+++ b/primer/storage/sqlite.py
@@ -229,6 +229,12 @@ class SqliteStorageProvider(StorageProvider):
             try:
                 yield True
             except BaseException:
+                # This only protects writers that actually enter here.
+                # Known bypassers (this module's own system_state setters,
+                # e.g. set_default_agent_id, and primer.channel.
+                # correlation's raw upsert) execute + commit directly on
+                # the connection and can wedge it by the same mechanism.
+                # Routing them through this guard is its own PR: 01a070ea.
                 await self.connection.rollback()
                 raise
 

--- a/primer/storage/sqlite.py
+++ b/primer/storage/sqlite.py
@@ -193,14 +193,44 @@ class SqliteStorageProvider(StorageProvider):
         transaction (which holds the lock for the whole BEGIN..COMMIT). Yields
         ``True`` when the caller should commit its own statement (standalone
         write), ``False`` when it must defer to the enclosing transaction.
+
+        01a06cb3: the standalone branch rolls back on ANY exception raised
+        by the caller's body (a failed ``execute`` -- e.g. a UNIQUE
+        violation surfaced as the expected ``ConflictError`` dedup path, or
+        a plain bug -- or a ``CancelledError`` landing between ``execute``
+        and ``commit``). aiosqlite's default isolation_level opens an
+        IMPLICIT transaction on the first DML statement; without this
+        rollback that transaction is left open on the shared connection
+        with nothing tracking it (``_txn_task`` is only set by
+        :meth:`transaction`/:meth:`read_snapshot`), so the very next
+        ``read_snapshot`` -- any unrelated ``list``/paged read on the same
+        connection, possibly by a different caller entirely -- fails its
+        own ``BEGIN`` with "cannot start a transaction within a
+        transaction". ``BaseException``, not ``Exception``, matching
+        :meth:`transaction`'s own pattern: a plain ``except Exception``
+        would let a cancellation slip through and wedge the connection by
+        the identical mechanism, just a sneakier trigger to hit.
+
+        The reentrant branch above (already-open outer :meth:`transaction`)
+        is deliberately untouched: a statement that fails there belongs to
+        the OUTER transaction, whose own ``except BaseException: rollback``
+        already owns it. Rolling back HERE too would discard whatever the
+        enclosing transaction had already written before this statement,
+        not just this statement's own (nonexistent, since it never
+        committed) effect.
         """
         if self._in_own_transaction():
             # Reentrant write from inside the held transaction: the lock is
-            # already held by this task and the transaction owns the commit.
+            # already held by this task and the transaction owns the commit
+            # AND the rollback -- see the docstring above.
             yield False
             return
         async with self._write_lock:
-            yield True
+            try:
+                yield True
+            except BaseException:
+                await self.connection.rollback()
+                raise
 
     @asynccontextmanager
     async def transaction(self):

--- a/primer/worker/graph_resume_coordinator.py
+++ b/primer/worker/graph_resume_coordinator.py
@@ -43,63 +43,46 @@ async def write_approval_record_for_graph(
 ) -> None:
     """Persist the resolved approval decision for a graph tool-call gate.
 
-    The gated call's metadata lives on the checkpoint's
-    ``pending_agent_yields`` entry for ``tcid``. We reshape it into the
-    ``parked_state`` blob form so the shared builder applies. Best-effort:
-    a missing entry or write failure is logged + swallowed.
+    Resolves the SPECIFIC pending entry ``tcid`` names via
+    :func:`primer.session.pending_gates.resolve_pending_gate` -- the same
+    shared helper the REST respond-time write (``tool_approval.py``'s
+    ``_publish_decision``) uses -- so the resume-time and respond-time
+    writes for the same gate can never disagree about which entry's
+    metadata a decision describes, and both now carry the gate's real
+    ``event_key`` into ``gate_event_key`` for idempotent dedup (01a068da).
+
+    This also picks up a real bugfix: an approval gate raised by a
+    ToolCall NODE (as opposed to an agent-node's own tool call) used to
+    resolve through ``pending_dispatch``, a denormalised channel-prompt
+    view that only ever carried ``original_call`` -- ``policy_id`` /
+    ``approval_type`` / ``gate_reason`` / ``approvers`` were silently
+    dropped from every such record. Resolving via ``pending_toolcalls``
+    (the raw checkpoint field the shared helper reads) carries the full
+    metadata tool_manager.py originally stamped.
+
+    A tcid that resolves to nothing (not an approval gate, or the legacy
+    single-event drain-all with no tcid) is skipped. Best-effort: a
+    missing entry or write failure is logged + swallowed
+    (``write_approval_record``'s own contract).
     """
     from primer.agent.approval_record import (
         record_from_parked_blob,
         write_approval_record,
     )
     from primer.model.tool_approval import ToolApprovalRecord
+    from primer.session.pending_gates import resolve_pending_gate
 
-    # Two gate shapes resolve here. An agent-node ``_approval`` yield lives
-    # in ``pending_agent_yields`` and carries its own resume_metadata. A
-    # tool-call-node gate lives in ``pending_toolcalls`` and its
-    # ``original_call`` (tool_id + arguments) is denormalised into
-    # ``pending_dispatch``. Either way, reshape into the parked_state blob
-    # form the shared builder expects. A tcid that matches neither (or no
-    # tcid at all -> legacy drain) is skipped.
-    resume_metadata: dict | None = None
-    ay_matches = [
-        e for e in (checkpoint.get("pending_agent_yields") or [])
-        if e.get("tool_call_id") == tcid
-    ]
-    if len(ay_matches) > 1:
-        # 01a0518f: two concurrent fan-out siblings can share a raw
-        # provider tool_call_id; the resume payload only ever carries
-        # tool_call_id, so first-match is the same ambiguity the resume
-        # path already has - logged so a real collision is visible.
-        logger.warning(
-            "write_approval_record_for_graph: %d pending_agent_yields "
-            "share tool_call_id=%r on session %s; resolving the first",
-            len(ay_matches), tcid, session.id,
-        )
-    entry = ay_matches[0] if ay_matches else None
-    if entry is not None and entry.get("tool_name") == "_approval":
-        resume_metadata = entry.get("resume_metadata") or {}
-    else:
-        disp_matches = [
-            d for d in (checkpoint.get("pending_dispatch") or [])
-            if d.get("tool_call_id") == tcid
-        ]
-        if len(disp_matches) > 1:
-            logger.warning(
-                "write_approval_record_for_graph: %d pending_dispatch "
-                "entries share tool_call_id=%r on session %s; resolving "
-                "the first",
-                len(disp_matches), tcid, session.id,
-            )
-        disp = disp_matches[0] if disp_matches else None
-        if disp is not None:
-            resume_metadata = disp.get("resume_metadata") or {}
-    if resume_metadata is None:
+    if not tcid:
+        return
+    gate = resolve_pending_gate(
+        {"graph_checkpoint": checkpoint}, tool_call_id=tcid, kind="_approval",
+    )
+    if gate is None:
         return
     decision, reason = classify_approval_payload(payload)
     blob = {
         "tool_call_id": tcid,
-        "yielded": {"resume_metadata": resume_metadata},
+        "yielded": {"resume_metadata": gate.get("resume_metadata") or {}},
     }
     record = record_from_parked_blob(
         blob=blob,
@@ -113,6 +96,7 @@ async def write_approval_record_for_graph(
         decided_by=(
             payload.get("decided_by") if isinstance(payload, dict) else None
         ),
+        gate_event_key=gate.get("event_key"),
     )
     storage = (
         pool._storage.get_storage(ToolApprovalRecord)

--- a/primer/worker/graph_resume_coordinator.py
+++ b/primer/worker/graph_resume_coordinator.py
@@ -29,6 +29,7 @@ from primer.worker.yield_resume_registry import get_resume_hook
 from primer.worker.yield_runtime import (
     classify_approval_payload,
     classify_resume_payload,
+    is_terminal_synthesis_payload,
     ParkedState,
 )
 
@@ -103,7 +104,10 @@ async def write_approval_record_for_graph(
         if pool._storage is not None
         else None
     )
-    await write_approval_record(storage, record)
+    await write_approval_record(
+        storage, record,
+        warn_on_decision_mismatch=is_terminal_synthesis_payload(payload),
+    )
 
 
 async def resume_graph_engine(pool: "WorkerPool", session, parked):

--- a/primer/worker/session_resume_coordinator.py
+++ b/primer/worker/session_resume_coordinator.py
@@ -42,6 +42,7 @@ from primer.worker.yield_runtime import (
     _resume_tool_approval,
     classify_approval_payload,
     classify_resume_payload,
+    is_terminal_synthesis_payload,
     ParkedState,
 )
 
@@ -98,7 +99,10 @@ async def write_approval_record_for_session(
         if pool._storage is not None
         else None
     )
-    await write_approval_record(storage, record)
+    await write_approval_record(
+        storage, record,
+        warn_on_decision_mismatch=is_terminal_synthesis_payload(payload),
+    )
 
 
 async def resume_engine_session(pool: "WorkerPool", engine_lease, session):

--- a/primer/worker/yield_runtime.py
+++ b/primer/worker/yield_runtime.py
@@ -457,6 +457,32 @@ def classify_approval_payload(
     return "rejected", "malformed approval payload (non-dict)"
 
 
+def is_terminal_synthesis_payload(payload: Any) -> bool:
+    """True when ``payload`` is a synthesised timeout/cancel outcome
+    rather than a real, direct operator decision.
+
+    01a06b82 gate-review R1: callers writing a resume-time
+    ToolApprovalRecord pass this to :func:`~primer.agent.approval_record.
+    write_approval_record`'s ``warn_on_decision_mismatch`` so a
+    ConflictError on THIS write (the one case that isn't an ordinary
+    benign dedup race - see that function's docstring) gets checked for
+    an actual disagreement instead of silently swallowed.
+
+    Handles both shapes a resume drain can see: the single-event path's
+    already-classified ``YieldTimeout``/``YieldCancelled`` instance (via
+    :func:`classify_resume_payload`), and the multi-event graph drain's
+    raw marker dict (``resume_event_payloads`` entries are stored and
+    replayed as plain JSON, never converted to a typed instance).
+    """
+    if isinstance(payload, (YieldTimeout, YieldCancelled)):
+        return True
+    if isinstance(payload, dict):
+        return bool(
+            payload.get(_YIELD_TIMEOUT_KEY) or payload.get(_YIELD_CANCELLED_KEY)
+        )
+    return False
+
+
 async def _resume_tool_approval(
     *,
     blob: dict,

--- a/tests/agent/test_approval_record.py
+++ b/tests/agent/test_approval_record.py
@@ -199,3 +199,114 @@ async def test_write_approval_record_still_logs_a_real_failure_as_an_error(caplo
     with caplog.at_level(logging.DEBUG, logger="primer.agent.approval_record"):
         await write_approval_record(_Boom(), rec)
     assert any(r.levelno >= logging.ERROR for r in caplog.records)
+
+
+class _StorageWithExistingRecord:
+    """Fake storage: create() always loses the gate_event_key race
+    (ConflictError), find() returns the ONE record that won it."""
+
+    def __init__(self, existing: ToolApprovalRecord) -> None:
+        self._existing = existing
+
+    async def create(self, _entity):
+        raise ConflictError("ToolApprovalRecord with id 'x' already exists")
+
+    async def find(self, _predicate, page, order_by=None):
+        from primer.model.storage import OffsetPageResponse
+
+        return OffsetPageResponse(
+            offset=page.offset, length=1, total=1, items=[self._existing],
+        )
+
+
+@pytest.mark.asyncio
+async def test_write_approval_record_warns_loudly_on_a_real_disagreement(caplog):
+    """01a06b82 gate-review R1: warn_on_decision_mismatch=True is what a
+    resume-time TERMINAL synthesis (timeout/cancel) passes. If the record
+    that already won the gate_event_key race disagrees with the true
+    terminal outcome computed here, that is NOT an ordinary benign dedup
+    race (a channel reply's "approved" write whose publish never actually
+    landed, followed by the gate genuinely timing out) -- it must be
+    logged loudly (ERROR, both values) rather than silently swallowed at
+    DEBUG like an everyday duplicate."""
+    import logging
+
+    existing = ToolApprovalRecord(
+        tool_name="x", decided_at=datetime.now(UTC), decision="approved",
+        gate_event_key="tool_approval:sess-1:c1",
+    )
+    rec = ToolApprovalRecord(
+        tool_name="x", decided_at=datetime.now(UTC), decision="rejected",
+        reason="timed-out", gate_event_key="tool_approval:sess-1:c1",
+    )
+    with caplog.at_level(logging.DEBUG, logger="primer.agent.approval_record"):
+        await write_approval_record(
+            _StorageWithExistingRecord(existing), rec,
+            warn_on_decision_mismatch=True,
+        )
+    error_records = [r for r in caplog.records if r.levelno >= logging.ERROR]
+    assert len(error_records) == 1
+    message = error_records[0].getMessage()
+    assert "disagreement" in message
+    assert "approved" in message
+    assert "rejected" in message
+    assert "timed-out" in message
+
+
+@pytest.mark.asyncio
+async def test_write_approval_record_stays_quiet_when_the_winning_decision_agrees(
+    caplog,
+):
+    """Even with warn_on_decision_mismatch=True, a race where both writers
+    agree (the common, ordinary case -- e.g. the same real operator
+    decision written twice) is still just a benign dedup no-op at DEBUG,
+    not a disagreement."""
+    import logging
+
+    existing = ToolApprovalRecord(
+        tool_name="x", decided_at=datetime.now(UTC), decision="approved",
+        gate_event_key="tool_approval:sess-1:c1",
+    )
+    rec = ToolApprovalRecord(
+        tool_name="x", decided_at=datetime.now(UTC), decision="approved",
+        gate_event_key="tool_approval:sess-1:c1",
+    )
+    with caplog.at_level(logging.DEBUG, logger="primer.agent.approval_record"):
+        await write_approval_record(
+            _StorageWithExistingRecord(existing), rec,
+            warn_on_decision_mismatch=True,
+        )
+    assert not any(r.levelno >= logging.ERROR for r in caplog.records)
+    assert any("gate_event_key" in r.getMessage() for r in caplog.records)
+
+
+@pytest.mark.asyncio
+async def test_write_approval_record_disagreement_check_read_failure_stays_diagnostic(
+    caplog,
+):
+    """A failure reading the winning record for the disagreement check
+    must not crash the write (still best-effort) and must not CLAIM a
+    disagreement it never actually confirmed."""
+    import logging
+
+    class _FindBoom:
+        async def create(self, _entity):
+            raise ConflictError("dup")
+
+        async def find(self, _predicate, _page, order_by=None):
+            raise RuntimeError("read backend down")
+
+    rec = ToolApprovalRecord(
+        tool_name="x", decided_at=datetime.now(UTC), decision="rejected",
+        reason="timed-out", gate_event_key="tool_approval:sess-1:c1",
+    )
+    with caplog.at_level(logging.DEBUG, logger="primer.agent.approval_record"):
+        await write_approval_record(
+            _FindBoom(), rec, warn_on_decision_mismatch=True,
+        )
+    # "the disagreement check itself failed" is fine (diagnostic); an
+    # actual "audit disagreement:" claim would not be, since nothing here
+    # confirmed one.
+    assert not any(
+        "audit disagreement" in r.getMessage() for r in caplog.records
+    )

--- a/tests/api/test_approver_routing.py
+++ b/tests/api/test_approver_routing.py
@@ -103,6 +103,80 @@ def _parked_session(
     )
 
 
+def _two_gate_graph_session_with_different_approvers(
+    *, session_id: str,
+) -> WorkspaceSession:
+    """Two concurrent fan-out approval gates with DIFFERENT approver
+    specs each: gate 1 (call-0) routed to alice, gate 2 (call-1) routed
+    to bob.
+
+    01a06b82 gate-review R3: per-gate approver enforcement was unpinned
+    -- every other fixture in this branch used ``approvers=None``, so a
+    regression that enforced the PRIMARY gate's spec against a
+    non-primary respond would pass the whole suite silently.
+    """
+    now = datetime.now(UTC)
+
+    def _entry(node_id: str, tool_call_id: str, approvers: dict) -> dict:
+        return {
+            "node_id": node_id,
+            "tool_call_id": tool_call_id,
+            "parked_event_key": f"tool_approval:{session_id}:{tool_call_id}",
+            "arguments": {"id": f"ws-{node_id}"},
+            "tool_name": "_approval",
+            "resume_metadata": {
+                "policy_id": "pol-fanout",
+                "approval_type": "required",
+                "gate_reason": "matched policy",
+                "approvers": approvers,
+                "original_call": {
+                    "id": tool_call_id, "name": "delete_workspace",
+                    "arguments": {"id": f"ws-{node_id}"},
+                },
+            },
+            "scoped_tool_call_id": None,
+        }
+
+    entries = [
+        _entry("worker[0]", "call-0", {"kind": "users", "users": ["alice"]}),
+        _entry("worker[1]", "call-1", {"kind": "users", "users": ["bob"]}),
+    ]
+    all_keys = [e["parked_event_key"] for e in entries]
+    primary = entries[0]
+    return WorkspaceSession(
+        id=session_id, workspace_id="ws",
+        binding=AgentSessionBinding(kind="agent", agent_id="agt"),
+        status=SessionStatus.RUNNING, created_at=now,
+        parked_status="parked", parked_at=now,
+        parked_event_key=primary["parked_event_key"],
+        parked_event_keys=all_keys,
+        parked_state={
+            "tool_call_id": primary["tool_call_id"],
+            "yielded": {
+                "tool_name": "_approval",
+                "event_key": primary["parked_event_key"],
+                "resume_metadata": primary["resume_metadata"],
+                "event_keys": all_keys,
+            },
+            "graph_checkpoint": {
+                "pending_toolcalls": entries,
+                "pending_agent_yields": [],
+                "pending_dispatch": [
+                    {
+                        "kind": "_approval",
+                        "node_id": e["node_id"],
+                        "tool_call_id": e["tool_call_id"],
+                        "resume_metadata": {
+                            "original_call": e["resume_metadata"]["original_call"],
+                        },
+                    }
+                    for e in entries
+                ],
+            },
+        },
+    )
+
+
 async def _register_admin(client) -> None:
     reg = await client.post(
         "/v1/auth/register",
@@ -194,3 +268,36 @@ async def test_users_can_decide_unrouted_parks_but_not_edit_policies(
         },
     )
     assert denied.status_code == 403, denied.text
+
+
+@pytest.mark.asyncio
+async def test_per_gate_approvers_are_enforced_independently(client, app) -> None:
+    """01a06b82 gate-review R3: responding to gate 2 (routed to bob) must
+    be judged against GATE 2's OWN approver spec, not gate 1's (the
+    checkpoint's primary, routed to alice) -- a bug that enforced the
+    primary gate's spec against every respond would let alice decide
+    bob's gate (or block bob from deciding his own), and every OTHER
+    test in this file uses approvers=None so none of them would catch
+    it."""
+    await _register_admin(client)
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(_two_gate_graph_session_with_different_approvers(
+        session_id="ar-graph-1",
+    ))
+
+    # alice is routed to gate 1, not gate 2: refused on gate 2.
+    await _login_user(client, app, "alice")
+    refused = await client.post(
+        "/v1/sessions/ar-graph-1/tool_approval/respond",
+        json={"tool_call_id": "call-1", "decision": "approved"},
+    )
+    assert refused.status_code == 403, refused.text
+    assert refused.json()["extensions"]["error"] == "approver_mismatch"
+
+    # bob IS routed to gate 2: succeeds.
+    await _login_user(client, app, "bob")
+    ok = await client.post(
+        "/v1/sessions/ar-graph-1/tool_approval/respond",
+        json={"tool_call_id": "call-1", "decision": "approved"},
+    )
+    assert ok.status_code == 202, ok.text

--- a/tests/api/test_tool_approval_graph_routing.py
+++ b/tests/api/test_tool_approval_graph_routing.py
@@ -113,6 +113,128 @@ def _two_gate_graph_parked_session(
     )
 
 
+def _mixed_checkpoint_session(
+    *, session_id: str, workspace_id: str,
+) -> WorkspaceSession:
+    """One ToolCall-node approval gate (pending_toolcalls) + one agent-node
+    ask_user yield (pending_agent_yields) pending at once.
+
+    01a06b82 gate-review R2: the pending_agent_yields arm of
+    enumerate_pending_gates -- which maps its own ``event_key`` field,
+    distinct from pending_toolcalls's ``parked_event_key`` -- had zero
+    test coverage; every other fixture in this branch hardcoded it to
+    ``[]``. This is the mixed case the routing-fix commit's own
+    docstring claims to handle.
+    """
+    now = datetime.now(UTC)
+    approval_key = f"tool_approval:{session_id}:call-approve"
+    ask_key = f"ask_user:{session_id}:worker[1]:call-ask"
+    approval_entry = {
+        "node_id": "worker[0]",
+        "tool_call_id": "call-approve",
+        "parked_event_key": approval_key,
+        "arguments": {"id": "ws-worker[0]"},
+        "tool_name": "_approval",
+        "resume_metadata": {
+            "policy_id": "pol-mixed",
+            "approval_type": "required",
+            "gate_reason": "matched policy",
+            "approvers": None,
+            "original_call": {
+                "id": "call-approve", "name": "delete_workspace",
+                "arguments": {"id": "ws-worker[0]"},
+            },
+        },
+        "scoped_tool_call_id": None,
+    }
+    ask_entry = {
+        "node_id": "worker[1]",
+        "tool_call_id": "call-ask",
+        "event_key": ask_key,
+        "tool_name": "ask_user",
+        "resume_metadata": {
+            "prompt": "Which currency?", "response_schema": None,
+        },
+        "llm_messages": [],
+        "iteration": 0,
+    }
+    return WorkspaceSession(
+        id=session_id,
+        workspace_id=workspace_id,
+        binding=AgentSessionBinding(kind="agent", agent_id="agt"),
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        parked_status="parked",
+        parked_at=now,
+        parked_event_key=approval_key,
+        parked_event_keys=[approval_key, ask_key],
+        parked_state={
+            "tool_call_id": "call-approve",
+            "yielded": {
+                "tool_name": "_approval",
+                "event_key": approval_key,
+                "resume_metadata": approval_entry["resume_metadata"],
+                "event_keys": [approval_key, ask_key],
+            },
+            "graph_checkpoint": {
+                "pending_toolcalls": [approval_entry],
+                "pending_agent_yields": [ask_entry],
+                "pending_dispatch": [
+                    {
+                        "kind": "_approval",
+                        "node_id": approval_entry["node_id"],
+                        "tool_call_id": approval_entry["tool_call_id"],
+                        "resume_metadata": {
+                            "original_call": (
+                                approval_entry["resume_metadata"]["original_call"]
+                            ),
+                        },
+                    },
+                ],
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_pending_yields_lists_mixed_approval_and_ask_user_gates(
+    app, client,
+):
+    """The lister (workspaces.py) must return BOTH gate kinds from the
+    SAME mixed checkpoint, proving enumerate_pending_gates's two arms
+    (pending_toolcalls + pending_agent_yields) combine correctly."""
+    sess = _mixed_checkpoint_session(session_id="g-mixed1", workspace_id="ws-g")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.get("/v1/workspaces/ws-g/sessions/g-mixed1/yields/pending")
+    assert resp.status_code == 200, resp.text
+    items = {i["tool_call_id"]: i for i in resp.json()["items"]}
+    assert set(items) == {"call-approve", "call-ask"}
+    assert items["call-approve"]["kind"] == "approval"
+    assert items["call-ask"]["kind"] == "ask_user"
+    assert items["call-ask"]["prompt"] == "Which currency?"
+
+
+@pytest.mark.asyncio
+async def test_tool_approval_pending_finds_the_gate_in_a_mixed_checkpoint(
+    app, client,
+):
+    """tool_approval.py's OWN GET /pending must find the _approval-kind
+    entry regardless of a coexisting ask_user yield in the SAME
+    checkpoint, and never surface the ask_user entry (this endpoint is
+    approval-only)."""
+    sess = _mixed_checkpoint_session(session_id="g-mixed2", workspace_id="ws-g")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.get("/v1/sessions/g-mixed2/tool_approval/pending")
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert body["tool_call_id"] == "call-approve"
+    assert body["tool_name"] == "delete_workspace"
+
+
 @pytest.mark.asyncio
 async def test_session_pending_yields_lists_every_concurrent_approval_gate(
     app, client,

--- a/tests/api/test_tool_approval_graph_routing.py
+++ b/tests/api/test_tool_approval_graph_routing.py
@@ -1,0 +1,184 @@
+"""REST routing for concurrent graph approval gates (01a06b82 / 01a06c94).
+
+A graph superstep can suspend on SEVERAL approval gates in the same park
+(e.g. two fan-out siblings, each awaiting its own decision). Before the
+shared enumerate/resolve helpers in :mod:`primer.session.pending_gates`,
+only the FIRST pending entry was ever visible over REST:
+``GET .../yields/pending`` returned at most one item (the top-level
+``parked_state.yielded`` projection) and ``POST .../tool_approval/respond``
+404'd for every ``tool_call_id`` but the primary's -- non-primary gates
+were stranded, answerable only through the channel/inbox surface (which
+already searched the full checkpoint). These tests drive a hand-built
+two-gate graph checkpoint through both REST surfaces and assert the
+second (non-primary) gate is now visible and answerable.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from primer.model.storage import OffsetPage
+from primer.model.tool_approval import ToolApprovalRecord
+from primer.model.workspace_session import (
+    AgentSessionBinding,
+    SessionStatus,
+    WorkspaceSession,
+)
+
+
+def _two_gate_graph_parked_session(
+    *, session_id: str, workspace_id: str,
+) -> WorkspaceSession:
+    """A session parked on a graph superstep with TWO pending approval
+    gates (two fan-out siblings), mirroring
+    ``_CheckpointMixin._build_pending_park_yield`` + ``snapshot_state``'s
+    real shape: the top-level ``yielded`` projects only the FIRST
+    (``worker[0]``) entry; ``worker[1]``'s gate lives only in the
+    checkpoint's ``pending_toolcalls``.
+    """
+    now = datetime.now(UTC)
+
+    def _entry(node_id: str, tool_call_id: str) -> dict:
+        return {
+            "node_id": node_id,
+            "tool_call_id": tool_call_id,
+            "parked_event_key": (
+                f"tool_approval:{session_id}:{node_id}:{tool_call_id}"
+            ),
+            "arguments": {"id": f"ws-{node_id}"},
+            "tool_name": "_approval",
+            "resume_metadata": {
+                "policy_id": "pol-fanout",
+                "approval_type": "required",
+                "gate_reason": "matched policy",
+                "approvers": None,
+                "original_call": {
+                    "id": tool_call_id, "name": "delete_workspace",
+                    "arguments": {"id": f"ws-{node_id}"},
+                },
+            },
+            "scoped_tool_call_id": None,
+        }
+
+    entries = [_entry("worker[0]", "call-0"), _entry("worker[1]", "call-1")]
+    all_keys = [e["parked_event_key"] for e in entries]
+    primary = entries[0]
+
+    return WorkspaceSession(
+        id=session_id,
+        workspace_id=workspace_id,
+        binding=AgentSessionBinding(kind="agent", agent_id="agt"),
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        parked_status="parked",
+        parked_at=now,
+        parked_event_key=primary["parked_event_key"],
+        # A real multi-gate park stamps the full key set here (dispatch.py
+        # ``parked_event_keys=getattr(yielded, "event_keys", None)``) --
+        # this is what routes durably_mark_session_resumable into its
+        # accumulating (not clobbering) branch.
+        parked_event_keys=all_keys,
+        parked_state={
+            "tool_call_id": primary["tool_call_id"],
+            "yielded": {
+                "tool_name": "_approval",
+                "event_key": primary["parked_event_key"],
+                "resume_metadata": primary["resume_metadata"],
+                "event_keys": all_keys,
+            },
+            "graph_checkpoint": {
+                "pending_toolcalls": entries,
+                "pending_agent_yields": [],
+                "pending_dispatch": [
+                    {
+                        "kind": "_approval",
+                        "node_id": e["node_id"],
+                        "tool_call_id": e["tool_call_id"],
+                        "resume_metadata": {
+                            "original_call": e["resume_metadata"]["original_call"],
+                        },
+                    }
+                    for e in entries
+                ],
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_session_pending_yields_lists_every_concurrent_approval_gate(
+    app, client,
+):
+    sess = _two_gate_graph_parked_session(session_id="g-multi1", workspace_id="ws-g")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.get("/v1/workspaces/ws-g/sessions/g-multi1/yields/pending")
+    assert resp.status_code == 200, resp.text
+    items = resp.json()["items"]
+    assert {i["tool_call_id"] for i in items} == {"call-0", "call-1"}
+    assert all(i["kind"] == "approval" for i in items)
+
+
+@pytest.mark.asyncio
+async def test_respond_to_second_of_two_concurrent_graph_approvals(app, client):
+    """The primary gate (call-0) is never touched here -- responding to
+    the SECOND (call-1) used to 404 because ``_publish_decision`` only
+    ever matched the top-level ``yielded`` blob's tool_call_id (call-0).
+    It must now resolve + wake call-1's own event_key and write a record
+    scoped to call-1, not call-0."""
+    sess = _two_gate_graph_parked_session(session_id="g-multi2", workspace_id="ws-g")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.post(
+        "/v1/sessions/g-multi2/tool_approval/respond",
+        json={
+            "tool_call_id": "call-1", "decision": "approved",
+            "reason": "sibling ok",
+        },
+    )
+    assert resp.status_code == 202, resp.text
+
+    row = await storage.get("g-multi2")
+    assert row is not None
+    assert row.parked_status == "resumable"
+    # The multi-event accumulation path (parked_event_keys was set on the
+    # row), not the singular resume_event_payload a single-gate park uses.
+    payloads = row.parked_state.get("resume_event_payloads") or {}
+    assert len(payloads) == 1
+    entry = next(iter(payloads.values()))
+    assert entry["payload"] == {
+        "decision": "approved", "reason": "sibling ok", "decided_by": "testuser",
+    }
+    assert entry["event_key"] == "tool_approval:g-multi2:worker[1]:call-1"
+    # The singular "last fired" hint still gets stamped too, per
+    # durably_mark_session_resumable's contract.
+    assert (
+        row.parked_state["resume_event_key"]
+        == "tool_approval:g-multi2:worker[1]:call-1"
+    )
+
+    records = app.state.storage_provider.get_storage(ToolApprovalRecord)
+    page = await records.list(OffsetPage(offset=0, length=50))
+    matches = [r for r in page.items if r.session_id == "g-multi2"]
+    assert len(matches) == 1
+    rec = matches[0]
+    assert rec.tool_call_id == "call-1"
+    assert rec.decision == "approved"
+    assert rec.gate_event_key == "tool_approval:g-multi2:worker[1]:call-1"
+
+
+@pytest.mark.asyncio
+async def test_respond_to_unknown_tool_call_id_still_404s(app, client):
+    sess = _two_gate_graph_parked_session(session_id="g-multi3", workspace_id="ws-g")
+    storage = app.state.storage_provider.get_storage(WorkspaceSession)
+    await storage.create(sess)
+
+    resp = await client.post(
+        "/v1/sessions/g-multi3/tool_approval/respond",
+        json={"tool_call_id": "call-does-not-exist", "decision": "approved"},
+    )
+    assert resp.status_code == 404, resp.text

--- a/tests/api/test_tool_approval_graph_routing.py
+++ b/tests/api/test_tool_approval_graph_routing.py
@@ -44,9 +44,15 @@ def _two_gate_graph_parked_session(
         return {
             "node_id": node_id,
             "tool_call_id": tool_call_id,
-            "parked_event_key": (
-                f"tool_approval:{session_id}:{node_id}:{tool_call_id}"
-            ),
+            # UNSCOPED: node-scoping (current_graph_node_id) only wraps
+            # agent/subgraph node dispatch (_node_dispatch.py), never a
+            # ToolCall node's own dispatch, so a ToolCall-node approval
+            # gate's key never folds in node_id - its tool_call_id is
+            # always a fresh uuid4 the graph engine mints itself, never
+            # provider-raw/collision-prone, so scoping was never needed
+            # for this gate type (see primer.channel.inbox._matching_
+            # event_keys's own comment on this exact invariant).
+            "parked_event_key": f"tool_approval:{session_id}:{tool_call_id}",
             "arguments": {"id": f"ws-{node_id}"},
             "tool_name": "_approval",
             "resume_metadata": {
@@ -153,12 +159,12 @@ async def test_respond_to_second_of_two_concurrent_graph_approvals(app, client):
     assert entry["payload"] == {
         "decision": "approved", "reason": "sibling ok", "decided_by": "testuser",
     }
-    assert entry["event_key"] == "tool_approval:g-multi2:worker[1]:call-1"
+    assert entry["event_key"] == "tool_approval:g-multi2:call-1"
     # The singular "last fired" hint still gets stamped too, per
     # durably_mark_session_resumable's contract.
     assert (
         row.parked_state["resume_event_key"]
-        == "tool_approval:g-multi2:worker[1]:call-1"
+        == "tool_approval:g-multi2:call-1"
     )
 
     records = app.state.storage_provider.get_storage(ToolApprovalRecord)
@@ -168,7 +174,7 @@ async def test_respond_to_second_of_two_concurrent_graph_approvals(app, client):
     rec = matches[0]
     assert rec.tool_call_id == "call-1"
     assert rec.decision == "approved"
-    assert rec.gate_event_key == "tool_approval:g-multi2:worker[1]:call-1"
+    assert rec.gate_event_key == "tool_approval:g-multi2:call-1"
 
 
 @pytest.mark.asyncio

--- a/tests/api/test_yields.py
+++ b/tests/api/test_yields.py
@@ -374,6 +374,80 @@ class TestAskUserRespond:
         # multi-event accumulation map carries the reply
         assert row.parked_state["resume_event_payloads"]["tc-g"]["payload"] == {"response": "blue"}
 
+    async def test_respond_to_ask_user_entry_in_a_mixed_checkpoint(
+        self, app, client,
+    ):
+        """01a06b82 gate-review R2: a checkpoint with an agent-node
+        ask_user yield (pending_agent_yields) AND a ToolCall-node
+        approval gate (pending_toolcalls) pending at the SAME time --
+        the mixed case commit 1 headline-claims (enumerate_pending_gates
+        combines both arms) but that had zero coverage. Answering the
+        ask_user entry must still work exactly as
+        test_respond_accepts_graph_park_via_checkpoint proves alone, with
+        the coexisting approval gate present and untouched.
+        """
+        now = datetime.now(timezone.utc)
+        ask_key = "ask_user:sess-mixed:tc-ask"
+        approval_key = "tool_approval:sess-mixed:call-approve"
+        sess = WorkspaceSession(
+            id="sess-mixed", workspace_id="ws-x",
+            binding=GraphSessionBinding(graph_id="g-x"),
+            status=SessionStatus.RUNNING, created_at=now,
+        )
+        sess.parked_status = "parked"
+        sess.parked_event_key = approval_key
+        sess.parked_event_keys = [approval_key, ask_key]
+        sess.parked_at = now
+        sess.parked_until = now + timedelta(seconds=600)
+        sess.parked_state = {
+            "schema_version": 1,
+            "tool_call_id": "call-approve",
+            "yielded": {
+                "tool_name": "_approval", "event_key": approval_key,
+                "timeout": 600.0, "resume_metadata": {},
+                "event_keys": [approval_key, ask_key],
+            },
+            "llm_messages": [], "turn_no": 1, "started_at": now.isoformat(),
+            "resume_event_payload": None,
+            "graph_checkpoint": {
+                "pending_toolcalls": [{
+                    "node_id": "worker[0]", "tool_call_id": "call-approve",
+                    "parked_event_key": approval_key,
+                    "arguments": {"id": "ws-x"}, "tool_name": "_approval",
+                    "resume_metadata": {
+                        "original_call": {
+                            "id": "call-approve", "name": "delete_workspace",
+                            "arguments": {"id": "ws-x"},
+                        },
+                    },
+                }],
+                "pending_agent_yields": [{
+                    "node_id": "worker[1]", "tool_call_id": "tc-ask",
+                    "event_key": ask_key, "tool_name": "ask_user",
+                    "resume_metadata": {"prompt": "color?"},
+                    "llm_messages": [], "iteration": 1,
+                }],
+            },
+        }
+        await _seed_session(app, sess)
+        resp = await client.post(
+            "/v1/sessions/sess-mixed/ask_user/respond",
+            json={"tool_call_id": "tc-ask", "response": "blue"},
+        )
+        assert resp.status_code == 202
+        storage = app.state.storage_provider.get_storage(WorkspaceSession)
+        row = None
+        for _ in range(50):
+            await asyncio.sleep(0.02)
+            row = await storage.get("sess-mixed")
+            if row is not None and row.parked_status == "resumable":
+                break
+        assert row is not None and row.parked_status == "resumable"
+        assert (
+            row.parked_state["resume_event_payloads"]["tc-ask"]["payload"]
+            == {"response": "blue"}
+        )
+
     async def test_respond_accepts_graph_toolcall_ask_user_park(
         self, app, client,
     ):

--- a/tests/channel/test_inbox.py
+++ b/tests/channel/test_inbox.py
@@ -324,3 +324,243 @@ async def test_lookup_warns_and_resolves_the_first_on_a_genuine_collision(
         )
     finally:
         await bus.aclose()
+
+
+# ===========================================================================
+# 01a06b82: best-effort ToolApprovalRecord write on the channel path
+# ===========================================================================
+
+
+def _graph_two_gate_session(sid: str) -> WorkspaceSession:
+    """Two concurrent fan-out ToolCall-node approval gates (worker[0]/
+    call-0 the checkpoint's primary, worker[1]/call-1 reachable only
+    through pending_toolcalls) - mirrors
+    tests/api/test_tool_approval_graph_routing.py's REST-layer fixture,
+    same scenario at the channel layer.
+    """
+    now = datetime.now(timezone.utc)
+
+    def _entry(node_id: str, tool_call_id: str) -> dict:
+        return {
+            "node_id": node_id,
+            "tool_call_id": tool_call_id,
+            # UNSCOPED: see tests/api/test_tool_approval_graph_routing.py's
+            # _two_gate_graph_parked_session._entry for why a ToolCall-node
+            # gate's key never folds in node_id (this file's own
+            # _matching_event_keys relies on the same invariant for its
+            # pending_dispatch branch above).
+            "parked_event_key": f"tool_approval:{sid}:{tool_call_id}",
+            "arguments": {"id": f"ws-{node_id}"},
+            "tool_name": "_approval",
+            "resume_metadata": {
+                "policy_id": "pol-fanout",
+                "approval_type": "required",
+                "gate_reason": "matched policy",
+                "approvers": None,
+                "original_call": {
+                    "id": tool_call_id, "name": "delete_workspace",
+                    "arguments": {"id": f"ws-{node_id}"},
+                },
+            },
+            "scoped_tool_call_id": None,
+        }
+
+    entries = [_entry("worker[0]", "call-0"), _entry("worker[1]", "call-1")]
+    all_keys = [e["parked_event_key"] for e in entries]
+    return WorkspaceSession(
+        id=sid,
+        workspace_id="ws-1",
+        binding=AgentSessionBinding(kind="agent", agent_id="agt"),
+        status=SessionStatus.RUNNING,
+        created_at=now,
+        parked_status="parked",
+        parked_at=now,
+        parked_event_key=entries[0]["parked_event_key"],
+        parked_event_keys=all_keys,
+        parked_state={
+            "tool_call_id": entries[0]["tool_call_id"],
+            "yielded": {
+                "tool_name": "_approval",
+                "event_key": entries[0]["parked_event_key"],
+                "resume_metadata": entries[0]["resume_metadata"],
+                "event_keys": all_keys,
+            },
+            "graph_checkpoint": {
+                "pending_toolcalls": entries,
+                "pending_agent_yields": [],
+                "pending_dispatch": [
+                    {
+                        "kind": "_approval",
+                        "node_id": e["node_id"],
+                        "tool_call_id": e["tool_call_id"],
+                        "resume_metadata": {
+                            "original_call": e["resume_metadata"]["original_call"],
+                        },
+                    }
+                    for e in entries
+                ],
+            },
+        },
+    )
+
+
+@pytest.mark.asyncio
+async def test_tool_approval_response_writes_a_durable_record():
+    """01a06b82: the channel surface never wrote a durable record before -
+    a decision answered via Slack/Discord/etc. had none unless the
+    session later happened to resume (the resume-time fallback)."""
+    from primer.model.storage import OffsetPage
+    from primer.model.tool_approval import ToolApprovalRecord
+    from tests.conftest import _FakeStorageProvider
+
+    sp = _FakeStorageProvider()
+    await sp.get_storage(WorkspaceSession).create(_session(
+        "s-rec-1",
+        parked_state={
+            "tool_call_id": "tc-1",
+            "yielded": {
+                "tool_name": "_approval",
+                "event_key": "tool_approval:s-rec-1:tc-1",
+                "resume_metadata": {
+                    "policy_id": "p1", "approval_type": "required",
+                    "gate_reason": "always-on", "approvers": None,
+                    "original_call": {
+                        "id": "tc-1", "name": "delete_workspace",
+                        "arguments": {"id": "ws-x"},
+                    },
+                },
+            },
+        },
+    ))
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    try:
+        inbox = ChannelInbox(event_bus=bus, storage_provider=sp)
+        await _handle_and_capture(
+            inbox,
+            ResponseEnvelope(
+                kind="tool_approval", workspace_id="ws-1", session_id="s-rec-1",
+                tool_call_id="tc-1", response=None,
+                decision="approved", reason="looks fine",
+            ),
+            bus,
+        )
+    finally:
+        await bus.aclose()
+
+    records = await sp.get_storage(ToolApprovalRecord).list(
+        OffsetPage(offset=0, length=50),
+    )
+    assert len(records.items) == 1
+    rec = records.items[0]
+    assert rec.tool_call_id == "tc-1"
+    assert rec.decision == "approved"
+    assert rec.reason == "looks fine"
+    assert rec.policy_id == "p1"
+    assert rec.gate_event_key == "tool_approval:s-rec-1:tc-1"
+
+
+@pytest.mark.asyncio
+async def test_respond_to_second_of_two_concurrent_graph_approvals_writes_the_right_record():
+    """THE second-of-N test for this layer (lead ruling: "the inbox path
+    can [test it] - test respond-to-second-of-N via handle_response +
+    assert its record lands"). The primary gate (call-0) is never touched
+    here - responding to call-1 must write a record scoped to call-1's
+    own metadata and event_key, not call-0's."""
+    from primer.model.storage import OffsetPage
+    from primer.model.tool_approval import ToolApprovalRecord
+    from tests.conftest import _FakeStorageProvider
+
+    sp = _FakeStorageProvider()
+    await sp.get_storage(WorkspaceSession).create(_graph_two_gate_session("s-rec-2"))
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    try:
+        inbox = ChannelInbox(event_bus=bus, storage_provider=sp)
+        event = await _handle_and_capture(
+            inbox,
+            ResponseEnvelope(
+                kind="tool_approval", workspace_id="ws-1", session_id="s-rec-2",
+                tool_call_id="call-1", response=None,
+                decision="rejected", reason="sibling no",
+            ),
+            bus,
+        )
+        assert event.event_key == "tool_approval:s-rec-2:call-1"
+    finally:
+        await bus.aclose()
+
+    records = await sp.get_storage(ToolApprovalRecord).list(
+        OffsetPage(offset=0, length=50),
+    )
+    assert len(records.items) == 1
+    rec = records.items[0]
+    assert rec.tool_call_id == "call-1"
+    assert rec.decision == "rejected"
+    assert rec.reason == "sibling no"
+    assert rec.policy_id == "pol-fanout"
+    assert rec.gate_event_key == "tool_approval:s-rec-2:call-1"
+
+
+@pytest.mark.asyncio
+async def test_record_write_failure_does_not_block_the_publish(monkeypatch, caplog):
+    """Design requirement: a record-write failure must never block or
+    delay the wake publish. Breaks the session lookup the record write
+    depends on (storage_provider present but raising) and asserts the
+    event still publishes via _resolve_event_key's own independent
+    fallback, while this function logs and swallows its own failure."""
+    from tests.conftest import _FakeStorageProvider
+
+    sp = _FakeStorageProvider()
+    await sp.get_storage(WorkspaceSession).create(_session(
+        "s-rec-3",
+        parked_state={
+            "tool_call_id": "tc-3",
+            "yielded": {
+                "tool_name": "_approval",
+                "event_key": "tool_approval:s-rec-3:tc-3",
+                "resume_metadata": {
+                    "original_call": {
+                        "id": "tc-3", "name": "delete_workspace", "arguments": {},
+                    },
+                },
+            },
+        },
+    ))
+
+    class _BoomSessionStorage:
+        async def get(self, *_a, **_kw):
+            raise RuntimeError("storage down")
+
+    original_get_storage = sp.get_storage
+
+    def _get_storage(model_cls):
+        if model_cls is WorkspaceSession:
+            return _BoomSessionStorage()
+        return original_get_storage(model_cls)
+
+    monkeypatch.setattr(sp, "get_storage", _get_storage)
+
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    try:
+        inbox = ChannelInbox(event_bus=bus, storage_provider=sp)
+        with caplog.at_level(logging.ERROR, logger="primer.channel.inbox"):
+            event = await _handle_and_capture(
+                inbox,
+                ResponseEnvelope(
+                    kind="tool_approval", workspace_id="ws-1", session_id="s-rec-3",
+                    tool_call_id="tc-3", response=None,
+                    decision="approved", reason=None,
+                ),
+                bus,
+            )
+        # _resolve_event_key hits the same broken storage independently,
+        # already-tested fallback: reconstructs the key and still publishes.
+        assert event.event_key == "tool_approval:s-rec-3:tc-3"
+        assert any(
+            "best-effort approval record write failed" in r.message
+            for r in caplog.records
+        )
+    finally:
+        await bus.aclose()

--- a/tests/storage/test_sqlite_transaction_safety.py
+++ b/tests/storage/test_sqlite_transaction_safety.py
@@ -255,3 +255,179 @@ async def test_offset_count_and_page_are_one_snapshot(
     after = await things.list(OffsetPage(offset=0, length=100))
     assert after.total == 7
     assert after.length == 7
+
+
+# ===========================================================================
+# 01a06cb3: a failed standalone write must not leave an implicit
+# transaction open on the shared connection.
+#
+# aiosqlite's default isolation_level opens an IMPLICIT transaction on the
+# first DML statement. _write_guard's standalone branch used to yield the
+# caller straight through with no except: a write that failed before its
+# own commit() (a UNIQUE violation -> the expected ConflictError dedup
+# path, a plain bug, or a CancelledError landing between execute and
+# commit) left that implicit transaction open, untracked by _txn_task
+# (only transaction()/read_snapshot() set that). The very next
+# read_snapshot -- ANY unrelated paginated read on the shared connection,
+# not just a retry of the same write -- then failed its own BEGIN with
+# "cannot start a transaction within a transaction".
+# ===========================================================================
+
+
+async def test_duplicate_create_conflict_does_not_wedge_the_connection(
+    provider: SqliteStorageProvider,
+) -> None:
+    """A standalone create() that fails with the expected ConflictError
+    (e.g. a raced gate_event_key dedup write) must not wedge the shared
+    connection for the very next read."""
+    from primer.model.except_ import ConflictError
+
+    things = provider.get_storage(_Thing)
+    await things.create(_Thing(id="dup", value="first"))
+
+    with pytest.raises(ConflictError):
+        await things.create(_Thing(id="dup", value="second"))
+
+    # Before the fix: this read_snapshot's own BEGIN raised "cannot start
+    # a transaction within a transaction".
+    page = await things.list(OffsetPage(offset=0, length=50))
+    assert {t.id for t in page.items} == {"dup"}
+
+    # The connection is genuinely usable again, not just readable.
+    await things.create(_Thing(id="after-conflict", value="ok"))
+    assert (await things.get("after-conflict")) is not None
+
+
+async def test_failing_update_does_not_wedge_the_connection(
+    provider: SqliteStorageProvider,
+) -> None:
+    """Same shape as the create() case, for update() -- proves the fix
+    lives at the _write_guard level (every standalone write method), not
+    a create()-specific patch. Simulates a generic failure (update()'s
+    own SQL has no natural UNIQUE trigger to reach for), matching the
+    fix's BaseException scope: ANY failure, not just IntegrityError.
+
+    The wrapper calls through to the REAL execute() first, so the
+    UPDATE's implicit transaction genuinely opens on the real
+    connection, and only THEN raises -- a wrapper that raises without
+    ever reaching the real driver never opens a transaction in the first
+    place, so it would prove nothing (the failure has to land AFTER real
+    DML, same as a driver error between execute and commit would).
+    """
+    import sqlite3
+
+    things = provider.get_storage(_Thing)
+    await things.create(_Thing(id="upd", value="before"))
+
+    real_conn = provider._conn  # noqa: SLF001
+
+    class _FailAfterRealUpdate:
+        def __init__(self, real: Any) -> None:
+            self._real = real
+
+        async def execute(self, sql: str, *args: Any, **kwargs: Any):  # noqa: ANN201
+            cur = await self._real.execute(sql, *args, **kwargs)
+            if sql.strip().upper().startswith("UPDATE"):
+                raise sqlite3.OperationalError(
+                    "simulated failure after the real write landed"
+                )
+            return cur
+
+        def __getattr__(self, name: str) -> Any:
+            return getattr(self._real, name)
+
+    provider._conn = _FailAfterRealUpdate(real_conn)  # noqa: SLF001
+    try:
+        with pytest.raises(Exception):
+            await things.update(_Thing(id="upd", value="after"))
+    finally:
+        provider._conn = real_conn  # noqa: SLF001
+
+    # Before the fix: this read_snapshot's own BEGIN raised "cannot start
+    # a transaction within a transaction".
+    page = await things.list(OffsetPage(offset=0, length=50))
+    assert page.items[0].value == "before"  # the update never committed
+
+
+async def test_failing_create_inside_transaction_rolls_back_cleanly(
+    provider: SqliteStorageProvider,
+) -> None:
+    """A create() that fails INSIDE an explicit transaction() block, when
+    the failure PROPAGATES out of the block, still rolls back the whole
+    unit and leaves the connection usable afterward.
+
+    This does NOT by itself prove the reentrant branch stayed untouched:
+    once the exception escapes transaction()'s own body, transaction()'s
+    existing rollback fires regardless of whether _write_guard's
+    reentrant branch wrongly rolled back too -- the observable end state
+    here is identical either way. See
+    test_txn_catch_and_continue_keeps_the_prior_write_in_the_same_unit
+    below for the case that actually discriminates the two (the failure
+    caught and handled INSIDE the transaction, which only a wrongly-
+    reentrant guard rollback can corrupt).
+    """
+    from primer.model.except_ import ConflictError
+
+    things = provider.get_storage(_Thing)
+    # A write from BEFORE the doomed transaction: proves only the
+    # transaction's own writes are lost, unrelated prior data is not.
+    await things.create(_Thing(id="before-txn", value="prior"))
+
+    with pytest.raises(ConflictError):
+        async with provider.transaction() as conn:
+            await things.create(_Thing(id="txn-ok", value="a"), conn=conn)
+            # Fails at the SQL level (duplicate id) INSIDE the transaction.
+            await things.create(_Thing(id="txn-ok", value="b"), conn=conn)
+
+    # The whole transaction rolled back -- including the FIRST write, even
+    # though it succeeded on its own, since it's part of the same atomic
+    # unit as the one that failed.
+    assert (await things.get("txn-ok")) is None
+    # The prior, unrelated write is untouched -- it committed BEFORE this
+    # transaction ever opened, not because anything here was caught.
+    assert (await things.get("before-txn")) is not None
+
+    # The connection is not wedged: both a read and a fresh write work.
+    page = await things.list(OffsetPage(offset=0, length=50))
+    assert {t.id for t in page.items} == {"before-txn"}
+    await things.create(_Thing(id="after-txn-fail", value="ok"))
+    assert (await things.get("after-txn-fail")) is not None
+
+
+async def test_txn_catch_and_continue_keeps_the_prior_write_in_the_same_unit(
+    provider: SqliteStorageProvider,
+) -> None:
+    """Discriminates a CORRECT guard-level fix from a WRONG one that also
+    rolls back in the reentrant branch.
+
+    The previous test (exception propagates out of the whole
+    transaction() block) can't tell the two apart: either way the
+    transaction rolls back once the exception escapes it, so both an
+    unscoped fix and a wrongly-reentrant one produce the same observable
+    result there. This test instead CATCHES the failing create()'s
+    ConflictError INSIDE the transaction body and continues -- exactly
+    the shape a caller doing conditional/idempotent writes inside one
+    atomic unit would use. If _write_guard's reentrant (yield False)
+    branch wrongly rolled back on its own, write A would be silently
+    destroyed the instant create() B fails, before the caller's except
+    even runs -- and the subsequent commit() would only ever have B to
+    commit. The correct fix leaves the reentrant branch untouched: the
+    failed statement's error surfaces to the caller, who decides what to
+    do with it, and the transaction commits whatever is left in it.
+    """
+    from primer.model.except_ import ConflictError
+
+    things = provider.get_storage(_Thing)
+
+    async with provider.transaction() as conn:
+        await things.create(_Thing(id="txn-a", value="a"), conn=conn)
+        try:
+            await things.create(_Thing(id="txn-a", value="dup"), conn=conn)
+        except ConflictError:
+            pass
+        await things.create(_Thing(id="txn-b", value="b"), conn=conn)
+
+    a = await things.get("txn-a")
+    b = await things.get("txn-b")
+    assert a is not None and a.value == "a"
+    assert b is not None and b.value == "b"

--- a/tests/ui/test_shell_attention_model.py
+++ b/tests/ui/test_shell_attention_model.py
@@ -373,3 +373,46 @@ def test_routing_line_names_the_spec_and_qualification() -> None:
         'SH_routingLine({approvers: {kind: "roles", roles: ["ops"]}}, '
         '{username: "usman", role: "engineer"})'
     ) == "who may decide: ops"
+
+
+def test_two_concurrent_gates_on_the_same_session_both_surface() -> None:
+    """01a06c94: a graph fan-out can park TWO approval gates on the SAME
+    session at once - list_session_pending_yields now returns one item
+    per gate instead of just the primary. SH_toAttentionItems must keep
+    both, each with a distinct id keyed on tool_call_id: that id is the
+    React key nv-session-doc.jsx's gateItems.map uses, so an id collision
+    here would silently drop one DecisionCard even though the backend
+    sent both.
+    """
+    ctx = _ctx()
+    out = json.loads(ctx.eval(
+        """
+        JSON.stringify(SH_toAttentionItems({
+          pending: [
+            {
+              session_id: "sess-fanout", tool_call_id: "call-0",
+              kind: "approval", prompt: "delete_workspace",
+              parked_at: "2026-09-04T00:00:00+00:00", approvers: null,
+              resume_metadata: {
+                original_call: {id: "call-0", name: "delete_workspace", arguments: {}},
+                response_schema: null
+              }
+            },
+            {
+              session_id: "sess-fanout", tool_call_id: "call-1",
+              kind: "approval", prompt: "delete_workspace",
+              parked_at: "2026-09-04T00:00:01+00:00", approvers: null,
+              resume_metadata: {
+                original_call: {id: "call-1", name: "delete_workspace", arguments: {}},
+                response_schema: null
+              }
+            }
+          ],
+          records: []
+        }).map(function (i) { return [i.id, i.toolCallId, i.sessionId]; }))
+        """
+    ))
+    assert len(out) == 2, out
+    assert {row[0] for row in out} == {"pending:call-0", "pending:call-1"}
+    assert {row[1] for row in out} == {"call-0", "call-1"}
+    assert all(row[2] == "sess-fanout" for row in out)

--- a/tests/worker/test_approval_record_resume_graph.py
+++ b/tests/worker/test_approval_record_resume_graph.py
@@ -77,6 +77,54 @@ def _two_gate_checkpoint(session_id: str) -> dict:
     }
 
 
+def _mixed_agent_yields_checkpoint(session_id: str) -> dict:
+    """An AGENT node's own approval gate (``tool_name="_approval"``) and
+    an AGENT node's ask_user yield, BOTH in ``pending_agent_yields``,
+    nothing in ``pending_toolcalls``.
+
+    01a06b82 gate-review R2: the ``pending_agent_yields`` arm of
+    ``enumerate_pending_gates`` (which maps its own ``event_key`` field)
+    had zero test coverage -- every fixture elsewhere in this branch put
+    its approval gate in ``pending_toolcalls`` instead. An agent node's
+    OWN gated tool call lands here (tool_manager.py fires the identical
+    approval yield whether the caller is a graph ToolCall node or an
+    agent node's own LLM-driven tool call), and this gate type DOES get
+    a node-scoped key (agent-node dispatch is wrapped in
+    ``set_current_graph_node_id``, unlike a ToolCall node's).
+    """
+    approval_key = f"tool_approval:{session_id}:worker[0]:call-approve"
+    ask_key = f"ask_user:{session_id}:worker[1]:call-ask"
+    return {
+        "pending_toolcalls": [],
+        "pending_agent_yields": [
+            {
+                "node_id": "worker[0]",
+                "tool_call_id": "call-approve",
+                "event_key": approval_key,
+                "tool_name": "_approval",
+                "resume_metadata": {
+                    "policy_id": "pol-agent",
+                    "approval_type": "required",
+                    "gate_reason": "matched policy",
+                    "approvers": None,
+                    "original_call": {
+                        "id": "call-approve", "name": "delete_workspace",
+                        "arguments": {"id": "ws-x"},
+                    },
+                },
+            },
+            {
+                "node_id": "worker[1]",
+                "tool_call_id": "call-ask",
+                "event_key": ask_key,
+                "tool_name": "ask_user",
+                "resume_metadata": {"prompt": "color?"},
+            },
+        ],
+        "pending_dispatch": [],
+    }
+
+
 def _session(session_id: str) -> SimpleNamespace:
     return SimpleNamespace(
         id=session_id,
@@ -90,6 +138,49 @@ async def _records_for(storage_provider) -> list:
         OffsetPage(offset=0, length=50),
     )
     return page.items
+
+
+@pytest.mark.asyncio
+async def test_resume_record_resolves_an_approval_gate_from_pending_agent_yields():
+    """01a06b82 gate-review R2: an approval gate living in
+    pending_agent_yields (not pending_toolcalls) must resolve correctly,
+    with its own event_key and full policy metadata."""
+    storage_provider = _FakeStorageProvider()
+    pool = SimpleNamespace(_storage=storage_provider)
+    session_id = "graph-rec-mixed"
+    checkpoint = _mixed_agent_yields_checkpoint(session_id)
+
+    await write_approval_record_for_graph(
+        pool, session=_session(session_id), checkpoint=checkpoint,
+        tcid="call-approve", payload={"decision": "approved"},
+    )
+
+    items = await _records_for(storage_provider)
+    assert len(items) == 1
+    rec = items[0]
+    assert rec.tool_call_id == "call-approve"
+    assert rec.decision == "approved"
+    assert rec.policy_id == "pol-agent"
+    assert rec.gate_event_key == f"tool_approval:{session_id}:worker[0]:call-approve"
+
+
+@pytest.mark.asyncio
+async def test_resume_record_skipped_for_the_ask_user_tcid_in_a_mixed_checkpoint():
+    """write_approval_record_for_graph must never write an approval
+    record for an ask_user-kind entry, even when its tcid resolves to
+    something in the checkpoint (the coexisting pending_agent_yields
+    entry) -- the kind="_approval" filter must hold across both arms."""
+    storage_provider = _FakeStorageProvider()
+    pool = SimpleNamespace(_storage=storage_provider)
+    session_id = "graph-rec-mixed2"
+    checkpoint = _mixed_agent_yields_checkpoint(session_id)
+
+    await write_approval_record_for_graph(
+        pool, session=_session(session_id), checkpoint=checkpoint,
+        tcid="call-ask", payload={"decision": "approved"},
+    )
+
+    assert await _records_for(storage_provider) == []
 
 
 @pytest.mark.asyncio

--- a/tests/worker/test_approval_record_resume_graph.py
+++ b/tests/worker/test_approval_record_resume_graph.py
@@ -1,0 +1,234 @@
+"""Graph-path analogue of test_approval_record_resume.py.
+
+A graph resume's per-gate approval decision must write a durable
+ToolApprovalRecord scoped to the SPECIFIC entry actually decided, not
+just the checkpoint's primary/first pending gate (01a06b82) -- the
+resume-time counterpart of the REST second-of-N routing fix
+(test_tool_approval_graph_routing.py). Calls
+write_approval_record_for_graph directly rather than driving the full
+pool resume loop: the function's own contract (resolve one entry by
+tcid, write best-effort) is what's under test here, not the surrounding
+drain machinery already covered elsewhere (test_pool_graph_resume.py).
+"""
+
+from __future__ import annotations
+
+from datetime import datetime, timedelta, timezone
+from types import SimpleNamespace
+
+import pytest
+
+from primer.model.storage import OffsetPage
+from primer.model.tool_approval import ToolApprovalRecord
+from primer.model.workspace_session import AgentSessionBinding
+from primer.worker.graph_resume_coordinator import write_approval_record_for_graph
+
+from tests.conftest import _FakeStorageProvider
+
+
+def _two_gate_checkpoint(session_id: str) -> dict:
+    """Two concurrent fan-out ToolCall-node approval gates: worker[0]
+    (call-0, the checkpoint's primary) and worker[1] (call-1, not
+    projected onto any top-level blob -- only reachable through
+    pending_toolcalls). Mirrors the graph-checkpoint shape
+    _CheckpointMixin.snapshot_state actually persists.
+    """
+    def _entry(node_id: str, tool_call_id: str) -> dict:
+        return {
+            "node_id": node_id,
+            "tool_call_id": tool_call_id,
+            "parked_event_key": (
+                f"tool_approval:{session_id}:{node_id}:{tool_call_id}"
+            ),
+            "arguments": {"id": f"ws-{node_id}"},
+            "tool_name": "_approval",
+            "resume_metadata": {
+                "policy_id": "pol-fanout",
+                "approval_type": "required",
+                "gate_reason": "matched policy",
+                "approvers": None,
+                "original_call": {
+                    "id": tool_call_id, "name": "delete_workspace",
+                    "arguments": {"id": f"ws-{node_id}"},
+                },
+            },
+            "scoped_tool_call_id": None,
+        }
+
+    entries = [_entry("worker[0]", "call-0"), _entry("worker[1]", "call-1")]
+    return {
+        "pending_toolcalls": entries,
+        "pending_agent_yields": [],
+        # The denormalised channel-prompt view: only original_call, no
+        # policy_id/approvers -- proves the record read does NOT fall
+        # back to this for its metadata.
+        "pending_dispatch": [
+            {
+                "kind": "_approval",
+                "node_id": e["node_id"],
+                "tool_call_id": e["tool_call_id"],
+                "resume_metadata": {
+                    "original_call": e["resume_metadata"]["original_call"],
+                },
+            }
+            for e in entries
+        ],
+    }
+
+
+def _session(session_id: str) -> SimpleNamespace:
+    return SimpleNamespace(
+        id=session_id,
+        binding=AgentSessionBinding(kind="agent", agent_id="agt-graph"),
+        parked_at=datetime.now(timezone.utc) - timedelta(seconds=5),
+    )
+
+
+async def _records_for(storage_provider) -> list:
+    page = await storage_provider.get_storage(ToolApprovalRecord).list(
+        OffsetPage(offset=0, length=50),
+    )
+    return page.items
+
+
+@pytest.mark.asyncio
+async def test_resume_record_for_second_of_two_concurrent_gates_is_scoped_correctly():
+    """The record for call-1 must carry call-1's own metadata + event_key,
+    not call-0's (the checkpoint's primary/first pending entry)."""
+    storage_provider = _FakeStorageProvider()
+    pool = SimpleNamespace(_storage=storage_provider)
+    session_id = "graph-rec-1"
+    checkpoint = _two_gate_checkpoint(session_id)
+
+    await write_approval_record_for_graph(
+        pool, session=_session(session_id), checkpoint=checkpoint,
+        tcid="call-1", payload={"decision": "approved", "decided_by": "alice"},
+    )
+
+    items = await _records_for(storage_provider)
+    assert len(items) == 1
+    rec = items[0]
+    assert rec.tool_call_id == "call-1"
+    assert rec.decision == "approved"
+    assert rec.decided_by == "alice"
+    assert rec.policy_id == "pol-fanout"
+    assert rec.approval_type == "required"
+    assert rec.gate_reason == "matched policy"
+    assert rec.gate_event_key == f"tool_approval:{session_id}:worker[1]:call-1"
+
+
+@pytest.mark.asyncio
+async def test_resume_record_carries_full_policy_metadata_not_just_original_call():
+    """Bugfix: resolving via pending_toolcalls (not pending_dispatch's
+    denormalised channel-prompt view) means a ToolCall-node approval's
+    resume-time record now carries policy_id/approval_type/gate_reason,
+    which pending_dispatch entries never stored at all."""
+    storage_provider = _FakeStorageProvider()
+    pool = SimpleNamespace(_storage=storage_provider)
+    session_id = "graph-rec-2"
+    checkpoint = _two_gate_checkpoint(session_id)
+
+    await write_approval_record_for_graph(
+        pool, session=_session(session_id), checkpoint=checkpoint,
+        tcid="call-0", payload={"decision": "rejected", "reason": "no"},
+    )
+
+    items = await _records_for(storage_provider)
+    assert len(items) == 1
+    assert items[0].policy_id == "pol-fanout"
+    assert items[0].approval_type == "required"
+    assert items[0].gate_reason == "matched policy"
+    assert items[0].reason == "no"
+
+
+@pytest.mark.asyncio
+async def test_resume_record_skipped_for_unknown_tcid():
+    storage_provider = _FakeStorageProvider()
+    pool = SimpleNamespace(_storage=storage_provider)
+    session_id = "graph-rec-3"
+    checkpoint = _two_gate_checkpoint(session_id)
+
+    await write_approval_record_for_graph(
+        pool, session=_session(session_id), checkpoint=checkpoint,
+        tcid="call-nonexistent", payload={"decision": "approved"},
+    )
+
+    assert await _records_for(storage_provider) == []
+
+
+@pytest.mark.asyncio
+async def test_resume_record_skipped_when_tcid_is_none():
+    """The legacy single-event drain-all path can resume with tcid=None;
+    there is no specific gate to attribute a record to, so none is
+    written (matches the pre-fix behaviour for this case)."""
+    storage_provider = _FakeStorageProvider()
+    pool = SimpleNamespace(_storage=storage_provider)
+    session_id = "graph-rec-4"
+    checkpoint = _two_gate_checkpoint(session_id)
+
+    await write_approval_record_for_graph(
+        pool, session=_session(session_id), checkpoint=checkpoint,
+        tcid=None, payload={"decision": "approved"},
+    )
+
+    assert await _records_for(storage_provider) == []
+
+
+@pytest.mark.asyncio
+async def test_resume_record_dedupes_against_a_respond_time_write_for_the_same_gate(
+    tmp_path,
+):
+    """01a068da's idempotency guarantee extended to the graph path: if
+    the respond route already wrote call-1's record (the normal case --
+    this resume-time write is a fallback), the resume must not add a
+    second row. Uses a REAL SqliteStorageProvider: the shared
+    _FakeStorageProvider only enforces uniqueness on the primary key, so
+    it would silently let a duplicate gate_event_key through and this
+    test would prove nothing (same gap test_approval_record_resume.py's
+    dedupe test guards against on the agent path).
+    """
+    from primer.model.provider import SqliteConfig
+    from primer.storage.sqlite import SqliteStorageProvider
+
+    session_id = "graph-rec-dedupe"
+    checkpoint = _two_gate_checkpoint(session_id)
+    gate_key = f"tool_approval:{session_id}:worker[1]:call-1"
+
+    storage_provider = SqliteStorageProvider(
+        SqliteConfig(path=str(tmp_path / "dedupe.sqlite")),
+    )
+    await storage_provider.initialize()
+    try:
+        preseeded = ToolApprovalRecord(
+            tool_name="delete_workspace",
+            arguments={"id": "ws-worker[1]"},
+            tool_call_id="call-1",
+            session_id=session_id,
+            agent_id="agt-graph",
+            decided_at=datetime.now(timezone.utc),
+            decision="approved",
+            gate_event_key=gate_key,
+        )
+        await storage_provider.get_storage(ToolApprovalRecord).create(preseeded)
+
+        pool = SimpleNamespace(_storage=storage_provider)
+        await write_approval_record_for_graph(
+            pool, session=_session(session_id), checkpoint=checkpoint,
+            tcid="call-1", payload={"decision": "approved"},
+        )
+        # Workaround for 01a06cb3 (filed, not yet fixed): the duplicate
+        # create() above hits the UNIQUE gate_event_key violation, which
+        # sqlite.py's create() catches -> ConflictError without rolling
+        # back the implicit transaction the failed INSERT opened. Nothing
+        # else touches this connection before the read below, so -- unlike
+        # the full pool-resume-loop drive in test_approval_record_resume.py,
+        # where a later unrelated write's own commit() incidentally clears
+        # it -- the dangling transaction survives to wedge the very next
+        # read_snapshot() BEGIN. Remove this rollback once 01a06cb3 lands.
+        await storage_provider.connection.rollback()
+
+        items = await _records_for(storage_provider)
+        assert len(items) == 1
+        assert items[0].id == preseeded.id
+    finally:
+        await storage_provider.aclose()

--- a/tests/worker/test_approval_record_resume_graph.py
+++ b/tests/worker/test_approval_record_resume_graph.py
@@ -37,9 +37,10 @@ def _two_gate_checkpoint(session_id: str) -> dict:
         return {
             "node_id": node_id,
             "tool_call_id": tool_call_id,
-            "parked_event_key": (
-                f"tool_approval:{session_id}:{node_id}:{tool_call_id}"
-            ),
+            # UNSCOPED: see tests/api/test_tool_approval_graph_routing.py's
+            # _two_gate_graph_parked_session._entry for why a ToolCall-node
+            # gate's key never folds in node_id.
+            "parked_event_key": f"tool_approval:{session_id}:{tool_call_id}",
             "arguments": {"id": f"ws-{node_id}"},
             "tool_name": "_approval",
             "resume_metadata": {
@@ -114,7 +115,7 @@ async def test_resume_record_for_second_of_two_concurrent_gates_is_scoped_correc
     assert rec.policy_id == "pol-fanout"
     assert rec.approval_type == "required"
     assert rec.gate_reason == "matched policy"
-    assert rec.gate_event_key == f"tool_approval:{session_id}:worker[1]:call-1"
+    assert rec.gate_event_key == f"tool_approval:{session_id}:call-1"
 
 
 @pytest.mark.asyncio
@@ -192,7 +193,7 @@ async def test_resume_record_dedupes_against_a_respond_time_write_for_the_same_g
 
     session_id = "graph-rec-dedupe"
     checkpoint = _two_gate_checkpoint(session_id)
-    gate_key = f"tool_approval:{session_id}:worker[1]:call-1"
+    gate_key = f"tool_approval:{session_id}:call-1"
 
     storage_provider = SqliteStorageProvider(
         SqliteConfig(path=str(tmp_path / "dedupe.sqlite")),
@@ -216,16 +217,6 @@ async def test_resume_record_dedupes_against_a_respond_time_write_for_the_same_g
             pool, session=_session(session_id), checkpoint=checkpoint,
             tcid="call-1", payload={"decision": "approved"},
         )
-        # Workaround for 01a06cb3 (filed, not yet fixed): the duplicate
-        # create() above hits the UNIQUE gate_event_key violation, which
-        # sqlite.py's create() catches -> ConflictError without rolling
-        # back the implicit transaction the failed INSERT opened. Nothing
-        # else touches this connection before the read below, so -- unlike
-        # the full pool-resume-loop drive in test_approval_record_resume.py,
-        # where a later unrelated write's own commit() incidentally clears
-        # it -- the dangling transaction survives to wedge the very next
-        # read_snapshot() BEGIN. Remove this rollback once 01a06cb3 lands.
-        await storage_provider.connection.rollback()
 
         items = await _records_for(storage_provider)
         assert len(items) == 1


### PR DESCRIPTION
## Summary

**Storage fix first, because the rest of this PR depends on it.** `SqliteStorage`'s `_write_guard` never rolled back on a failed *standalone* write. aiosqlite's default isolation_level opens an implicit transaction on the first DML statement, so a write that raised before its own `commit()` — including the *normal*, expected `ConflictError` a `gate_event_key` unique-index dedup race produces — left that transaction open on the shared connection, untracked, wedging the very next unrelated read with "cannot start a transaction within a transaction". Fixed at the guard level (`except BaseException: rollback(); raise`), not per-method, so it covers `create`/`update`/`update_unless`/`delete` and every future write method, not just the one that surfaced it. `postgres.py` audited and confirmed not exposed (per-call pooled connections + asyncpg's own `conn.transaction()`, evidence in the commit).

**Why that mattered here:** the actual defect is that non-primary graph approval gates were unanswerable. A graph superstep can park on several approval gates at once (concurrent fan-out siblings), but only the first pending entry was ever projected onto `parked_state.yielded`. The console's DecisionCards showed just the primary gate, and responding to any other one 404'd over REST — stranded, even though the channel/inbox surface already resolved any entry correctly. That's the user-visible headline; the audit-record threading below is the rider, and it's what made the storage bug reachable: making the record write idempotent per-gate is exactly what put the *normal* dedup race — and therefore the wedge — on a path this PR exercises for the first time.

**Idempotency invariant (what a reviewer should check):** a single approval gate can now be recorded by up to three independent writers — the REST respond route (`tool_approval.py`'s `_publish_decision`), the channel/inbox respond path (`ChannelInbox.handle_response`), and the resume-time synthesis fallback (`write_approval_record_for_graph` / the agent-path equivalent). All three race safely because every write is keyed on the SAME `gate_event_key` (resolved via the one shared `primer.session.pending_gates` helper) and `ToolApprovalRecord.gate_event_key` carries a NULL-tolerant UNIQUE index (01a068da) — the loser of any race gets `ConflictError`, which `write_approval_record` swallows as an expected no-op. That race is now safe end-to-end only because of the storage fix above.

## What changed

- **`fix(storage): failed standalone SQLite write no longer wedges the connection`** — see above.
- **`fix(approval): non-primary graph approval gates are answerable over REST`** — new `primer/session/pending_gates.py` (`enumerate_pending_gates` + `resolve_pending_gate`), the one shared implementation reading the checkpoint's raw `pending_toolcalls`/`pending_agent_yields` (not the denormalized `pending_dispatch` channel-prompt view, which drops `policy_id`/`approvers`/the real `parked_event_key`). Wired into `workspaces.py`'s `list_session_pending_yields` (the console's real data source) and `tool_approval.py`'s GET/POST routes, mirroring `yields.py`'s `_graph_ask_user_dispatch` pattern. Includes the second-of-N REST test and a UI verification (no UI code changes needed — `SH_toAttentionItems` was already correct, just starved of more than one item).
- **`fix(approval): resume-time graph record write threads gate_event_key`** — `write_approval_record_for_graph` now resolves via the same shared helper, so `gate_event_key` threads through for idempotent dedup, and a `ToolCall`-node approval's resume-time record no longer silently drops `policy_id`/`approval_type`/`gate_reason`/`approvers` (the `pending_dispatch` denormalization trap, third occurrence of this pattern in this codebase).
- **`fix(approval): channel-answered gates write a durable audit record too`** — `ChannelInbox.handle_response` now writes a best-effort `ToolApprovalRecord` for `tool_approval`-kind replies (Slack/Discord/etc. previously had none unless the session later happened to resume), explicitly documented as best-effort since there's no durable flip to hang the write off.

## Test plan

- [x] `tests/storage/test_sqlite_transaction_safety.py` — 4 new tests including the catch-and-continue discriminator that distinguishes a correct guard-level fix from a wrongly-reentrant one
- [x] `tests/api/test_tool_approval_graph_routing.py` (new) — GET lists every concurrent gate; POST resolves the second-of-N gate; unknown tool_call_id still 404s
- [x] `tests/worker/test_approval_record_resume_graph.py` (new) — resume-time record scoping, the policy-metadata bugfix, unknown/None tcid skip, real-SQLite dedupe
- [x] `tests/channel/test_inbox.py` — durable record write, second-of-N at the channel layer, record-failure-never-blocks-publish
- [x] `tests/ui/test_shell_attention_model.py` — two concurrent gates on one session both surface with distinct ids
- [x] Full-branch sweep (156 passed, 2 pre-existing skips) across every file touched or exercising touched code

🤖 Generated with [Claude Code](https://claude.com/claude-code)
