### PR TITLE
fix(llm): NetworkError carries a network_error code across every classifier family

### DIFF
--- a/primer/common/anthropic_errors.py
+++ b/primer/common/anthropic_errors.py
@@ -80,6 +80,7 @@ def classify_anthropic_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, (APIConnectionError, APITimeoutError)):
         return NetworkError(
             f"Anthropic network failure: {type(exc).__name__}",
+            code="network_error",
             cause=exc,
         )
     return ProviderError(str(exc), cause=exc)

--- a/primer/common/google_errors.py
+++ b/primer/common/google_errors.py
@@ -84,6 +84,7 @@ def classify_google_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError)):
         return NetworkError(
             f"Google network failure: {type(exc).__name__}",
+            code="network_error",
             cause=exc,
         )
     return ProviderError(str(exc), cause=exc)

--- a/primer/common/mcp_errors.py
+++ b/primer/common/mcp_errors.py
@@ -87,6 +87,7 @@ def classify_mcp_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, _CONNECT_ERRORS):
         return NetworkError(
             f"could not connect to the MCP server: {exc}",
+            code="network_error",
             cause=exc,
         )
     if isinstance(exc, _STATUS_ERRORS):
@@ -123,6 +124,7 @@ def classify_mcp_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, _NETWORK_ERRORS):
         return NetworkError(
             f"MCP network failure: {type(exc).__name__}",
+            code="network_error",
             cause=exc,
         )
     if isinstance(exc, MCPError):

--- a/primer/common/openai_errors.py
+++ b/primer/common/openai_errors.py
@@ -91,6 +91,7 @@ def classify_openai_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, (APIConnectionError, APITimeoutError)):
         return NetworkError(
             f"OpenAI network failure: {type(exc).__name__}",
+            code="network_error",
             cause=exc,
         )
     return ProviderError(str(exc), cause=exc)

--- a/primer/llm/aggregated.py
+++ b/primer/llm/aggregated.py
@@ -82,17 +82,25 @@ _CONFIG_EXC: tuple[type[BaseException], ...] = (
     BadRequestError,
 )
 
-# YIELDED-error eligibility. DEFENSIVE ONLY: every current adapter RAISES
-# its timeouts mid-stream (ProviderTimeoutError - openchat.py:284,
-# anthropic.py:760), so these codes never actually arrive on a yielded
-# Error today. They are matched here so the policy stays correct if an
-# adapter ever starts yielding a timeout instead of raising it. Every
-# other transient/server/rate-limit/auth/network error classifies with
-# code=None (see primer/common/anthropic_errors.py and primer/llm/ollama.py).
+# YIELDED-error eligibility. The timeout codes are DEFENSIVE ONLY: every
+# current adapter RAISES its timeouts mid-stream (ProviderTimeoutError -
+# openchat.py:284, anthropic.py:760), so these never actually arrive on a
+# yielded Error today. They are matched here so the policy stays correct
+# if an adapter ever starts yielding a timeout instead of raising it.
+# "network_error" is NOT defensive: 01a082f3 gave every classifier's
+# NetworkError construction (ollama.py, anthropic_errors.py,
+# openai_errors.py, google_errors.py, mcp_errors.py) a real code where
+# it previously fell through as None, so a yielded network failure now
+# arrives with this code and must stay classified as transient-eligible
+# under either policy, exactly as the null-code case was before.
+# Rate-limit, server, AND auth still classify with code=None (see those
+# same classifier files) - unchanged by 01a082f3, still covered by the
+# `code is None` branch below.
 _TRANSIENT_CODES: frozenset[str] = frozenset({
     "stream_timeout",
     "generation_timeout",
     "connect_timeout",
+    "network_error",
 })
 
 
@@ -107,9 +115,10 @@ def _exc_eligible(exc: BaseException, failover_on: FailoverClasses) -> bool:
 def _yielded_eligible(code: str | None, failover_on: FailoverClasses) -> bool:
     """Best-effort eligibility for a YIELDED fatal Error, keyed on ``code``.
 
-    - a known timeout code -> eligible under either policy.
-    - ``None`` -> eligible under either policy. Rate-limit, server, network,
-      AND auth all classify with code=None in every classifier family
+    - a known transient code (a timeout, or "network_error" since
+      01a082f3) -> eligible under either policy.
+    - ``None`` -> eligible under either policy. Rate-limit, server, AND
+      auth all still classify with code=None in every classifier family
       (anthropic_errors.py, ollama.py, and the OpenAI-compatible
       classifiers), and a code-less bad-request is itself config-eligible,
       so None is treated as eligible. NOTE: this means the yielded channel
@@ -118,9 +127,9 @@ def _yielded_eligible(code: str | None, failover_on: FailoverClasses) -> bool:
       under TRANSIENT. This is safe because the yielded-error failover
       window closes before any token is emitted downstream (auth failures
       also RAISE at connect in practice, where the class IS preserved).
-    - any other (non-null) code appears only on bad-request (provider code)
-      or OpenAI-native mid-stream errors -> config-eligible, i.e. matched
-      only under TRANSIENT_AND_CONFIG.
+    - any other (non-null, non-transient) code appears only on bad-request
+      (provider code) or OpenAI-native mid-stream errors -> config-eligible,
+      i.e. matched only under TRANSIENT_AND_CONFIG.
     """
     if code in _TRANSIENT_CODES or code is None:
         return True

--- a/primer/llm/ollama.py
+++ b/primer/llm/ollama.py
@@ -109,11 +109,13 @@ def _classify_ollama_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, ollama.RequestError):
         return NetworkError(
             f"Ollama request failure: {type(exc).__name__}",
+            code="network_error",
             cause=exc,
         )
     if isinstance(exc, (httpx.TimeoutException, httpx.NetworkError)):
         return NetworkError(
             f"Ollama network failure: {type(exc).__name__}",
+            code="network_error",
             cause=exc,
         )
     return ProviderError(str(exc), cause=exc)

--- a/tests/common/test_mcp_errors.py
+++ b/tests/common/test_mcp_errors.py
@@ -82,11 +82,13 @@ class TestNetworkErrors:
         exc = lib.ReadTimeout("timed out")
         result = classify_mcp_exception(exc)
         assert isinstance(result, NetworkError)
+        assert result.code == "network_error"
 
     def test_network_error_maps_to_network_error(self, lib) -> None:
         exc = lib.ConnectError("refused")
         result = classify_mcp_exception(exc)
         assert isinstance(result, NetworkError)
+        assert result.code == "network_error"
 
     def test_httpx2_families_share_no_httpx_ancestry(self) -> None:
         """The premise this whole parametrization exists for: if httpx2

--- a/tests/llm/test_aggregated.py
+++ b/tests/llm/test_aggregated.py
@@ -417,6 +417,36 @@ def test_yielded_eligibility_policy():
     assert _yielded_eligible("invalid_request_error", FailoverClasses.TRANSIENT_AND_CONFIG) is True
 
 
+def test_yielded_eligibility_network_error_matches_the_null_code_case():
+    """01a082f3: every classifier's NetworkError construction now sets
+    code="network_error" instead of leaving it None. This must remain
+    eligible under BOTH policies, identically to the null-code case it
+    replaces - a regression here would make an aggregated-pool network
+    failure stop failing over under the default TRANSIENT policy, the
+    canonical case a failover pool exists for."""
+    from primer.llm.aggregated import _yielded_eligible
+    for policy in (FailoverClasses.TRANSIENT, FailoverClasses.TRANSIENT_AND_CONFIG):
+        assert _yielded_eligible("network_error", policy) is True
+
+
+@pytest.mark.asyncio
+async def test_first_event_network_error_fails_over_under_transient_only():
+    """01a082f3: end-to-end companion to the _yielded_eligible unit test
+    above - a yielded network_error-coded Error must still fail over to
+    the next member under the DEFAULT, narrower TRANSIENT policy (not
+    just TRANSIENT_AND_CONFIG)."""
+    bad = _FakeLLM(events=[ChatError(fatal=True, code="network_error", message="dropped")])
+    good = _FakeLLM(events=[TextDelta(text="ok", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    profile = _profile(members=["bad", "good"], failover_on=FailoverClasses.TRANSIENT)
+    agg = AggregatedLLM(profile, resolve_member=_resolver(
+        {"bad": (bad, "m1"), "good": (good, "m2")}
+    ))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert not any(isinstance(e, ChatError) for e in events)
+    assert any(isinstance(e, TextDelta) for e in events)
+
+
 @pytest.mark.asyncio
 async def test_round_robin_cursor_is_concurrency_safe():
     # N concurrent stream calls must each get a distinct start member (a clean

--- a/tests/llm/test_retry.py
+++ b/tests/llm/test_retry.py
@@ -143,6 +143,21 @@ class TestRetryBehaviour:
         assert attempts["n"] == 2
         assert [type(e).__name__ for e in events] == ["StreamStart", "TextDelta", "Done"]
 
+    async def test_network_error_coded_terminal_error_is_still_replayed(self) -> None:
+        """01a082f3: every classifier now sets code="network_error" on a
+        yielded NetworkError instead of leaving it None - _RETRYABLE_CODES
+        already listed "network_error" before this change, so this must
+        replay identically to the null-code case above. A regression here
+        would silently stop retrying the exact failure class this
+        mechanism exists for."""
+        open_stream, attempts = _make_source([
+            [ChatError(message="dropped", fatal=True, code="network_error")],
+            _ok_events(),
+        ])
+        events = await _drain(_run(open_stream))
+        assert attempts["n"] == 2
+        assert [type(e).__name__ for e in events] == ["StreamStart", "TextDelta", "Done"]
+
     async def test_failure_after_first_event_is_not_replayed(self) -> None:
         """The consumer has already seen output; replaying would duplicate it."""
         open_stream, attempts = _make_source([

--- a/tests/llm_adapters/test_ollama_adapter_cov.py
+++ b/tests/llm_adapters/test_ollama_adapter_cov.py
@@ -168,14 +168,17 @@ class TestClassify:
     def test_request_error_network(self) -> None:
         out = _classify_ollama_exception(ollama.RequestError("conn refused"))
         assert isinstance(out, NetworkError)
+        assert out.code == "network_error"
 
     def test_httpx_timeout_network(self) -> None:
-        assert isinstance(
-            _classify_ollama_exception(httpx.TimeoutException("t")), NetworkError
-        )
+        out = _classify_ollama_exception(httpx.TimeoutException("t"))
+        assert isinstance(out, NetworkError)
+        assert out.code == "network_error"
 
     def test_httpx_network_error_network(self) -> None:
-        assert isinstance(_classify_ollama_exception(httpx.NetworkError("down")), NetworkError)
+        out = _classify_ollama_exception(httpx.NetworkError("down"))
+        assert isinstance(out, NetworkError)
+        assert out.code == "network_error"
 
     def test_unknown_provider_error(self) -> None:
         exc = RuntimeError("mystery")
@@ -703,6 +706,30 @@ class TestStream:
         ]
         assert isinstance(events[0], StreamStart)
         assert isinstance(events[-1], ChatError) and events[-1].fatal is True
+
+    async def test_mid_stream_network_error_yields_coded_chat_error(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """01a082f3: the classifier's code="network_error" must actually
+        reach the yielded ChatError (yield ChatError(..., code=err.code,
+        ...)), not just the classifier's own return value - this is what
+        the retry/aggregated-pool/ended_detail consumers all read."""
+        llm = OllamaLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+
+        async def failing() -> AsyncIterator:
+            yield NS(model="llama3", done=False, message=NS(content="hi", thinking=None, tool_calls=None))
+            raise httpx.NetworkError("connection reset")
+
+        client.chat.return_value = failing()
+        events = [
+            e
+            async for e in llm.stream(
+                model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+            )
+        ]
+        assert isinstance(events[-1], ChatError) and events[-1].fatal is True
+        assert events[-1].code == "network_error"
 
     async def test_connect_timeout_propagates(self, monkeypatch: pytest.MonkeyPatch) -> None:
         llm = OllamaLLM(_make_provider())

--- a/tests/test_anthropic_errors.py
+++ b/tests/test_anthropic_errors.py
@@ -78,3 +78,18 @@ class TestClassifyAnthropicException:
         result = classify_anthropic_exception(sdk_exc)
         assert isinstance(result, ProviderError)
         assert "unexpected" in str(result)
+
+    def test_connection_error_maps_to_network_error(self) -> None:
+        sdk_exc = anthropic.APIConnectionError.__new__(anthropic.APIConnectionError)
+        Exception.__init__(sdk_exc, "connection failed")
+        result = classify_anthropic_exception(sdk_exc)
+        assert isinstance(result, NetworkError)
+        assert result.code == "network_error"
+        assert result.cause is sdk_exc
+
+    def test_timeout_error_maps_to_network_error(self) -> None:
+        sdk_exc = anthropic.APITimeoutError.__new__(anthropic.APITimeoutError)
+        Exception.__init__(sdk_exc, "timed out")
+        result = classify_anthropic_exception(sdk_exc)
+        assert isinstance(result, NetworkError)
+        assert result.code == "network_error"

--- a/tests/test_google_errors.py
+++ b/tests/test_google_errors.py
@@ -80,11 +80,13 @@ class TestClassifyGoogleException:
         result = classify_google_exception(sdk_exc)
         assert isinstance(result, NetworkError)
         assert result.cause is sdk_exc
+        assert result.code == "network_error"
 
     def test_connect_error_maps_to_network_error(self) -> None:
         sdk_exc = httpx.ConnectError("connection refused")
         result = classify_google_exception(sdk_exc)
         assert isinstance(result, NetworkError)
+        assert result.code == "network_error"
 
     def test_arbitrary_exception_maps_to_provider_error(self) -> None:
         sdk_exc = RuntimeError("totally unexpected")

--- a/tests/test_openai_errors.py
+++ b/tests/test_openai_errors.py
@@ -82,11 +82,13 @@ class TestClassifyOpenaiException:
         result = classify_openai_exception(sdk_exc)
         assert isinstance(result, NetworkError)
         assert result.cause is sdk_exc
+        assert result.code == "network_error"
 
     def test_timeout_error_maps_to_network_error(self) -> None:
         sdk_exc = openai.APITimeoutError(request=MagicMock())  # type: ignore[arg-type]
         result = classify_openai_exception(sdk_exc)
         assert isinstance(result, NetworkError)
+        assert result.code == "network_error"
 
     def test_unknown_exception_maps_to_provider_error(self) -> None:
         sdk_exc = RuntimeError("totally unexpected")


### PR DESCRIPTION
`NetworkError` was constructed with no `code` at 7 sites across 5 classifier families, so a network failure was indistinguishable from any other uncoded error.

**The two halves are one fix, not two related ones.** `_yielded_eligible` treats `code is None` as the transient sentinel, so adding `code="network_error"` *without* adding it to `_TRANSIENT_CODES` in the same change would make aggregated-pool network failures ineligible for failover. Tidying up either side alone reintroduces that regression.

Proven failover-preserving under the **strict TRANSIENT policy specifically** (not just TRANSIENT_AND_CONFIG), with both a direct `_yielded_eligible` unit test and an end-to-end `AggregatedLLM.stream()` test. `_retry.py` invariant pinned. Also closes a pre-existing zero-coverage gap: `anthropic_errors.py` had no NetworkError test at all.

🤖 Generated with [Claude Code](https://claude.com/claude-code)