### PR TITLE
chore(providers): document + pin _probe_llm_models' exhaustiveness fallback

### DIFF
--- a/tests/api/test_provider_types_routes.py
+++ b/tests/api/test_provider_types_routes.py
@@ -95,6 +95,30 @@ async def test_discoverable_flag_matches_the_probe_helper(client) -> None:
 
 
 @pytest.mark.asyncio
+async def test_probe_dispatch_falls_back_cleanly_for_an_unknown_kind(
+    monkeypatch,
+) -> None:
+    """01a06918: _probe_llm_models' final else (no probe branch matched)
+    is currently unreachable through any real caller - LLMProviderType's
+    6 members (aggregated left the enum for a ModelProfile kind instead)
+    each have an explicit if/elif branch, and _build_stub_provider's own
+    validation rejects any `provider` string outside the enum before
+    dispatch ever runs. Bypass that validation directly to prove the
+    fallback itself still behaves - it's kept as the exhaustiveness
+    net for a future LLMProviderType member added without a matching
+    probe branch, so it must still raise a clean 400 rather than
+    silently doing nothing."""
+    from primer.api.routers import providers as providers_router
+    from primer.model.except_ import BadRequestError
+
+    monkeypatch.setattr(
+        providers_router, "_build_stub_provider", lambda *a, **kw: None,
+    )
+    with pytest.raises(BadRequestError, match="not supported for provider"):
+        await providers_router._probe_llm_models("some-future-kind", {})
+
+
+@pytest.mark.asyncio
 async def test_llm_rows_declare_no_models_field(client) -> None:
     """models[] left LLMProvider when ModelProfile became the registry of
     what a provider serves (primer/model/providers/llm.py:317-322)."""


### PR DESCRIPTION
## Summary

- Verified a suspicion from the 01a067c4 batch-2 rewrite: `_probe_llm_models`' final `else` branch (raised when no provider-specific probe branch matches) is now unreachable through any real caller. `LLMProviderType` is down to 6 members since `aggregated` left the enum for a ModelProfile kind instead, each of the 6 has an explicit `if`/`elif` branch, and `_build_stub_provider`'s own enum validation (called at the top of `_probe_llm_models` itself, not just at the router layer) rejects any provider string outside the enum before dispatch ever reaches the `else`.
- Kept rather than removed: it's the exhaustiveness fallback for a future `LLMProviderType` member added without a matching probe branch — that member would pass `_build_stub_provider`'s validation (it's a real enum value) and land on the `else`, getting a clean 400 instead of an `UnboundLocalError` from `result` never being assigned. Documented the reasoning inline so it isn't re-flagged as dead code later.
- Added a test that bypasses the validation gate directly (monkeypatches `_build_stub_provider`) to prove the fallback's own message still fires correctly.

## Test plan

- [x] `tests/api/test_provider_types_routes.py` + `tests/api/test_llm_providers_router.py` (27 passed)
- [x] `ruff check` + `lint-imports` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)