### PR TITLE
fix(approval): resume-time approval-record truth hardening round 2

### DIFF
--- a/primer/channel/inbox.py
+++ b/primer/channel/inbox.py
@@ -121,6 +121,18 @@ class ChannelInbox:
             {"response": env.response} if env.kind == "ask_user"
             else {"decision": env.decision, "reason": env.reason}
         )
+        # 01a07be5 gate-review-2 finding 4: capture the gate's data BEFORE
+        # publish, not after. A post-publish re-read can resolve a
+        # SUCCESSOR gate re-parked under the same tool_call_id (e.g. a
+        # nested continuation minting a fresh pending entry that reuses
+        # this raw id once the park has already advanced) if the publish
+        # is processed synchronously within this same tick. Capturing
+        # first guarantees the record describes the gate actually being
+        # decided right now, not whatever is pending by the time we look.
+        captured = (
+            await self._capture_gate_for_record(env)
+            if env.kind == "tool_approval" else None
+        )
         logger.info(
             "channel inbox publishing %s for session=%s tool_call=%s "
             "event_key=%s",
@@ -141,13 +153,56 @@ class ChannelInbox:
         # where publish() itself succeeds but the listener still never
         # advances the park.
         await self._event_bus.publish(event_key, payload)
-        if env.kind == "tool_approval":
-            await self._record_decision_best_effort(env, event_key=event_key)
+        if captured is not None:
+            await self._write_captured_record(
+                env, captured, event_key=event_key,
+            )
 
-    async def _record_decision_best_effort(
-        self, env: ResponseEnvelope, *, event_key: str,
+    async def _capture_gate_for_record(
+        self, env: ResponseEnvelope,
+    ) -> "dict | None":
+        """Resolve the SPECIFIC pending gate ``env`` answers, read BEFORE
+        the publish (finding 4 above). Returns ``None`` on any problem
+        (no storage_provider wired, session lookup failing, or the gate
+        not resolving) -- the caller then simply skips the record, same
+        as the old single-function version did.
+        """
+        if self._storage_provider is None:
+            return None
+        try:
+            from primer.model.workspace_session import WorkspaceSession
+            from primer.session.pending_gates import resolve_pending_gate
+
+            row = await self._storage_provider.get_storage(
+                WorkspaceSession,
+            ).get(env.session_id)
+            if row is None:
+                return None
+            blob = getattr(row, "parked_state", None) or {}
+            gate = resolve_pending_gate(
+                blob, tool_call_id=env.tool_call_id, kind="_approval",
+            )
+            if gate is None:
+                return None
+            return {
+                "gate": gate,
+                "agent_id": getattr(row.binding, "agent_id", None),
+                "parked_at": getattr(row, "parked_at", None),
+            }
+        except Exception:  # noqa: BLE001 -- advisory; must never block the publish
+            logger.exception(
+                "channel inbox: failed to capture gate data before "
+                "publish for session=%s tool_call=%s",
+                env.session_id, env.tool_call_id,
+            )
+            return None
+
+    async def _write_captured_record(
+        self, env: ResponseEnvelope, captured: dict, *, event_key: str,
     ) -> None:
-        """Persist a durable ToolApprovalRecord for a channel-answered gate.
+        """Persist a durable ToolApprovalRecord for a channel-answered gate,
+        using data captured BEFORE the publish (see
+        :meth:`_capture_gate_for_record`).
 
         01a06b82: the REST respond route (tool_approval.py's
         _publish_decision) has written this record at decision time since
@@ -163,41 +218,25 @@ class ChannelInbox:
         of its own -- it publishes straight onto the event bus, and the
         durable flip happens elsewhere (the bus listener / durable event
         dispatcher). So there is no natural place to hang a hard failure
-        off: ANY problem here (no storage_provider wired, the session
-        lookup failing, the gate not resolving, or the write itself
-        failing) is logged and swallowed. Called AFTER the publish
-        (R1): writing this BEFORE the publish used to mean a publish
-        that raised (or a listener that never actually advanced the
-        park) left a permanently wrong "decided" record on the books
+        off: ANY problem here is logged and swallowed. Called AFTER the
+        publish (R1): writing this BEFORE the publish used to mean a
+        publish that raised (or a listener that never actually advanced
+        the park) left a permanently wrong "decided" record on the books
         with nothing to correct it. A missed record here is recoverable
         (the resume-time write is still a backstop, now with its own
         disagreement check for exactly this residual race - see
         write_approval_record's warn_on_decision_mismatch); a missed or
         delayed wake would not have been.
         """
-        if self._storage_provider is None:
-            return
         try:
             from primer.agent.approval_record import (
                 record_from_parked_blob,
                 write_approval_record,
             )
             from primer.model.tool_approval import ToolApprovalRecord
-            from primer.model.workspace_session import WorkspaceSession
-            from primer.session.pending_gates import resolve_pending_gate
             from primer.worker.yield_runtime import classify_approval_payload
 
-            row = await self._storage_provider.get_storage(
-                WorkspaceSession,
-            ).get(env.session_id)
-            if row is None:
-                return
-            blob = getattr(row, "parked_state", None) or {}
-            gate = resolve_pending_gate(
-                blob, tool_call_id=env.tool_call_id, kind="_approval",
-            )
-            if gate is None:
-                return
+            gate = captured["gate"]
             decision, reason = classify_approval_payload(
                 {"decision": env.decision, "reason": env.reason},
             )
@@ -208,9 +247,9 @@ class ChannelInbox:
                 },
                 decision=decision,
                 reason=reason,
-                agent_id=getattr(row.binding, "agent_id", None),
+                agent_id=captured["agent_id"],
                 session_id=env.session_id,
-                requested_at=getattr(row, "parked_at", None),
+                requested_at=captured["parked_at"],
                 gate_event_key=gate.get("event_key") or event_key,
             )
             await write_approval_record(

--- a/primer/worker/graph_resume_coordinator.py
+++ b/primer/worker/graph_resume_coordinator.py
@@ -29,7 +29,6 @@ from primer.worker.yield_resume_registry import get_resume_hook
 from primer.worker.yield_runtime import (
     classify_approval_payload,
     classify_resume_payload,
-    is_terminal_synthesis_payload,
     ParkedState,
 )
 
@@ -65,6 +64,19 @@ async def write_approval_record_for_graph(
     single-event drain-all with no tcid) is skipped. Best-effort: a
     missing entry or write failure is logged + swallowed
     (``write_approval_record``'s own contract).
+
+    01a07be5 gate-review-2 finding 2: always passes
+    ``warn_on_decision_mismatch=True``, not just for a synthesised
+    timeout/cancel. The flip-winner (whichever publish actually advanced
+    this park) and the record-winner (whichever write_approval_record
+    call wins the gate_event_key race) are INDEPENDENT races -- a
+    respond-time writer can lose the flip but still win the record race
+    with a DIFFERENT decision than the one that actually resumed the
+    park. This resume-time write is the one place that knows the TRUE
+    resumed decision (``payload``, whatever actually flipped the row),
+    so it is always worth checking a losing ConflictError against: an
+    agreeing race (the overwhelming common case, one operator, one
+    decision) stays quiet at DEBUG either way.
     """
     from primer.agent.approval_record import (
         record_from_parked_blob,
@@ -105,8 +117,7 @@ async def write_approval_record_for_graph(
         else None
     )
     await write_approval_record(
-        storage, record,
-        warn_on_decision_mismatch=is_terminal_synthesis_payload(payload),
+        storage, record, warn_on_decision_mismatch=True,
     )
 
 
@@ -190,6 +201,24 @@ async def resume_graph_engine(pool: "WorkerPool", session, parked):
         if nested is not None:
             cont = await pool._resume_graph_continuation(
                 session, parked, ck, nested, payload, workspace, executor,
+            )
+            # 01a07be5 gate-review-2 finding 1: the leaf this nested
+            # entry unwinds can itself be an approval gate. write_
+            # approval_record_for_graph already resolves via checkpoint
+            # + tcid regardless of nesting -- pending_agent_yields'
+            # top-level tool_name/event_key/resume_metadata are always
+            # the LEAF's own values (frames/leaf are additive bookkeeping
+            # for the continuation walk, not a different identity), and
+            # the function no-ops internally for a non-"_approval" kind
+            # -- so this call is safe unconditionally. Before this fix,
+            # taking this branch skipped the write entirely: real
+            # decisions AND terminal synthesis for a nested approval gate
+            # left no audit record at all, silently. Written BEFORE the
+            # repark_outcome check: tcid's own decision is settled by
+            # payload regardless of whether the chain reparks deeper
+            # afterward on a DIFFERENT, unrelated gate.
+            await pool._write_approval_record_for_graph(
+                session=session, checkpoint=ck, tcid=tcid, payload=payload,
             )
             if cont.repark_outcome is not None:
                 return cont.repark_outcome

--- a/primer/worker/session_resume_coordinator.py
+++ b/primer/worker/session_resume_coordinator.py
@@ -42,7 +42,6 @@ from primer.worker.yield_runtime import (
     _resume_tool_approval,
     classify_approval_payload,
     classify_resume_payload,
-    is_terminal_synthesis_payload,
     ParkedState,
 )
 
@@ -71,6 +70,14 @@ async def write_approval_record_for_session(
 
     Best-effort: a write failure is logged and swallowed so the resume
     proceeds.
+
+    01a07be5 gate-review-2 finding 2: always passes
+    ``warn_on_decision_mismatch=True`` -- see
+    ``write_approval_record_for_graph``'s matching docstring note. The
+    flip-winner and record-winner are independent races even for a real
+    operator decision (not just a synthesised timeout/cancel), and this
+    write is the one place that knows the decision that ACTUALLY resumed
+    the park.
     """
     from primer.agent.approval_record import (
         record_from_parked_blob,
@@ -100,8 +107,7 @@ async def write_approval_record_for_session(
         else None
     )
     await write_approval_record(
-        storage, record,
-        warn_on_decision_mismatch=is_terminal_synthesis_payload(payload),
+        storage, record, warn_on_decision_mismatch=True,
     )
 
 
@@ -204,6 +210,19 @@ async def resume_engine_session(pool: "WorkerPool", engine_lease, session):
         services = pool._build_invocation_services(
             session, workspace, executor, tool_manager,
         )
+        # 01a07be5 gate-review-2 finding 1: the leaf gate this frames
+        # stack unwinds can itself be an approval gate (a tool call
+        # somewhere inside a nested invoke_agent chain that was gated).
+        # parked.yielded IS that leaf here -- frames/leaf bookkeeping is
+        # orthogonal identity plumbing, not a different object -- so the
+        # SAME write the non-nested branch below uses applies unchanged.
+        # Before this fix, taking this branch skipped the write entirely:
+        # real decisions AND terminal synthesis for a nested approval
+        # gate left no audit record at all, silently.
+        if parked.yielded.tool_name == "_approval":
+            await pool._write_approval_record_for_session(
+                session=session, blob=blob, payload=resume_payload.payload,
+            )
         try:
             outcome = await resume_continuation(
                 parked.frames,

--- a/primer/worker/yield_runtime.py
+++ b/primer/worker/yield_runtime.py
@@ -441,12 +441,28 @@ def classify_approval_payload(
     resume (:func:`_resume_tool_approval`) and the graph resume adapter
     (:func:`primer.worker.graph_resume._decision_from_payload`) call this so
     the two paths cannot drift.
+
+    01a07be5 gate-review-2 finding 3: recognises the RAW
+    ``__yield_timeout__``/``__yield_cancelled__`` marker dict shape, not
+    just the already-classified ``YieldTimeout``/``YieldCancelled``
+    instances :func:`classify_resume_payload` builds for the single-event
+    resume path. The multi-event graph drain (``resume_graph_engine``'s
+    ``payloads_map`` branch) replays ``resume_event_payloads`` entries as
+    plain JSON dicts, never converting them to typed instances -- a
+    genuine multi-event timeout/cancel used to classify here as
+    "malformed approval payload (missing decision)" instead of
+    "timed-out"/"cancelled", landing that wrong reason in the durable
+    audit record.
     """
     if isinstance(payload, YieldTimeout):
         return "rejected", "timed-out"
     if isinstance(payload, YieldCancelled):
         return "rejected", payload.reason or "cancelled"
     if isinstance(payload, dict):
+        if payload.get(_YIELD_TIMEOUT_KEY):
+            return "rejected", "timed-out"
+        if payload.get(_YIELD_CANCELLED_KEY):
+            return "rejected", payload.get("reason") or "cancelled"
         raw = payload.get("decision")
         reason = payload.get("reason")
         if raw == "approved":
@@ -455,32 +471,6 @@ def classify_approval_payload(
             return "rejected", reason
         return "rejected", "malformed approval payload (missing decision)"
     return "rejected", "malformed approval payload (non-dict)"
-
-
-def is_terminal_synthesis_payload(payload: Any) -> bool:
-    """True when ``payload`` is a synthesised timeout/cancel outcome
-    rather than a real, direct operator decision.
-
-    01a06b82 gate-review R1: callers writing a resume-time
-    ToolApprovalRecord pass this to :func:`~primer.agent.approval_record.
-    write_approval_record`'s ``warn_on_decision_mismatch`` so a
-    ConflictError on THIS write (the one case that isn't an ordinary
-    benign dedup race - see that function's docstring) gets checked for
-    an actual disagreement instead of silently swallowed.
-
-    Handles both shapes a resume drain can see: the single-event path's
-    already-classified ``YieldTimeout``/``YieldCancelled`` instance (via
-    :func:`classify_resume_payload`), and the multi-event graph drain's
-    raw marker dict (``resume_event_payloads`` entries are stored and
-    replayed as plain JSON, never converted to a typed instance).
-    """
-    if isinstance(payload, (YieldTimeout, YieldCancelled)):
-        return True
-    if isinstance(payload, dict):
-        return bool(
-            payload.get(_YIELD_TIMEOUT_KEY) or payload.get(_YIELD_CANCELLED_KEY)
-        )
-    return False
 
 
 async def _resume_tool_approval(

--- a/tests/channel/test_inbox.py
+++ b/tests/channel/test_inbox.py
@@ -508,7 +508,12 @@ async def test_record_write_failure_does_not_block_the_publish(monkeypatch, capl
     delay the wake publish. Breaks the session lookup the record write
     depends on (storage_provider present but raising) and asserts the
     event still publishes via _resolve_event_key's own independent
-    fallback, while this function logs and swallows its own failure."""
+    fallback, while this function logs and swallows its own failure.
+
+    01a07be5 finding 4: the gate is now captured BEFORE the publish, so
+    a broken session lookup fails in _capture_gate_for_record (not the
+    post-publish write) -- same "never blocks the publish" property,
+    different failure point."""
     from tests.conftest import _FakeStorageProvider
 
     sp = _FakeStorageProvider()
@@ -559,8 +564,91 @@ async def test_record_write_failure_does_not_block_the_publish(monkeypatch, capl
         # already-tested fallback: reconstructs the key and still publishes.
         assert event.event_key == "tool_approval:s-rec-3:tc-3"
         assert any(
-            "best-effort approval record write failed" in r.message
+            "failed to capture gate data before publish" in r.message
             for r in caplog.records
         )
     finally:
         await bus.aclose()
+
+
+@pytest.mark.asyncio
+async def test_gate_captured_before_publish_survives_a_reparked_successor(
+    monkeypatch,
+):
+    """01a07be5 finding 4: a post-publish re-read can resolve a SUCCESSOR
+    gate re-parked under the same tool_call_id if the park has already
+    advanced by the time anything reads again. Simulates the race
+    directly: publish() triggers (standing in for a listener that
+    processes it synchronously) the row being reparked under a DIFFERENT
+    gate's metadata for the identical tool_call_id, before the record
+    write runs. The persisted record must still describe the ORIGINAL
+    gate actually decided (captured before publish), not the successor.
+    """
+    from primer.model.storage import OffsetPage
+    from primer.model.tool_approval import ToolApprovalRecord
+    from tests.conftest import _FakeStorageProvider
+
+    sp = _FakeStorageProvider()
+    original_session = _session(
+        "s-race",
+        parked_state={
+            "tool_call_id": "tc-race",
+            "yielded": {
+                "tool_name": "_approval",
+                "event_key": "tool_approval:s-race:tc-race",
+                "resume_metadata": {
+                    "original_call": {
+                        "id": "tc-race", "name": "delete_workspace", "arguments": {},
+                    },
+                },
+            },
+        },
+    )
+    await sp.get_storage(WorkspaceSession).create(original_session)
+
+    successor_session = original_session.model_copy(update={
+        "parked_state": {
+            "tool_call_id": "tc-race",
+            "yielded": {
+                "tool_name": "_approval",
+                "event_key": "tool_approval:s-race:tc-race",
+                "resume_metadata": {
+                    "original_call": {
+                        "id": "tc-race", "name": "send_email", "arguments": {},
+                    },
+                },
+            },
+        },
+    })
+
+    bus = InMemoryEventBus()
+    await bus.initialize()
+    original_publish = bus.publish
+
+    async def _publish_then_reparks_a_successor(event_key, payload):
+        await original_publish(event_key, payload)
+        # By the time anything reads the row again, a DIFFERENT gate has
+        # already reparked under the identical tool_call_id.
+        await sp.get_storage(WorkspaceSession).update(successor_session)
+
+    monkeypatch.setattr(bus, "publish", _publish_then_reparks_a_successor)
+
+    try:
+        inbox = ChannelInbox(event_bus=bus, storage_provider=sp)
+        await inbox.handle_response(
+            ResponseEnvelope(
+                kind="tool_approval", workspace_id="ws-1", session_id="s-race",
+                tool_call_id="tc-race", response=None,
+                decision="approved", reason=None,
+            ),
+        )
+    finally:
+        await bus.aclose()
+
+    page = await sp.get_storage(ToolApprovalRecord).list(
+        OffsetPage(offset=0, length=50),
+    )
+    matches = [r for r in page.items if r.session_id == "s-race"]
+    assert len(matches) == 1
+    # The ORIGINAL gate's tool_name, not the reparked successor's.
+    assert matches[0].tool_name == "delete_workspace"

--- a/tests/worker/test_approval_record_resume_graph.py
+++ b/tests/worker/test_approval_record_resume_graph.py
@@ -314,3 +314,150 @@ async def test_resume_record_dedupes_against_a_respond_time_write_for_the_same_g
         assert items[0].id == preseeded.id
     finally:
         await storage_provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_resume_record_warns_on_a_real_vs_real_decision_disagreement(
+    tmp_path, caplog,
+):
+    """01a07be5 gate-review-2 finding 2: warn_on_decision_mismatch is now
+    unconditional, not just for a synthesised timeout/cancel. The
+    flip-winner (whichever publish actually resumed this park) and the
+    record-winner (whichever write_approval_record call wins the
+    gate_event_key race) are independent races even for two REAL operator
+    decisions -- a respond-time writer can lose the flip but still win
+    the record race with a DIFFERENT decision than the one that actually
+    resumed the park. This resume-time write knows the TRUE resumed
+    decision (the payload it was actually called with), so a losing
+    ConflictError against a DISAGREEING real decision must be loud now,
+    not silently swallowed at DEBUG the way it would have been when the
+    check only fired for terminal synthesis.
+    """
+    import logging
+
+    from primer.model.provider import SqliteConfig
+    from primer.storage.sqlite import SqliteStorageProvider
+
+    session_id = "graph-rec-real-disagree"
+    checkpoint = _two_gate_checkpoint(session_id)
+    gate_key = f"tool_approval:{session_id}:call-1"
+
+    storage_provider = SqliteStorageProvider(
+        SqliteConfig(path=str(tmp_path / "real-disagree.sqlite")),
+    )
+    await storage_provider.initialize()
+    try:
+        # A DIFFERENT writer already recorded "rejected" for this gate.
+        preseeded = ToolApprovalRecord(
+            tool_name="delete_workspace",
+            arguments={"id": "ws-worker[1]"},
+            tool_call_id="call-1",
+            session_id=session_id,
+            agent_id="agt-graph",
+            decided_at=datetime.now(timezone.utc),
+            decision="rejected",
+            gate_event_key=gate_key,
+        )
+        await storage_provider.get_storage(ToolApprovalRecord).create(preseeded)
+
+        pool = SimpleNamespace(_storage=storage_provider)
+        # This resume-time write reflects the REAL decision that actually
+        # resumed the park -- "approved" -- a genuine disagreement with
+        # the preseeded "rejected", NOT a terminal synthesis.
+        with caplog.at_level(
+            logging.DEBUG, logger="primer.agent.approval_record",
+        ):
+            await write_approval_record_for_graph(
+                pool, session=_session(session_id), checkpoint=checkpoint,
+                tcid="call-1", payload={"decision": "approved"},
+            )
+
+        # Append-only still holds: the preseeded row is untouched.
+        items = await _records_for(storage_provider)
+        assert len(items) == 1
+        assert items[0].id == preseeded.id
+        assert items[0].decision == "rejected"
+
+        error_records = [
+            r for r in caplog.records if r.levelno >= logging.ERROR
+        ]
+        assert len(error_records) == 1
+        message = error_records[0].getMessage()
+        assert "audit disagreement" in message
+        assert "rejected" in message
+        assert "approved" in message
+    finally:
+        await storage_provider.aclose()
+
+
+@pytest.mark.asyncio
+async def test_resume_record_resolves_a_nested_approval_leaf_with_frames_populated():
+    """01a07be5 gate-review-2 finding 1: the pending_agent_yields arm's
+    resolution must be identical whether or not the entry carries a
+    nested continuation frames/leaf stack -- resolve_pending_gate never
+    inspects those fields, only the entry's own top-level tool_name/
+    tool_call_id/event_key/resume_metadata (which are always the LEAF's
+    own values regardless of nesting, per _node_dispatch.py's
+    construction). This is the exact entry shape resume_graph_engine's
+    nested branch now writes a record for, which nothing exercised
+    before this round.
+    """
+    from primer.worker.frames import frames_to_jsonable
+    from primer.worker.frames import AgentFrame, AgentResumeContext
+
+    session_id = "graph-rec-nested"
+    tcid = "call-nested"
+    event_key = f"tool_approval:{session_id}:worker[0]:{tcid}"
+    resume_metadata = {
+        "policy_id": "pol-nested",
+        "approval_type": "required",
+        "gate_reason": "matched policy",
+        "approvers": None,
+        "original_call": {
+            "id": tcid, "name": "delete_workspace", "arguments": {},
+        },
+    }
+    frame = AgentFrame(
+        agent_id="sub",
+        llm_messages=[{"role": "assistant", "parts": []}],
+        tool_call_id="invoke-tc",
+        depth=0,
+        context=AgentResumeContext(
+            session_id=session_id, workspace_id="w", chat_id=None,
+            principal="p", tools=["misc__gated_tool"],
+        ),
+    )
+    checkpoint = {
+        "pending_toolcalls": [],
+        "pending_agent_yields": [{
+            "node_id": "worker[0]",
+            "tool_call_id": tcid,
+            "event_key": event_key,
+            "tool_name": "_approval",
+            "resume_metadata": resume_metadata,
+            "llm_messages": [],
+            "iteration": 0,
+            "frames": frames_to_jsonable([frame]),
+            "leaf": {
+                "tool_name": "_approval", "event_key": event_key,
+                "resume_metadata": resume_metadata,
+            },
+        }],
+        "pending_dispatch": [],
+    }
+
+    storage_provider = _FakeStorageProvider()
+    pool = SimpleNamespace(_storage=storage_provider)
+
+    await write_approval_record_for_graph(
+        pool, session=_session(session_id), checkpoint=checkpoint,
+        tcid=tcid, payload={"decision": "approved"},
+    )
+
+    items = await _records_for(storage_provider)
+    assert len(items) == 1
+    rec = items[0]
+    assert rec.tool_call_id == tcid
+    assert rec.decision == "approved"
+    assert rec.policy_id == "pol-nested"
+    assert rec.gate_event_key == event_key

--- a/tests/worker/test_graph_node_subagent_resume.py
+++ b/tests/worker/test_graph_node_subagent_resume.py
@@ -97,6 +97,49 @@ def test_nested_agent_yield_detected_only_with_frames():
     assert pool._graph_nested_agent_yield(_checkpoint_with_nested_entry(), "nope") is None
 
 
+def test_nested_agent_yield_detected_for_an_approval_leaf_too():
+    """01a07be5 gate-review-2 finding 1: the leaf a frames stack unwinds
+    can itself be an approval gate (a tool call somewhere inside a nested
+    invoke_agent chain that was gated), not just ask_user. The nested-
+    yield DETECTION is tool_name-agnostic -- it keys on frames alone --
+    so resume_graph_engine's nested branch is reachable for this case
+    exactly like the ask_user one, which is why that branch skipping
+    write_approval_record_for_graph entirely was a real, reachable gap."""
+    pool = _bare_pool()
+    ck = {
+        "pending_agent_yields": [
+            {
+                "node_id": "A",
+                "tool_call_id": _LEAF_TCID,
+                "event_key": f"tool_approval:s:{_LEAF_TCID}",
+                "tool_name": "_approval",
+                "resume_metadata": {
+                    "policy_id": "p1", "approval_type": "required",
+                    "gate_reason": "always-on", "approvers": None,
+                    "original_call": {
+                        "id": _LEAF_TCID, "name": "delete_workspace",
+                        "arguments": {},
+                    },
+                },
+                "llm_messages": [{"role": "assistant", "parts": []}],
+                "iteration": 0,
+                "frames": frames_to_jsonable([_frame()]),
+                "leaf": Yielded(
+                    tool_name="_approval",
+                    event_key=f"tool_approval:s:{_LEAF_TCID}",
+                    resume_metadata={
+                        "original_call": {
+                            "id": _LEAF_TCID, "name": "delete_workspace",
+                            "arguments": {},
+                        },
+                    },
+                ).to_jsonable(),
+            }
+        ],
+    }
+    assert pool._graph_nested_agent_yield(ck, _LEAF_TCID) is not None
+
+
 # ---------------------------------------------------------------------------
 # Deliver: the continuation result becomes the node's agent_tool_result
 # ---------------------------------------------------------------------------

--- a/tests/worker/test_nested_yield_matrix.py
+++ b/tests/worker/test_nested_yield_matrix.py
@@ -563,6 +563,24 @@ async def test_subagent_approval_gate_approve_redispatches_and_delivers(monkeypa
     assert row.parked_status is None  # park cleared on release
     assert row.status != SessionStatus.ENDED
 
+    # 01a07be5 gate-review-2 finding 1: the leaf gate here is an approval
+    # gate raised INSIDE a nested invoke_agent chain, resumed through the
+    # `if parked.frames:` continuation branch -- before this fix, that
+    # branch never called write_approval_record_for_session at all, so a
+    # nested approval gate left no audit record no matter how it
+    # resolved (approve, reject, or a synthesised timeout/cancel).
+    from primer.model.storage import OffsetPage
+    from primer.model.tool_approval import ToolApprovalRecord
+
+    records = await base.get_storage(ToolApprovalRecord).list(
+        OffsetPage(offset=0, length=50),
+    )
+    matches = [r for r in records.items if r.session_id == sid]
+    assert len(matches) == 1
+    assert matches[0].tool_call_id == gated_call_id
+    assert matches[0].decision == "approved"
+    assert matches[0].tool_name == "t1__do_it"
+
 
 @pytest.mark.asyncio
 async def test_subagent_approval_gate_reject_clean_error_tool_never_runs(monkeypatch):
@@ -630,6 +648,20 @@ async def test_subagent_approval_gate_reject_clean_error_tool_never_runs(monkeyp
     # exploding toolset proves it), and the subagent's own completion is clean.
     part = _injected_tool_result(executor, invoke_tcid)
     assert json.loads(part.output) == {"output": "ok it was rejected"}
+
+    # 01a07be5 gate-review-2 finding 1: same audit-record gap as the
+    # approve variant above, for a rejection this time.
+    from primer.model.storage import OffsetPage
+    from primer.model.tool_approval import ToolApprovalRecord
+
+    records = await base.get_storage(ToolApprovalRecord).list(
+        OffsetPage(offset=0, length=50),
+    )
+    matches = [r for r in records.items if r.session_id == sid]
+    assert len(matches) == 1
+    assert matches[0].tool_call_id == gated_call_id
+    assert matches[0].decision == "rejected"
+    assert matches[0].reason == "no thanks"
 
 
 # ===========================================================================

--- a/tests/worker/test_yield_runtime.py
+++ b/tests/worker/test_yield_runtime.py
@@ -15,6 +15,7 @@ from primer.model.yield_ import YieldCancelled, YieldTimeout, Yielded
 from primer.worker.yield_runtime import (
     PARKED_STATE_SCHEMA_VERSION,
     ParkedState,
+    classify_approval_payload,
     classify_resume_payload,
     make_cancelled_payload,
     make_timeout_payload,
@@ -310,3 +311,78 @@ class TestPublisherHelpers:
         # tz-aware datetime.
         parsed = datetime.fromisoformat(payload["cancelled_at"])
         assert parsed.tzinfo is not None
+
+
+# ===========================================================================
+# classify_approval_payload
+# ===========================================================================
+
+
+class TestClassifyApprovalPayload:
+    """01a07be5 gate-review-2 finding 3: classify_approval_payload must
+    recognise the RAW __yield_timeout__/__yield_cancelled__ marker dict
+    shape, not just the already-classified YieldTimeout/YieldCancelled
+    instances classify_resume_payload builds for the single-event resume
+    path. The multi-event graph drain (resume_graph_engine's
+    payloads_map branch) replays resume_event_payloads entries as plain
+    JSON dicts, never converting them to typed instances first -- before
+    this fix, a genuine multi-event timeout/cancel classified here as
+    "malformed approval payload (missing decision)", landing the wrong
+    reason in the durable audit record.
+    """
+
+    def test_typed_yield_timeout_instance(self):
+        assert classify_approval_payload(YieldTimeout(elapsed_seconds=5)) == (
+            "rejected", "timed-out",
+        )
+
+    def test_typed_yield_cancelled_instance_with_reason(self, t0: datetime):
+        result = classify_approval_payload(
+            YieldCancelled(reason="user closed", cancelled_at=t0, elapsed_seconds=1),
+        )
+        assert result == ("rejected", "user closed")
+
+    def test_typed_yield_cancelled_instance_defaults_reason(self, t0: datetime):
+        result = classify_approval_payload(
+            YieldCancelled(reason=None, cancelled_at=t0, elapsed_seconds=1),
+        )
+        assert result == ("rejected", "cancelled")
+
+    def test_raw_timeout_marker_dict(self):
+        """The multi-event graph drain's shape: a raw marker dict, never
+        converted to a YieldTimeout instance."""
+        assert classify_approval_payload({"__yield_timeout__": True}) == (
+            "rejected", "timed-out",
+        )
+
+    def test_raw_cancelled_marker_dict_with_reason(self):
+        assert classify_approval_payload({
+            "__yield_cancelled__": True, "reason": "user closed",
+            "cancelled_at": "2026-01-01T00:00:00+00:00",
+        }) == ("rejected", "user closed")
+
+    def test_raw_cancelled_marker_dict_defaults_reason(self):
+        assert classify_approval_payload({
+            "__yield_cancelled__": True,
+            "cancelled_at": "2026-01-01T00:00:00+00:00",
+        }) == ("rejected", "cancelled")
+
+    def test_real_approved_decision(self):
+        assert classify_approval_payload(
+            {"decision": "approved", "reason": "fine"},
+        ) == ("approved", "fine")
+
+    def test_real_rejected_decision(self):
+        assert classify_approval_payload(
+            {"decision": "rejected", "reason": "no"},
+        ) == ("rejected", "no")
+
+    def test_malformed_dict_missing_decision(self):
+        assert classify_approval_payload({"reason": "huh"}) == (
+            "rejected", "malformed approval payload (missing decision)",
+        )
+
+    def test_malformed_non_dict(self):
+        assert classify_approval_payload("not a payload") == (
+            "rejected", "malformed approval payload (non-dict)",
+        )


### PR DESCRIPTION
## Summary

Post-merge adversarial verify on #245's R1 (approval-record truth hardening) surfaced four further gaps, all landing on the resume-time / channel-respond write path R1 introduced. This is task 01a07be5, follow-up to #245 (merged).

- **Finding 1 (major)** — a nested/frames approval gate wrote NO record on either coordinator. When a parked entry's continuation frames are non-empty (the gate was raised INSIDE a nested `invoke_agent` chain), both `resume_graph_engine` and `resume_engine_session` took a separate control-flow branch that skipped the approval-record write entirely — real decisions AND terminal synthesis for a nested approval gate left no audit trail at all. Both frames branches now call the same write functions the flat branch already used.
- **Finding 2 (major)** — the flip-winner (whichever publish actually resumed a park) and the record-winner (whichever `write_approval_record` call wins the `gate_event_key` race) are independent races, not just for a synthesised timeout/cancel but for two REAL operator decisions too. Both resume-time writers now pass `warn_on_decision_mismatch=True` unconditionally — an agreeing race (the common case) still stays quiet at DEBUG. `is_terminal_synthesis_payload` is now dead and removed.
- **Finding 3 (minor)** — `classify_approval_payload` didn't recognise the raw `__yield_timeout__`/`__yield_cancelled__` marker dict shape the multi-event graph drain replays (only the already-classified typed instances the single-event path builds). A genuine multi-event timeout/cancel classified as "malformed approval payload (missing decision)" instead of "timed-out"/"cancelled", landing the wrong reason in the durable record.
- **Finding 4 (minor)** — `handle_response` resolved the channel gate's record data AFTER the publish. A post-publish re-read can resolve a SUCCESSOR gate re-parked under the identical `tool_call_id` (e.g. a nested continuation minting a fresh entry that reuses the raw id) before the write runs. The gate's data is now captured BEFORE publish and the write still happens AFTER — preserving R1's "never write for a decision that never reached the system" property while fixing which gate the record describes.

## Test plan

- [x] `tests/worker/test_yield_runtime.py` — full `classify_approval_payload` input matrix, including the raw marker dicts (finding 3)
- [x] `tests/worker/test_approval_record_resume_graph.py` — real-vs-real decision disagreement warns loudly (finding 2); a checkpoint entry with frames/leaf populated resolves identically to a flat one (finding 1)
- [x] `tests/worker/test_graph_node_subagent_resume.py` — the graph nested-yield detector fires for an approval-typed leaf, not just ask_user (finding 1)
- [x] `tests/worker/test_nested_yield_matrix.py` — extended the EXISTING faithful full-loop nested-subagent-approval-gate tests (real pool/storage/claim engine) with the record assertion they were missing, for both approve and reject (finding 1, end-to-end)
- [x] `tests/channel/test_inbox.py` — a monkeypatched publish reparks a successor gate under the same tool_call_id; the persisted record still describes the original gate (finding 4)
- [x] Full regression sweep: 199 passed, 1 pre-existing skip

Scope note: no full-loop test exists for the graph-path equivalent of the nested-subagent scenario (this codebase's own established convention deliberately avoids full-`resume_graph_engine` orchestration tests, per `test_graph_node_subagent_resume.py`'s and `test_graph_node_subagent_yield.py`'s own docstrings) — the graph side of finding 1 is covered at the same modular level those files already established as sufficient for this function's neighbors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)