### PR TITLE
fix(ui): system dashboard worker-pool value stops rendering a permanent ellipsis

### DIFF
--- a/tests/ui/test_console_system.py
+++ b/tests/ui/test_console_system.py
@@ -95,6 +95,19 @@ def test_worker_pool_capacity_falls_back_to_a_clean_label_not_a_bare_question_ma
     assert 'wp.capacity == null ? "n/a" : wp.capacity' in SYS
 
 
+def test_worker_pool_in_flight_renders_na_not_a_permanent_ellipsis():
+    # dogfood defect hunt: worker_pool.in_flight is documented (health.py
+    # WorkerPoolHealth) as PERMANENTLY null on an API-only pod - live
+    # per-worker load is never persisted, by design, not merely "not
+    # loaded yet". The card's main value rendered a literal "…" for this
+    # case, which reads identically to a transient loading state that
+    # will resolve - it never does, on this deployment topology. Same
+    # fallback the capacity subtitle already uses one line below (this
+    # exact file, same commit that fixed capacity's own "?" case).
+    assert 'wp.in_flight == null ? "…"' not in SYS
+    assert 'wp.in_flight == null ? "n/a" : wp.in_flight' in SYS
+
+
 def test_worker_rows_carry_turns_and_uptime():
     # notes section 4: "worker rows show ... turns + uptime". Turns come
     # from grouping /workers/stats by worker id (workers.jsx's own lane

--- a/ui/components/console/nv-system.jsx
+++ b/ui/components/console/nv-system.jsx
@@ -100,7 +100,7 @@ function NV_HealthCards() {
       tone: schedOk ? "var(--green)" : (sched.alive ? "var(--amber)" : "var(--red)"),
     },
     {
-      k: "worker pool", v: String(wp.in_flight == null ? "…" : wp.in_flight),
+      k: "worker pool", v: String(wp.in_flight == null ? "n/a" : wp.in_flight),
       sub: "of " + (wp.capacity == null ? "n/a" : wp.capacity) + " capacity",
       tone: "var(--blue)",
     },


### PR DESCRIPTION
The worker-pool health card rendered `…` when `wp.in_flight` was null. That reads as "still loading" when it actually means "unavailable and never arriving".

Found via a dogfood pass against the live console.

**Scope is deliberately one card, not four.** The other three cards in `NV_HealthCards` use the same `== null ? "…"` shape, but each was traced to its backend and they structurally cannot resolve to null on a successful response (`SchedulerHealth.alive` is a required non-Optional bool; sessions and yields handlers always return an int total). Their `…` is honest pre-first-fetch loading. Changing them would have been a regression.

The correct convention was already present inside the changed line: `sub: "of " + (wp.capacity == null ? "n/a" : wp.capacity)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)