### PR TITLE
fix(tests): e2e SSP config reads PRIMER_DB_PORT via a shared helper, plus a guard

### DIFF
--- a/tests/e2e/conftest.py
+++ b/tests/e2e/conftest.py
@@ -131,3 +131,61 @@ async def authed_client(client):
     # Back-compat alias: ``client`` is now authenticated by default. Retained
     # so the many modules that request ``authed_client`` keep working.
     return client
+
+
+# ---------------------------------------------------------------------------
+# Shared pgvector SemanticSearchProvider body (2026-09-09).
+#
+# 14 e2e test modules each carried their own copy-pasted version of this
+# POST body, hardcoding hostname=localhost/port=5432/database=primer_e2e/
+# username=primer/password=primer with NO env override at all - correct
+# only by coincidence on hosts where 5432 happens to be this bringup's own
+# postgres. Silently wrong (pointed at a DIFFERENT, unrelated postgres) on
+# any host where it isn't, as it is on the dev host this was found on. Same
+# hazard class, same day, as the fixes to test_approvals_journey.py and
+# test_halfvec_e2e.py - see those commits for the concrete failure mode
+# (an InvalidPasswordError against someone else's postgres, reproduced and
+# proven live). One test_builtin_toolsets.py instance additionally named
+# the wrong DATABASE ("primer_dogfood", which bringup.sh never creates) -
+# also covered by using this helper instead.
+#
+# PRIMER_DB_PORT/PRIMER_DB_USER/PRIMER_DB_PASSWORD are the SAME variables
+# scripts/e2e/bringup.sh and docker-compose.yml already read - not a new,
+# independent knob. hostname and database are not env-overridable because
+# bringup.sh doesn't make them configurable either (it always creates a
+# database literally named "primer_e2e", reachable at "localhost" from the
+# process running these tests) - overriding them here is for tests that
+# deliberately want a DIFFERENT target, not a portability escape hatch.
+# ---------------------------------------------------------------------------
+
+
+def pgvector_ssp_config(
+    *,
+    hostname: str | None = None,
+    port: int | None = None,
+    database: str | None = None,
+    username: str | None = None,
+    password: str | None = None,
+    db_schema: str = "public",
+) -> dict:
+    """The pgvector "config" sub-object alone, for call sites that build
+    their own {"id": ..., "provider": "pgvector", "config": ...} shape."""
+    return {
+        "hostname": hostname or "localhost",
+        "port": port if port is not None
+        else int(os.environ.get("PRIMER_DB_PORT", "5432")),
+        "database": database or "primer_e2e",
+        "username": username or os.environ.get("PRIMER_DB_USER", "primer"),
+        "password": password or os.environ.get("PRIMER_DB_PASSWORD", "primer"),
+        "db_schema": db_schema,
+    }
+
+
+def pgvector_ssp_body(entity_id: str, **config_overrides) -> dict:
+    """Full POST /v1/ssp body for a pgvector SemanticSearchProvider pointed
+    at the postgres scripts/e2e/bringup.sh actually created for this run."""
+    return {
+        "id": entity_id,
+        "provider": "pgvector",
+        "config": pgvector_ssp_config(**config_overrides),
+    }

--- a/tests/e2e/test_builtin_toolsets.py
+++ b/tests/e2e/test_builtin_toolsets.py
@@ -12,6 +12,8 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from tests.e2e.conftest import pgvector_ssp_body
+
 
 @pytest.mark.asyncio
 async def test_t0140_system_toolset_lists_tools(
@@ -465,20 +467,7 @@ async def test_t0247_delete_search_toolset_before_activation_clean(
     )
     assert pr_emb.status_code == 201, pr_emb.text
 
-    pr_ssp = await client.post(
-        "/v1/ssp",
-        json={
-            "id": ssp_id,
-            "provider": "pgvector",
-            "config": {
-                "hostname": "127.0.0.1",
-                "port": 5432,
-                "username": "primer",
-                "password": "primer",
-                "database": "primer_dogfood",
-            },
-        },
-    )
+    pr_ssp = await client.post("/v1/ssp", json=pgvector_ssp_body(ssp_id))
     assert pr_ssp.status_code == 201, pr_ssp.text
 
     config_created = False

--- a/tests/e2e/test_collection_documents_by_path.py
+++ b/tests/e2e/test_collection_documents_by_path.py
@@ -23,17 +23,12 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from tests.e2e.conftest import pgvector_ssp_config
+
 
 _PGVECTOR_SSP = {
     "provider": "pgvector",
-    "config": {
-        "hostname": "localhost",
-        "port": 5432,
-        "database": "primer_e2e",
-        "username": "primer",
-        "password": "primer",
-        "db_schema": "public",
-    },
+    "config": pgvector_ssp_config(),
 }
 
 _EMBED_PROVIDER = {

--- a/tests/e2e/test_collection_search_config.py
+++ b/tests/e2e/test_collection_search_config.py
@@ -25,17 +25,12 @@ from __future__ import annotations
 import httpx
 import pytest
 
+from tests.e2e.conftest import pgvector_ssp_config
+
 
 _PGVECTOR_SSP = {
     "provider": "pgvector",
-    "config": {
-        "hostname": "localhost",
-        "port": 5432,
-        "database": "primer_e2e",
-        "username": "primer",
-        "password": "primer",
-        "db_schema": "public",
-    },
+    "config": pgvector_ssp_config(),
 }
 
 _EMBED_PROVIDER = {

--- a/tests/e2e/test_cookbook_app_builder.py
+++ b/tests/e2e/test_cookbook_app_builder.py
@@ -60,16 +60,14 @@ from tests._support.runs import (
 from tests._support.smk import smk
 from tests._support.testconfig import requires
 from tests._support.model_profiles import agent_model, seed_llm_provider
+from tests.e2e.conftest import pgvector_ssp_config
 
 pytestmark = [pytest.mark.asyncio]
 
 
 _SSP = {
     "provider": "pgvector",
-    "config": {
-        "hostname": "localhost", "port": 5432, "database": "primer_e2e",
-        "username": "primer", "password": "primer", "db_schema": "public",
-    },
+    "config": pgvector_ssp_config(),
 }
 _EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 _EMBED = {

--- a/tests/e2e/test_cookbook_harness_packaging.py
+++ b/tests/e2e/test_cookbook_harness_packaging.py
@@ -30,6 +30,7 @@ import pytest
 
 from tests._support.smk import smk
 from tests._support.model_profiles import agent_model, seed_llm_provider
+from tests.e2e.conftest import pgvector_ssp_config
 
 pytestmark = pytest.mark.asyncio
 
@@ -39,10 +40,7 @@ pytestmark = pytest.mark.asyncio
 # rows still exist, so a verbatim template installs cleanly.
 _PGVECTOR_SSP = {
     "provider": "pgvector",
-    "config": {
-        "hostname": "localhost", "port": 5432, "database": "primer_e2e",
-        "username": "primer", "password": "primer", "db_schema": "public",
-    },
+    "config": pgvector_ssp_config(),
 }
 _EMBED_PROVIDER = {
     "provider": "huggingface",

--- a/tests/e2e/test_cookbook_meta_agent_builder.py
+++ b/tests/e2e/test_cookbook_meta_agent_builder.py
@@ -36,16 +36,14 @@ from tests._support.runs import (
 from tests._support.smk import smk
 from tests._support.testconfig import requires
 from tests._support.model_profiles import agent_model
+from tests.e2e.conftest import pgvector_ssp_config
 
 pytestmark = pytest.mark.asyncio
 
 
 _SSP = {
     "provider": "pgvector",
-    "config": {
-        "hostname": "localhost", "port": 5432, "database": "primer_e2e",
-        "username": "primer", "password": "primer", "db_schema": "public",
-    },
+    "config": pgvector_ssp_config(),
 }
 _EMBED_MODEL = "sentence-transformers/all-MiniLM-L6-v2"
 _EMBED = {

--- a/tests/e2e/test_cookbook_policy_desk.py
+++ b/tests/e2e/test_cookbook_policy_desk.py
@@ -56,6 +56,7 @@ from tests._support.runs import (
 )
 from tests._support.smk import smk
 from tests._support.testconfig import load_config, requires
+from tests.e2e.conftest import pgvector_ssp_config as _pgvector_dsn_cfg
 
 pytestmark = [
     pytest.mark.asyncio,
@@ -72,13 +73,7 @@ def _cross_encoder_cfg() -> dict:
     return load_config()["cross_encoder"]
 
 
-_PGVECTOR_DSN = {
-    "hostname": "localhost",
-    "port": 5432,
-    "database": "primer_e2e",
-    "username": "primer",
-    "password": "primer",
-}
+_PGVECTOR_DSN = _pgvector_dsn_cfg()
 
 # --- The policy corpus -----------------------------------------------------
 # The PRECISE answer to the deadline question is the terse 72-hour clause in

--- a/tests/e2e/test_cookbook_rag_knowledge_base.py
+++ b/tests/e2e/test_cookbook_rag_knowledge_base.py
@@ -44,6 +44,7 @@ from tests._support.runs import (
 )
 from tests._support.smk import smk
 from tests._support.testconfig import load_config, requires
+from tests.e2e.conftest import pgvector_ssp_config as _pgvector_dsn_cfg
 
 pytestmark = [pytest.mark.asyncio, requires("embedder", "pgvector")]
 
@@ -53,13 +54,7 @@ def _embedder_cfg() -> dict:
     return load_config()["embedder"]
 
 
-_PGVECTOR_DSN = {
-    "hostname": "localhost",
-    "port": 5432,
-    "database": "primer_e2e",
-    "username": "primer",
-    "password": "primer",
-}
+_PGVECTOR_DSN = _pgvector_dsn_cfg()
 
 # The KB docs. Each is path-addressed; the printer doc deliberately avoids the
 # words in the test query ("add a printer") so the match is SEMANTIC, not

--- a/tests/e2e/test_cookbook_skills_loop.py
+++ b/tests/e2e/test_cookbook_skills_loop.py
@@ -37,6 +37,7 @@ from tests._support.runs import (
 )
 from tests._support.smk import smk
 from tests._support.testconfig import requires
+from tests.e2e.conftest import pgvector_ssp_config
 
 pytestmark = pytest.mark.asyncio
 
@@ -61,10 +62,7 @@ _REVISED_SKILL = (
 # inactive); the loop's correctness does not depend on indexing.
 _SSP = {
     "provider": "pgvector",
-    "config": {
-        "hostname": "localhost", "port": 5432, "database": "primer_e2e",
-        "username": "primer", "password": "primer", "db_schema": "public",
-    },
+    "config": pgvector_ssp_config(),
 }
 _EMBED = {
     "provider": "huggingface",

--- a/tests/e2e/test_cookbook_support_desk.py
+++ b/tests/e2e/test_cookbook_support_desk.py
@@ -47,6 +47,7 @@ from tests._support.runs import (
 )
 from tests._support.smk import smk
 from tests._support.testconfig import load_config, requires
+from tests.e2e.conftest import pgvector_ssp_config as _pgvector_dsn_cfg
 
 pytestmark = [pytest.mark.asyncio, requires("embedder", "pgvector")]
 
@@ -55,13 +56,7 @@ def _embedder_cfg() -> dict:
     return load_config()["embedder"]
 
 
-_PGVECTOR_DSN = {
-    "hostname": "localhost",
-    "port": 5432,
-    "database": "primer_e2e",
-    "username": "primer",
-    "password": "primer",
-}
+_PGVECTOR_DSN = _pgvector_dsn_cfg()
 
 # Two support docs. The queries deliberately avoid exact keyword overlap so
 # the match is semantic.

--- a/tests/e2e/test_internal_collections_lifecycle.py
+++ b/tests/e2e/test_internal_collections_lifecycle.py
@@ -38,6 +38,7 @@ import httpx
 import pytest
 import pytest_asyncio
 from tests._support.model_profiles import agent_model, seed_llm_provider
+from tests.e2e.conftest import pgvector_ssp_body as _ssp_body
 
 
 # Bootstrap is synchronous and now genuinely indexes the system
@@ -64,28 +65,6 @@ def _embedding_provider_body(entity_id: str) -> dict:
         ],
         "config": {"token": "hf-placeholder"},
         "limits": {"max_concurrency": 1},
-    }
-
-
-def _ssp_body(entity_id: str) -> dict:
-    """pgvector SemanticSearchProvider backed by the e2e postgres instance.
-
-    The internal-collections config PUT now requires a valid
-    search_provider_id that references an existing SemanticSearchProvider
-    row. This helper creates that prerequisite using the same postgres
-    DSN as the e2e bringup script (primer:primer@localhost/primer_e2e).
-    """
-    return {
-        "id": entity_id,
-        "provider": "pgvector",
-        "config": {
-            "hostname": "localhost",
-            "port": 5432,
-            "database": "primer_e2e",
-            "username": "primer",
-            "password": "primer",
-            "db_schema": "public",
-        },
     }
 
 

--- a/tests/e2e/test_semantic_search_journey.py
+++ b/tests/e2e/test_semantic_search_journey.py
@@ -29,20 +29,7 @@ from __future__ import annotations
 import httpx
 import pytest
 
-
-def _ssp_body(sid: str) -> dict:
-    return {
-        "id": sid,
-        "provider": "pgvector",
-        "config": {
-            "hostname": "localhost",
-            "port": 5432,
-            "database": "primer_e2e",
-            "username": "primer",
-            "password": "primer",
-            "db_schema": "public",
-        },
-    }
+from tests.e2e.conftest import pgvector_ssp_body as _ssp_body
 
 
 def _emb_body(eid: str) -> dict:

--- a/tests/e2e/test_sessions_top_level.py
+++ b/tests/e2e/test_sessions_top_level.py
@@ -20,6 +20,7 @@ from pathlib import Path
 import httpx
 import pytest
 from tests._support.model_profiles import agent_model, seed_llm_provider
+from tests.e2e.conftest import pgvector_ssp_body
 
 
 # The lifecycle tests below need a real agent turn to converge to a terminal
@@ -6303,18 +6304,7 @@ async def test_t0754_delete_embedding_provider_referenced_by_ic_config(
     ssp_created = False
     try:
         # 1. Seed a search provider (pgvector, pointing at the e2e DB).
-        ssp = await client.post("/v1/ssp", json={
-            "id": ssp_id,
-            "provider": "pgvector",
-            "config": {
-                "hostname": "localhost",
-                "port": 5432,
-                "database": "primer_e2e",
-                "username": "primer",
-                "password": "primer",
-                "db_schema": "public",
-            },
-        })
+        ssp = await client.post("/v1/ssp", json=pgvector_ssp_body(ssp_id))
         assert ssp.status_code == 201, ssp.text
         ssp_created = True
 

--- a/tests/e2e/test_smk_knowledge.py
+++ b/tests/e2e/test_smk_knowledge.py
@@ -28,6 +28,7 @@ import pytest
 
 from tests._support.smk import smk
 from tests._support.testconfig import load_config, requires
+from tests.e2e.conftest import pgvector_ssp_config as _pgvector_dsn_cfg
 
 pytestmark = pytest.mark.asyncio
 
@@ -43,23 +44,6 @@ def _embedder_cfg() -> dict:
 
 def _cross_encoder_cfg() -> dict:
     return load_config()["cross_encoder"]
-
-
-def _pgvector_dsn_cfg() -> dict:
-    """pgvector connection fields matching the bringup server's vector store.
-
-    The live e2e server (tests/.e2e/config.yaml) points pgvector at the
-    compose Postgres on localhost:5432, db primer_e2e, user/pass primer.
-    Reuse exactly that instance so collections created via the API are
-    visible to the same store.
-    """
-    return {
-        "hostname": "localhost",
-        "port": 5432,
-        "database": "primer_e2e",
-        "username": "primer",
-        "password": "primer",
-    }
 
 
 async def _make_real_embedder(authed_client, suffix, *, url: str | None = None) -> str:

--- a/tests/e2e/test_sqlite_multi_router_journey.py
+++ b/tests/e2e/test_sqlite_multi_router_journey.py
@@ -58,6 +58,7 @@ from primer.model.scheduler import (
     SchedulerProviderType,
 )
 from tests._support.model_profiles import agent_model, seed_llm_provider
+from tests.e2e.conftest import pgvector_ssp_body
 
 
 # 60-char placeholder for DiscordChannelProviderConfig.bot_token
@@ -282,23 +283,14 @@ async def test_t0852_sqlite_multi_router_crud_journey(tmp_path: Path) -> None:
             # 7. SemanticSearchProvider — §7 surface against SQLite
             # =============================================================
             ssp_id = "t852-ssp"
-            r = await client.post(
-                "/v1/ssp",
-                json={
-                    "id": ssp_id,
-                    "provider": "pgvector",
-                    "config": {
-                        "hostname": "127.0.0.1",
-                        "port": 5432,
-                        "username": "user",
-                        "password": "pass",
-                        "database": "vectors",
-                        "embedder": {
-                            "provider_id": llm_id, "model": "fake-model",
-                        },
-                    },
-                },
+            ssp_body = pgvector_ssp_body(
+                ssp_id, hostname="127.0.0.1",
+                username="user", password="pass", database="vectors",
             )
+            ssp_body["config"]["embedder"] = {
+                "provider_id": llm_id, "model": "fake-model",
+            }
+            r = await client.post("/v1/ssp", json=ssp_body)
             assert r.status_code == 201, r.text
 
             # =============================================================

--- a/tests/test_e2e_db_config_hygiene.py
+++ b/tests/test_e2e_db_config_hygiene.py
@@ -1,0 +1,86 @@
+"""Guard against tests/e2e/*.py re-introducing hardcoded pgvector DB config.
+
+2026-09-09: 14 tests/e2e/*.py modules each independently hardcoded
+hostname=localhost/port=5432/database=primer_e2e/username=primer/
+password=primer for their SemanticSearchProvider POST body, with no
+PRIMER_DB_PORT override anywhere - silently wrong on any host where 5432
+isn't this bringup's own postgres, which is exactly the case on the
+primary dev host (5432 there is an unrelated pre-existing service). One
+occurrence additionally named the wrong database entirely
+("primer_dogfood", which no bringup script creates). All 14 are now
+migrated onto tests/e2e/conftest.py's pgvector_ssp_config()/
+pgvector_ssp_body().
+
+This test is the guard against the class quietly returning: four
+independent hardcoded-DB-config recurrences surfaced across this repo in
+one day (this class, plus tests/ui_e2e/test_approvals_journey.py's DB
+helper and tests/vector/test_halfvec_e2e.py, both fixed separately) -
+fixing occurrences one at a time was losing to the rate at which they
+reappear, so this closes the door specifically for tests/e2e.
+
+Deliberately scoped to tests/e2e ONLY - do NOT widen this to tests/
+broadly. The same 2026-09-09 sweep found plenty of LEGITIMATE literal-5432
+and hardcoded-credential occurrences elsewhere (tests/api's `_FakeStorage
+Provider`-backed CRUD round-trips that never dial postgres, tests/model's
+deliberately-unreachable "db.invalid" coercion test, tests/knowledge's
+SQLite-backed fixture) that a repo-wide rule would wrongly flag as
+hazards. tests/e2e specifically is the one directory where every test
+runs against a REAL, bringup.sh-provisioned postgres, which is exactly
+why a hardcoded literal there is never inert.
+
+Lives outside tests/e2e/ itself (not tests/e2e/test_*.py) so it is not
+caught by that directory's own collect_ignore_glob, which skips every
+test_*.py module there unless PRIMER_RUN_E2E=1 is set - this is pure
+source-text scanning and needs neither a live server nor that flag.
+"""
+
+from __future__ import annotations
+
+import re
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+E2E_DIR = ROOT / "tests" / "e2e"
+
+# conftest.py is the shared helper itself - it legitimately contains the
+# literal defaults (PRIMER_DB_PORT's own "5432" fallback, "primer_e2e" as
+# the database pgvector_ssp_config() defaults to).
+_ALLOWLISTED_FILES = {"conftest.py"}
+
+# The hazard shape: a PORT KEY assigned the literal 5432 directly, not an
+# env-var-driven resolution. Does NOT match
+# `os.environ.get("PRIMER_DB_PORT", "5432")` - there "5432" is a quoted
+# string default argument, never adjacent to a `port`/`"port"` key.
+_PORT_LITERAL = re.compile(r'"port"\s*:\s*5432\b|(?<!_)\bport\s*=\s*5432\b')
+
+# "primer_e2e" itself is NOT flagged: it's the one hardcoded value that IS
+# correct everywhere, because bringup.sh always creates a database by
+# that literal name and never makes it configurable - the clean
+# PRIMER_DB_PORT-only files (e.g. test_multi_cycle_resume_stability_
+# journey.py's own _pg()) hardcode it too, deliberately. "primer_dogfood"
+# is different: no bringup script anywhere creates a database by that
+# name, so its only prior appearance (test_builtin_toolsets.py) was a
+# second, independent bug layered on top of the port one - a hardcoded
+# database name that isn't even the RIGHT one.
+_HARDCODED_DB_NAME = re.compile(r'"primer_dogfood"')
+
+
+def test_no_hardcoded_pgvector_config_outside_the_shared_helper() -> None:
+    offenders = []
+    for path in sorted(E2E_DIR.glob("*.py")):
+        if path.name in _ALLOWLISTED_FILES:
+            continue
+        text = path.read_text(encoding="utf-8")
+        hit_port = _PORT_LITERAL.search(text)
+        hit_db = _HARDCODED_DB_NAME.search(text)
+        if hit_port or hit_db:
+            reason = "port=5432 literal" if hit_port else "hardcoded database name"
+            offenders.append(f"{path.name} ({reason})")
+    assert not offenders, (
+        "tests/e2e/*.py file(s) hardcode pgvector DB config instead of "
+        "using tests/e2e/conftest.py's pgvector_ssp_body()/"
+        "pgvector_ssp_config(): "
+        f"{offenders}. Import the shared helper instead - see "
+        "conftest.py's own docstring for why a literal here is a "
+        "silent-wrong-database hazard, not just a portability nit."
+    )


### PR DESCRIPTION
15 files in `tests/e2e` hardcoded `hostname/port/database/username/password` and fed it into a **real** `/v1/internal_collections/config` activation. Inert in CI (`PRIMER_DB_PORT` unset, 5432 correct); on any other host all 15 silently point a real activation at the wrong database. This is why local e2e runs have been unreliable.

Adds `pgvector_ssp_config()`/`pgvector_ssp_body()` to `tests/e2e/conftest.py` — which all 15 already import from — reading the **same** env vars `bringup.sh` and `docker-compose.yml` already use, not new ones.

**Includes a guard** (`tests/test_e2e_db_config_hygiene.py`) so the class cannot silently return. Scoped to `tests/e2e` only: a repo-wide rule would be wrong, because a full inventory confirmed legitimate literals elsewhere (in-memory `_FakeStorageProvider` tests, an RFC-2606 `db.invalid` coercion test). Guard proven to catch a reintroduced violation, then reverted.

Placed outside `tests/e2e/` deliberately — that directory `collect_ignore_glob`s itself without `PRIMER_RUN_E2E=1`, so a guard living inside it would never run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)