### PR TITLE
fix(session): executor-error turns mirror ENDED on-disk; t0865 stops racing itself

### DIFF
--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -786,6 +786,7 @@ async def run_one_session_turn(
                 session,
                 new_status=SessionStatus.ENDED,
                 ended_reason="failed",
+                executor=executor,
                 expected_epoch=session.binding_epoch,
             )
             await _clear_interrupt_requested(session_storage, session_id)

--- a/tests/e2e/test_multi_cycle_resume_stability_journey.py
+++ b/tests/e2e/test_multi_cycle_resume_stability_journey.py
@@ -68,6 +68,7 @@ import asyncpg
 import httpx
 import pytest
 from tests._support.model_profiles import agent_model, seed_llm_provider
+from tests._support.runs import wait_terminal
 
 
 def _pg_port() -> int:
@@ -368,9 +369,22 @@ async def test_t0865_resume_after_on_disk_ended_clears_park(
         body1 = await _wait_for_resume(client, sid)
         assert body1["parked_status"] is None, body1
         assert body1["turn_no"] > baseline, body1
-        # The post-resume LLM call fails. Wait briefly for the
-        # fatal handler to advance status. We don't strictly
-        # depend on this — the next inject resets status='running'.
+        # 01a06bc1: parked_status clears as soon as the resume
+        # machinery injects the tool result and converts the park
+        # back into a normal turn - BEFORE that turn's own LLM call
+        # (the one that hits the bogus URL) actually runs and fails.
+        # Racing straight into cycle 2's inject after only the above
+        # assertions meant the defensive branch this test exists to
+        # pin could go unexercised while the test still passed: 5/5
+        # live runs (Dev-Backend, 2026-09-04) showed cycle 2's inject
+        # winning that race every time, with the bogus-URL turn never
+        # having run yet. Block on the row actually reaching its
+        # terminal ENDED/failed state before cycle 2 touches it, so
+        # the on-disk-ENDED edge case this test is named for is
+        # guaranteed to exist by the time cycle 2 fires.
+        body1b = await wait_terminal(client, sid, timeout_s=20.0)
+        assert body1b.get("status") == "ended", body1b
+        assert body1b.get("ended_reason") == "failed", body1b
 
         # ----- Cycle 2: inject onto post-fatal row ---------------
         # The on-disk AgentSession is now ENDED (cycle 1's fatal

--- a/tests/e2e/test_multi_cycle_resume_stability_journey.py
+++ b/tests/e2e/test_multi_cycle_resume_stability_journey.py
@@ -372,19 +372,31 @@ async def test_t0865_resume_after_on_disk_ended_clears_park(
         # 01a06bc1: parked_status clears as soon as the resume
         # machinery injects the tool result and converts the park
         # back into a normal turn - BEFORE that turn's own LLM call
-        # (the one that hits the bogus URL) actually runs and fails.
+        # (the one that hits the bogus URL) actually runs and settles.
         # Racing straight into cycle 2's inject after only the above
         # assertions meant the defensive branch this test exists to
         # pin could go unexercised while the test still passed: 5/5
         # live runs (Dev-Backend, 2026-09-04) showed cycle 2's inject
         # winning that race every time, with the bogus-URL turn never
-        # having run yet. Block on the row actually reaching its
-        # terminal ENDED/failed state before cycle 2 touches it, so
-        # the on-disk-ENDED edge case this test is named for is
-        # guaranteed to exist by the time cycle 2 fires.
+        # having run yet. Block on the row actually reaching ENDED
+        # before cycle 2 touches it, so the on-disk-ENDED edge case
+        # this test is named for is guaranteed to exist by the time
+        # cycle 2 fires.
+        #
+        # Only status is asserted here, not ended_reason: a connect
+        # failure against the bogus URL surfaces as an in-band Error
+        # stream event, not a raised exception - run_agent_turn's
+        # output_to_message raises ValueError on the resulting
+        # error-only stream, which is caught and returns quietly
+        # (no assistant content to persist), so the turn settles as
+        # ended_reason="completed", not "failed" (live-traced
+        # 2026-09-04). _sync_agent_session_ended mirrors ENDED onto
+        # the on-disk AgentSession slot for EITHER ended_reason, so
+        # the edge case this test pins - DB row reset to running by
+        # cycle 2 while the on-disk slot is still ENDED - is created
+        # either way; only the terminal status matters for this gate.
         body1b = await wait_terminal(client, sid, timeout_s=20.0)
         assert body1b.get("status") == "ended", body1b
-        assert body1b.get("ended_reason") == "failed", body1b
 
         # ----- Cycle 2: inject onto post-fatal row ---------------
         # The on-disk AgentSession is now ENDED (cycle 1's fatal

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -836,6 +836,44 @@ async def test_executor_error_transitions_to_ended_failed(
 
 
 @pytest.mark.asyncio
+async def test_executor_error_mirrors_ended_onto_agent_session_slot(
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """01a06bc1: the executor-error branch's _transition_session_status
+    call omitted executor=executor, unlike the cancel and clean-completion
+    branches right below it - so the mirror onto the on-disk AgentSession
+    slot silently no-op'd for every executor-raised failure (a missing
+    set_status, not an exception, since _sync_agent_session_ended treats
+    a None executor as "nothing to mirror onto"). The scheduler row still
+    transitioned to ENDED/failed (test_executor_error_transitions_to_ended_
+    failed pins that), so this gap was invisible to every existing test -
+    none of them used an executor exposing a `.session` slot on this path.
+    Mirrors test_clean_completion_mirrors_ended_onto_agent_session_slot's
+    shape, applied to the error branch instead of the happy path.
+    """
+    session = await _seed_session(fake_storage_provider, autonomous=True)
+    slot = _RecordingSlotSession()
+    fake_executor = _ExecutorWithSession([RuntimeError("kaboom")], slot)
+
+    async def _build_executor(session: WorkspaceSession):
+        return fake_executor
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    outcome = await run_one_session_turn(_make_lease(session.id), deps)
+    assert outcome.success is False
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    assert (await storage.get(session.id)).status == SessionStatus.ENDED
+    assert slot.calls == [(SessionStatus.ENDED, "failed")]
+
+
+@pytest.mark.asyncio
 async def test_executor_error_plus_write_failure_still_ends_session(
     seeded_session: WorkspaceSession,
     fake_event_bus: InMemoryEventBus,


### PR DESCRIPTION
## Summary

**1. dispatch.py: executor-error branch now mirrors ENDED onto the on-disk AgentSession slot**

`_transition_session_status`'s executor-raised-error branch (line 784, inside the "executor raised unexpected error" catch) omitted `executor=executor`, unlike the cancel branch (878) and clean-completion branch (929) sitting right below it. `_sync_agent_session_ended` treats a `None` executor as "nothing to mirror onto", so every executor-raised failure silently skipped mirroring ENDED onto the on-disk AgentSession slot — the scheduler row still transitioned correctly, so this was invisible to every existing test.

Audited all 5 `_transition_session_status` call sites:
- line 212 (`pause_requested` branch): `new_status=PAUSED`, no executor passed — **not affected**, `_sync_agent_session_ended` only fires for `ENDED`.
- line 313 (`build_executor` itself raised): no executor object exists at all at this point — **structurally different**, not the same bug. Filed as its own design-first follow-up (01a070d6-ish family / 01a06cbc), not fixed here.
- **line 784 (executor-error branch): the gap.** executor is in scope (built successfully earlier, used throughout the preceding try body) — straightforward omission, now fixed.
- line 878 (cancel branch): passes `executor=executor` correctly.
- line 929 (clean-completion branch): passes `executor=executor` correctly.

New test `test_executor_error_mirrors_ended_onto_agent_session_slot` proved load-bearing: temporarily reverted just the added kwarg and reran — `slot.calls` read empty instead of `[(ENDED, "failed")]`, confirming the mirror really was silently no-op'ing pre-fix.

**2. t0865 e2e test: stops racing its own scenario**

`test_t0865_resume_after_on_disk_ended_clears_park` injected cycle 2's park immediately after cycle 1's `parked_status` cleared — but `parked_status` clears as soon as the resume machinery injects the tool result and converts the park back into a normal turn, *before* that turn's own LLM call (the one hitting the bogus URL) actually runs and settles. Racing straight into cycle 2's inject meant the defensive branch this test exists to pin could go unexercised while the test still passed: 5/5 live runs (Dev-Backend, 2026-09-04) showed cycle 2's inject winning that race every time, with the bogus-URL turn never having run yet.

Fix reuses the existing `tests._support.runs.wait_terminal` helper to block on the row actually reaching `status="ended"` before cycle 2 touches it.

Only `status` is asserted, not `ended_reason` — see "found along the way" below for why.

## Found along the way

- **`ended_reason` lands `"completed"`, not `"failed"`, on an LLM connect failure.** Live-traced: the bogus-URL LLM call doesn't raise a fatal exception — it surfaces as an in-band `Error` stream event. `primer/agent/loop.py`'s `run_agent_turn` captures it, yields it (so a durable ERROR record is written), then `output_to_message` raises `ValueError` on the resulting error-only stream (no assistant content) — caught, and the function returns quietly. No exception ever reaches dispatch.py's fatal branch, so the turn settles as `ended_reason="completed"`. This doesn't undermine the test's fix — `_sync_agent_session_ended` mirrors ENDED onto the on-disk slot for either `ended_reason` — but it's a "terminal signal lies" class finding (same family as the `turn_status` incident) filed as its own design-first task.
- The test's injected `inner_tool="_workspaces__exec"` isn't a registered tool name anywhere in the current codebase (0 matches). The seeded test agent also has `tools: []`, so the injected tool call was always going to hit `UnsupportedContentError` (caught and synthesized into an error tool_result by `session_resume_coordinator`, not a crash) — stale naming, not chased further here.

## Test plan

- [x] `tests/session/test_dispatch.py` + `tests/session/test_epoch_fencing.py` (32 passed, 1 xfailed)
- [x] Reverted the `executor=executor` kwarg and reran the new test — proved it fails without the fix
- [x] `ruff check` + `lint-imports` clean
- [x] Live e2e: `test_t0865_resume_after_on_disk_ended_clears_park` run 3x against a fresh stack — green all 3

🤖 Generated with [Claude Code](https://claude.com/claude-code)