### PR TITLE
fix(ui): ApiError surfaces a domain error detail instead of a generic 422 fallback

### DIFF
--- a/tests/ui/test_foundation_api.py
+++ b/tests/ui/test_foundation_api.py
@@ -1,0 +1,129 @@
+"""ui/foundation/api.js — ApiError's 422 handling.
+
+Pure logic (no DOM/fetch involved in the constructor itself), so it is
+EXECUTED here via MiniRacer rather than substring-matched, mirroring
+tests/ui/test_shell_url.py's own convention for foundation/*.js.
+
+Dogfood defect hunt (2026-09-09): the constructor used to branch on
+`envelope.status === 422` ALONE, discarding the backend's own `detail`
+for EVERY 422 - including a domain-level PrimerError (e.g.
+primer/session/rewind.py's ValidationError, "seq 1 is the newest
+visible record; nothing to discard"), which never populates
+`extensions.errors` the way FastAPI's own RequestValidationError does.
+The operator saw a generic "Some required fields are missing or
+invalid." instead of the real, specific reason. Fixed to branch on the
+SHAPE of the payload (a non-empty `extensions.errors` array) instead of
+the status code alone.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE = ROOT / "ui" / "foundation" / "api.js"
+
+
+def _ctx():
+    from py_mini_racer import MiniRacer
+
+    ctx = MiniRacer()
+    ctx.eval("var window = globalThis;")
+    ctx.eval(MODULE.read_text(encoding="utf-8"))
+    return ctx
+
+
+def _new_api_error(ctx, envelope: dict) -> dict:
+    ctx.eval(f"var __envelope = {json.dumps(envelope)};")
+    ctx.eval("var __err = new window.primerApi.ApiError(__envelope);")
+    return json.loads(ctx.eval(
+        "JSON.stringify({title: __err.title, detail: __err.detail, "
+        "fieldErrors: __err.fieldErrors})"
+    ))
+
+
+def test_registered_on_primer_api() -> None:
+    src = MODULE.read_text(encoding="utf-8")
+    assert "ns.ApiError = ApiError" in src
+    assert 'src="foundation/api.js"' in (
+        (ROOT / "ui" / "index.html").read_text(encoding="utf-8")
+    )
+
+
+def test_domain_422_surfaces_its_own_specific_detail() -> None:
+    # primer/api/errors.py's _make_primer_error_handler shape: no
+    # `extensions.errors` field list, just a specific `detail` message.
+    envelope = {
+        "status": 422,
+        "type": "/errors/validation-error",
+        "title": "Validation Error",
+        "detail": "seq 1 is the newest visible record; nothing to discard",
+        "extensions": {"request_id": "req-abc123"},
+    }
+    out = _new_api_error(_ctx(), envelope)
+    assert out["detail"] == "seq 1 is the newest visible record; nothing to discard"
+    assert out["title"] == "Validation Error"
+
+
+def test_domain_422_with_no_extensions_at_all_also_surfaces_detail() -> None:
+    # Some domain 422s carry no extensions object at all (envelope.extensions
+    # is undefined, not even an empty dict) - must not crash and must still
+    # prefer the real detail.
+    envelope = {
+        "status": 422,
+        "type": "/errors/conflict",
+        "title": "Validation Error",
+        "detail": "workspace is archived; cannot create a session",
+    }
+    out = _new_api_error(_ctx(), envelope)
+    assert out["detail"] == "workspace is archived; cannot create a session"
+
+
+def test_pydantic_422_still_gets_the_friendly_field_summary() -> None:
+    # FastAPI's own RequestValidationError shape: extensions.errors is a
+    # non-empty field-error list. This behavior must survive unchanged -
+    # the fix narrows the OLD status-only branch to this shape, it does
+    # not remove the friendliness for genuine field-validation failures.
+    envelope = {
+        "status": 422,
+        "type": "/errors/validation-error",
+        "title": "Validation Error",
+        "detail": "field required",
+        "extensions": {
+            "errors": [
+                {"loc": ["body", "name"], "msg": "field required"},
+                {"loc": ["body", "email"], "msg": "field required"},
+            ],
+        },
+    }
+    out = _new_api_error(_ctx(), envelope)
+    assert out["title"] == "Data is incomplete"
+    assert out["detail"] == "Missing or invalid: name, email."
+
+
+def test_pydantic_422_with_empty_errors_array_falls_back_to_envelope_detail() -> None:
+    # extensions.errors present but EMPTY is the same "no field list"
+    # shape as absent - must not render the friendly-fallback string
+    # ("Some required fields are missing or invalid.") over a real detail.
+    envelope = {
+        "status": 422,
+        "type": "/errors/validation-error",
+        "title": "Validation Error",
+        "detail": "a specific real reason",
+        "extensions": {"errors": []},
+    }
+    out = _new_api_error(_ctx(), envelope)
+    assert out["detail"] == "a specific real reason"
+
+
+def test_non_422_status_is_unaffected() -> None:
+    envelope = {
+        "status": 409,
+        "type": "/errors/conflict",
+        "title": "Conflict",
+        "detail": "session is not idle; rewind requires no turn in flight",
+    }
+    out = _new_api_error(_ctx(), envelope)
+    assert out["title"] == "Conflict"
+    assert out["detail"] == "session is not idle; rewind requires no turn in flight"

--- a/tests/ui_e2e/test_ask_user_panel.py
+++ b/tests/ui_e2e/test_ask_user_panel.py
@@ -373,6 +373,20 @@ def test_u0051_ask_user_panel_renders_422_inline_for_schema_violation(
     branch - a single ``respond`` input backs every ask_user park - so this
     now pins purely the server-error-renders-inline half of the old
     contract, which is the operator-facing invariant that survived.)
+
+    The mocked envelope below carries no ``extensions.errors`` - it's the
+    domain-PrimerError shape (see primer/api/errors.py's
+    _make_primer_error_handler), not FastAPI's own field-validation shape.
+    ui/foundation/api.js's ApiError constructor branches on that shape, not
+    on the 422 status alone: with no field list, it takes the domain-detail
+    branch and surfaces ``envelope.detail`` verbatim rather than the
+    generic "Some required fields are missing or invalid." fallback that
+    branch is reserved for. This test used to assert that generic fallback
+    text was correct here - it was pinning the bug that fix used to have,
+    not the intended behaviour. Do not revert the assertion below to the
+    generic text without first checking whether the mocked envelope has
+    grown an ``extensions.errors`` field; if it hasn't, the specific detail
+    is the right thing to render.
     """
     wid, sid, cleanup_urls = _seed_ladder(base_url, unique_suffix, tmp_path)
     try:
@@ -408,13 +422,17 @@ def test_u0051_ask_user_panel_renders_422_inline_for_schema_violation(
         respond.fill("something")
         respond.press("Enter")
 
-        # Inline error text renders on the item; the friendly 422 summary the
-        # API client builds surfaces (ui/foundation/api.js
-        # ``_friendlyValidationDetail``). It is inline, not a toast.
+        # Inline error text renders on the item: the mocked envelope's own
+        # `detail` (no extensions.errors on this envelope, so ApiError
+        # surfaces the domain detail verbatim rather than the generic
+        # field-validation summary). Matching the stable prefix rather
+        # than the full string keeps this test from being brittle to an
+        # unrelated wording tweak on the mocked message's suffix. It is
+        # inline, not a toast.
         expect(card).to_contain_text(
-            "required fields are missing or invalid", timeout=5_000,
+            "response failed schema validation", timeout=5_000,
         )
-        assert page.locator(".toast").filter(has_text="required fields").count() == 0, (
+        assert page.locator(".toast").filter(has_text="response failed schema validation").count() == 0, (
             "422 should render inline on the decision card, not as a toast"
         )
         # The card stays put so the operator can retry.

--- a/ui/foundation/api.js
+++ b/ui/foundation/api.js
@@ -17,10 +17,9 @@
   }
 
   // Build the friendly 422 summary: "Missing or invalid: a, b (max 4)".
+  // Callers must guarantee a non-empty array (ApiError's constructor,
+  // the only caller, checks `fieldErrors.length > 0` before calling).
   function _friendlyValidationDetail(fieldErrors) {
-    if (!Array.isArray(fieldErrors) || fieldErrors.length === 0) {
-      return "Some required fields are missing or invalid.";
-    }
     const seen = new Set();
     const labels = [];
     for (const fe of fieldErrors) {

--- a/ui/foundation/api.js
+++ b/ui/foundation/api.js
@@ -43,11 +43,19 @@
       this.requestId = envelope.extensions?.request_id ?? null;
       this.fieldErrors = envelope.extensions?.errors ?? null;
       this.envelope = envelope;
-      // Holistic 422 friendliness: any schema-violation response is
-      // presented as "Data is incomplete" + a humanized field list, so
-      // form toasts/inline errors that fall back on title/detail show
-      // something useful instead of "Validation Error".
-      if (envelope.status === 422) {
+      // Holistic 422 friendliness applies ONLY to genuine field-shaped
+      // validation errors (FastAPI's own RequestValidationError, which
+      // populates extensions.errors) - presented as "Data is incomplete"
+      // + a humanized field list, so form toasts/inline errors that fall
+      // back on title/detail show something useful instead of
+      // "Validation Error". A domain-level PrimerError mapped to 422
+      // (primer/api/errors.py's _make_primer_error_handler) never
+      // populates extensions.errors - it has no field list, but it DOES
+      // have its own specific, correct `detail` message (e.g. "seq 1 is
+      // the newest visible record; nothing to discard"), which branching
+      // on status alone used to discard in favor of the generic
+      // fallback. Branch on the shape of the payload instead.
+      if (Array.isArray(this.fieldErrors) && this.fieldErrors.length > 0) {
         this.title = "Data is incomplete";
         this.detail = _friendlyValidationDetail(this.fieldErrors);
       } else {


### PR DESCRIPTION
The console replaced every backend 422 body with a generic field-validation message, discarding the real reason.

Fix branches on **payload shape rather than status code**: if `fieldErrors` is a non-empty array, render the field-validation view; otherwise surface the domain detail. A 422 carrying a domain error now says what actually went wrong.

🤖 Generated with [Claude Code](https://claude.com/claude-code)