### PR TITLE
fix(ui_e2e): close the rest of the same-document-navigation class

### DIFF
--- a/tests/ui_e2e/_shell_helpers.py
+++ b/tests/ui_e2e/_shell_helpers.py
@@ -113,6 +113,31 @@ def open_view(page: Page, console_url: str, wid: str, view: str,
         page.goto(f"{console_url}{fragment}")
 
 
+def open_root(page: Page, console_url: str) -> None:
+    """Navigate back to the bare console root (no workspace/overlay/view).
+
+    01a08248: shares open_view/open_overlay's same-document hash-
+    assignment fix. Once the console has resolved a default workspace,
+    its own URL-sync write effect (SH_buildUrl in shell-url.js) has
+    already rewritten the hash to "#/w/<wid>" - a caller is essentially
+    never on a genuinely hash-less URL by the time it wants "back to the
+    shell," so a raw page.goto() to "#/" is a same-document, hash-only
+    change whose hashchange/popstate firing isn't guaranteed, and
+    nv-shell.jsx's URL-sync listener only reacts to those two events.
+
+    No post-nav assertion here (unlike open_overlay) - "the shell" means
+    different things on desktop (nv-root) vs mobile (nv-mobile-shell,
+    US-014), so the caller waits on whichever applies.
+    """
+    fragment = "#/"
+    current_origin = page.url.split("#", 1)[0].rstrip("/")
+    console_origin = console_url.rstrip("/")
+    if current_origin == console_origin:
+        page.evaluate("(h) => { window.location.hash = h; }", fragment)
+    else:
+        page.goto(f"{console_url}{fragment}")
+
+
 def open_palette(page: Page) -> None:
     """Open the command palette, by its own affordance.
 

--- a/tests/ui_e2e/_studio_helpers.py
+++ b/tests/ui_e2e/_studio_helpers.py
@@ -206,8 +206,21 @@ def open_workspace_settings(
     Returns the overlay body locator so callers can scope subsequent
     queries inside it (avoiding strict-mode clashes with the nested
     Link-channel / Destroy-confirm modals rendered on top).
+
+    01a08248: same same-document-navigation hazard open_overlay/open_view
+    were fixed for in _shell_helpers.py - on a page already bootstrapped
+    at the console origin, a raw page.goto() to a hash-only URL is not
+    guaranteed to fire hashchange/popstate, and nv-shell.jsx's URL-sync
+    listener only reacts to those two events. Direct hash assignment is
+    the browser's own primitive that unambiguously queues one.
     """
-    page.goto(f"{console_url}#/w/{wid}?overlay=workspaces:detail:{wid}")
+    fragment = f"#/w/{wid}?overlay=workspaces:detail:{wid}"
+    current_origin = page.url.split("#", 1)[0].rstrip("/")
+    console_origin = console_url.rstrip("/")
+    if current_origin == console_origin:
+        page.evaluate("(h) => { window.location.hash = h; }", fragment)
+    else:
+        page.goto(f"{console_url}{fragment}")
     body = page.get_by_test_id("nv-overlay-body")
     expect(body).to_be_visible(timeout=timeout)
     tab = page.get_by_test_id(f"workspace-tab:{section}")
@@ -258,6 +271,13 @@ def open_provider_catalog(
 
     ``wid`` defaults to the workspace already open, which is what a test
     that only cares about the catalog wants.
+
+    01a08248: same same-document-navigation hazard as
+    open_workspace_settings above - a raw page.goto() to a hash-only URL
+    on an already-bootstrapped page is not guaranteed to fire
+    hashchange/popstate, which is the only thing nv-shell.jsx's URL-sync
+    listener reacts to. Direct hash assignment is the browser's own
+    primitive that unambiguously queues one.
     """
     if via == "url":
         # RETARGET (IA restructure 01a04d6a): the "providers" overlay
@@ -268,10 +288,15 @@ def open_provider_catalog(
             target += ":" + cls
             if instance_id:
                 target += ":" + instance_id
-        if wid:
-            page.goto(f"{console_url}#/w/{wid}?overlay={target}")
+        fragment = (
+            f"#/w/{wid}?overlay={target}" if wid else f"#/w/?overlay={target}"
+        )
+        current_origin = page.url.split("#", 1)[0].rstrip("/")
+        console_origin = console_url.rstrip("/")
+        if current_origin == console_origin:
+            page.evaluate("(h) => { window.location.hash = h; }", fragment)
         else:
-            page.goto(f"{console_url}#/w/?overlay={target}")
+            page.goto(f"{console_url}{fragment}")
         body = page.get_by_test_id("nv-overlay-body")
         expect(body).to_be_visible(timeout=timeout)
         return body

--- a/tests/ui_e2e/test_full_operator_journey.py
+++ b/tests/ui_e2e/test_full_operator_journey.py
@@ -32,7 +32,7 @@ import pytest
 
 from tests._support.smk import smk  # noqa: E402
 from tests._support.model_profiles import agent_model, seed_llm_provider_with
-from tests.ui_e2e._shell_helpers import open_legacy_route, wait_for_overlay_url
+from tests.ui_e2e._shell_helpers import open_legacy_route, open_root, wait_for_overlay_url
 pytestmark = smk("SMK-UI-02", "SMK-UI-03", "SMK-UI-04", "SMK-UI-06")
 
 
@@ -272,7 +272,11 @@ def test_multi_page_operator_journey_no_llm(
         # There is no dashboard page and no page title outside an
         # overlay, same as step 1: landing on the console lands you in a
         # workspace.
-        page.goto(f"{console_url}#/", wait_until="domcontentloaded")
+        # 01a08248: raw page.goto() to a hash-only URL here is a same-
+        # document navigation (the page is deep in the providers/llm
+        # overlay from step 8) whose hashchange/popstate firing isn't
+        # guaranteed - see open_root's docstring.
+        open_root(page, console_url)
         page.get_by_test_id("nv-root").wait_for(
             state="visible", timeout=10_000,
         )

--- a/tests/ui_e2e/test_mobile_no_horizontal_overflow.py
+++ b/tests/ui_e2e/test_mobile_no_horizontal_overflow.py
@@ -24,7 +24,7 @@ from playwright.sync_api import Page  # noqa: E402
 
 
 from tests._support.smk import smk  # noqa: E402
-from tests.ui_e2e._shell_helpers import MOBILE_TABS, open_mobile_tab
+from tests.ui_e2e._shell_helpers import MOBILE_TABS, open_mobile_tab, open_root
 
 pytestmark = smk("SMK-UI-01", status="partial")
 
@@ -123,7 +123,12 @@ def test_the_worker_pill_stays_one_line_on_a_phone(page: Page, console_url: str)
     """Letting the pill shrink is only half the fix -- unconstrained it wraps
     'N/N workers - N in flight' mid-phrase and doubles its own height."""
     page.set_viewport_size({"width": 390, "height": 844})
-    page.goto(f"{console_url}#/")
+    # 01a08248: once the console has picked a default workspace its own
+    # URL-sync effect has already rewritten the hash to "#/w/<wid>", so
+    # this is a same-document, hash-only navigation whose hashchange may
+    # never fire (see open_root's docstring) - not the hash-less no-op
+    # it looks like at a glance.
+    open_root(page, console_url)
     page.wait_for_load_state("domcontentloaded")
     page.wait_for_timeout(1500)
 


### PR DESCRIPTION
Follow-up to #254 (u0073 worker-pill flake / open_view + open_overlay). That PR surveyed the rest of `tests/ui_e2e/` for the same bug class and reported four more sites, deliberately left unfixed pending their own verification pass. This is that batch.

## Mechanism (same as #254)

A raw `page.goto()` to a URL differing from the current one only by its hash fragment is, on a page already bootstrapped at the console origin, a **same-document navigation** — and that kind of navigation is not guaranteed to fire `hashchange`/`popstate`. `nv-shell.jsx`'s URL-sync effect is wired exclusively to those two events, so a navigation that doesn't fire one leaves the console showing whatever it was already on. These four sites were latent (not yet reported as flaky) rather than known-failing, but the same mechanism applies.

## Fixed

- **`_studio_helpers.py::open_workspace_settings`** — single unconditional `page.goto()` to a `?overlay=workspaces:detail:...` URL.
- **`_studio_helpers.py::open_provider_catalog`** — both branches of its `via=="url"` path had their own unconditional `page.goto()`.
- **New `open_root()` helper** in `_shell_helpers.py` for the two remaining bare `"#/"` sites (`test_full_operator_journey.py`, `test_mobile_no_horizontal_overflow.py`).

All three mirror `open_overlay`'s exact pattern: assign `window.location.hash` directly when already on the console origin, fall back to a real `goto()` only for a genuinely fresh navigation.

`open_root()` has no built-in post-nav assertion (unlike `open_overlay`): "the shell" renders as `nv-root` on desktop but `nv-mobile-shell` on mobile (US-014), so each caller waits on whichever applies.

## A correction on my own survey

The mobile site (`test_mobile_no_horizontal_overflow.py:126`) was flagged as "likely inert" in the original survey, since the `page` fixture never puts a hash on the URL before this test runs, so `goto("#/")` looked like it might be going nowhere. Tracing `nv-shell.jsx`'s own URL-sync *write* effect (`SH_buildUrl` in `shell-url.js`) shows it rewrites the hash to `"#/w/<wid>"` as soon as any workspace resolves — which the shared e2e stack normally has, from other tests' fixture residue. So in practice this is a real hash change, not the harmless lookalike it first appeared to be. Fixed for real rather than left as a documented landmine.

## Verification

Live stack run of every caller of the two touched `_studio_helpers.py` functions, across all 11 affected test files (33 tests total):

```
29 passed, 4 skipped in 46.01s
```

The 4 skips are pre-existing, unrelated skip-soft conditions (container/host filesystem mismatch, login-not-ready precondition, absent worker pill on this deployment) — none caused by this change. 0 failures, 0 regressions.

## Test plan

- [x] `test_channels_onboarding_journey.py`, `test_session_files_toast_lasterr.py`, `test_signals_files_workers.py`, `test_workspace_destroy_graph_provider.py`, `test_workspace_reply_binding.py`, `test_workspace_session_graph_signals.py`, `test_workspace_tap_events.py`, `test_backfill_sister_2.py`, `test_provider_catalog_journey.py`, `test_full_operator_journey.py`, `test_mobile_no_horizontal_overflow.py` — all green (see above)
- [x] `py_compile` + `ruff check` clean on all four changed files