### PR TITLE
fix(session): mirror ENDED onto the AgentSession slot on a build_executor failure

### DIFF
--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -315,6 +315,11 @@ async def run_one_session_turn(
                 session,
                 new_status=SessionStatus.ENDED,
                 ended_reason="failed",
+                # 01a06cbc: no executor was ever built (that's what just
+                # raised), so the AgentSession-slot mirror has nothing to
+                # unwrap via .session -- workspace_registry lets it fall
+                # back to loading the slot independently instead.
+                workspace_registry=deps.workspace_registry,
             )
             await _clear_interrupt_requested(session_storage, session_id)
             await _clear_turn_running(session_storage, session_id)
@@ -1635,6 +1640,7 @@ async def _transition_session_status(
     ended_reason: str | None = None,
     executor=None,
     expected_epoch: int | None = None,
+    workspace_registry: Any | None = None,
 ) -> None:
     """Update the WorkspaceSession row in storage. Idempotent on no-op.
 
@@ -1651,6 +1657,12 @@ async def _transition_session_status(
     ``LocalWorkspace.get_session``) -- report a terminated session as
     permanently ``running``, because the worker ran in a different process
     (or workspace-cache instance) than the one those reads resolve.
+
+    ``workspace_registry`` (01a06cbc) is the fallback for the one caller
+    that has no ``executor`` at all -- a ``build_executor`` failure, which
+    means no executor object was ever created. See
+    :func:`_sync_agent_session_ended`'s docstring for why the slot is
+    still reachable in that case.
     """
     # Re-read the current row so we don't overwrite concurrent changes.
     fresh = await session_storage.get(session.id)
@@ -1684,10 +1696,19 @@ async def _transition_session_status(
             session.id, new_status.value,
         )
     if new_status == SessionStatus.ENDED:
-        await _sync_agent_session_ended(executor, ended_reason)
+        await _sync_agent_session_ended(
+            executor, ended_reason,
+            session=session, workspace_registry=workspace_registry,
+        )
 
 
-async def _sync_agent_session_ended(executor, ended_reason: str | None) -> None:
+async def _sync_agent_session_ended(
+    executor,
+    ended_reason: str | None,
+    *,
+    session: WorkspaceSession | None = None,
+    workspace_registry: Any | None = None,
+) -> None:
     """Mirror a terminal ENDED transition onto the on-disk AgentSession slot.
 
     Commits ``session.json`` (status=ENDED) so the workspace-side reads
@@ -1697,8 +1718,39 @@ async def _sync_agent_session_ended(executor, ended_reason: str | None) -> None:
     log. ``ended_reason`` is constrained to the three terminal reasons the
     AgentSession transition table accepts; an unknown value falls back to
     ``"completed"`` so the on-disk slot still reaches a terminal state.
+
+    01a06cbc: when a ``build_executor`` failure means no executor was ever
+    created, there is no ``.session`` to unwrap -- but the on-disk slot
+    itself isn't a build_executor artifact at all. It was allocated by the
+    REST API at session-creation time (``Workspace.start_session(...,
+    id=sid)``); both ``build_agent_executor`` / ``build_graph_executor``
+    just LOAD it mid-build, after the steps that actually fail (agent/LLM/
+    toolset resolution, or graph/state_repo resolution). So its existence
+    doesn't depend on the rest of the build succeeding, and it can be
+    re-resolved independently from nothing but ``(workspace_id, session_id)``
+    via ``workspace_registry`` -- the SAME primitive
+    (``workspace.get_session(session.id)``) the builders already call.
+    Only attempted when the executor path found nothing (so the three
+    existing callers that already pass a real executor are unaffected). A
+    graph-bound session predating holder allocation can have no slot at
+    all (``get_session`` returns ``None``) -- that's a normal no-op here,
+    same tolerance a missing executor already gets.
     """
     inner = getattr(executor, "session", None) if executor is not None else None
+    if inner is None and workspace_registry is not None and session is not None:
+        try:
+            workspace = await workspace_registry.get_workspace(session.workspace_id)
+            inner = (
+                await workspace.get_session(session.id)
+                if workspace is not None else None
+            )
+        except Exception:  # noqa: BLE001 -- advisory; never block release
+            logger.warning(
+                "dispatch: failed to load the on-disk AgentSession slot "
+                "for %s while mirroring ENDED (no executor was built)",
+                session.id, exc_info=True,
+            )
+            return
     set_status = getattr(inner, "set_status", None)
     if set_status is None:
         return

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -972,6 +972,132 @@ async def test_build_executor_notfound_converges_to_ended_failed(
     assert row.turn_started_at is None
 
 
+class _SlotWorkspace:
+    """Minimal Workspace stand-in exposing only get_session, for the
+    build-executor-failure mirror fallback (no executor was ever built,
+    so there's nothing else this path needs)."""
+
+    def __init__(self, slot) -> None:
+        self._slot = slot
+
+    async def get_session(self, session_id: str):
+        return self._slot
+
+
+class _SlotWorkspaceRegistry:
+    def __init__(self, workspace) -> None:
+        self._workspace = workspace
+
+    async def get_workspace(self, workspace_id: str):
+        return self._workspace
+
+
+@pytest.mark.asyncio
+async def test_build_executor_failure_mirrors_ended_onto_agent_session_slot(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """01a06cbc: build_executor raising means no executor object was ever
+    created, so the .session-unwrap mirror path has nothing to work with
+    -- unlike test_executor_error_mirrors_ended_onto_agent_session_slot's
+    branch (executor exists, just wasn't threaded through). The on-disk
+    AgentSession slot isn't a build_executor artifact though: it was
+    allocated by the REST API at session-creation time and merely LOADED
+    mid-build (after the steps that actually fail), so it's reachable
+    from workspace_registry alone, independent of the failed build.
+    """
+    from primer.model.except_ import NotFoundError
+
+    slot = _RecordingSlotSession()
+    registry = _SlotWorkspaceRegistry(_SlotWorkspace(slot))
+
+    async def _build_executor(session: WorkspaceSession):
+        raise NotFoundError(f"Graph 'g-gone' not found for session {session.id!r}")
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+        workspace_registry=registry,
+    )
+    outcome = await run_one_session_turn(_make_lease(seeded_session.id), deps)
+    assert outcome.success is False
+
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    assert (await storage.get(seeded_session.id)).status == SessionStatus.ENDED
+    assert slot.calls == [(SessionStatus.ENDED, "failed")]
+
+
+@pytest.mark.asyncio
+async def test_build_executor_failure_with_no_slot_does_not_crash(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """A graph-bound session predating holder allocation can have NO
+    on-disk slot at all (get_session returns None) -- the mirror fallback
+    must treat that as a normal no-op, same tolerance a missing executor
+    already gets, and the row must still converge to ENDED/failed."""
+    from primer.model.except_ import NotFoundError
+
+    registry = _SlotWorkspaceRegistry(_SlotWorkspace(None))
+
+    async def _build_executor(session: WorkspaceSession):
+        raise NotFoundError(f"Graph 'g-gone' not found for session {session.id!r}")
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+        workspace_registry=registry,
+    )
+    outcome = await run_one_session_turn(_make_lease(seeded_session.id), deps)
+    assert outcome.success is False
+
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    row = await storage.get(seeded_session.id)
+    assert row.status == SessionStatus.ENDED
+    assert row.ended_reason == "failed"
+
+
+@pytest.mark.asyncio
+async def test_build_executor_failure_without_workspace_registry_does_not_crash(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """workspace_registry is optional on SessionDispatchDeps (older/other
+    call paths that never thread it) -- when it's None (the default,
+    unset here), the mirror fallback must skip cleanly rather than
+    attempting a lookup, same as before this fix existed. The row must
+    still converge to ENDED/failed regardless."""
+    from primer.model.except_ import NotFoundError
+
+    async def _build_executor(session: WorkspaceSession):
+        raise NotFoundError(f"Graph 'g-gone' not found for session {session.id!r}")
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+        # workspace_registry intentionally omitted -> defaults to None.
+    )
+    outcome = await run_one_session_turn(_make_lease(seeded_session.id), deps)
+    assert outcome.success is False
+
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    row = await storage.get(seeded_session.id)
+    assert row.status == SessionStatus.ENDED
+    assert row.ended_reason == "failed"
+
+
 # ---------------------------------------------------------------------------
 # Task 9 — Stop (interrupt) stays alive: WAITING, not ENDED
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Task 01a06cbc. `dispatch.py`'s `build_executor`-failure branch (:313) transitions the session row to ENDED/failed but never mirrored that onto the on-disk `AgentSession` slot (`session.json`) — `_transition_session_status`'s mirror only fires when an `executor` is passed, and this branch has none (the build itself raised, so no executor was ever created). Same user-visible symptom as the executor-error branch's gap fixed at 01a06bc1 (workspace tools report the session as stuck "running" forever), but a different root cause: there, an executor existed and just wasn't threaded through; here, none exists to thread.

**Where the mirror's needed state comes from when the build itself failed:** the on-disk slot isn't a `build_executor` artifact. It's allocated by the REST API at session-creation time (`Workspace.start_session(..., id=sid)`). Both `build_agent_executor` and `build_graph_executor` merely LOAD it mid-build via `workspace.get_session(session.id)`, and that load happens AFTER the steps that actually fail (agent/LLM/toolset resolution for the agent path; graph/state_repo resolution for the graph path). So the slot's existence doesn't depend on the rest of the build succeeding — it's re-resolvable from nothing but `(workspace_id, session_id)`.

`_sync_agent_session_ended` now falls back to `workspace_registry.get_workspace(session.workspace_id).get_session(session.id)` — the same primitive both executor builders already call — whenever the executor path found nothing. Only the `build_executor`-failure call site gains the new `workspace_registry` kwarg; the two call sites that already pass a real executor are unaffected. A graph-bound session predating holder allocation can have no slot at all (`get_session` returns `None`, same as `build_graph_executor`'s own tolerance there) — the fallback treats that as a normal no-op.

## Test plan

- [x] The mirror fires via the fallback when `build_executor` raises
- [x] A missing slot (`get_session` returns `None`) stays a clean no-op
- [x] `workspace_registry` unset (the common case for callers that never wire it) also stays a clean no-op, same as before this fix existed
- [x] Full `tests/session/test_dispatch.py` (28 passed, 1 pre-existing xfail) and `tests/session/test_epoch_fencing.py` (7 passed) — no regressions on the other three `_transition_session_status` call sites

🤖 Generated with [Claude Code](https://claude.com/claude-code)