### PR TITLE
fix(tests): the mobile bundle boot-smoke test has never passed

### DIFF
--- a/tests/ui/test_mobile_bundle_smoke.py
+++ b/tests/ui/test_mobile_bundle_smoke.py
@@ -5,37 +5,77 @@ from __future__ import annotations
 
 import os
 import subprocess
+import tempfile
 import time
 from contextlib import contextmanager
 
 import httpx
 import pytest
 
+# Tail length for the captured boot log included in a failure message -
+# enough to show a Python traceback without dumping an unbounded log.
+_LOG_TAIL_CHARS = 4000
+
+
+def _tail(path: str) -> str:
+    try:
+        with open(path, "rb") as f:
+            data = f.read()
+    except OSError as exc:  # noqa: BLE001 -- best-effort diagnostic read
+        return f"<could not read boot log: {exc}>"
+    text = data.decode("utf-8", errors="replace")
+    if len(text) > _LOG_TAIL_CHARS:
+        text = "...(truncated)...\n" + text[-_LOG_TAIL_CHARS:]
+    return text or "<boot log is empty>"
+
 
 @contextmanager
 def _primer_running():
     env = os.environ.copy()
-    env.setdefault("PRIMER_BIND_PORT", "8766")
-    proc = subprocess.Popen(
-        ["uv", "run", "primer", "api", "--no-worker"],
-        env=env,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.STDOUT,
-    )
+    env.setdefault("PRIMER_PORT", "8766")
+    # The server's own stdout/stderr used to go to DEVNULL, so a genuine
+    # boot failure (config error, DB connection failure, missing dep -
+    # anything) surfaced to the test only as "connection refused" from the
+    # httpx retry loop below, with no indication of WHY. Captured to a
+    # file instead so a failure can quote the server's own output.
+    with tempfile.NamedTemporaryFile(
+        prefix="primer-boot-smoke-", suffix=".log", delete=False,
+    ) as log_file:
+        log_path = log_file.name
+        proc = subprocess.Popen(
+            ["uv", "run", "primer", "api", "--no-worker"],
+            env=env,
+            stdout=log_file,
+            stderr=subprocess.STDOUT,
+        )
     try:
         # Wait up to 30s for the server to come up.
         deadline = time.time() + 30
         last_err: Exception | None = None
+        last_status: int | None = None
         while time.time() < deadline:
+            # Fail fast on a crashed process instead of burning the full
+            # 30s busy-polling a port nothing will ever answer on.
+            exit_code = proc.poll()
+            if exit_code is not None:
+                raise RuntimeError(
+                    f"primer server process exited early (code={exit_code}) "
+                    f"before becoming healthy; boot log:\n{_tail(log_path)}"
+                )
             try:
-                r = httpx.get("http://127.0.0.1:8766/healthz", timeout=1.0)
+                r = httpx.get("http://127.0.0.1:8766/v1/health", timeout=1.0)
+                last_status = r.status_code
                 if r.status_code == 200:
                     break
             except Exception as e:  # noqa: BLE001
                 last_err = e
-                time.sleep(0.5)
+            time.sleep(0.5)
         else:
-            raise RuntimeError(f"server failed to come up: {last_err}")
+            raise RuntimeError(
+                f"server failed to come up within 30s "
+                f"(last_status={last_status!r}, last_error={last_err!r}); "
+                f"boot log:\n{_tail(log_path)}"
+            )
         yield "http://127.0.0.1:8766"
     finally:
         proc.terminate()
@@ -43,6 +83,10 @@ def _primer_running():
             proc.wait(timeout=5)
         except subprocess.TimeoutExpired:
             proc.kill()
+        try:
+            os.unlink(log_path)
+        except OSError:
+            pass
 
 
 @pytest.mark.skipif(
@@ -55,12 +99,21 @@ def test_bundle_contains_mobile_primitives() -> None:
         assert r.status_code == 200
         body = r.text
         for symbol in (
+            # Classic mobile suite (ui/components/shared/*.jsx) - still
+            # live; provider-catalog pages stay on this suite by design
+            # (not mobile-ported to the uiv2 shell below).
             "useViewport",
             "CardList",
             "BottomSheet",
             "MobileTabs",
             "Fab",
-            "MobileNav",
             "sheet-overlay",
+            # uiv2 mobile shell (ui/components/console/nv-mobile-shell.jsx,
+            # NV_Mobile*-prefixed, US-014 through 214be5f1) - the live
+            # console mobile experience. "MobileNav" (the old chrome's
+            # drawer component, added 8eba64cb, retired f891557c) had no
+            # replacement-in-kind here; anchoring on this instead of
+            # dropping the uiv2 shell from coverage entirely.
+            "NV_MobileChatScreen",
         ):
             assert symbol in body, f"bundle missing {symbol}"


### PR DESCRIPTION
## Summary

Task 01a08117. `tests/ui/test_mobile_bundle_smoke.py` is opt-in (`PRIMER_RUN_BOOT_SMOKE=1`) and has been since it was added — nobody has ever seen it go green. Running it opt-in for the first time surfaced three stacked bugs, **each masking the next**, found by making the harness loud *first* rather than assuming the obvious rename was the whole fix:

1. **Wrong env var.** Line 18 set `PRIMER_BIND_PORT=8766`, a name that appears nowhere else in the tree. `AppConfig` uses `env_prefix="PRIMER_"` with field `port` (`primer/api/config.py:92,131`), so the real var is `PRIMER_PORT`. The subprocess bound the default 8000 while the test polled 8766.
2. **Quiet failure mode.** The retry loop's own weaknesses hid bug 3 behind it: subprocess output went to `DEVNULL`, a non-200 response never got recorded anywhere (only exceptions set `last_err`, so the loop busy-spun with no sleep between a non-200 response), and nothing checked whether the process had already exited. A real boot crash would burn the full 30s and then report `"server failed to come up: None"` — telling nobody why. Fixed by capturing the boot log to a temp file (quoted in the failure message), tracking the last HTTP status seen, and polling `proc.poll()` every iteration so a crashed process fails immediately instead of waiting out the clock.
3. **Wrong probe path.** Once (1) and the loudness fix from (2) let the server actually boot and get polled, it revealed the *real* remaining bug: the test polled `/healthz`, which has never existed anywhere in this codebase (grep-confirmed, zero hits). The liveness probe is `primer/api/routers/health.py`'s `/health` route, mounted under the version prefix at `/v1/health`. Confirmed via the captured boot log showing ~40 consecutive `GET /healthz 404` lines that a bare timeout would have discarded — the loudness fix found this bug on its first real execution.

With all three fixed, the test finally reaches its own assertion — which then failed for real: the bundle has no `"MobileNav"` (git-blamed to `8eba64cb`, retired at `f891557c` along with the rest of the old chrome; no replacement-in-kind exists in the tree today). Its six sibling symbols (`useViewport`/`CardList`/`BottomSheet`/`MobileTabs`/`Fab`/`sheet-overlay`, the still-live classic mobile suite) are untouched and were verified present. Added one anchor from the *current* console mobile surface instead — `NV_MobileChatScreen` (`ui/components/console/nv-mobile-shell.jsx`, the uiv2 mobile shell, US-014 through `214be5f1`) — verified present in the actually-served bundle (not just in source) before adding it.

## Test plan

- [x] Fixed test passes opt-in: `PRIMER_RUN_BOOT_SMOKE=1 ... pytest tests/ui/test_mobile_bundle_smoke.py` → 1 passed in ~7s
- [x] Red path verified empirically, not assumed: deliberately broke the boot (`PRIMER_PORT=not-a-number`, an invalid config value) → fails in ~4s with the actual pydantic `ValidationError` quoted in the message, instead of burning 30s and reporting nothing useful
- [x] Checked `tests/ui/test_drawer_sidebar_visible.py` while in the area — its docstring shares the same now-stale "MobileNav renders a nested Sidebar" premise, but its three assertions check only static CSS selector text in `styles.css`'s mobile media block (`.drawer .sidebar` / `.drawer .sidebar.is-collapsed` / `.drawer .sidebar .nav-group`), with no dependency on any JS component's existence or behavior. Still 3/3 passing today — the docstring's premise is stale, the test itself is not. Left as-is (out of scope here); worth a docstring-only follow-up.
- [x] `ui/styles.css:2318` also still carries a comment describing the retired `MobileNav` component — harmless dead documentation, noted here rather than touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)