### PR TITLE
fix(storage): route lock-bypassing SQLite writers through _write_guard

### DIFF
--- a/primer/channel/correlation.py
+++ b/primer/channel/correlation.py
@@ -115,6 +115,7 @@ class CorrelationStore:
             )
             async with self._sp.pool.acquire() as conn:
                 await conn.execute(sql)
+            self._unique_index_ensured = True
         elif backend == "sqlite":
             sql = (
                 f'CREATE UNIQUE INDEX IF NOT EXISTS "{_UNIQUE_INDEX}" '
@@ -122,9 +123,26 @@ class CorrelationStore:
                 "(json_extract(data, '$.channel_id'), "
                 "json_extract(data, '$.anchor'))"
             )
-            await self._sp.connection.execute(sql)
-            await self._sp.connection.commit()
-        self._unique_index_ensured = True
+            # _write_guard is taken for lock discipline AND correctness:
+            # SQLite DDL is NOT immune to an already-open enclosing
+            # transaction() - once that block's manual BEGIN is in effect,
+            # this CREATE INDEX participates in it like any other statement
+            # and rolls back with it. Mirrors _ensure_table's own pattern
+            # (primer/storage/sqlite.py).
+            async with self._sp._write_guard() as should_commit:  # noqa: SLF001
+                await self._sp.connection.execute(sql)
+                if should_commit:
+                    await self._sp.connection.commit()
+            # Only cache "ensured" when the DDL was actually COMMITTED, not
+            # merely executed. Caching True on a deferred (should_commit=
+            # False) run would skip re-creating the index the next time
+            # this store is used, if the enclosing transaction() then rolls
+            # back - the next upsert's INSERT...ON CONFLICT (unique-index
+            # expression) fails outright since the index never actually
+            # exists ("does not match any... constraint"; live-caught by
+            # test_atomic_upsert_inside_a_rolled_back_transaction_is_undone).
+            if should_commit:
+                self._unique_index_ensured = True
 
     def _to_row(self, record: ChannelCorrelation) -> tuple[str, str]:
         """Dump a record to ``(id, data_json)`` -- mirrors the storage
@@ -168,9 +186,11 @@ class CorrelationStore:
             "DO UPDATE SET data = excluded.data, updated_at = datetime('now') "
             "RETURNING id, data"
         )
-        cur = await self._sp.connection.execute(sql, (entity_id, data_json))
-        row = await cur.fetchone()
-        await self._sp.connection.commit()
+        async with self._sp._write_guard() as should_commit:  # noqa: SLF001
+            cur = await self._sp.connection.execute(sql, (entity_id, data_json))
+            row = await cur.fetchone()
+            if should_commit:
+                await self._sp.connection.commit()
         data = json.loads(row[1])
         data["id"] = row[0]
         return ChannelCorrelation.model_validate(data)

--- a/primer/storage/sqlite.py
+++ b/primer/storage/sqlite.py
@@ -472,11 +472,13 @@ class SqliteStorageProvider(StorageProvider):
 
     async def set_default_agent_id(self, agent_id: str | None) -> None:
         """Set (or clear, with None) the system default agent."""
-        await self.connection.execute(
-            "UPDATE system_state SET default_agent_id = ? WHERE id = ?",
-            (agent_id, "singleton"),
-        )
-        await self.connection.commit()
+        async with self._write_guard() as should_commit:
+            await self.connection.execute(
+                "UPDATE system_state SET default_agent_id = ? WHERE id = ?",
+                (agent_id, "singleton"),
+            )
+            if should_commit:
+                await self.connection.commit()
 
     async def set_bootstrap_completed(self, ts: datetime) -> None:
         """Stamp ``bootstrap_completed_at`` on the singleton row."""
@@ -485,8 +487,10 @@ class SqliteStorageProvider(StorageProvider):
         sql = (
             "UPDATE system_state SET bootstrap_completed_at = ? WHERE id = ?"
         )
-        await self.connection.execute(sql, (ts_str, "singleton"))
-        await self.connection.commit()
+        async with self._write_guard() as should_commit:
+            await self.connection.execute(sql, (ts_str, "singleton"))
+            if should_commit:
+                await self.connection.commit()
 
     async def set_schema_version(
         self, version: int, *, migrated_at: datetime | None = None,
@@ -497,8 +501,10 @@ class SqliteStorageProvider(StorageProvider):
             "UPDATE system_state SET schema_version = ?, last_migration_at = ? "
             "WHERE id = ?"
         )
-        await self.connection.execute(sql, (version, ts, "singleton"))
-        await self.connection.commit()
+        async with self._write_guard() as should_commit:
+            await self.connection.execute(sql, (version, ts, "singleton"))
+            if should_commit:
+                await self.connection.commit()
 
     async def set_session_secret(self, secret: str) -> None:
         """Persist the cookie-signing HMAC secret on the singleton row.
@@ -506,27 +512,33 @@ class SqliteStorageProvider(StorageProvider):
         Called by the auth layer the first time it needs a secret and
         ``PRIMER_SESSION_SECRET`` env var is not set.
         """
-        await self.connection.execute(
-            "UPDATE system_state SET session_secret = ? WHERE id = ?",
-            (secret, "singleton"),
-        )
-        await self.connection.commit()
+        async with self._write_guard() as should_commit:
+            await self.connection.execute(
+                "UPDATE system_state SET session_secret = ? WHERE id = ?",
+                (secret, "singleton"),
+            )
+            if should_commit:
+                await self.connection.commit()
 
     async def set_sso_jit_enabled(self, enabled: bool) -> None:
         """Persist whether SSO just-in-time user provisioning is enabled."""
-        await self.connection.execute(
-            "UPDATE system_state SET sso_jit_enabled = ? WHERE id = ?",
-            (enabled, "singleton"),
-        )
-        await self.connection.commit()
+        async with self._write_guard() as should_commit:
+            await self.connection.execute(
+                "UPDATE system_state SET sso_jit_enabled = ? WHERE id = ?",
+                (enabled, "singleton"),
+            )
+            if should_commit:
+                await self.connection.commit()
 
     async def set_sso_default_access(self, access: str | None) -> None:
         """Persist the default access level granted to JIT-provisioned users."""
-        await self.connection.execute(
-            "UPDATE system_state SET sso_default_access = ? WHERE id = ?",
-            (access, "singleton"),
-        )
-        await self.connection.commit()
+        async with self._write_guard() as should_commit:
+            await self.connection.execute(
+                "UPDATE system_state SET sso_default_access = ? WHERE id = ?",
+                (access, "singleton"),
+            )
+            if should_commit:
+                await self.connection.commit()
 
     def get_content_store(self) -> "SqliteDocumentContentStore":
         """Return the document-body store bound to this provider's connection."""

--- a/tests/storage/test_write_guard_coverage.py
+++ b/tests/storage/test_write_guard_coverage.py
@@ -1,0 +1,212 @@
+"""01a070ea: every writer on the SQLite shared connection must route
+through ``_write_guard()`` - a bypasser that executes+commits outside the
+guard interacts badly with the guard's own rollback semantics: a guarded
+write failing while a bypasser sits between its own execute and commit
+either loses the bypasser's statement (post-fix, via the guard's
+rollback) or silently mis-commits it through the same interleave
+(pre-fix). ``CorrelationStore._atomic_upsert``/``_ensure_unique_index``
+and ``SqliteStorageProvider``'s six ``system_state`` setters were the
+known bypassers; this file pins the fix (behavior) and adds a structural
+check so the NEXT bypasser can't slip in unnoticed.
+"""
+from __future__ import annotations
+
+import ast
+import inspect
+import textwrap
+from pathlib import Path
+
+import pytest
+import pytest_asyncio
+
+import primer.channel.correlation as correlation_module
+import primer.storage.sqlite as sqlite_module
+from primer.channel.correlation import CorrelationStore
+from primer.model.provider import SqliteConfig
+from primer.storage.sqlite import SqliteStorageProvider
+
+
+# ---------------------------------------------------------------------------
+# Structural: no commit() on the shared connection lives outside a
+# _write_guard() block.
+# ---------------------------------------------------------------------------
+
+# transaction/read_snapshot issue their own BEGIN..COMMIT to IMPLEMENT the
+# guard mechanism itself; _write_guard is the guard; initialize() runs once
+# at startup, synchronously, before the provider is shared with any other
+# coroutine, so no concurrent writer can race its DDL. All four are exempt
+# by design, not bypassers.
+_EXEMPT_FUNCTIONS = {"_write_guard", "transaction", "read_snapshot", "initialize"}
+
+
+def _is_write_guard_call(node: ast.expr) -> bool:
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+        and node.func.attr == "_write_guard"
+
+
+def _is_commit_call(node: ast.expr) -> bool:
+    return isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+        and node.func.attr == "commit"
+
+
+class _UnguardedCommitFinder(ast.NodeVisitor):
+    """Walks a module's AST tracking enclosing function name + whether the
+    current position is nested inside an ``async with ..._write_guard():``
+    block, and records every commit() call found outside one."""
+
+    def __init__(self) -> None:
+        self.function_stack: list[str] = []
+        self.guard_depth = 0
+        self.violations: list[str] = []
+
+    def _visit_function(self, node: ast.AST) -> None:
+        self.function_stack.append(node.name)  # type: ignore[attr-defined]
+        self.generic_visit(node)
+        self.function_stack.pop()
+
+    def visit_FunctionDef(self, node: ast.FunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncFunctionDef(self, node: ast.AsyncFunctionDef) -> None:
+        self._visit_function(node)
+
+    def visit_AsyncWith(self, node: ast.AsyncWith) -> None:
+        is_guard = any(_is_write_guard_call(item.context_expr) for item in node.items)
+        if is_guard:
+            self.guard_depth += 1
+        self.generic_visit(node)
+        if is_guard:
+            self.guard_depth -= 1
+
+    def visit_Call(self, node: ast.Call) -> None:
+        if _is_commit_call(node) and self.guard_depth == 0:
+            fn_name = self.function_stack[-1] if self.function_stack else "<module>"
+            if fn_name not in _EXEMPT_FUNCTIONS:
+                self.violations.append(f"{fn_name}(): {ast.unparse(node)}")
+        self.generic_visit(node)
+
+
+def _find_unguarded_commits(module) -> list[str]:
+    src = textwrap.dedent(inspect.getsource(module))
+    tree = ast.parse(src)
+    finder = _UnguardedCommitFinder()
+    finder.visit(tree)
+    return finder.violations
+
+
+def test_sqlite_provider_has_no_unguarded_commits() -> None:
+    violations = _find_unguarded_commits(sqlite_module)
+    assert violations == [], (
+        "commit() on the shared SQLite connection found outside "
+        f"_write_guard(): {violations}"
+    )
+
+
+def test_correlation_store_has_no_unguarded_commits() -> None:
+    violations = _find_unguarded_commits(correlation_module)
+    assert violations == [], (
+        "commit() on the shared SQLite connection found outside "
+        f"_write_guard(): {violations}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Behavior: CorrelationStore._atomic_upsert standalone AND deferred inside
+# an enclosing transaction().
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def provider(tmp_path: Path):
+    cfg = SqliteConfig(path=tmp_path / "write_guard_coverage.sqlite")
+    p = SqliteStorageProvider(cfg)
+    await p.initialize()
+    try:
+        yield p
+    finally:
+        await p.aclose()
+
+
+async def test_atomic_upsert_standalone_commits_immediately(
+    provider: SqliteStorageProvider,
+) -> None:
+    store = CorrelationStore(provider)
+    await store.upsert_session(
+        channel_id="ch1", anchor="a1", workspace_id="w1",
+        session_id="s1", tool_call_id="tc1",
+    )
+    found = await store.lookup("ch1", "a1")
+    assert found is not None
+    assert found.session_id == "s1"
+
+
+async def test_atomic_upsert_inside_transaction_commits_with_the_txn(
+    provider: SqliteStorageProvider,
+) -> None:
+    """Standalone-vs-deferred parity: an upsert issued while an enclosing
+    transaction() is open must ride that transaction's own commit, not
+    commit itself early - the single INSERT...ON CONFLICT...RETURNING
+    statement's result is visible within the same connection/transaction
+    even before COMMIT, so nothing about the upsert's own return value
+    should differ from the standalone case."""
+    store = CorrelationStore(provider)
+    async with provider.transaction():
+        result = await store.upsert_session(
+            channel_id="ch2", anchor="a2", workspace_id="w1",
+            session_id="s2", tool_call_id="tc2",
+        )
+    assert result.session_id == "s2"
+    found = await store.lookup("ch2", "a2")
+    assert found is not None
+    assert found.session_id == "s2"
+
+
+async def test_atomic_upsert_inside_a_rolled_back_transaction_is_undone(
+    provider: SqliteStorageProvider,
+) -> None:
+    """The crown-jewel proof: pre-fix, _atomic_upsert called
+    self._sp.connection.commit() UNCONDITIONALLY, so an upsert issued
+    inside an enclosing transaction() would commit itself immediately and
+    survive that transaction's later rollback - a silent mis-commit
+    through the exact interleave 01a070ea describes. Post-fix, the
+    upsert defers to _write_guard's should_commit=False inside an owned
+    transaction, so a rollback of the enclosing unit must undo it too."""
+    store = CorrelationStore(provider)
+    with pytest.raises(RuntimeError):
+        async with provider.transaction():
+            await store.upsert_session(
+                channel_id="ch3", anchor="a3", workspace_id="w1",
+                session_id="s3", tool_call_id="tc3",
+            )
+            raise RuntimeError("roll back after the upsert")
+
+    found = await store.lookup("ch3", "a3")
+    assert found is None, (
+        "the upsert must not survive the enclosing transaction's rollback"
+    )
+    # The connection must not be left wedged in a skip-commit state.
+    await store.upsert_session(
+        channel_id="ch3", anchor="a3", workspace_id="w1",
+        session_id="s3-after", tool_call_id="tc3-after",
+    )
+    after = await store.lookup("ch3", "a3")
+    assert after is not None and after.session_id == "s3-after"
+
+
+async def test_system_state_setter_inside_a_rolled_back_transaction_is_undone(
+    provider: SqliteStorageProvider,
+) -> None:
+    """Same interleave, the sqlite.py side: a system_state setter issued
+    inside an enclosing transaction() must roll back with it, not survive
+    via its own unconditional pre-fix commit()."""
+    with pytest.raises(RuntimeError):
+        async with provider.transaction():
+            await provider.set_default_agent_id("ag-doomed")
+            raise RuntimeError("roll back after the setter")
+
+    state = await provider.get_system_state()
+    assert state.default_agent_id is None
+
+    await provider.set_default_agent_id("ag-after")
+    state_after = await provider.get_system_state()
+    assert state_after.default_agent_id == "ag-after"


### PR DESCRIPTION
## Summary

- `CorrelationStore._atomic_upsert`/`_ensure_unique_index` and `SqliteStorageProvider`'s six `system_state` setters executed+committed on the shared connection without going through `_write_guard()`, unlike every other writer in the codebase. This interacts badly with the guard's own semantics: a write issued while an enclosing `transaction()` is open would commit itself immediately instead of deferring to `should_commit=False`, silently surviving that transaction's later rollback.
- Audited every other `.connection.execute`/`.connection.commit` call on the shared connection outside `SqliteStorageProvider`'s own class body — these were the only two bypassers; nothing else needed fixing. `initialize()` also executes+commits unguarded and stays that way deliberately: it runs once, synchronously, at startup, before the provider is shared with any coroutine that could race it.
- **Found along the way**: `_ensure_unique_index`'s "index ensured" cache flag was being set unconditionally. SQLite DDL is NOT immune to an already-open enclosing `transaction()` — once that block's manual `BEGIN` is in effect, `CREATE INDEX` participates in it and rolls back with it like any other statement. Caching the flag on a deferred (`should_commit=False`) run meant a later rollback left the index never actually created while the cache said otherwise, so the next upsert's `INSERT...ON CONFLICT` failed outright (`does not match any... constraint`) — caught live by this PR's own rollback test before it could reach anyone else. Gated the flag on `should_commit`, mirroring `SqliteStorage._ensure_table`'s existing pattern.

## Test plan

- [x] Behavior tests for `_atomic_upsert` standalone, deferred inside an owned `transaction()`, and rolled back inside one (the crown-jewel proof: the upsert must not survive that rollback)
- [x] Same rollback proof for a `system_state` setter
- [x] AST structural test walking `primer/storage/sqlite.py` and `primer/channel/correlation.py` for any `commit()` call not nested in a `_write_guard()` async-with block — proved load-bearing by temporarily injecting an unguarded commit and confirming the test catches it
- [x] Full targeted regression sweep (243 tests across storage/channel/api) green
- [x] `ruff check` + `lint-imports` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)