### PR TITLE
fix(ui_e2e): u0073 worker-pill flake was a same-document navigation, not a slow one

### DIFF
--- a/tests/ui_e2e/_shell_helpers.py
+++ b/tests/ui_e2e/_shell_helpers.py
@@ -58,8 +58,59 @@ def open_doc(page: Page, console_url: str, wid: str, kind: str, ref: str,
 
 def open_overlay(page: Page, console_url: str, wid: str, name: str,
                  *, timeout: int = 20_000) -> None:
-    page.goto(f"{console_url}#/w/{wid}?overlay={name}")
+    """Navigate to a workspace-scoped ``?overlay=`` route and wait for it
+    to actually render.
+
+    01a0823a: shares open_view's same-document hash-assignment fix — this
+    used a raw page.goto() to a hash-only URL, which is the identical
+    bug (see open_view's docstring): on a page already bootstrapped at
+    this origin, that's a same-document navigation whose hashchange/
+    popstate firing isn't guaranteed, and nv-shell.jsx's URL-sync
+    listener only reacts to those two events. Direct hash assignment is
+    the browser's own primitive that unambiguously queues a hashchange.
+    """
+    fragment = f"#/w/{wid}?overlay={name}"
+    current_origin = page.url.split("#", 1)[0].rstrip("/")
+    console_origin = console_url.rstrip("/")
+    if current_origin == console_origin:
+        page.evaluate("(h) => { window.location.hash = h; }", fragment)
+    else:
+        page.goto(f"{console_url}{fragment}")
     expect(page.get_by_test_id(f"nv-overlay:{name}")).to_be_visible(timeout=timeout)
+
+
+def open_view(page: Page, console_url: str, wid: str, view: str,
+              *, timeout: int = 20_000) -> None:
+    """Navigate to a workspace-scoped ``?view=`` route (e.g. the System
+    dashboard's ``system:dashboard``) and wait for it to actually render.
+
+    01a0823a: uses the SAME same-document hash-assignment
+    ``open_legacy_route`` already earned its 45s budget over, not a
+    fresh ``page.goto()``. Every real caller reaches this with the
+    console already loaded (the ``page`` fixture's own pre-navigation
+    guarantees it - see that fixture's docstring), so a ``page.goto()``
+    to a URL differing only by hash is a same-document navigation whose
+    ``hashchange``/``popstate`` firing is NOT guaranteed across
+    Playwright/browser navigation classification - and
+    ``nv-shell.jsx``'s URL-sync listener (the only thing that ever calls
+    ``setView``) only runs on those two events. A ``page.goto()`` here
+    that doesn't fire one leaves the console showing whatever view the
+    page was already on: the target view's content (here,
+    ``NV_WorkerFleet``) never mounts, and a caller waiting on one of its
+    test ids waits out its full timeout against a view that was never
+    going to change - indistinguishable from "still loading" without
+    reading nv-shell.jsx's own event wiring. Direct hash assignment is
+    the browser's own native primitive for this, which unambiguously
+    queues a hashchange task per spec regardless of how Playwright
+    classifies the navigation.
+    """
+    fragment = f"#/w/{wid}?view={view}"
+    current_origin = page.url.split("#", 1)[0].rstrip("/")
+    console_origin = console_url.rstrip("/")
+    if current_origin == console_origin:
+        page.evaluate("(h) => { window.location.hash = h; }", fragment)
+    else:
+        page.goto(f"{console_url}{fragment}")
 
 
 def open_palette(page: Page) -> None:

--- a/tests/ui_e2e/test_signals_files_workers.py
+++ b/tests/ui_e2e/test_signals_files_workers.py
@@ -16,6 +16,7 @@ import httpx
 import pytest
 from playwright.sync_api import expect
 
+from tests.ui_e2e._shell_helpers import open_view
 from tests.ui_e2e._studio_helpers import open_workspace_settings, open_session_in_studio
 
 
@@ -232,14 +233,19 @@ def test_u0072_workspace_files_tab_lists_api_written_file(
 def test_u0073_worker_pill_reflects_drain_within_polling(
     page, base_url, console_url, unique_suffix,
 ) -> None:
-    """U0073 — The topbar worker-pill text is "{active}/{total}"
-    computed from /v1/workers items filtered by status=active.
-    POSTing /workers/{id}/drain on the sole worker changes its
-    status from 'active' to 'draining'; the pill polls every ~5s
-    and should update from "1/1" to "0/1" within ~10s.
+    """U0073 — A per-worker row in NV_WorkerFleet (System dashboard)
+    reflects a drain signal. POSTing /workers/{id}/drain on the sole
+    worker changes its status from 'active' to 'draining'; the row's
+    text should stop containing "active" within the fleet's ~8s
+    poll cadence.
 
-    Pins the worker-pill polling cadence + status filter in
-    primer's the console shell TopBar.
+    Pins the worker-fleet row's polling + status rendering on the
+    System dashboard.
+
+    The "worker_pill" in this test's name is historical: it predates
+    the flag-day re-point that moved this surface from a topbar pill
+    ("{active}/{total}") to the per-worker dashboard row tested here.
+    Kept for CI-history/board-task traceability rather than renamed.
     """
     # Find the registered worker via API. If no active workers
     # remain (a prior test already drained the sole worker — drain
@@ -261,30 +267,29 @@ def test_u0073_worker_pill_reflects_drain_within_polling(
     try:
         # Re-pointed (flag day): the worker fleet lives on the System
         # dashboard now, one row per worker with its live status.
-        page.goto(f"{console_url}#/w/primer?view=system:dashboard",
-                  wait_until="domcontentloaded")
+        #
+        # 01a0823a: the u0073 recurrence after 91fcb2ae's timeout-headroom
+        # bump (30s, previously 15s) proved headroom was never the fix --
+        # the raw page.goto() below used to navigate this hash-only URL
+        # change, which is NOT guaranteed to fire the hashchange/popstate
+        # event nv-shell.jsx's URL-sync listener depends on to actually
+        # switch the rendered view (the exact same Playwright/browser
+        # navigation-classification quirk _shell_helpers.open_legacy_route
+        # was already fixed for, over in the ?overlay= grammar - see its
+        # own comment). When the event doesn't fire, the console keeps
+        # showing whichever view the `page` fixture's own initial
+        # navigation left it on: NV_WorkerFleet never mounts, and the row
+        # search below waits out its FULL timeout against a view that was
+        # never going to gain that row, no matter how long the wait is --
+        # indistinguishable from "still loading" without reading
+        # nv-shell.jsx's own hashchange wiring. open_view uses the
+        # browser's native window.location.hash assignment instead, which
+        # unambiguously queues a hashchange task per spec.
+        open_view(page, console_url, "primer", "system:dashboard")
         row = page.get_by_test_id(f"nv-worker:{worker_id}")
-        # 01a0651f (4-strike CI flake, root-caused from 3 real CI log
-        # occurrences across PR #215 and #220, evidence-first per the
-        # de-flake convention this repo already uses for the same
-        # shape - see 7d404cac/cd949f69): "domcontentloaded" only means
-        # the initial HTML loaded, not that React has mounted. This
-        # no-build app transpiles its whole JSX bundle with babel-
-        # standalone IN the browser on every load, then NV_WorkerFleet
-        # mounts and fires its FIRST /v1/workers fetch immediately (not
-        # poll-gated - confirmed in ui/foundation/use-resource.js,
-        # runFetch() runs synchronously on mount, pollMs only paces
-        # SUBSEQUENT fetches). The 15s budget covers that entire
-        # navigate -> transpile -> mount -> fetch -> render chain in
-        # ONE wait with no margin; two of the three CI failures also
-        # had OTHER, unrelated bootstrap-dependent waits fail in the
-        # same run, pointing at general CI-runner contention (shared
-        # CPU under the full ui_e2e suite) rather than anything specific
-        # to worker draining or /v1/workers itself - the API confirms
-        # the worker is genuinely active moments before this wait even
-        # starts. 30s matches this repo's existing convention for this
-        # exact flake shape (absorb runner load, not chase a phantom
-        # backend bug).
+        # With the navigation itself now reliable, this covers only the
+        # genuine remaining async chain (mount -> fetch -> render) under
+        # CI load - not a phantom "maybe the route switched" wait.
         row.wait_for(state="visible", timeout=30_000)
         assert "active" in (row.text_content() or ""), (
             f"expected an active worker row, got {row.text_content()!r}"


### PR DESCRIPTION
## Mechanism

`test_u0073_worker_pill_reflects_drain_within_polling` navigated to the System dashboard with a raw `page.goto()` to a URL differing from the current one only by its hash fragment. The shared `page` fixture already loads the console before every test body runs, so this is a **same-document navigation** in Playwright/browser terms — and that kind of navigation is not guaranteed to fire `hashchange`/`popstate`. `nv-shell.jsx`'s URL-sync effect is wired exclusively to those two events; when neither fires, the console keeps rendering whatever view it was already on, `NV_WorkerFleet` never mounts, and the row-visibility wait times out no matter how long its budget is — it was waiting on a view that was never going to change.

**Commit 91fcb2ae bumped that wait from 15s to 30s ("CI-load headroom") and the flake recurred anyway, because more time cannot help a navigation that was never going to complete.** This is the same failure mode `_shell_helpers.open_legacy_route` was already fixed for, in the same file, for the `?overlay=` grammar: assigning `window.location.hash` directly is the browser's own primitive for this, and it unambiguously queues a `hashchange` task regardless of how Playwright classifies the navigation.

## Fix

- New `open_view()` helper mirrors `open_legacy_route`'s exact pattern (hash-assign when already on the console origin, `goto()` fallback otherwise) for the `?view=` grammar; `test_u0073` now uses it instead of a raw `goto()`.
- The 30s row-wait budget is left alone — with the navigation itself reliable, it was never the actual bug and still covers the genuine mount → fetch → render chain under CI load.
- Negative result worth noting: the row's data source is `useResource` at `pollMs=8000`, and the drain path's own 20s post-drain wait comfortably covers a full poll cycle, so that second wait was never implicated either. It's the first (navigation) wait that fails, which is what isolates the fix to this.

## Folded in

`open_overlay()` had the identical raw-goto-on-hash-only bug for the `?overlay=` grammar. Its only caller is `test_shell_journeys.py::test_a_management_surface_opens_as_an_overlay` (parametrized over providers/agents/collections/workers) — verified passing twice against a live stack after the fix, no regressions.

Also rewrote `test_u0073`'s docstring, which still described a retired topbar `"{active}/{total}"` pill rather than the per-worker dashboard row the test body actually exercises (since a prior flag-day re-point). Kept the function name — including the `u0073` prefix — for CI-history and board-task traceability, with a line documenting the historical mismatch.

## Verification

- 5 live cycles of `test_u0073` against a fresh active worker each time (drain has no public undo, so the app container was restarted between cycles) — all green.
- `test_a_management_surface_opens_as_an_overlay` (4 parametrized cases) run twice against a live stack — all green, no regressions from the `open_overlay()` fix.
- Grepped `tests/ui_e2e/` for the rest of this bug class (raw `page.goto()` with a `#` in the URL). A few more instances turned up in `_studio_helpers.py` (`open_workspace_settings`, `open_provider_catalog`) and two tests (`test_full_operator_journey.py`, `test_mobile_no_horizontal_overflow.py`). Reported to the lead, deliberately left unfixed here pending its own verification pass.

## Test plan

- [x] `test_u0073_worker_pill_reflects_drain_within_polling` — 5 cycles, all green
- [x] `test_a_management_surface_opens_as_an_overlay[providers|agents|collections|workers]` — 2 runs, all green
- [x] `py_compile` + `ruff check` clean on both changed files