### PR TITLE
fix(llm): rate_limit, server and auth failures carry real codes; auth stops being retryable

### DIFF
--- a/primer/common/anthropic_errors.py
+++ b/primer/common/anthropic_errors.py
@@ -37,12 +37,14 @@ def classify_anthropic_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, (AnthropicAuthenticationError, AnthropicPermissionDeniedError)):
         return AuthenticationError(
             "Anthropic authentication failed",
+            code="auth_error",
             status_code=getattr(exc, "status_code", 401),
             cause=exc,
         )
     if isinstance(exc, AnthropicRateLimitError):
         return RateLimitError(
             "Anthropic rate limit exceeded",
+            code="rate_limit",
             status_code=getattr(exc, "status_code", 429),
             cause=exc,
         )
@@ -61,6 +63,7 @@ def classify_anthropic_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, AnthropicInternalServerError):
         return ServerError(
             "Anthropic server error",
+            code="server_error",
             status_code=getattr(exc, "status_code", 500),
             cause=exc,
         )
@@ -69,6 +72,7 @@ def classify_anthropic_exception(exc: Exception) -> PrimerError:
         if status is not None and status >= 500:
             return ServerError(
                 f"Anthropic server error ({status})",
+                code="server_error",
                 status_code=status,
                 cause=exc,
             )

--- a/primer/common/google_errors.py
+++ b/primer/common/google_errors.py
@@ -55,24 +55,28 @@ def classify_google_exception(exc: Exception) -> PrimerError:
         if code in (401, 403):
             return AuthenticationError(
                 "Google authentication failed",
+                code="auth_error",
                 status_code=code,
                 cause=exc,
             )
         if code == 429:
             return RateLimitError(
                 "Google rate limit exceeded",
+                code="rate_limit",
                 status_code=code,
                 cause=exc,
             )
         if 400 <= code < 500:
             return BadRequestError(
                 message or "Google rejected the request",
+                code="bad_request",
                 status_code=code,
                 cause=exc,
             )
         if code >= 500:
             return ServerError(
                 f"Google server error ({code})",
+                code="server_error",
                 status_code=code,
                 cause=exc,
             )

--- a/primer/common/mcp_errors.py
+++ b/primer/common/mcp_errors.py
@@ -95,12 +95,14 @@ def classify_mcp_exception(exc: Exception) -> PrimerError:
         if status in (401, 403):
             return AuthenticationError(
                 f"MCP server rejected credentials ({status})",
+                code="auth_error",
                 status_code=status,
                 cause=exc,
             )
         if status == 429:
             return RateLimitError(
                 "MCP server rate limit exceeded",
+                code="rate_limit",
                 status_code=status,
                 cause=exc,
             )
@@ -113,6 +115,7 @@ def classify_mcp_exception(exc: Exception) -> PrimerError:
         if status >= 500:
             return ServerError(
                 f"MCP server error ({status})",
+                code="server_error",
                 status_code=status,
                 cause=exc,
             )

--- a/primer/common/openai_errors.py
+++ b/primer/common/openai_errors.py
@@ -53,12 +53,14 @@ def classify_openai_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, OpenAIAuthenticationError):
         return AuthenticationError(
             "OpenAI authentication failed",
+            code="auth_error",
             status_code=getattr(exc, "status_code", 401),
             cause=exc,
         )
     if isinstance(exc, OpenAIRateLimitError):
         return RateLimitError(
             "OpenAI rate limit exceeded",
+            code="rate_limit",
             status_code=getattr(exc, "status_code", 429),
             cause=exc,
         )
@@ -72,6 +74,7 @@ def classify_openai_exception(exc: Exception) -> PrimerError:
     if isinstance(exc, OpenAIInternalServerError):
         return ServerError(
             "OpenAI server error",
+            code="server_error",
             status_code=getattr(exc, "status_code", 500),
             cause=exc,
         )
@@ -80,6 +83,7 @@ def classify_openai_exception(exc: Exception) -> PrimerError:
         if status is not None and status >= 500:
             return ServerError(
                 f"OpenAI server error ({status})",
+                code="server_error",
                 status_code=status,
                 cause=exc,
             )

--- a/primer/llm/aggregated.py
+++ b/primer/llm/aggregated.py
@@ -87,20 +87,23 @@ _CONFIG_EXC: tuple[type[BaseException], ...] = (
 # openchat.py:284, anthropic.py:760), so these never actually arrive on a
 # yielded Error today. They are matched here so the policy stays correct
 # if an adapter ever starts yielding a timeout instead of raising it.
-# "network_error" is NOT defensive: 01a082f3 gave every classifier's
-# NetworkError construction (ollama.py, anthropic_errors.py,
-# openai_errors.py, google_errors.py, mcp_errors.py) a real code where
-# it previously fell through as None, so a yielded network failure now
-# arrives with this code and must stay classified as transient-eligible
-# under either policy, exactly as the null-code case was before.
-# Rate-limit, server, AND auth still classify with code=None (see those
-# same classifier files) - unchanged by 01a082f3, still covered by the
-# `code is None` branch below.
+# "network_error", "rate_limit", and "server_error" are NOT defensive:
+# 01a082f3 gave every classifier's NetworkError construction a real code,
+# and 01a08598 did the same for RateLimitError/ServerError (ollama.py,
+# anthropic_errors.py, openai_errors.py, google_errors.py, mcp_errors.py),
+# where all three previously fell through as None. A yielded failure of
+# any of these three kinds now arrives with one of these codes and must
+# stay classified as transient-eligible under either policy, exactly as
+# the null-code case was before. Auth and bad-request DELIBERATELY do NOT
+# appear here - see _yielded_eligible's own docstring for why they're
+# excluded from this set on purpose, not merely omitted.
 _TRANSIENT_CODES: frozenset[str] = frozenset({
     "stream_timeout",
     "generation_timeout",
     "connect_timeout",
     "network_error",
+    "rate_limit",
+    "server_error",
 })
 
 
@@ -115,21 +118,47 @@ def _exc_eligible(exc: BaseException, failover_on: FailoverClasses) -> bool:
 def _yielded_eligible(code: str | None, failover_on: FailoverClasses) -> bool:
     """Best-effort eligibility for a YIELDED fatal Error, keyed on ``code``.
 
-    - a known transient code (a timeout, or "network_error" since
-      01a082f3) -> eligible under either policy.
-    - ``None`` -> eligible under either policy. Rate-limit, server, AND
-      auth all still classify with code=None in every classifier family
-      (anthropic_errors.py, ollama.py, and the OpenAI-compatible
-      classifiers), and a code-less bad-request is itself config-eligible,
-      so None is treated as eligible. NOTE: this means the yielded channel
-      CANNOT honor the TRANSIENT policy's "exclude auth" guarantee - an auth
-      error that surfaced as a yielded fatal Error would fail over even
-      under TRANSIENT. This is safe because the yielded-error failover
-      window closes before any token is emitted downstream (auth failures
-      also RAISE at connect in practice, where the class IS preserved).
-    - any other (non-null, non-transient) code appears only on bad-request
-      (provider code) or OpenAI-native mid-stream errors -> config-eligible,
-      i.e. matched only under TRANSIENT_AND_CONFIG.
+    - a known transient code (a timeout, "network_error", "rate_limit",
+      or "server_error") -> eligible under either policy.
+    - ``None`` -> eligible under either policy. Nothing in the five named
+      exception families (Network/RateLimit/Server/Authentication/
+      BadRequest) classifies as None anymore after 01a082f3 and 01a08598;
+      what still lands here is an unclassified `ProviderError` (the
+      "totally unexpected exception" catch-all every classifier falls
+      back to) or any future adapter that hasn't been taught a code yet -
+      "no more specific info" is exactly the shape this sentinel exists
+      for, so treating it as eligible is the conservative default.
+    - "auth_error" and "bad_request" -> config-eligible only, i.e.
+      matched under TRANSIENT_AND_CONFIG but NOT plain TRANSIENT. 01a08598
+      traced why this matters: every classifier's AuthenticationError/
+      BadRequestError construction used to leave code unset too, which
+      meant an auth failure that arrived as a YIELDED fatal Error (not a
+      raised exception) fell into the `code is None` branch above and
+      failed over even under the strict TRANSIENT policy - silently
+      contradicting _exc_eligible's _CONFIG_EXC exclusion for the exact
+      same error class on the RAISED path a few lines up. This was not
+      hypothetical: ollama's and google-genai's streaming SDK calls build
+      their async generator LAZILY (``return inner()`` / ``return
+      stream_generator()`` before any request is sent), so the actual
+      HTTP call - and any 401/403/400 it returns - happens on the
+      caller's first iteration, landing in the adapter's mid-stream
+      "yield a terminal Error" branch rather than the pre-stream-open
+      raise branch a reader would expect. Anthropic and the OpenAI-family
+      adapters build their request EAGERLY (the HTTP call happens inside
+      the awaited call itself, before any stream is returned), so their
+      auth/bad-request failures always raise and never reach this
+      function at all - which is why this asymmetry was invisible until
+      traced per adapter rather than assumed from one adapter's behavior.
+      Giving both codes a real, non-null, non-transient value routes them
+      through this same branch regardless of which adapter yielded them,
+      unifying the yielded path with the raised path's already-correct
+      exclusion instead of inventing a new policy.
+    - any other (non-null, non-transient) code appears only on a raw
+      provider-native bad-request code (e.g. Anthropic/OpenAI's own
+      `.code`, still passed through when present) or OpenAI-native
+      mid-stream errors -> also config-eligible, i.e. matched only under
+      TRANSIENT_AND_CONFIG - the same bucket "bad_request" now falls
+      into by construction.
     """
     if code in _TRANSIENT_CODES or code is None:
         return True

--- a/primer/llm/ollama.py
+++ b/primer/llm/ollama.py
@@ -88,20 +88,25 @@ def _classify_ollama_exception(exc: Exception) -> PrimerError:
         if status in (401, 403):
             return AuthenticationError(
                 "Ollama authentication failed",
+                code="auth_error",
                 status_code=status,
                 cause=exc,
             )
         if status == 429:
             return RateLimitError(
                 "Ollama rate limit exceeded",
+                code="rate_limit",
                 status_code=status,
                 cause=exc,
             )
         if status is not None and 400 <= status < 500:
-            return BadRequestError(msg, status_code=status, cause=exc)
+            return BadRequestError(
+                msg, code="bad_request", status_code=status, cause=exc,
+            )
         if status is not None and status >= 500:
             return ServerError(
                 f"Ollama server error ({status})",
+                code="server_error",
                 status_code=status,
                 cause=exc,
             )

--- a/tests/common/test_mcp_errors.py
+++ b/tests/common/test_mcp_errors.py
@@ -39,16 +39,19 @@ class TestHttpStatusErrorMapping:
         result = classify_mcp_exception(_http_status_error(401, lib))
         assert isinstance(result, AuthenticationError)
         assert result.status_code == 401
+        assert result.code == "auth_error"
 
     def test_403_maps_to_authentication_error(self, lib) -> None:
         result = classify_mcp_exception(_http_status_error(403, lib))
         assert isinstance(result, AuthenticationError)
         assert result.status_code == 403
+        assert result.code == "auth_error"
 
     def test_429_maps_to_rate_limit(self, lib) -> None:
         result = classify_mcp_exception(_http_status_error(429, lib))
         assert isinstance(result, RateLimitError)
         assert result.status_code == 429
+        assert result.code == "rate_limit"
 
     def test_400_maps_to_bad_request(self, lib) -> None:
         result = classify_mcp_exception(_http_status_error(400, lib))
@@ -59,6 +62,7 @@ class TestHttpStatusErrorMapping:
         result = classify_mcp_exception(_http_status_error(503, lib))
         assert isinstance(result, ServerError)
         assert result.status_code == 503
+        assert result.code == "server_error"
 
     def test_other_4xx_maps_to_provider_error(self, lib) -> None:
         result = classify_mcp_exception(_http_status_error(418, lib))

--- a/tests/llm/test_aggregated.py
+++ b/tests/llm/test_aggregated.py
@@ -159,9 +159,11 @@ async def test_connect_raise_fails_over_to_next_member():
 
 @pytest.mark.asyncio
 async def test_first_event_error_fails_over_no_tokens_emitted():
-    # Realistic: real classifiers emit code=None for a rate-limit that
-    # surfaces as a YIELDED fatal Error (anthropic_errors.py, ollama.py).
-    # code=None is eligible under either policy.
+    # Realistic: real classifiers still emit code=None for a network or
+    # auth failure that surfaces as a YIELDED fatal Error (anthropic_errors.py,
+    # ollama.py) - rate-limit and server errors got a real code in 01a08598,
+    # so this null-code case now represents network/auth specifically, not
+    # rate-limit. code=None is eligible under either policy either way.
     bad = _FakeLLM(events=[ChatError(fatal=True, code=None, message="429")])
     good = _FakeLLM(events=[StreamStart(model="m2"), TextDelta(text="ok", index=0),
                             Done(stop_reason="stop", raw_reason="stop")])
@@ -177,9 +179,12 @@ async def test_first_event_error_fails_over_no_tokens_emitted():
 
 @pytest.mark.asyncio
 async def test_first_event_error_with_hypothetical_transient_code_fails_over():
-    # Hypothetical: no current adapter emits a non-null transient code on a
-    # yielded Error, but if one did, a config-eligible code fails over under
-    # the default TRANSIENT_AND_CONFIG. Kept as the one non-null-code case.
+    # 01a08598: no longer hypothetical - every classifier now emits
+    # code="rate_limit" on a yielded fatal Error for a 429 (previously
+    # code=None). Fails over under the default TRANSIENT_AND_CONFIG here;
+    # see the dedicated strict-TRANSIENT test below for the invariant
+    # that actually mattered (a naive "give it a code" fix would have
+    # made this INELIGIBLE under the narrower policy).
     bad = _FakeLLM(events=[ChatError(fatal=True, code="rate_limit", message="429")])
     good = _FakeLLM(events=[TextDelta(text="ok", index=0),
                             Done(stop_reason="stop", raw_reason="stop")])
@@ -188,6 +193,68 @@ async def test_first_event_error_with_hypothetical_transient_code_fails_over():
         {"bad": (bad, "m1"), "good": (good, "m2")}
     ))
     events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert any(isinstance(e, TextDelta) for e in events)
+
+
+@pytest.mark.asyncio
+async def test_first_event_rate_limit_and_server_error_fail_over_under_transient_only():
+    """01a08598: rate_limit and server_error must stay failover-eligible
+    under the STRICT TRANSIENT policy (not just the default TRANSIENT_
+    AND_CONFIG) - identically to the null-code case they replace. This
+    is the exact regression 01a082f3's network_error fix had to avoid
+    for aggregated.py; same proof, same reason, for these two codes."""
+    for code in ("rate_limit", "server_error"):
+        bad = _FakeLLM(events=[ChatError(fatal=True, code=code, message="failed")])
+        good = _FakeLLM(events=[TextDelta(text="ok", index=0),
+                                Done(stop_reason="stop", raw_reason="stop")])
+        profile = _profile(members=["bad", "good"], failover_on=FailoverClasses.TRANSIENT)
+        agg = AggregatedLLM(profile, resolve_member=_resolver(
+            {"bad": (bad, "m1"), "good": (good, "m2")}
+        ))
+        events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+        assert not any(isinstance(e, ChatError) for e in events), code
+        assert any(isinstance(e, TextDelta) for e in events), code
+
+
+@pytest.mark.asyncio
+async def test_first_event_auth_error_does_not_fail_over_under_transient_only():
+    """01a08598: the fix, end to end. A yielded fatal Error coded
+    "auth_error" (e.g. a lazily-classified ollama/gemini 401 - see
+    aggregated.py's own docstring for why those two adapters can yield
+    rather than raise an auth failure) must SURFACE, not fail over,
+    under the strict TRANSIENT policy - identically to how a RAISED
+    AuthenticationError already behaves via _exc_eligible. Before the
+    fix this incorrectly failed over (code=None fell into the
+    universally-eligible branch)."""
+    bad = _FakeLLM(events=[ChatError(fatal=True, code="auth_error", message="401")])
+    good = _FakeLLM(events=[TextDelta(text="SHOULD-NOT-APPEAR", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    profile = _profile(members=["bad", "good"], failover_on=FailoverClasses.TRANSIENT)
+    agg = AggregatedLLM(profile, resolve_member=_resolver(
+        {"bad": (bad, "m1"), "good": (good, "m2")}
+    ))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert isinstance(events[-1], ChatError)
+    assert not any(isinstance(e, TextDelta) for e in events)  # member[1] never ran
+
+
+@pytest.mark.asyncio
+async def test_first_event_auth_error_fails_over_under_transient_and_config():
+    """Companion to the strict-policy test above: under the OPT-IN
+    TRANSIENT_AND_CONFIG policy, the same yielded auth_error DOES fail
+    over - matching _exc_eligible's _CONFIG_EXC treatment of a raised
+    AuthenticationError under the same policy."""
+    bad = _FakeLLM(events=[ChatError(fatal=True, code="auth_error", message="401")])
+    good = _FakeLLM(events=[TextDelta(text="ok", index=0),
+                            Done(stop_reason="stop", raw_reason="stop")])
+    profile = _profile(
+        members=["bad", "good"], failover_on=FailoverClasses.TRANSIENT_AND_CONFIG,
+    )
+    agg = AggregatedLLM(profile, resolve_member=_resolver(
+        {"bad": (bad, "m1"), "good": (good, "m2")}
+    ))
+    events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
+    assert not any(isinstance(e, ChatError) for e in events)
     assert any(isinstance(e, TextDelta) for e in events)
 
 
@@ -445,6 +512,34 @@ async def test_first_event_network_error_fails_over_under_transient_only():
     events = await _drain(agg.stream(model="virtual-1", messages=_MSG))
     assert not any(isinstance(e, ChatError) for e in events)
     assert any(isinstance(e, TextDelta) for e in events)
+
+
+def test_yielded_eligibility_rate_limit_and_server_error_match_the_null_code_case():
+    """01a08598: every classifier's RateLimitError/ServerError construction
+    now sets a real code instead of leaving it None. Both must remain
+    eligible under BOTH policies, identically to the null-code case they
+    replace - a regression here would make an aggregated-pool rate-limit
+    or server failure stop failing over under the default TRANSIENT
+    policy, the canonical case a failover pool exists for."""
+    from primer.llm.aggregated import _yielded_eligible
+    for policy in (FailoverClasses.TRANSIENT, FailoverClasses.TRANSIENT_AND_CONFIG):
+        assert _yielded_eligible("rate_limit", policy) is True
+        assert _yielded_eligible("server_error", policy) is True
+
+
+def test_yielded_eligibility_auth_and_bad_request_are_config_only():
+    """01a08598 auth-exclusion fix: unlike network/rate-limit/server,
+    "auth_error" and "bad_request" must NOT be eligible under plain
+    TRANSIENT - only under TRANSIENT_AND_CONFIG. This is what closes the
+    gap the trace found: before giving AuthenticationError/BadRequestError
+    a real code, a yielded auth/bad-request failure fell into the
+    `code is None` branch and failed over even under strict TRANSIENT,
+    contradicting _exc_eligible's _CONFIG_EXC exclusion for the SAME
+    error classes on the raised path."""
+    from primer.llm.aggregated import _yielded_eligible
+    for code in ("auth_error", "bad_request"):
+        assert _yielded_eligible(code, FailoverClasses.TRANSIENT) is False
+        assert _yielded_eligible(code, FailoverClasses.TRANSIENT_AND_CONFIG) is True
 
 
 @pytest.mark.asyncio

--- a/tests/llm/test_retry.py
+++ b/tests/llm/test_retry.py
@@ -158,6 +158,49 @@ class TestRetryBehaviour:
         assert attempts["n"] == 2
         assert [type(e).__name__ for e in events] == ["StreamStart", "TextDelta", "Done"]
 
+    @pytest.mark.parametrize("code", ["rate_limit", "server_error"])
+    async def test_rate_limit_and_server_coded_terminal_error_is_still_replayed(
+        self, code: str,
+    ) -> None:
+        """01a08598: every classifier now sets a real code on a yielded
+        RateLimitError/ServerError instead of leaving it None -
+        _RETRYABLE_CODES already listed both before this change, so this
+        must replay identically to the null-code case above. A regression
+        here would silently stop retrying the exact failure classes this
+        mechanism exists for."""
+        open_stream, attempts = _make_source([
+            [ChatError(message="dropped", fatal=True, code=code)],
+            _ok_events(),
+        ])
+        events = await _drain(_run(open_stream))
+        assert attempts["n"] == 2
+        assert [type(e).__name__ for e in events] == ["StreamStart", "TextDelta", "Done"]
+
+    @pytest.mark.parametrize("code", ["auth_error", "bad_request"])
+    async def test_auth_and_bad_request_coded_terminal_error_is_not_replayed(
+        self, code: str,
+    ) -> None:
+        """01a08598: this is the sharper half of the auth-exclusion fix -
+        not just "don't fail over to another pool member" (aggregated.py)
+        but "don't retry the SAME bad credentials against the SAME
+        provider". Before AuthenticationError/BadRequestError carried a
+        real code, a lazily-classified 401/400 (ollama, google-genai -
+        see aggregated.py's docstring for why those two SDKs yield rather
+        than raise it) had code=None, which _RETRYABLE_CODES treats as
+        transport-retryable - so stream_with_retry would replay the exact
+        same request against the exact same endpoint up to max_retries
+        times. "auth_error"/"bad_request" are deliberately absent from
+        _RETRYABLE_CODES, so this must NOT replay - a single attempt,
+        the terminal error forwarded as-is."""
+        open_stream, attempts = _make_source([
+            [ChatError(message="rejected", fatal=True, code=code)],
+            _ok_events(),
+        ])
+        events = await _drain(_run(open_stream))
+        assert attempts["n"] == 1, "a coded auth/bad-request failure must not replay"
+        assert [type(e).__name__ for e in events] == ["Error"]
+        assert events[0].code == code
+
     async def test_failure_after_first_event_is_not_replayed(self) -> None:
         """The consumer has already seen output; replaying would duplicate it."""
         open_stream, attempts = _make_source([

--- a/tests/llm_adapters/test_ollama_adapter_cov.py
+++ b/tests/llm_adapters/test_ollama_adapter_cov.py
@@ -150,17 +150,23 @@ class TestClassify:
         assert isinstance(out, AuthenticationError)
         assert out.status_code == status
         assert out.cause is exc
+        assert out.code == "auth_error"
 
     def test_rate_limit(self) -> None:
-        assert isinstance(_classify_ollama_exception(_response_error(429)), RateLimitError)
+        out = _classify_ollama_exception(_response_error(429))
+        assert isinstance(out, RateLimitError)
+        assert out.code == "rate_limit"
 
     def test_bad_request(self) -> None:
-        assert isinstance(_classify_ollama_exception(_response_error(400)), BadRequestError)
+        out = _classify_ollama_exception(_response_error(400))
+        assert isinstance(out, BadRequestError)
+        assert out.code == "bad_request"
 
     def test_server_error(self) -> None:
         out = _classify_ollama_exception(_response_error(503))
         assert isinstance(out, ServerError)
         assert out.status_code == 503
+        assert out.code == "server_error"
 
     def test_no_status_provider_error(self) -> None:
         assert isinstance(_classify_ollama_exception(_response_error(None)), ProviderError)
@@ -689,6 +695,39 @@ class TestStream:
             ):
                 pass
 
+    async def test_first_iteration_auth_error_yields_coded_chat_error(
+        self, monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """01a08598: the scenario test_pre_stream_error_reraised does NOT
+        cover, and the one that actually matters for the aggregated-pool
+        fix. The real ollama SDK's `_request(stream=True)` returns an
+        un-started async generator (`return inner()`) with zero awaits in
+        that branch - the ACTUAL HTTP call, and any 401/403 response, only
+        happens on the caller's first `__anext__()`. That means a real
+        auth failure lands here, in the mid-stream except-branch, with
+        ZERO prior content - not via client.chat() raising synchronously
+        (test_pre_stream_error_reraised's mock models a scenario the real
+        SDK's streaming path cannot actually produce for this error class).
+        code="auth_error" must reach the yielded ChatError so aggregated.py
+        and _retry.py can both correctly exclude it."""
+        llm = OllamaLLM(_make_provider())
+        client = _patched_client(monkeypatch)
+
+        async def failing() -> AsyncIterator:
+            if False:
+                yield  # pragma: no cover - never reached; zero prior content
+            raise _response_error(401)
+
+        client.chat.return_value = failing()
+        events = [
+            e
+            async for e in llm.stream(
+                model="llama3", messages=[Message(role="user", parts=[TextPart(text="hi")])]
+            )
+        ]
+        assert isinstance(events[-1], ChatError) and events[-1].fatal is True
+        assert events[-1].code == "auth_error"
+
     async def test_mid_stream_error_yields_chat_error(self, monkeypatch: pytest.MonkeyPatch) -> None:
         llm = OllamaLLM(_make_provider())
         client = _patched_client(monkeypatch)
@@ -706,6 +745,10 @@ class TestStream:
         ]
         assert isinstance(events[0], StreamStart)
         assert isinstance(events[-1], ChatError) and events[-1].fatal is True
+        # 01a08598: the classifier's code="rate_limit" must reach the
+        # actually-yielded ChatError, not just the classifier's own
+        # return value.
+        assert events[-1].code == "rate_limit"
 
     async def test_mid_stream_network_error_yields_coded_chat_error(
         self, monkeypatch: pytest.MonkeyPatch,

--- a/tests/test_anthropic_errors.py
+++ b/tests/test_anthropic_errors.py
@@ -31,16 +31,19 @@ class TestClassifyAnthropicException:
         result = classify_anthropic_exception(sdk_exc)
         assert isinstance(result, AuthenticationError)
         assert result.cause is sdk_exc
+        assert result.code == "auth_error"
 
     def test_permission_denied_maps_to_authentication(self) -> None:
         sdk_exc = _make_anthropic_error(anthropic.PermissionDeniedError, status_code=403)
         result = classify_anthropic_exception(sdk_exc)
         assert isinstance(result, AuthenticationError)
+        assert result.code == "auth_error"
 
     def test_rate_limit(self) -> None:
         sdk_exc = _make_anthropic_error(anthropic.RateLimitError, status_code=429)
         result = classify_anthropic_exception(sdk_exc)
         assert isinstance(result, RateLimitError)
+        assert result.code == "rate_limit"
 
     def test_bad_request(self) -> None:
         sdk_exc = _make_anthropic_error(anthropic.BadRequestError, status_code=400)
@@ -61,11 +64,13 @@ class TestClassifyAnthropicException:
         sdk_exc = _make_anthropic_error(anthropic.InternalServerError, status_code=500)
         result = classify_anthropic_exception(sdk_exc)
         assert isinstance(result, ServerError)
+        assert result.code == "server_error"
 
     def test_5xx_apistatus_to_server(self) -> None:
         sdk_exc = _make_anthropic_error(anthropic.APIStatusError, status_code=503)
         result = classify_anthropic_exception(sdk_exc)
         assert isinstance(result, ServerError)
+        assert result.code == "server_error"
 
     def test_other_4xx_apistatus_to_provider(self) -> None:
         sdk_exc = _make_anthropic_error(anthropic.APIStatusError, status_code=499)

--- a/tests/test_google_errors.py
+++ b/tests/test_google_errors.py
@@ -37,24 +37,28 @@ class TestClassifyGoogleException:
         assert isinstance(result, AuthenticationError)
         assert result.status_code == 401
         assert result.cause is sdk_exc
+        assert result.code == "auth_error"
 
     def test_403_maps_to_authentication(self) -> None:
         sdk_exc = _make_api_error(403)
         result = classify_google_exception(sdk_exc)
         assert isinstance(result, AuthenticationError)
         assert result.status_code == 403
+        assert result.code == "auth_error"
 
     def test_429_maps_to_rate_limit(self) -> None:
         sdk_exc = _make_api_error(429)
         result = classify_google_exception(sdk_exc)
         assert isinstance(result, RateLimitError)
         assert result.status_code == 429
+        assert result.code == "rate_limit"
 
     def test_400_maps_to_bad_request(self) -> None:
         sdk_exc = _make_api_error(400, message="bad argument")
         result = classify_google_exception(sdk_exc)
         assert isinstance(result, BadRequestError)
         assert result.status_code == 400
+        assert result.code == "bad_request"
 
     def test_other_4xx_maps_to_bad_request(self) -> None:
         # 404 isn't an explicit branch, falls through the 4xx default.
@@ -68,12 +72,14 @@ class TestClassifyGoogleException:
         result = classify_google_exception(sdk_exc)
         assert isinstance(result, ServerError)
         assert result.status_code == 500
+        assert result.code == "server_error"
 
     def test_503_maps_to_server_error(self) -> None:
         sdk_exc = _make_api_error(503)
         result = classify_google_exception(sdk_exc)
         assert isinstance(result, ServerError)
         assert result.status_code == 503
+        assert result.code == "server_error"
 
     def test_timeout_exception_maps_to_network_error(self) -> None:
         sdk_exc = httpx.TimeoutException("read timeout")

--- a/tests/test_openai_errors.py
+++ b/tests/test_openai_errors.py
@@ -40,12 +40,14 @@ class TestClassifyOpenaiException:
         assert isinstance(result, AuthenticationError)
         assert result.status_code == 401
         assert result.cause is sdk_exc
+        assert result.code == "auth_error"
 
     def test_rate_limit_error_maps_to_primer_rate_limit(self) -> None:
         sdk_exc = _make_openai_error(openai.RateLimitError, status_code=429)
         result = classify_openai_exception(sdk_exc)
         assert isinstance(result, RateLimitError)
         assert result.status_code == 429
+        assert result.code == "rate_limit"
 
     def test_bad_request_error_maps_to_primer_bad_request(self) -> None:
         sdk_exc = _make_openai_error(
@@ -61,12 +63,14 @@ class TestClassifyOpenaiException:
         result = classify_openai_exception(sdk_exc)
         assert isinstance(result, ServerError)
         assert result.status_code == 500
+        assert result.code == "server_error"
 
     def test_5xx_api_status_error_maps_to_primer_server(self) -> None:
         sdk_exc = _make_openai_error(openai.APIStatusError, status_code=503)
         result = classify_openai_exception(sdk_exc)
         assert isinstance(result, ServerError)
         assert result.status_code == 503
+        assert result.code == "server_error"
 
     def test_other_4xx_api_status_error_maps_to_provider_error(self) -> None:
         sdk_exc = _make_openai_error(openai.APIStatusError, status_code=404)


### PR DESCRIPTION
Extends the taxonomy to `rate_limit`/`server_error` (12 sites) and then closes a genuine operational hazard.

**Root cause, and the reason this is not uniform across providers: eager vs lazy stream construction.** Anthropic and OpenAI perform the HTTP inside the awaited call, so a 401 raises synchronously and is already handled correctly via `_CONFIG_EXC`. Ollama (`return inner()`) and google-genai (`return stream_generator()`) return an un-started generator, so the request — and the 401 — happen on the caller first iteration, landing in the mid-stream *yielded* branch instead. Verified by reading the installed SDK source, not inferred from comments. Same mechanism as the connect-failure bug in the companion PR.

**Consequence fixed:** a yielded auth failure carried `code=None`, which is the sentinel in *both* `_TRANSIENT_CODES` and `_retry.py` `_RETRYABLE_CODES`. A single non-pooled ollama/gemini provider would therefore retry the same bad credentials against the same endpoint up to `max_retries`.

Fix changes **no logic**: a non-null non-transient code already falls through to exactly how a *raised* auth failure is treated. It deletes an inconsistency rather than inventing a policy. `BadRequestError` traced and given the same treatment where the asymmetry exists; MCP errors traced and correctly left alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)