### PR TITLE
fix(session): LLM stream failure ends a turn as failed, not completed

### DIFF
--- a/primer/agent/loop.py
+++ b/primer/agent/loop.py
@@ -40,6 +40,7 @@ from primer.model.chat import (
     StreamEvent,
     ToolCallPart,
     ToolResultPart,
+    TurnStreamFailure,
     Usage,
     output_to_message,
     _ClientAction,
@@ -257,6 +258,12 @@ async def run_agent_turn(
         Propagated from a tool dispatch -- callers handle this
         (chat: terminal stream Error; workspace: WAITING transition;
         graph: per-node FAILED).
+    primer.model.chat.TurnStreamFailure
+        The LLM stream ended in a terminal :class:`Error` for this call
+        (e.g. a connect failure), whether or not it produced any
+        assistant content first (01a070d6). Callers must not treat an
+        unraised return from this generator as success without checking
+        for this -- see each caller's own handling.
     """
     tools = await tool_manager.list_tools(principal=principal)
 
@@ -333,9 +340,21 @@ async def run_agent_turn(
         try:
             assistant_msg = output_to_message(buffered)
         except ValueError as exc:
-            # Empty / error-only stream. The events were already emitted to
-            # subscribers, so the user sees something, but the orchestrator
-            # would otherwise treat the turn as a quiet success and tight-loop
+            if isinstance(held_done, Error):
+                # 01a070d6: an error-only stream (e.g. an LLM connect
+                # failure) used to end here quietly - the ERROR record
+                # already yielded above is durable, but nothing told the
+                # caller the TURN failed, so every caller read this as an
+                # ordinary empty completion.
+                raise TurnStreamFailure(
+                    held_done,
+                    partial_messages=[],
+                    rounds_completed=tool_round,
+                ) from exc
+            # Empty stream, no error: the LLM legitimately produced
+            # nothing. The events were already emitted to subscribers, so
+            # the user sees something, but the orchestrator would
+            # otherwise treat the turn as a quiet success and tight-loop
             # the LLM. Log enough to make the situation diagnosable from
             # production logs.
             logger.warning(
@@ -347,6 +366,20 @@ async def run_agent_turn(
 
         if messages_out is not None:
             messages_out.append(assistant_msg)
+
+        if isinstance(held_done, Error):
+            # 01a070d6: partial-content-then-error. output_to_message only
+            # raises on ZERO convertible content, so any TextDelta before
+            # the terminal error lets this succeed with a truncated-but-
+            # normal-looking assistant message - worse than the empty
+            # case, since it reads as a complete answer rather than an
+            # obviously-empty one. The ERROR record is already durable;
+            # this is what tells the turn itself it failed.
+            raise TurnStreamFailure(
+                held_done,
+                partial_messages=[assistant_msg],
+                rounds_completed=tool_round,
+            )
 
         tool_calls = [
             p for p in assistant_msg.parts if isinstance(p, ToolCallPart)

--- a/primer/graph/_node_dispatch.py
+++ b/primer/graph/_node_dispatch.py
@@ -55,7 +55,7 @@ from primer.graph._node_refs import (
     _resolve_toolcall_arguments,
 )
 from primer.graph.template import render_input_template
-from primer.model.chat import Message, StreamEvent, TextPart
+from primer.model.chat import Message, StreamEvent, TextPart, TurnStreamFailure
 from primer.model.except_ import ConfigError
 from primer.model.graph import (
     FanOutSpec,
@@ -509,8 +509,22 @@ class _NodeDispatchMixin:
             )
             return
         except BaseException as exc:
+            # 01a070d6: to_problem_details doesn't know TurnStreamFailure
+            # (it isn't a PrimerError), so the generic BaseException path
+            # would otherwise lose the LLM error's own code entirely -
+            # ended_detail stays None and the node's failure reads as
+            # generic. ended_detail_code always resolves to something
+            # usable, never None.
             await queue.put(
-                _NodeDone(node_id=node_id, output=None, error=exc)
+                _NodeDone(
+                    node_id=node_id,
+                    output=None,
+                    error=exc,
+                    ended_detail=(
+                        exc.ended_detail_code
+                        if isinstance(exc, TurnStreamFailure) else None
+                    ),
+                )
             )
             if isinstance(exc, asyncio.CancelledError):
                 raise

--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -58,6 +58,7 @@ from primer.model.chat import (
     Message,
     StreamEvent,
     ToolResultPart,
+    TurnStreamFailure,
     _GraphNodeEvent,
 )
 from primer.model.except_ import ConfigError
@@ -845,10 +846,20 @@ class _BaseGraphExecutor(
                     )
                     continue
                 except Exception as exc:  # noqa: BLE001 -- map to node failure
+                    # 01a070d6: a TurnStreamFailure means the LLM stream
+                    # itself is why this resumed turn failed - "tool_
+                    # execution_failed" would be an actively wrong label
+                    # for it (nothing about a tool ran), and ended_detail_
+                    # code always resolves to something usable, never None.
+                    detail = (
+                        exc.ended_detail_code
+                        if isinstance(exc, TurnStreamFailure)
+                        else "tool_execution_failed"
+                    )
                     fail_out = NodeOutput(
                         text="", parsed=None, history=[],
                         iteration=context.iteration, error=str(exc),
-                        ended_detail="tool_execution_failed",
+                        ended_detail=detail,
                     )
                     context.nodes[ay.node_id] = fail_out
                     node_states[ay.node_id] = NodeRuntimeState(
@@ -858,7 +869,7 @@ class _BaseGraphExecutor(
                         error=str(exc),
                     )
                     yield _GraphErrorEvent(  # type: ignore[misc]
-                        code="tool_execution_failed", message=str(exc),
+                        code=detail, message=str(exc),
                         node_id=ay.node_id,
                     )
                     # Balanced exit for this resumed agent-yield node (parked →
@@ -873,7 +884,7 @@ class _BaseGraphExecutor(
                     await self._save_state(
                         iteration=context.iteration, node_states=node_states,
                         status=SessionStatus.ENDED, ended_reason="failed",
-                        ended_detail="tool_execution_failed",
+                        ended_detail=detail,
                     )
                     return
                 context.nodes[ay.node_id] = out

--- a/primer/model/chat.py
+++ b/primer/model/chat.py
@@ -1017,6 +1017,57 @@ class Error(BaseModel):
     )
 
 
+class TurnStreamFailure(Exception):
+    """Raised when an LLM stream ends without producing a usable turn.
+
+    Carries the terminal :class:`Error` plus whatever the turn had
+    already produced before the failing call, so callers can salvage
+    partial output and construct an accurate ``ended_detail`` (e.g. the
+    error's own ``code``) instead of a generic "failed" string.
+
+    Covers two shapes, distinguished by whether ``partial_messages`` is
+    empty: a stream that produced no convertible content at all, and one
+    that produced some assistant text before the terminal error (which
+    would otherwise round-trip as a plausible-looking, silently
+    truncated answer). ``partial_messages`` is for in-memory callers
+    only — durable stream records already preserve this content
+    independently, so this is not a second copy of the record trail.
+
+    01a070d6: retry semantics are deliberately out of scope. This does
+    not carry the prompt or enough state to retry the failing call — a
+    future retry design gets to decide what state it needs; this
+    exception isn't pre-loaded to guess at it.
+    """
+
+    def __init__(
+        self,
+        error: Error,
+        *,
+        partial_messages: list[Message],
+        rounds_completed: int,
+    ) -> None:
+        super().__init__(error.message)
+        self.error = error
+        self.partial_messages = partial_messages
+        self.rounds_completed = rounds_completed
+
+    @property
+    def ended_detail_code(self) -> str:
+        """``error.code``, or a generic fallback when the classifier left it
+        unset.
+
+        Several provider error classifiers construct their
+        :class:`~primer.model.except_.PrimerError` with no ``code`` at all
+        (verified 01a070d6: every ``NetworkError`` site across ollama,
+        anthropic, openai, google, and mcp), so ``error.code`` alone cannot
+        be trusted to always carry a usable value. Every caller that wants
+        a terminal-state detail string should read THIS, not ``error.code``
+        directly, so a future classifier that forgets to set a code still
+        produces something better than ``None``.
+        """
+        return self.error.code or "llm_stream_error"
+
+
 # ---- Extended stream events (wrapped via ExtendedEvent) ---------------------
 
 

--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -31,6 +31,7 @@ from primer.int.claim import ClaimKind, Lease, ParkRequest, ReleaseOutcome
 from primer.int.event_bus import EventBus
 from primer.int.storage_provider import StorageProvider
 import primer.observability.metrics as _metrics
+from primer.model.chat import TurnStreamFailure
 from primer.model.envelope import RELAY_EVERY_TURN_KEY
 from primer.model.workspace import Workspace
 from primer.model.workspace_session import (
@@ -1057,6 +1058,16 @@ async def run_one_session_turn(
                 session,
                 new_status=SessionStatus.ENDED,
                 ended_reason="failed",
+                # 01a070d6: a TurnStreamFailure means the LLM stream itself
+                # is why the turn failed - ended_detail_code always resolves
+                # to something usable (a real classifier code, or its own
+                # fallback), so monitoring can tell "the LLM was
+                # unreachable" apart from "some other internal error"
+                # instead of both reading as an undifferentiated "failed".
+                ended_detail=(
+                    exc.ended_detail_code
+                    if isinstance(exc, TurnStreamFailure) else None
+                ),
                 executor=executor,
                 expected_epoch=session.binding_epoch,
             )
@@ -1963,6 +1974,7 @@ async def _transition_session_status(
     *,
     new_status: SessionStatus,
     ended_reason: str | None = None,
+    ended_detail: str | None = None,
     executor=None,
     expected_epoch: int | None = None,
     workspace_registry: Any | None = None,
@@ -2013,6 +2025,8 @@ async def _transition_session_status(
         updates["ended_at"] = datetime.now(timezone.utc)
         if ended_reason is not None:
             updates["ended_reason"] = ended_reason
+        if ended_detail is not None:
+            updates["ended_detail"] = ended_detail
     try:
         await session_storage.update(fresh.model_copy(update=updates))
     except Exception:  # noqa: BLE001

--- a/primer/toolset/system.py
+++ b/primer/toolset/system.py
@@ -77,7 +77,7 @@ from primer.agent.invoke import (
 )
 from primer.model.agent import Agent
 from primer.model.model_profile import ModelProfile
-from primer.model.chat import Tool, ToolCallResult, ToolExample
+from primer.model.chat import Tool, ToolCallResult, ToolExample, TurnStreamFailure
 from primer.toolset._describe import make_tool
 from primer.toolset._helpers import err as _err, ok as _ok
 from primer.model.collection import Collection, Document
@@ -724,6 +724,16 @@ def build_system_toolset(
             )
         except ValueError as exc:
             return _err(str(exc), error_type="bad-request")
+        except TurnStreamFailure as exc:
+            # 01a070d6: without this, a subagent whose LLM connection
+            # failed returned "" as if it had legitimately said nothing -
+            # the parent agent saw a SUCCESSFUL tool result with no signal
+            # anywhere that the subagent's LLM call actually failed.
+            return _err(
+                f"subagent {args.agent_id!r} LLM stream failed: "
+                f"{exc.error.message}",
+                error_type="provider-error",
+            )
         return _ok({"output": text})
 
     registry["invoke_agent"] = (

--- a/primer/worker/frames.py
+++ b/primer/worker/frames.py
@@ -35,7 +35,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from primer.graph.invoke_graph import resume_invoke_graph
-from primer.model.chat import ToolCallPart, ToolResultPart
+from primer.model.chat import ToolCallPart, ToolResultPart, TurnStreamFailure
 from primer.model.principal import PrincipalRef
 from primer.model.yield_ import YieldToWorker
 from primer.worker.yield_resume_registry import (
@@ -242,6 +242,22 @@ class AgentFrame:
             )
         except YieldToWorker as yld:
             return Reparked(new_yield=yld)
+        except TurnStreamFailure as exc:
+            # 01a070d6: same reasoning as run_subagent's own first-dispatch
+            # caller (primer.toolset.system._invoke_agent_handler) - without
+            # this, a subagent continuation whose LLM connection failed
+            # resolves this frame as a SUCCESSFUL empty-string tool result,
+            # with nothing telling the parent turn the subagent's own LLM
+            # call actually failed.
+            return Completed(
+                value=ToolResultPart(
+                    id=self.tool_call_id,
+                    output=json.dumps({
+                        "error": f"subagent LLM stream failed: {exc.error.message}",
+                    }),
+                    error=True,
+                )
+            )
         return Completed(
             value=ToolResultPart(
                 id=self.tool_call_id,

--- a/tests/agent/test_turn_stream_failure.py
+++ b/tests/agent/test_turn_stream_failure.py
@@ -1,0 +1,177 @@
+"""01a070d6: run_agent_turn raises TurnStreamFailure instead of quietly
+returning when a stream ends in a terminal Error.
+
+Covers the two failure shapes (zero-content, partial-content-then-error)
+and the one non-failure shape that must NOT raise (a genuinely empty but
+otherwise clean stream) so the fix doesn't over-fire on a legitimate
+"the LLM said nothing" turn.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import AsyncIterator
+
+import pytest
+
+from primer.agent.loop import run_agent_turn
+from primer.model.agent import Agent, AgentModel
+from primer.model.chat import (
+    Done,
+    Error,
+    Message,
+    StreamEvent,
+    TextDelta,
+    TextPart,
+    TurnStreamFailure,
+)
+from primer.model.model_profile import ModelProfileConfig
+from primer.model_profile import ResolvedModel
+
+
+def _agent() -> Agent:
+    return Agent(id="ag", description="x", model=AgentModel(profile_id="p--m"))
+
+
+def _model() -> ResolvedModel:
+    return ResolvedModel(
+        profile_id="test-profile", provider_id="test-provider",
+        model_name="m", context_length=4096, config=ModelProfileConfig(),
+    )
+
+
+class _NoToolManager:
+    def is_notifying(self, tool_name: str) -> bool:
+        del tool_name
+        return False
+
+    async def list_tools(self, *, principal=None):
+        return []
+
+    async def execute(self, call, *, principal=None):
+        raise AssertionError("no tool call expected in these scenarios")
+
+
+class _ScriptedLLM:
+    """Replays one fixed event list per call, advancing through a script."""
+
+    def __init__(self, *rounds: list[StreamEvent]) -> None:
+        self._rounds = list(rounds)
+        self.calls = 0
+
+    def stream(self, *, model, messages, **kwargs):
+        events = self._rounds[self.calls]
+        self.calls += 1
+
+        async def _gen() -> AsyncIterator[StreamEvent]:
+            for ev in events:
+                yield ev
+
+        return _gen()
+
+    async def aclose(self):
+        return None
+
+
+async def _drive(llm, *, messages_out=None) -> list[StreamEvent]:
+    seen: list[StreamEvent] = []
+
+    async def _run() -> None:
+        async for ev in run_agent_turn(
+            agent=_agent(), llm=llm, llm_model=_model(),
+            tool_manager=_NoToolManager(),
+            prompt=[Message(role="user", parts=[TextPart(text="go")])],
+            messages_out=messages_out,
+        ):
+            seen.append(ev)
+
+    await asyncio.wait_for(_run(), timeout=5.0)
+    return seen
+
+
+@pytest.mark.asyncio
+async def test_zero_content_error_stream_raises_turn_stream_failure() -> None:
+    err = Error(code=None, message="connection refused", fatal=True)
+    llm = _ScriptedLLM([err])
+    with pytest.raises(TurnStreamFailure) as exc_info:
+        await _drive(llm)
+    failure = exc_info.value
+    assert failure.error is err
+    assert failure.partial_messages == []
+    assert failure.rounds_completed == 0
+
+
+@pytest.mark.asyncio
+async def test_partial_content_then_error_raises_with_salvaged_text() -> None:
+    err = Error(code="server_error", message="upstream died mid-stream", fatal=True)
+    llm = _ScriptedLLM([TextDelta(index=0, text="partial answer"), err])
+    with pytest.raises(TurnStreamFailure) as exc_info:
+        await _drive(llm)
+    failure = exc_info.value
+    assert failure.error is err
+    assert len(failure.partial_messages) == 1
+    assert failure.partial_messages[0].role == "assistant"
+    assert failure.rounds_completed == 0
+
+
+@pytest.mark.asyncio
+async def test_genuinely_empty_clean_stream_does_not_raise() -> None:
+    """A Done-terminated, zero-content stream is a legitimate empty
+    answer, not a failure -- must keep the pre-01a070d6 quiet-return
+    behavior."""
+    llm = _ScriptedLLM([Done(stop_reason="stop", raw_reason="stop")])
+    events = await _drive(llm)
+    assert any(isinstance(ev, Done) for ev in events)
+    assert not any(isinstance(ev, Error) for ev in events)
+
+
+@pytest.mark.asyncio
+async def test_rounds_completed_counts_only_prior_clean_rounds() -> None:
+    """01a070d6 sec 3: emptiness/failure is evaluated per-LLM-call-attempt.
+    A later round's failure must report how many EARLIER rounds
+    completed cleanly, not conflate the whole turn."""
+    from primer.model.chat import ToolCallEnd, ToolCallStart
+
+    err = Error(code=None, message="dropped", fatal=True)
+    llm = _ScriptedLLM(
+        [
+            ToolCallStart(id="tc1", name="loop_tool", index=0),
+            ToolCallEnd(id="tc1", arguments={}, index=0),
+            Done(stop_reason="tool_use", raw_reason="tool_use"),
+        ],
+        [err],
+    )
+
+    class _OneToolManager(_NoToolManager):
+        async def list_tools(self, *, principal=None):
+            return [{"name": "loop_tool", "description": "d", "parameters": {}}]
+
+        async def execute(self, call, *, principal=None):
+            from primer.model.chat import ToolResultPart
+            return ToolResultPart(id=call.id, output="ok", error=False)
+
+    async def _run() -> None:
+        async for _ in run_agent_turn(
+            agent=_agent(), llm=llm, llm_model=_model(),
+            tool_manager=_OneToolManager(),
+            prompt=[Message(role="user", parts=[TextPart(text="go")])],
+        ):
+            pass
+
+    with pytest.raises(TurnStreamFailure) as exc_info:
+        await asyncio.wait_for(_run(), timeout=5.0)
+    assert exc_info.value.rounds_completed == 1
+
+
+def test_ended_detail_code_falls_back_when_classifier_left_code_unset() -> None:
+    coded = TurnStreamFailure(
+        Error(code="llm_connect_error", message="x", fatal=True),
+        partial_messages=[], rounds_completed=0,
+    )
+    assert coded.ended_detail_code == "llm_connect_error"
+
+    uncoded = TurnStreamFailure(
+        Error(code=None, message="x", fatal=True),
+        partial_messages=[], rounds_completed=0,
+    )
+    assert uncoded.ended_detail_code == "llm_stream_error"

--- a/tests/e2e/test_multi_cycle_resume_stability_journey.py
+++ b/tests/e2e/test_multi_cycle_resume_stability_journey.py
@@ -372,31 +372,31 @@ async def test_t0865_resume_after_on_disk_ended_clears_park(
         # 01a06bc1: parked_status clears as soon as the resume
         # machinery injects the tool result and converts the park
         # back into a normal turn - BEFORE that turn's own LLM call
-        # (the one that hits the bogus URL) actually runs and settles.
+        # (the one that hits the bogus URL) actually runs and fails.
         # Racing straight into cycle 2's inject after only the above
         # assertions meant the defensive branch this test exists to
         # pin could go unexercised while the test still passed: 5/5
         # live runs (Dev-Backend, 2026-09-04) showed cycle 2's inject
         # winning that race every time, with the bogus-URL turn never
-        # having run yet. Block on the row actually reaching ENDED
-        # before cycle 2 touches it, so the on-disk-ENDED edge case
-        # this test is named for is guaranteed to exist by the time
-        # cycle 2 fires.
+        # having run yet. Block on the row actually reaching its
+        # terminal ENDED/failed state before cycle 2 touches it, so
+        # the on-disk-ENDED edge case this test is named for is
+        # guaranteed to exist by the time cycle 2 fires.
         #
-        # Only status is asserted here, not ended_reason: a connect
-        # failure against the bogus URL surfaces as an in-band Error
-        # stream event, not a raised exception - run_agent_turn's
-        # output_to_message raises ValueError on the resulting
-        # error-only stream, which is caught and returns quietly
-        # (no assistant content to persist), so the turn settles as
-        # ended_reason="completed", not "failed" (live-traced
-        # 2026-09-04). _sync_agent_session_ended mirrors ENDED onto
-        # the on-disk AgentSession slot for EITHER ended_reason, so
-        # the edge case this test pins - DB row reset to running by
-        # cycle 2 while the on-disk slot is still ENDED - is created
-        # either way; only the terminal status matters for this gate.
+        # 01a070d6: ended_reason=="failed" was weakened to a status-
+        # only check on 2026-09-04 (d5353a49) because the connect
+        # failure surfaced as an in-band Error stream event that
+        # run_agent_turn quietly swallowed rather than raised, so the
+        # turn actually settled "completed" - the wrong terminal
+        # reason, not just an untested one. run_agent_turn now raises
+        # TurnStreamFailure for exactly this shape, which reaches
+        # dispatch.py's existing fatal-exception handling and ends the
+        # session "failed" for real. Restoring the original assertion
+        # is this fix's live e2e proof: it must pass now, and if it
+        # doesn't, the lie isn't fully retired.
         body1b = await wait_terminal(client, sid, timeout_s=20.0)
         assert body1b.get("status") == "ended", body1b
+        assert body1b.get("ended_reason") == "failed", body1b
 
         # ----- Cycle 2: inject onto post-fatal row ---------------
         # The on-disk AgentSession is now ENDED (cycle 1's fatal

--- a/tests/graph/test_agent_node_resume.py
+++ b/tests/graph/test_agent_node_resume.py
@@ -347,3 +347,43 @@ async def test_two_agent_yields_resume_one_reparks_on_other(tmp_path):
         checkpoint, resumed_tcid="tc0", agent_tool_result=tool_result))
     assert repark is not None, "must re-park while tc1 is still pending"
     assert repark.yielded.event_keys == ["ask_user:t:tc1"]
+
+
+class _FailingContinuationLLM:
+    """01a070d6: the resumed turn's OWN LLM call ends in a terminal
+    Error (e.g. a connect failure) with no content - run_agent_turn
+    raises TurnStreamFailure instead of quietly returning."""
+    async def list_models(self): return ["m"]
+    def stream(self, **kw) -> AsyncIterator[StreamEvent]:
+        from primer.model.chat import Error
+
+        async def _g():
+            yield Error(code="llm_connect_error", message="connect failed", fatal=True)
+        return _g()
+
+
+@pytest.mark.asyncio
+async def test_agent_node_resume_llm_failure_ends_failed_with_code(tmp_path):
+    """01a070d6: before this fix, resume_from_checkpoint's ay_pending
+    loop hardcoded ended_detail="tool_execution_failed" for EVERY
+    exception reaching its generic except-Exception branch - an actively
+    wrong label for an LLM stream failure, since nothing about a tool
+    ran. Must now carry the classifier's own code instead."""
+    ex1 = await _build(tmp_path, _YieldingLLM(), "gsid-r-fail")
+    raised = await _drain_until_yield(ex1.invoke([]))
+    assert raised is not None and raised.graph_checkpoint is not None
+    checkpoint = raised.graph_checkpoint
+
+    ex2 = await _build(tmp_path, _FailingContinuationLLM(), "gsid-r-fail")
+    tool_result = Message(role="tool",
+                          parts=[ToolResultPart(id="tc1", output="blue")])
+    async for _ev in ex2.resume_from_checkpoint(
+        checkpoint, resumed_tcid="tc1", agent_tool_result=tool_result):
+        pass
+
+    state = await ex2.load_state()
+    assert state is not None
+    assert state["status"] == "ended"
+    assert state["ended_reason"] == "failed"
+    assert state["ended_detail"] == "llm_connect_error"
+    assert state["node_states"]["A"]["status"] == "failed"

--- a/tests/graph/test_spec_b_error_codes.py
+++ b/tests/graph/test_spec_b_error_codes.py
@@ -34,6 +34,7 @@ from primer.graph.workspace_executor import WorkspaceGraphExecutor
 from primer.model.agent import Agent, AgentModel
 from primer.model.chat import (
     Done,
+    Error,
     Message,
     StreamEvent,
     TextDelta,
@@ -437,3 +438,55 @@ async def test_fanin_upstream_failed_reaches_session_as_error_record(
     assert state is not None
     assert state["ended_reason"] == "failed"
     assert state["ended_detail"] == "fanin_upstream_failed"
+
+
+@pytest.mark.asyncio
+async def test_llm_connect_failure_reaches_session_as_error_record(
+    tmp_path: Path,
+) -> None:
+    """01a070d6: an agent node's LLM stream ending in a terminal Error
+    (e.g. a connect failure) raises TurnStreamFailure out of
+    run_agent_turn -> _GraphErrorEvent(code=<the classifier's code>) ->
+    ERROR record. Before the fix, the generic except-BaseException path
+    left ended_detail unset for ANY exception without special handling,
+    so this specific check (`if done.ended_detail is not None`) never
+    fired at all - no _GraphErrorEvent, no code, just an undifferentiated
+    node failure."""
+    graph = Graph(
+        id="g-llm-connect-failure",
+        description="begin -> worker (agent, LLM connect fails) -> end",
+        nodes=[
+            _BeginNode(id="begin"),
+            _AgentNodeRef(id="worker", agent_id="ag"),
+            _EndNode(id="exit"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="worker"),
+            _StaticEdge(from_node="worker", to_node="exit"),
+        ],
+    )
+
+    llm = _ScriptedLLM(scripts=[[
+        Error(code="llm_connect_error", message="connect failed", fatal=True),
+    ]])
+
+    executor = await _build_test_executor(
+        graph=graph,
+        tmp_path=tmp_path,
+        graph_session_id="gsid-llm-connect-failure",
+        llm=llm,
+    )
+    events = await _drain(executor.invoke([]))
+
+    err = _terminal_error(events)
+    assert err.code == "llm_connect_error"
+
+    rec = _translate_to_record(err)
+    assert rec.kind == SessionMessageKind.ERROR
+    assert rec.payload["code"] == "llm_connect_error"
+    assert rec.payload["node_id"] == "worker"
+
+    state = await executor.load_state()
+    assert state is not None
+    assert state["ended_reason"] == "failed"
+    assert state["ended_detail"] == "llm_connect_error"

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -19,7 +19,14 @@ import pytest
 
 from primer.bus.in_memory import InMemoryEventBus
 from primer.int.claim import ClaimKind, Lease, ReleaseOutcome
-from primer.model.chat import Done, Error, TextDelta, ToolCallEnd, ToolCallStart
+from primer.model.chat import (
+    Done,
+    Error,
+    TextDelta,
+    ToolCallEnd,
+    ToolCallStart,
+    TurnStreamFailure,
+)
 from primer.model.workspace_session import (
     AgentSessionBinding,
     SessionMessageKind,
@@ -975,6 +982,78 @@ async def test_executor_error_transitions_to_ended_failed(
     # to idle on every exit the try/except covers, including this one.
     assert row.turn_status == "idle"
     assert row.turn_started_at is None
+
+
+@pytest.mark.asyncio
+async def test_turn_stream_failure_ended_detail_carries_the_error_code(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """01a070d6: a TurnStreamFailure means the LLM stream itself is why
+    the turn failed - ended_detail must carry that classifier code (not
+    a generic "failed"/exception-class string) so monitoring can tell
+    "the LLM was unreachable" apart from any other internal error."""
+    fake_executor = FakeExecutor([
+        TurnStreamFailure(
+            Error(code="llm_connect_error", message="connect failed", fatal=True),
+            partial_messages=[], rounds_completed=0,
+        ),
+    ])
+
+    async def _build_executor(session: WorkspaceSession):
+        return fake_executor
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    outcome = await run_one_session_turn(_make_lease(seeded_session.id), deps)
+
+    assert outcome.success is False
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    row = await storage.get(seeded_session.id)
+    assert row.status == SessionStatus.ENDED
+    assert row.ended_reason == "failed"
+    assert row.ended_detail == "llm_connect_error"
+
+
+@pytest.mark.asyncio
+async def test_turn_stream_failure_ended_detail_falls_back_when_code_unset(
+    seeded_session: WorkspaceSession,
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """01a070d6: several provider classifiers (NetworkError across ollama,
+    anthropic, openai, google, mcp) leave Error.code unset - ended_detail
+    must still resolve to something usable rather than None."""
+    fake_executor = FakeExecutor([
+        TurnStreamFailure(
+            Error(code=None, message="connection refused", fatal=True),
+            partial_messages=[], rounds_completed=0,
+        ),
+    ])
+
+    async def _build_executor(session: WorkspaceSession):
+        return fake_executor
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    outcome = await run_one_session_turn(_make_lease(seeded_session.id), deps)
+
+    assert outcome.success is False
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    row = await storage.get(seeded_session.id)
+    assert row.ended_reason == "failed"
+    assert row.ended_detail == "llm_stream_error"
 
 
 @pytest.mark.asyncio

--- a/tests/toolset/test_system_invoke_agent.py
+++ b/tests/toolset/test_system_invoke_agent.py
@@ -99,3 +99,30 @@ async def test_invoke_agent_depth_exceeded_is_error(monkeypatch, system_provider
     )
     assert res.is_error is True
     assert "depth" in res.output.lower()
+
+
+@pytest.mark.asyncio
+async def test_invoke_agent_turn_stream_failure_is_error_not_empty_success(
+    monkeypatch, system_provider,
+):
+    """01a070d6: before this, a subagent whose LLM connection failed
+    returned "" as if it had legitimately said nothing - the parent
+    agent read a SUCCESSFUL empty tool result with no signal anywhere
+    that the subagent's own LLM call actually failed."""
+    from primer.model.chat import Error, TurnStreamFailure
+
+    async def _boom(**kwargs):
+        raise TurnStreamFailure(
+            Error(code="llm_connect_error", message="connect failed", fatal=True),
+            partial_messages=[], rounds_completed=0,
+        )
+
+    monkeypatch.setattr("primer.toolset.system.run_subagent", _boom)
+    res = await system_provider.call(
+        tool_name="invoke_agent",
+        arguments={"agent_id": "a", "prompt": "p"},
+        principal=None,
+        ctx=None,
+    )
+    assert res.is_error is True
+    assert "connect failed" in res.output

--- a/tests/worker/test_agent_frame_resume.py
+++ b/tests/worker/test_agent_frame_resume.py
@@ -19,6 +19,14 @@ class _ServicesReyields:
     async def resume_subagent(self, **kw):
         raise YieldToWorker(Yielded(tool_name="ask_user", event_key="ask_user:ses:n2"), tool_call_id="n2")
 
+class _ServicesStreamFails:
+    async def resume_subagent(self, **kw):
+        from primer.model.chat import Error, TurnStreamFailure
+        raise TurnStreamFailure(
+            Error(code="llm_connect_error", message="connect failed", fatal=True),
+            partial_messages=[], rounds_completed=0,
+        )
+
 @pytest.mark.asyncio
 async def test_agent_frame_resume_completes_returns_text_toolresult():
     svc = _ServicesCompletes()
@@ -35,3 +43,17 @@ async def test_agent_frame_resume_completes_returns_text_toolresult():
 async def test_agent_frame_resume_reyields_reparks():
     out = await _frame().resume(ToolResultPart(id="x", output="child", error=False), _ServicesReyields())
     assert isinstance(out, Reparked) and out.new_yield.yielded.tool_name == "ask_user"
+
+@pytest.mark.asyncio
+async def test_agent_frame_resume_turn_stream_failure_completes_as_error():
+    """01a070d6: a subagent CONTINUATION whose LLM connection failed must
+    not resolve this frame as a SUCCESSFUL empty-text tool result - the
+    parent turn needs to see the failure, not silently believe the
+    subagent finished with nothing to say."""
+    out = await _frame().resume(
+        ToolResultPart(id="x", output="child", error=False), _ServicesStreamFails(),
+    )
+    assert isinstance(out, Completed)
+    assert out.value.id == "inv-tc"
+    assert out.value.error is True
+    assert "connect failed" in json.loads(out.value.output)["error"]


### PR DESCRIPTION
An LLM connect failure surfaced as `ended_reason="completed"` — the system reporting success on failure. `ollama.py` yields `ChatError` as an in-band stream event rather than raising, so the failure never reached the terminal-state mapping.

Introduces `TurnStreamFailure` and maps it consistently across four surfaces. Includes a restored assertion (`t0865`) verified green across three live cycles.

🤖 Generated with [Claude Code](https://claude.com/claude-code)