### PR TITLE
fix(graph): REMOVE-ON-SETTLE ready-set invariant + persisted failure across a park

### DIFF
--- a/primer/graph/_checkpoint.py
+++ b/primer/graph/_checkpoint.py
@@ -170,6 +170,11 @@ class _CheckpointMixin:
           ``{"fanout_node_id": ..., "spec": <FanOutSpec.model_dump>}``.
         * ``fanout_drain_state`` — drain_key → drain_state dict.
         * ``pending_toolcalls`` — list of pending ToolCall dicts.
+        * ``pending_ended_reason`` / ``pending_ended_detail`` (01a0812c) —
+          a sticky, un-suppressed node failure discovered before a park,
+          so the eventual terminal outcome doesn't silently downgrade to
+          "completed" once the park resolves. ``None`` when no failure
+          has been discovered yet.
         """
         ctx_payload: dict[str, Any] | None = None
         if self._context is not None:
@@ -177,6 +182,8 @@ class _CheckpointMixin:
         return {
             "context": ctx_payload,
             "ready_set": sorted(self._ready_set),
+            "pending_ended_reason": self._pending_ended_reason,
+            "pending_ended_detail": self._pending_ended_detail,
             "node_states": {
                 nid: ns.model_dump(mode="json")
                 for nid, ns in self._node_states.items()
@@ -339,6 +346,15 @@ class _CheckpointMixin:
         else:
             self._context = GraphContext.model_validate(ctx_raw)
         self._ready_set = set(payload.get("ready_set") or [])
+        # 01a0812c: absent -> None (no failure discovered yet), same
+        # degrade-gracefully policy as every other new-field-on-old-
+        # checkpoint case in this codebase - a checkpoint written before
+        # this field existed simply resumes as if nothing had failed,
+        # which is the correct behaviour for a checkpoint that predates
+        # this field's existence (it could not have discovered a failure
+        # this field didn't exist yet to record).
+        self._pending_ended_reason = payload.get("pending_ended_reason")
+        self._pending_ended_detail = payload.get("pending_ended_detail")
         # Re-seed the admitted-set used by the FanIn callable-router gate.
         # The restored ready-set is the in-flight frontier; completed nodes
         # already have output (so they never block). This keeps a resumed

--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -2026,16 +2026,55 @@ class _BaseGraphExecutor(
                     next_ready.add(inst.synthesized_id)
                 del self._pending_fanout[fanout_id]
 
-            # 01a0812c: additive, not a bare reset - unlike the ONE site
-            # in resume_from_checkpoint that's specifically verified safe
-            # as a bare assignment (self._ready_set provably empty
-            # there), this general pattern is the one to default to for
-            # every other successor-fold site: self._ready_set has
-            # already had every settled ready_ordered member discarded
-            # above (nothing pending reaches this line - the park branch
-            # above already returned if anything were), so a bare
-            # assignment would likely be a no-op today, but the union is
-            # what stays correct if that ever stops being true.
+            # 01a0812c: additive, not a bare reset - union is the default
+            # pattern for every successor-fold site in this class (see
+            # resume_from_checkpoint's own fold, which learned the hard
+            # way that "provably empty" claims on this function don't
+            # survive contact with a real run). This ONE site is the
+            # exception: self._ready_set IS provably empty here, not just
+            # "likely" - a bare `self._ready_set = next_ready` would be
+            # exactly as correct as this union, by construction, not by
+            # inference:
+            #   1. self._ready_set has exactly ONE admission site besides
+            #      this one that can fire mid-loop: none. The full list of
+            #      every place this executor ever adds to self._ready_set
+            #      is: invoke()'s initial seed and resume_from_checkpoint's
+            #      own fold (both BEFORE this while loop is entered), the
+            #      max_iterations hard reset a few lines up (a `continue`
+            #      that restarts the loop with a completely fresh
+            #      ready_ordered snapshot next iteration, so it never
+            #      reaches this line either), and this fold itself. Grep
+            #      ``self\._ready_set`` in this file to re-verify; nothing
+            #      else ever calls .add()/|= on it.
+            #   2. ready_ordered (a few lines up) is `sorted(self._ready_set)`
+            #      taken as a snapshot - by definition it captures every
+            #      member self._ready_set has AT THAT INSTANT, regardless
+            #      of which of the sites in (1) put them there.
+            #   3. Every nid in that snapshot is discarded by the
+            #      classification loop above UNLESS it parks (the
+            #      must-not-settle guard skips the discard for a park).
+            #   4. If ANYTHING parked, the pending-park check a few lines
+            #      up already raised and returned - this line is
+            #      unreachable that iteration. So by the time control
+            #      reaches this line, every nid from the snapshot in (2)
+            #      settled and was discarded in (3); nothing from the
+            #      snapshot survives.
+            #   5. Nothing between the snapshot (2) and this line adds
+            #      anything to self._ready_set (only discards happen in
+            #      that span) - so self._ready_set is empty here, full
+            #      stop, not "probably".
+            # Kept as a union anyway (not "simplified" to a bare
+            # assignment) because a union that's empirically a no-op is
+            # free, while a bare assignment is a live footgun for the
+            # next person who adds a 7th admission site to this class and
+            # doesn't re-derive this whole proof first. See
+            # test_ready_set_is_actually_empty_at_every_loop_tail_fold
+            # in tests/graph/test_tool_wait_graph_park.py, which pins (2)-(5)
+            # empirically across a multi-resume, same-superstep-collision
+            # run (the topology round 4's BLOCKER needed) rather than
+            # leaving this proof unverified by execution - the standard
+            # this function has earned after four rounds of "provably
+            # safe" static reasoning conflicting with what actually ran.
             self._ready_set |= next_ready
             context.iteration += 1
 

--- a/primer/graph/base.py
+++ b/primer/graph/base.py
@@ -312,7 +312,33 @@ class _BaseGraphExecutor(
         # :meth:`snapshot_state` can serialise them mid-flight. ``None``
         # before the first superstep / after termination.
         self._context: GraphContext | None = None
+        # 01a0812c: the single source of truth for "nodes that still need
+        # a superstep dispatch or have an in-flight (possibly parked) turn
+        # that hasn't reached a terminal outcome yet" - maintained
+        # incrementally (add on admission, discard on settle - success or
+        # failure, never a park) rather than by set arithmetic at read
+        # time. Four prior fix rounds each patched a variant of "ready
+        # minus an accumulating exclusion set computed at read time" and
+        # each patch introduced a new bug (see the ready-set discard/add
+        # sites throughout this class + resume_from_checkpoint) - the
+        # replacement is this field having no second, separately-
+        # accumulating set that could ever go stale relative to it.
         self._ready_set: set[str] = set()
+        # 01a0812c: sticky terminal-reason fields, set once (first
+        # un-suppressed failure wins) the moment ``any_failed`` fires in
+        # _run_superstep_loop's classification loop, and round-tripped
+        # through snapshot_state/restore_state exactly like _ready_set -
+        # so a failure discovered in the same superstep as an unrelated
+        # park is not silently discarded when that park raises (any_failed
+        # itself is a pure per-call local of _run_superstep_loop and does
+        # NOT survive the exception unwind on its own). Mirrors the
+        # ended_reason/ended_detail local pair's own asymmetry exactly:
+        # reason is unconditional once a failure is un-suppressed, detail
+        # is conditional (only set when the failing node's own
+        # ``done.ended_detail`` is populated) - see the write site for why
+        # two fields, not one tuple.
+        self._pending_ended_reason: str | None = None
+        self._pending_ended_detail: str | None = None
         # Node ids that have entered the ready set at least once this run.
         # Used by ``_fanin_ready`` to decide whether a callable-router source
         # is a *live* potential upstream (admitted but not yet resolved) that
@@ -435,7 +461,6 @@ class _BaseGraphExecutor(
             # treat as a no-op completion.
             return
         node_states = self._node_states
-        ready = self._ready_set
 
         # Select which pending entries to resume this cycle. Legacy
         # (resumed_tcid None): every pending ToolCall. Per-entry: only the
@@ -476,6 +501,11 @@ class _BaseGraphExecutor(
                     ),
                 )
                 completed_ids.append(entry.node_id)
+                # 01a0812c: this node just settled (FAILED) - remove it
+                # from the live ready-set invariant now, at the write
+                # site, rather than tracking it in a second exclusion set
+                # to subtract later. See _ready_set's own docstring.
+                self._ready_set.discard(entry.node_id)
                 continue
             if _is_value_yield_toolcall(entry):
                 # Value-yielding tool_call node (e.g. ``system__ask_user``):
@@ -569,6 +599,8 @@ class _BaseGraphExecutor(
                     last_run_at=datetime.now(timezone.utc),
                 )
                 completed_ids.append(entry.node_id)
+                # 01a0812c: settled (ENDED) - see the discard above.
+                self._ready_set.discard(entry.node_id)
                 continue
             try:
                 result = await self._dispatch_toolcall_with_bypass(
@@ -734,6 +766,8 @@ class _BaseGraphExecutor(
                 last_run_at=datetime.now(timezone.utc),
             )
             completed_ids.append(entry.node_id)
+            # 01a0812c: settled (ENDED) - see the discard above.
+            self._ready_set.discard(entry.node_id)
 
         # Resume the selected agent-node yields: continue each node's turn
         # with the human's answer / decision injected as the tool result.
@@ -883,6 +917,9 @@ class _BaseGraphExecutor(
                     last_run_at=datetime.now(timezone.utc),
                 )
                 completed_ids.append(ay.node_id)
+                # 01a0812c: settled (ENDED) - see the tc_pending discards
+                # above.
+                self._ready_set.discard(ay.node_id)
             finally:
                 reset_current_graph_node_id(token)
 
@@ -1009,6 +1046,9 @@ class _BaseGraphExecutor(
                     last_run_at=datetime.now(timezone.utc),
                 )
                 completed_ids.append(tw.node_id)
+                # 01a0812c: settled (ENDED) - see the tc_pending discards
+                # above.
+                self._ready_set.discard(tw.node_id)
             finally:
                 reset_current_graph_node_id(token)
 
@@ -1038,55 +1078,24 @@ class _BaseGraphExecutor(
                 status=_status,
             )
 
-        # Full concurrency: if other human-interaction nodes OR tool_wait
-        # batches (01a0518b boundary d - a fan-out sibling's batch can
-        # still be mid-flight after a PARTIAL wake) are still pending,
-        # re-park on the remaining keys instead of advancing the graph.
-        if (
-            self._pending_toolcalls
-            or self._pending_agent_yields
-            or self._pending_tool_waits
-        ):
-            await self._save_state(
-                iteration=context.iteration,
-                node_states=node_states,
-                status=SessionStatus.WAITING,
-            )
-            raise self._build_pending_park_exception()
-
-        # Persist the drained-state snapshot so observers can see the
-        # ToolCalls finished before the next superstep starts.
-        await self._save_state(
-            iteration=context.iteration,
-            node_states=node_states,
-            status=SessionStatus.RUNNING,
-        )
-
-        # Compute the next ready set from the now-completed pending
-        # ToolCall nodes. The ``ready`` set on the executor at the time
-        # of the yield was the set of in-flight nodes; the just-completed
-        # subset is ``completed_ids`` (the others, if any, already had
-        # their results applied before the yield fired).
-        #
-        # 01a0812c (FLAG-ON PREREQUISITE, alongside recovery-boot
-        # 01a07c06): resume-dispatch correctness across a MULTI-entry
-        # partial wake (a sibling that completed/failed before the park
-        # surviving into the eventual `ready = next_ready` bare
-        # assignment below) is a KNOWN GAP here, deliberately reverted
-        # off this branch rather than fixed. Four consecutive rounds
-        # patched this exact expression and each introduced a NEW bug
-        # (reorder+union -> completed-sibling re-execution; ENDED-only
-        # already_ended -> cyclic loop-back drop + FAILED-sibling hole;
-        # settled_ids -> accumulated-ready deletion + failure-swallowing
-        # past a park) - none of it needed for THIS arc's merge, since
-        # tool_calls_as_claims_enabled OFF means tw_pending is always
-        # empty and this exact bare assignment is byte-identical to
-        # main (f49bdf0d). The accumulated scenario knowledge from all
-        # four rounds is preserved as xfail tests pointing at 01a0812c,
-        # which absorbs 01a08016 (same function, same class of bug) and
-        # requires a full design (remove-on-settle instead of
-        # filter-on-resume; persist failure across a park) plus a
-        # scenario matrix before any further code here.
+        # 01a0812c / 01a08016 (absorbed into this task): compute + fold
+        # THIS resume's own completed_ids' successors into self._ready_set
+        # BEFORE checking whether other pending entries remain and
+        # re-parking - not after. Ordering correction found live (this
+        # block used to sit after the re-park check, on this branch's
+        # merge-base): a re-park exits via `raise` immediately below, so
+        # if the edge-walk ran AFTER that check, a node's OWN successor
+        # (e.g. A resolves, A -> C, while sibling B is still pending)
+        # would never be computed at all before the function exits -
+        # A's whole downstream branch silently vanishes, invisible even
+        # to the checkpoint the re-park persists (self._ready_set would
+        # never have gained C in the first place). Each
+        # ``completed_ids.append`` above already discarded that node from
+        # ``self._ready_set`` at the moment it settled (see the discard
+        # sites in the tc/ay/tw_pending loops above) - what's left in
+        # ``self._ready_set`` at this point is exactly the
+        # parked-and-not-yet-resolved entries plus anything an EARLIER
+        # partial resume of this same drain already folded in.
         if completed_ids:
             try:
                 next_ready = await self._compute_next_ready(
@@ -1112,16 +1121,68 @@ class _BaseGraphExecutor(
                     self._fanout_instances[inst.synthesized_id] = inst
                     next_ready.add(inst.synthesized_id)
                 del self._pending_fanout[fanout_id]
+            # NOTE: context.iteration is bumped further down, only once we
+            # know this superstep is actually fully drained (past the
+            # pending-recheck below) - see the comment there. Do not move
+            # the bump up here: R2-4 (test_iteration_bumps_once_per_
+            # drained_superstep_not_per_partial_resume) requires a
+            # still-partial resume (a sibling still pending) to leave
+            # context.iteration untouched even though this resume's own
+            # completed_ids's successors get computed and folded in.
+            # Union, not replace: self._ready_set can already hold a
+            # successor folded in by an EARLIER partial resume of this
+            # same drain (e.g. C, admitted by A's own edge-walk on a
+            # PRIOR resume while sibling B was still pending) that is
+            # neither settled NOR itself tracked in any pending list -
+            # THIS resume's own next_ready (computed from THIS resume's
+            # completed_ids only) says nothing about that earlier fold,
+            # so a bare assignment would silently drop it. Do not
+            # "simplify" this to `self._ready_set = next_ready` - that
+            # exact change was tried, reviewed, ruled "provably safe",
+            # and then falsified live by test_node_a_before_node_b_
+            # partial_wake and test_cyclic_loop_back_across_two_partial_
+            # resumes_still_dispatches, both of which silently lost a
+            # node under it.
+            self._ready_set |= next_ready
+
+        # Full concurrency: if other human-interaction nodes OR tool_wait
+        # batches (01a0518b boundary d - a fan-out sibling's batch can
+        # still be mid-flight after a PARTIAL wake) are still pending,
+        # re-park on the remaining keys instead of advancing the graph -
+        # self._ready_set already carries this resume's own fold (above),
+        # so the re-parked checkpoint does not lose it.
+        if (
+            self._pending_toolcalls
+            or self._pending_agent_yields
+            or self._pending_tool_waits
+        ):
+            await self._save_state(
+                iteration=context.iteration,
+                node_states=node_states,
+                status=SessionStatus.WAITING,
+            )
+            raise self._build_pending_park_exception()
+
+        # This superstep is now confirmed fully drained (the pending-recheck
+        # above did not re-park): bump context.iteration exactly once for
+        # it here, not per partial resume - see the NOTE above the fold
+        # block for why this can't live there.
+        if completed_ids:
             context.iteration += 1
-            ready = next_ready
-            self._ready_set = ready
+
+        # Persist the drained-state snapshot so observers can see the
+        # ToolCalls finished before the next superstep starts.
+        await self._save_state(
+            iteration=context.iteration,
+            node_states=node_states,
+            status=SessionStatus.RUNNING,
+        )
 
         async for ev in self._run_superstep_loop(
             context=context,
             node_states=node_states,
-            ready=ready,
-            ended_reason_in=None,
-            ended_detail_in=None,
+            ended_reason_in=self._pending_ended_reason,
+            ended_detail_in=self._pending_ended_detail,
         ):
             yield ev
 
@@ -1252,8 +1313,6 @@ class _BaseGraphExecutor(
         ready: set[str] = {_resolve_initial_ready_node(self._graph)}
         self._admitted = set(ready)
         self._max_iter_routed = False
-        ended_reason: str | None = None
-        ended_detail: str | None = None
         # Phase 6 — expose mid-flight state on the executor so
         # :meth:`snapshot_state` can capture it the moment a ToolCall
         # yields for approval. Kept in sync after every superstep
@@ -1265,9 +1324,8 @@ class _BaseGraphExecutor(
         async for ev in self._run_superstep_loop(
             context=context,
             node_states=node_states,
-            ready=ready,
-            ended_reason_in=ended_reason,
-            ended_detail_in=ended_detail,
+            ended_reason_in=self._pending_ended_reason,
+            ended_detail_in=self._pending_ended_detail,
         ):
             yield ev
 
@@ -1276,21 +1334,61 @@ class _BaseGraphExecutor(
         *,
         context: GraphContext,
         node_states: dict[str, NodeRuntimeState],
-        ready: set[str],
         ended_reason_in: str | None,
         ended_detail_in: str | None,
     ) -> AsyncIterator[StreamEvent]:
         """Pregel superstep loop — extracted so :meth:`resume_from_checkpoint`
         can re-enter at the same point after the approval-yield round-trip.
 
-        Spec B §2.3 step 3 / Phase 6. ``ready``, ``context``, ``node_states``
-        are passed by reference (the executor's instance attrs hold the same
+        Spec B §2.3 step 3 / Phase 6. ``context``, ``node_states`` are
+        passed by reference (the executor's instance attrs hold the same
         objects) so the snapshot path always sees up-to-date state.
+        ``self._ready_set`` (not a separately-threaded parameter, 01a0812c)
+        is the same story: both callers (:meth:`invoke`, freshly-seeded;
+        :meth:`resume_from_checkpoint`, restored + discard/fold-updated)
+        already sync it before calling in, so this method reads it
+        directly rather than accepting a value that could ever diverge
+        from it.
         """
         ended_reason = ended_reason_in
         ended_detail = ended_detail_in
 
-        while ready:
+        while self._ready_set:
+            # 01a0812c (M5): a failure discovered in an EARLIER superstep
+            # (this call, or a prior resume of the SAME park) is sticky -
+            # seeded via ended_reason_in from self._pending_ended_reason.
+            # fail_fast means STOP, not just eventually-report-correctly:
+            # once seeded, do not admit self._ready_set's contents for a
+            # fresh dispatch. `break`, not `return` - a `return` would
+            # skip the post-loop tail below (self._last_ended_reason /
+            # self._last_ended_detail exposure for a parent subgraph, and
+            # the final `_save_state(status=ENDED, ...)` call), silently
+            # stranding the run in a state a parent can't observe as
+            # failed and never persisting the terminal row. This is
+            # exactly the class of silent-skip bug that produced every
+            # prior round's regression - if a future refactor reaches for
+            # `return` here as the "simpler" exit, that is the bug this
+            # comment exists to stop.
+            #
+            # Placed first, before the max_iterations check: a seeded
+            # failure always wins over a cycle-bound reroute.
+            #
+            # Scoped out of v1, deliberately: a resumed continuation can
+            # still raise a NEW park after a failure is already seeded
+            # (self._pending_ended_reason non-None) - e.g. the one
+            # pending entry resume_from_checkpoint's drain is still
+            # finishing raises YieldToWorker/ToolWaitPark again
+            # mid-continuation. This is not special-cased: the re-park
+            # proceeds normally (existing machinery, untouched) and this
+            # check simply doesn't fire again until the NEXT resume,
+            # since resume_from_checkpoint returns via the re-park branch
+            # before ever reaching this loop. Net effect: one needless
+            # round-trip (a doomed session waits on a tool call it didn't
+            # strictly need to) rather than ending failed the instant it
+            # could have - accepted, not a bug.
+            if ended_reason is not None:
+                break
+
             # Cycle bound check. Spec §5.4 maps this to ended_reason='failed'
             # with the detail code carried separately so the public contract
             # has a single failure reason and a finite set of codes.
@@ -1311,7 +1409,13 @@ class _BaseGraphExecutor(
                         "on_max_iterations=%r instead of failing",
                         self._graph.id, self._graph.max_iterations, route_to,
                     )
-                    ready = {route_to}
+                    # Deliberate hard reset, not a union: this reroute
+                    # abandons the normal graph flow entirely (whatever
+                    # was in self._ready_set before is no longer wanted)
+                    # in favour of jumping straight to one finalize node -
+                    # unlike every other self._ready_set mutation in this
+                    # method, which is additive/incremental.
+                    self._ready_set = {route_to}
                     self._admitted.add(route_to)
                     continue
                 yield _GraphErrorEvent(  # type: ignore[misc]
@@ -1330,7 +1434,7 @@ class _BaseGraphExecutor(
             # on the same append+tick path every other record uses; no extra
             # tick publisher. node_kind comes from the resolved node def's
             # ``kind`` discriminator. Sorted for deterministic stream order.
-            for nid in sorted(ready):
+            for nid in sorted(self._ready_set):
                 node_states[nid] = NodeRuntimeState(
                     status=NodeRuntimeStatus.RUNNING,
                     last_run_iteration=context.iteration,
@@ -1361,7 +1465,7 @@ class _BaseGraphExecutor(
                     ts=ss_started_at,
                     iteration=context.iteration,
                     superstep_id=superstep_id,
-                    ready_node_ids=sorted(ready),
+                    ready_node_ids=sorted(self._ready_set),
                 ),
             )
 
@@ -1376,7 +1480,16 @@ class _BaseGraphExecutor(
             # The outer loop terminates naturally when the ready set
             # drains AND no nodes are in-flight; the sort here is kept
             # purely for deterministic stream ordering.
-            ready_ordered = sorted(ready)
+            #
+            # Stable per-iteration snapshot of self._ready_set (01a0812c):
+            # this superstep's dispatch BATCH is fixed at this instant,
+            # even though self._ready_set itself keeps mutating (discard
+            # on settle, below) for the rest of this iteration - a
+            # same-superstep addition (e.g. a drained fan-out plan) must
+            # not retroactively join THIS iteration's already-spawned
+            # tasks; it lands in self._ready_set for the next `while`
+            # iteration only.
+            ready_ordered = sorted(self._ready_set)
             queue: "asyncio.Queue[StreamEvent | _NodeDone | _ToolDispatchBarrier]" = (
                 asyncio.Queue()
             )
@@ -1605,6 +1718,16 @@ class _BaseGraphExecutor(
                 # detects pending entries and propagates YieldToWorker.
                 if done is not None and done.suspended:
                     continue
+                # 01a0812c: every branch reached from here on settles this
+                # node ONE way or another this superstep - an ordinary
+                # FAILED, a suppressed-fanout FAILED (its own sub-branch
+                # below, which still sets node_states[nid] to FAILED
+                # before its own continue), or ENDED. The suspended guard
+                # above is the ONLY branch that must NOT settle (a park,
+                # not a completion). Discard at the write site instead of
+                # tracking a second exclusion set to subtract later - see
+                # self._ready_set's own docstring in __init__.
+                self._ready_set.discard(nid)
                 if done is None or done.error is not None:
                     err_text = (
                         str(done.error) if done is not None else "no result"
@@ -1691,6 +1814,28 @@ class _BaseGraphExecutor(
                                     )
                             continue
                     any_failed = True
+                    # 01a0812c: persist that an un-suppressed failure
+                    # occurred so it survives a park - any_failed and
+                    # ended_reason/ended_detail below are pure locals of
+                    # THIS call to _run_superstep_loop, discarded if a
+                    # park raises before the `if any_failed:` check
+                    # further down ever runs (the pending-park branch is
+                    # checked FIRST). Sticky: first un-suppressed failure
+                    # wins, never overwritten by a later one - mirrors
+                    # ended_reason's own `if ended_reason is None:`
+                    # pattern below. Mirrors ended_reason/ended_detail's
+                    # own conditional structure exactly, not a blanket
+                    # "set both here": reason is unconditional (matches
+                    # how the `if any_failed:` fallback below always
+                    # eventually produces SOME reason even with no
+                    # specific detail), detail is set only inside the
+                    # SAME conditional ended_detail is - setting both
+                    # unconditionally would manufacture a detail value
+                    # (e.g. coercing None) that today's code never
+                    # produces, changing observable behavior for callers
+                    # that branch on ended_detail.
+                    if self._pending_ended_reason is None:
+                        self._pending_ended_reason = "failed"
                     # When the failure carries a spec §5.4 code (e.g. End-node
                     # output validation), propagate it so the executor's
                     # final state records both reason="failed" and the code,
@@ -1698,6 +1843,8 @@ class _BaseGraphExecutor(
                     if done is not None and done.ended_detail is not None:
                         ended_reason = "failed"
                         ended_detail = done.ended_detail
+                        if self._pending_ended_detail is None:
+                            self._pending_ended_detail = done.ended_detail
                         error_events.append(
                             _GraphErrorEvent(
                                 code=done.ended_detail,
@@ -1771,9 +1918,18 @@ class _BaseGraphExecutor(
                 or self._pending_agent_yields
                 or self._pending_tool_waits
             ):
-                # Keep ready set / context up to date on the executor for
-                # the snapshot.
-                self._ready_set = set(ready_ordered)
+                # 01a0812c: NO self._ready_set reset here (deleted, not
+                # adapted - this was the round-4 BLOCKER's exact
+                # mechanism). By this point in the classification loop
+                # above, self._ready_set has ALREADY been correctly
+                # discarded-from for every node that settled THIS
+                # superstep; what remains is exactly the parked entries
+                # plus anything not yet folded in. Resetting to the raw
+                # ready_ordered snapshot here would stomp those discards
+                # and re-admit same-superstep settlers for re-dispatch on
+                # a later resume - the exact bug this design exists to
+                # eliminate. Keep context / node_states up to date on the
+                # executor for the snapshot.
                 self._context = context
                 self._node_states = node_states
                 await self._save_state(
@@ -1870,7 +2026,17 @@ class _BaseGraphExecutor(
                     next_ready.add(inst.synthesized_id)
                 del self._pending_fanout[fanout_id]
 
-            ready = next_ready
+            # 01a0812c: additive, not a bare reset - unlike the ONE site
+            # in resume_from_checkpoint that's specifically verified safe
+            # as a bare assignment (self._ready_set provably empty
+            # there), this general pattern is the one to default to for
+            # every other successor-fold site: self._ready_set has
+            # already had every settled ready_ordered member discarded
+            # above (nothing pending reaches this line - the park branch
+            # above already returned if anything were), so a bare
+            # assignment would likely be a no-op today, but the union is
+            # what stays correct if that ever stops being true.
+            self._ready_set |= next_ready
             context.iteration += 1
 
         if ended_reason is None:

--- a/tests/graph/test_graph_checkpoint_roundtrip.py
+++ b/tests/graph/test_graph_checkpoint_roundtrip.py
@@ -212,3 +212,106 @@ async def test_snapshot_and_restore_preserves_state() -> None:
     assert p.parked_event_key == "tool_approval:gsid-1:tc-abc"
     assert p.arguments == {"q": "x", "limit": 10}
     assert p.scoped_tool_call_id == "worker[1]:tool:3:1"
+
+
+def _minimal_begin_end_graph() -> Graph:
+    return Graph(
+        id="g-cp-minimal",
+        description="checkpoint round-trip - minimal begin -> end",
+        nodes=[_BeginNode(id="begin"), _EndNode(id="end")],
+        edges=[_StaticEdge(from_node="begin", to_node="end")],
+    )
+
+
+async def _mk_roundtrip_pair(graph: Graph):
+    """Build two independent executors (fresh, distinct threads) sharing
+    one thread_storage - the same "genuine checkpoint round-trip, not one
+    in-memory object reused" discipline every test in this file applies.
+    Returns (executor1, build_executor2) where build_executor2() lazily
+    constructs the second, freshly-open-threaded executor on demand.
+    """
+
+    async def agent_resolver(agent_id: str) -> Agent:
+        raise KeyError(agent_id)
+
+    async def llm_resolver(agent):  # pragma: no cover -- not used
+        raise NotImplementedError
+
+    thread_storage: _InMemoryStorage[GraphThread] = _InMemoryStorage(GraphThread)
+    message_storage: _InMemoryStorage[GraphNodeMessage] = _InMemoryStorage(GraphNodeMessage)
+    thread1 = await GraphExecutor.open_thread(
+        graph=graph, thread_storage=thread_storage,  # type: ignore[arg-type]
+    )
+    executor1 = GraphExecutor(
+        graph=graph,
+        agent_resolver=agent_resolver,
+        llm_resolver=llm_resolver,  # type: ignore[arg-type]
+        thread_storage=thread_storage,  # type: ignore[arg-type]
+        message_storage=message_storage,  # type: ignore[arg-type]
+        graph_thread_id=thread1.id,
+    )
+
+    async def build_executor2() -> _BaseGraphExecutor:
+        thread2 = await GraphExecutor.open_thread(
+            graph=graph, thread_storage=thread_storage,  # type: ignore[arg-type]
+        )
+        return GraphExecutor(
+            graph=graph,
+            agent_resolver=agent_resolver,
+            llm_resolver=llm_resolver,  # type: ignore[arg-type]
+            thread_storage=thread_storage,  # type: ignore[arg-type]
+            message_storage=message_storage,  # type: ignore[arg-type]
+            graph_thread_id=thread2.id,
+        )
+
+    return executor1, build_executor2
+
+
+@pytest.mark.asyncio
+async def test_snapshot_and_restore_preserves_a_real_pending_failure() -> None:
+    """01a0812c matrix item M9b: _pending_ended_reason/_pending_ended_detail
+    must round-trip through a genuine checkpoint (fresh executor,
+    snapshot -> restore), carrying a REAL (non-None) failure - not just
+    tolerate their absence (M10's separate, different proof). A field
+    that only round-trips correctly when empty isn't proven to round-trip
+    at all.
+    """
+    executor, build_executor2 = await _mk_roundtrip_pair(_minimal_begin_end_graph())
+    executor._pending_ended_reason = "failed"
+    executor._pending_ended_detail = "routing_failed"
+
+    payload = executor.snapshot_state()
+    import json
+
+    json.dumps(payload)
+    assert payload["pending_ended_reason"] == "failed"
+    assert payload["pending_ended_detail"] == "routing_failed"
+
+    executor2 = await build_executor2()
+    executor2.restore_state(payload)
+
+    assert executor2._pending_ended_reason == "failed"
+    assert executor2._pending_ended_detail == "routing_failed"
+
+
+@pytest.mark.asyncio
+async def test_restore_tolerates_a_stale_round3_checkpoint() -> None:
+    """01a0812c matrix item M10: a checkpoint written by round-3 code
+    (``settled_ids`` key present, no ``pending_ended_reason`` /
+    ``pending_ended_detail`` keys at all - they did not exist yet) must
+    still restore cleanly under the redesigned code. ``settled_ids`` is
+    simply no longer read (dead key, ignored); the new fields degrade to
+    their documented one-resume-only fallback (None), exactly like every
+    other new-field-on-old-checkpoint case in this codebase.
+    """
+    executor, build_executor2 = await _mk_roundtrip_pair(_minimal_begin_end_graph())
+    payload = executor.snapshot_state()
+    payload["settled_ids"] = ["some-stale-node-id"]
+    payload.pop("pending_ended_reason", None)
+    payload.pop("pending_ended_detail", None)
+
+    executor2 = await build_executor2()
+    executor2.restore_state(payload)  # must not raise
+
+    assert executor2._pending_ended_reason is None
+    assert executor2._pending_ended_detail is None

--- a/tests/graph/test_tool_wait_graph_park.py
+++ b/tests/graph/test_tool_wait_graph_park.py
@@ -36,8 +36,8 @@ from primer.graph.executor import GraphExecutor
 from primer.model.agent import Agent, AgentModel
 from primer.model.chat import Message, StreamEvent, ToolResultPart
 from primer.model.graph import (
-    Graph, GraphNodeMessage, GraphThread, NodeRuntimeStatus,
-    _AgentNodeRef, _BeginNode, _EndNode, _StaticEdge,
+    FanOutSpec, Graph, GraphNodeMessage, GraphThread, NodeRuntimeStatus,
+    _AgentNodeRef, _BeginNode, _EndNode, _FanOutNode, _StaticEdge,
 )
 from primer.model.model_profile import ModelProfileConfig
 from primer.model.yield_ import ToolWaitPark, Yielded, YieldToWorker
@@ -268,22 +268,6 @@ async def test_gate_answers_first_tool_wait_survives_the_reprk(monkeypatch) -> N
     assert "A:tool:0:1" in repark.outstanding_task_ids
 
 
-@pytest.mark.xfail(
-    reason=(
-        "round-4 gate ruling: reverted resume_from_checkpoint's ready-set "
-        "line (rounds 1-3: reorder, union, already_ended, settled_ids) back "
-        "to merge-base `ready = next_ready` after four consecutive fix "
-        "rounds each introduced a new bug - two of them flag-off "
-        "regressions, on code not needed for merge (flag off means "
-        "tw_pending is always empty). This test's final assertions pin "
-        "item 2's original successor-drop finding, which merge-base "
-        "semantics reintroduce for a MULTI-entry partial wake (each "
-        "resume's own edge-walk only sees its own completed_ids, and a "
-        "PRIOR resume's fold is a bare-assignment casualty of the NEXT "
-        "resume). Kept as specification, not deleted - see task 01a0812c."
-    ),
-    strict=True,
-)
 @pytest.mark.asyncio
 async def test_node_a_before_node_b_partial_wake(monkeypatch) -> None:
     """PURE park (no human gate at all): both A and B raise their own
@@ -539,6 +523,14 @@ async def test_failed_sibling_is_not_re_executed_and_stays_failed(
     assert ex._node_states["B"].status == NodeRuntimeStatus.FAILED
     assert ex._node_states["B"].error == b_error_at_park
 
+    # 01a0812c matrix item M2: the run-level verdict must survive A's own
+    # park too, not just B's per-node FAILED status - round 4's own MAJOR
+    # finding was that fail_fast's run-level verdict got discarded by the
+    # exact re-park exception unwind this drain took (any_failed/
+    # ended_reason are pure locals of _run_superstep_loop, never
+    # checkpointed). self._pending_ended_reason is what survives instead.
+    assert ex._last_ended_reason == "failed"
+
 
 def _cyclic_collision_graph() -> Graph:
     """begin -> X -> {A, B}; A -> X (the cycle); B -> D.
@@ -573,21 +565,6 @@ def _cyclic_collision_graph() -> Graph:
     )
 
 
-@pytest.mark.xfail(
-    reason=(
-        "round-4 gate ruling: this test pins R3-1's own fix (settled_ids), "
-        "which was itself reverted after the gate found a BLOCKER in it - "
-        "subtracting settled_ids from the ACCUMULATED ready deletes a "
-        "loop-back target a PRIOR resume legitimately folded in, in a "
-        "same-superstep topology this test doesn't cover (X completes "
-        "ALONE in its own superstep here). resume_from_checkpoint's "
-        "ready-set line is back to merge-base `ready = next_ready` after "
-        "four rounds each introduced a new bug. Kept as specification, not "
-        "deleted - the cyclic loop-back scenario is real and becomes part "
-        "of task 01a0812c's mandatory scenario matrix."
-    ),
-    strict=True,
-)
 @pytest.mark.asyncio
 async def test_cyclic_loop_back_across_two_partial_resumes_still_dispatches(
     monkeypatch,
@@ -679,4 +656,467 @@ async def test_cyclic_loop_back_across_two_partial_resumes_still_dispatches(
     # and re-parking for real, on the SAME node_id.
     assert call_counts["agent-x"] == 2
     assert second_repark.outstanding_task_ids == ["X:tool:0:2"]
+
+
+def _same_superstep_collision_graph() -> Graph:
+    """begin -> {A, B, X} (ALL THREE together, one superstep); A -> X (the
+    cycle-collision edge); B -> D. Unlike ``_cyclic_collision_graph``, X is
+    NOT dispatched alone in its own earlier superstep - it settles in the
+    SAME superstep A and B park in, which is the exact round-4 BLOCKER
+    topology (design doc §2): a per-superstep reset can't save X here
+    since there IS no superstep boundary between X's original settle and
+    its re-admission via A's cycle edge - both happen within the same
+    nominal superstep, across two separate resumes of it.
+    """
+    return Graph(
+        id="g-same-superstep-collision",
+        description="begin -> {A,B,X}; A -> X; B -> D",
+        nodes=[
+            _BeginNode(id="begin"),
+            _AgentNodeRef(id="A", agent_id="agent-a"),
+            _AgentNodeRef(id="B", agent_id="agent-b"),
+            _AgentNodeRef(id="X", agent_id="agent-x"),
+            _EndNode(id="D"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="A"),
+            _StaticEdge(from_node="begin", to_node="B"),
+            _StaticEdge(from_node="begin", to_node="X"),
+            _StaticEdge(from_node="A", to_node="X"),
+            _StaticEdge(from_node="B", to_node="D"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_same_superstep_settle_survives_two_resumes_via_cycle_fold(
+    monkeypatch,
+) -> None:
+    """Test matrix item M3 - the exact round-4 BLOCKER topology (design doc
+    §2), distinct from M4's earlier-separate-superstep cyclic case: {A, B,
+    X} dispatch TOGETHER in one superstep. X completes normally (no park).
+    A parks with edge A -> X (cycles back to the SAME-superstep sibling
+    that already finished). B parks with an unrelated edge B -> D. A
+    resolves first (folding X back into self._ready_set via A's own
+    next_ready); B resolves second, with a next_ready that says nothing
+    about X at all.
+
+    X must survive BOTH resumes and dispatch for real - round 3's
+    ``settled_ids`` formula deleted X here specifically because it
+    subtracted from the ACCUMULATED ready set using a same-superstep
+    exclusion set that still (validly) remembered X's ORIGINAL, unrelated
+    settle; B's own, unrelated resume had no next_ready mention of X to
+    union it back in a second time.
+    """
+    call_counts: dict[str, int] = {}
+    ex = await _mk_executor_for_graph(_same_superstep_collision_graph())
+
+    import primer.graph._agent_node as agent_node_mod
+
+    async def _spy(**kwargs):
+        agent = kwargs["agent"]
+        call_counts[agent.id] = call_counts.get(agent.id, 0) + 1
+        if agent.id == "agent-x":
+            if call_counts["agent-x"] == 1:
+                # X's FIRST visit: completes normally, in the SAME
+                # superstep A and B park in.
+                return
+                yield  # pragma: no cover - unreachable, keeps this a generator
+            # X's SECOND visit (via A's cycle edge): park again so the
+            # test can observe the dispatch happened for real.
+            raise _tool_wait_park("X", "2")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-a" and call_counts["agent-a"] == 1:
+            raise _tool_wait_park("A", "1")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-b" and call_counts["agent-b"] == 1:
+            raise _tool_wait_park("B", "1")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        return
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    monkeypatch.setattr(agent_node_mod, "run_agent_turn", _spy)
+
+    with pytest.raises(ToolWaitPark) as excinfo:
+        async for _ev in ex.invoke([]):
+            pass
+    first_park = excinfo.value
+    assert ex._node_states["X"].status == NodeRuntimeStatus.ENDED
+    assert call_counts == {"agent-x": 1, "agent-a": 1, "agent-b": 1}
+
+    # Resume 1: A resolves. A's own edge (A -> X) folds X back into
+    # self._ready_set. B is still pending -> re-park.
+    result_a = ToolResultPart(id="A:tool:0:1", output="result A", error=False)
+    with pytest.raises(ToolWaitPark) as excinfo2:
+        async for _ev in ex.resume_from_checkpoint(
+            first_park.graph_checkpoint,
+            resolved_tool_wait={"A": [result_a]},
+        ):
+            pass
+    repark = excinfo2.value
+
+    # Resume 2: B resolves. B's own next_ready says nothing about X - this
+    # is the exact resume the round-4 BLOCKER's stale exclusion-set
+    # formula deleted X on.
+    result_b = ToolResultPart(id="B:tool:0:1", output="result B", error=False)
+    with pytest.raises(ToolWaitPark) as excinfo3:
+        async for _ev in ex.resume_from_checkpoint(
+            repark.graph_checkpoint,
+            resolved_tool_wait={"B": [result_b]},
+        ):
+            pass
+    second_repark = excinfo3.value
+
+    # X actually dispatched a second time.
+    assert call_counts["agent-x"] == 2
+    assert second_repark.outstanding_task_ids == ["X:tool:0:2"]
+    assert ex._node_states["D"].status == NodeRuntimeStatus.ENDED
+
+
+def _fail_fast_with_own_successor_graph() -> Graph:
+    """begin -> {A, F}; A -> C. A parks (possibly more than once); F fails
+    immediately, un-suppressed (no fan-out spec at all - an ordinary node
+    failure is inherently fail-fast, no on_failure config to read). A's
+    own successor C is exactly the 'more ready work' a naive resume would
+    dispatch despite the seeded failure (design doc §4b, matrix item M5).
+    """
+    return Graph(
+        id="g-seeded-failure", description="begin -> {A,F}; A -> C",
+        nodes=[
+            _BeginNode(id="begin"),
+            _AgentNodeRef(id="A", agent_id="agent-a"),
+            _AgentNodeRef(id="F", agent_id="agent-f"),
+            _EndNode(id="C"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="A"),
+            _StaticEdge(from_node="begin", to_node="F"),
+            _StaticEdge(from_node="A", to_node="C"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_seeded_failure_stops_admitting_new_work_but_lets_a_resumed_park_through(
+    monkeypatch,
+) -> None:
+    """Test matrix items M5 + M5b (design doc §4b, §7 item 2 - the single
+    highest-risk piece of this design). {A parks, F fails un-suppressed}
+    in one superstep.
+
+    M5b first: A's FIRST park resolves into a SECOND park (a resumed
+    continuation raising a NEW park after the failure is already seeded)
+    - explicitly scoped OUT of special-casing (§4b): the re-park proceeds
+    normally, the seeded failure is picked up on the NEXT resume instead
+    of ending immediately. One needless round-trip, not a bug.
+
+    M5 second: A's SECOND park resolves and genuinely completes. The
+    drain is now fully clear, so ``_run_superstep_loop`` runs with
+    ``ended_reason_in="failed"`` already seeded - it must NOT dispatch A's
+    own successor (C) for fresh work despite C being folded into
+    self._ready_set by this same resume's edge-walk, and must still reach
+    the post-loop tail (break, not return) so ``_last_ended_reason`` and
+    the final ENDED ``_save_state`` both fire.
+    """
+    call_counts: dict[str, int] = {}
+    ex = await _mk_executor_for_graph(_fail_fast_with_own_successor_graph())
+
+    import primer.graph._agent_node as agent_node_mod
+
+    async def _spy(**kwargs):
+        agent = kwargs["agent"]
+        call_counts[agent.id] = call_counts.get(agent.id, 0) + 1
+        if agent.id == "agent-a":
+            if call_counts["agent-a"] == 1:
+                raise _tool_wait_park("A", "1")
+                yield  # pragma: no cover - unreachable, keeps this a generator
+            if call_counts["agent-a"] == 2:
+                # M5b: the resumed continuation parks AGAIN, after the
+                # failure below has already been seeded.
+                raise _tool_wait_park("A", "2")
+                yield  # pragma: no cover - unreachable, keeps this a generator
+            return
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-f":
+            raise RuntimeError("agent-f boom")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        return
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    monkeypatch.setattr(agent_node_mod, "run_agent_turn", _spy)
+
+    with pytest.raises(ToolWaitPark) as excinfo:
+        async for _ev in ex.invoke([]):
+            pass
+    first_park = excinfo.value
+    assert ex._node_states["F"].status == NodeRuntimeStatus.FAILED
+    # The seeded failure survives the park immediately - set the moment F
+    # fails, in the SAME original dispatch A parks in.
+    assert ex._pending_ended_reason == "failed"
+
+    # M5b: resolve A's first park; its resumed continuation parks AGAIN.
+    # This must re-park normally, NOT end the run immediately even though
+    # a failure is already seeded.
+    result_a1 = ToolResultPart(id="A:tool:0:1", output="result A", error=False)
+    with pytest.raises(ToolWaitPark) as excinfo2:
+        async for _ev in ex.resume_from_checkpoint(
+            first_park.graph_checkpoint,
+            resolved_tool_wait={"A": [result_a1]},
+        ):
+            pass
+    repark = excinfo2.value
+    assert call_counts["agent-a"] == 2
+    # Not ended yet - the seeded failure did not short-circuit this park.
+    assert getattr(ex, "_last_ended_reason", None) is None
+    # The seeded failure itself survives this re-park's own checkpoint
+    # round-trip untouched.
+    assert repark.graph_checkpoint is not None
+    assert repark.graph_checkpoint.get("pending_ended_reason") == "failed"
+
+    # M5: resolve A's second park. A completes for real this time - the
+    # drain is now fully clear, so the seeded failure finally takes over.
+    result_a2 = ToolResultPart(id="A:tool:0:2", output="result A2", error=False)
+    drained = False
+    try:
+        async for _ev in ex.resume_from_checkpoint(
+            repark.graph_checkpoint,
+            resolved_tool_wait={"A": [result_a2]},
+        ):
+            pass
+        drained = True
+    except (ToolWaitPark, YieldToWorker):
+        drained = False
+    assert drained is True
+
+    # A's own successor (C) was folded into self._ready_set by this
+    # resume's edge-walk (same mechanism M3/M8 rely on) but must NOT have
+    # been dispatched - the seeded failure stopped admission of new work
+    # as the very first statement of the next _run_superstep_loop
+    # iteration, before C was ever classified.
+    assert ex._node_states["C"].status == NodeRuntimeStatus.PENDING
+    # The post-loop tail still ran (break, not return): the terminal
+    # outcome is exposed for a parent subgraph to read.
+    assert ex._last_ended_reason == "failed"
+
+
+def _multi_resume_collision_graph() -> Graph:
+    """begin -> {A, B, E, X}; A -> X (cycle-collision, M3-style); B -> D1;
+    E -> D2. Same-superstep collision (X settles immediately) extended to
+    THREE parking siblings resolved across three SEPARATE resumes, per
+    matrix item M7 - correctness must not depend on resume count/order.
+    """
+    return Graph(
+        id="g-multi-resume-collision",
+        description="begin -> {A,B,E,X}; A -> X; B -> D1; E -> D2",
+        nodes=[
+            _BeginNode(id="begin"),
+            _AgentNodeRef(id="A", agent_id="agent-a"),
+            _AgentNodeRef(id="B", agent_id="agent-b"),
+            _AgentNodeRef(id="E", agent_id="agent-e"),
+            _AgentNodeRef(id="X", agent_id="agent-x"),
+            _EndNode(id="D1"),
+            _EndNode(id="D2"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="A"),
+            _StaticEdge(from_node="begin", to_node="B"),
+            _StaticEdge(from_node="begin", to_node="E"),
+            _StaticEdge(from_node="begin", to_node="X"),
+            _StaticEdge(from_node="A", to_node="X"),
+            _StaticEdge(from_node="B", to_node="D1"),
+            _StaticEdge(from_node="E", to_node="D2"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_multi_resume_accumulation_survives_three_separate_resumes(
+    monkeypatch,
+) -> None:
+    """Test matrix item M7: extends M3's same-superstep collision to
+    THREE parking siblings (A, B, E), each resolved via its own SEPARATE
+    ``resume_from_checkpoint`` call, with X (the collision target) folded
+    in by the FIRST of the three (A) and never touched by the other two's
+    own (unrelated) next_ready. self._ready_set's discard/add invariant
+    makes correctness independent of resume count and ordering by
+    construction - each mutation is a local, atomic edit, not part of a
+    running tally whose correctness depends on which resume observes it.
+    """
+    call_counts: dict[str, int] = {}
+    ex = await _mk_executor_for_graph(_multi_resume_collision_graph())
+
+    import primer.graph._agent_node as agent_node_mod
+
+    async def _spy(**kwargs):
+        agent = kwargs["agent"]
+        call_counts[agent.id] = call_counts.get(agent.id, 0) + 1
+        if agent.id == "agent-x":
+            if call_counts["agent-x"] == 1:
+                return
+                yield  # pragma: no cover - unreachable, keeps this a generator
+            raise _tool_wait_park("X", "2")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-a" and call_counts["agent-a"] == 1:
+            raise _tool_wait_park("A", "1")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-b" and call_counts["agent-b"] == 1:
+            raise _tool_wait_park("B", "1")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-e" and call_counts["agent-e"] == 1:
+            raise _tool_wait_park("E", "1")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        return
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    monkeypatch.setattr(agent_node_mod, "run_agent_turn", _spy)
+
+    with pytest.raises(ToolWaitPark) as excinfo:
+        async for _ev in ex.invoke([]):
+            pass
+    first_park = excinfo.value
+    assert ex._node_states["X"].status == NodeRuntimeStatus.ENDED
+    assert call_counts == {
+        "agent-x": 1, "agent-a": 1, "agent-b": 1, "agent-e": 1,
+    }
+
+    # Resume 1: A resolves, folding X in. B and E still pending -> re-park.
+    result_a = ToolResultPart(id="A:tool:0:1", output="result A", error=False)
+    with pytest.raises(ToolWaitPark) as excinfo2:
+        async for _ev in ex.resume_from_checkpoint(
+            first_park.graph_checkpoint,
+            resolved_tool_wait={"A": [result_a]},
+        ):
+            pass
+    repark1 = excinfo2.value
+
+    # Resume 2: B resolves (own edge to D1, unrelated to X). E still
+    # pending -> re-park.
+    result_b = ToolResultPart(id="B:tool:0:1", output="result B", error=False)
+    with pytest.raises(ToolWaitPark) as excinfo3:
+        async for _ev in ex.resume_from_checkpoint(
+            repark1.graph_checkpoint,
+            resolved_tool_wait={"B": [result_b]},
+        ):
+            pass
+    repark2 = excinfo3.value
+
+    # Resume 3: E resolves (own edge to D2, unrelated to X). Nothing
+    # pending now - the drain proceeds and dispatches everything folded
+    # so far: D1, D2, and X (still surviving from resume 1, two resumes
+    # after its own fold and none of which mentioned it again).
+    result_e = ToolResultPart(id="E:tool:0:1", output="result E", error=False)
+    with pytest.raises(ToolWaitPark) as excinfo4:
+        async for _ev in ex.resume_from_checkpoint(
+            repark2.graph_checkpoint,
+            resolved_tool_wait={"E": [result_e]},
+        ):
+            pass
+    third_repark = excinfo4.value
+
+    assert call_counts["agent-x"] == 2
+    assert third_repark.outstanding_task_ids == ["X:tool:0:2"]
+    assert ex._node_states["D1"].status == NodeRuntimeStatus.ENDED
+    assert ex._node_states["D2"].status == NodeRuntimeStatus.ENDED
+
+
+def _suppressed_fanout_plus_park_graph() -> Graph:
+    """begin -> fan(FanOut with TWO specs run concurrently, Spec B §1.1):
+    a broadcast(worker, count=1, on_failure="collect") AND a
+    tee(park_node) - both specs' instances land in the SAME next
+    superstep. worker[0] fails (suppressed by collect); park_node parks
+    independently, in that SAME superstep, per matrix item M6.
+    """
+    return Graph(
+        id="g-suppressed-fanout-plus-park",
+        description="begin -> fan({worker collect} + {park_node tee})",
+        nodes=[
+            _BeginNode(id="begin"),
+            _FanOutNode(
+                id="fan",
+                specs=[
+                    FanOutSpec(
+                        kind="broadcast", target_node_id="worker",
+                        count=1, on_failure="collect",
+                    ),
+                    FanOutSpec(kind="tee", target_node_ids=["park_node"]),
+                ],
+            ),
+            _AgentNodeRef(id="worker", agent_id="agent-worker"),
+            _AgentNodeRef(id="park_node", agent_id="agent-park"),
+        ],
+        edges=[
+            _StaticEdge(from_node="begin", to_node="fan"),
+        ],
+    )
+
+
+@pytest.mark.asyncio
+async def test_suppressed_fanout_failure_does_not_seed_run_level_failure(
+    monkeypatch,
+) -> None:
+    """Test matrix item M6: a FAILED fan-out instance with a SUPPRESSED
+    on_failure policy (``collect``), in the SAME superstep as an unrelated
+    park, must NOT set self._pending_ended_reason - the suppressed branch
+    ``continue``s (base.py, right after stamping NodeOutput.error) before
+    ever reaching the ``any_failed = True`` / _pending_ended_reason write
+    site, so it structurally can't seed a run-level failure. The run must
+    NOT end failed, must NOT stop admitting new work, and the co-pending
+    park must resolve completely normally.
+    """
+    ex = await _mk_executor_for_graph(_suppressed_fanout_plus_park_graph())
+    parked_once: set[str] = set()
+
+    import primer.graph._agent_node as agent_node_mod
+
+    async def _spy(**kwargs):
+        agent = kwargs["agent"]
+        if agent.id == "agent-worker":
+            raise RuntimeError("collect boom")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-park" and agent.id not in parked_once:
+            parked_once.add(agent.id)
+            raise _tool_wait_park("park_node", "1")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        return
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    monkeypatch.setattr(agent_node_mod, "run_agent_turn", _spy)
+
+    with pytest.raises(ToolWaitPark) as excinfo:
+        async for _ev in ex.invoke([]):
+            pass
+    first_park = excinfo.value
+
+    # The suppressed failure was recorded (collect stamps the error)...
+    assert ex._node_states["worker[0]"].status == NodeRuntimeStatus.FAILED
+    worker_output = ex._context.nodes.get("worker[0]")
+    assert worker_output is not None and worker_output.error is not None
+    assert ex._fanout_drain_state["fan__worker"].any_failed is True
+    # ...but it must NOT have seeded a run-level failure - the suppressed
+    # branch continues before ever reaching that write site.
+    assert ex._pending_ended_reason is None
+
+    # The co-pending park is untouched by the suppressed failure.
+    assert len(ex._pending_tool_waits) == 1
+    assert ex._pending_tool_waits[0].node_id == "park_node"
+    assert first_park.graph_checkpoint is not None
+    assert first_park.graph_checkpoint.get("pending_ended_reason") is None
+
+    # Resolve the park - the run must drain to genuine completion, not
+    # end failed, proving the suppressed failure never stopped admitting
+    # new work either.
+    result = ToolResultPart(id="park_node:tool:0:1", output="ok", error=False)
+    drained = False
+    try:
+        async for _ev in ex.resume_from_checkpoint(
+            first_park.graph_checkpoint,
+            resolved_tool_wait={"park_node": [result]},
+        ):
+            pass
+        drained = True
+    except (ToolWaitPark, YieldToWorker):
+        drained = False
+    assert drained is True
+    assert ex._pending_ended_reason is None
+    assert ex._last_ended_reason == "completed"
 

--- a/tests/graph/test_tool_wait_graph_park.py
+++ b/tests/graph/test_tool_wait_graph_park.py
@@ -1120,3 +1120,107 @@ async def test_suppressed_fanout_failure_does_not_seed_run_level_failure(
     assert ex._pending_ended_reason is None
     assert ex._last_ended_reason == "completed"
 
+
+@pytest.mark.asyncio
+async def test_ready_set_is_actually_empty_at_every_loop_tail_fold(
+    monkeypatch,
+) -> None:
+    """Pins the proof in _run_superstep_loop's own tail-fold comment
+    empirically, not just on paper: self._ready_set must be genuinely
+    EMPTY every time _compute_next_ready is called from inside
+    _run_superstep_loop's own while-loop tail - as opposed to
+    resume_from_checkpoint's OWN, separate call site to the same method,
+    which is NOT provably empty (that's exactly why THAT site uses a
+    union, not a bare assignment; see its own comment). Runs the M7
+    multi-resume, same-superstep-collision topology (three parking
+    siblings + a same-superstep collision target, the exact shape the
+    round-4 BLOCKER needed) across a full invoke() + three resumes, taps
+    _compute_next_ready, and records self._ready_set's contents at the
+    moment of every call made from _run_superstep_loop specifically
+    (distinguished from resume_from_checkpoint's own calls via the
+    immediate caller's frame) - every single one must be empty. A proof
+    sketch is a hypothesis until a test executes it; this is that test.
+    """
+    import sys
+
+    call_counts: dict[str, int] = {}
+    ex = await _mk_executor_for_graph(_multi_resume_collision_graph())
+    ready_set_snapshots_from_loop_tail: list[set[str]] = []
+
+    original_compute = ex._compute_next_ready
+
+    async def tap_compute(just_ran, context):
+        caller = sys._getframe(1).f_code.co_name
+        if caller == "_run_superstep_loop":
+            ready_set_snapshots_from_loop_tail.append(set(ex._ready_set))
+        return await original_compute(just_ran, context)
+
+    ex._compute_next_ready = tap_compute  # type: ignore[method-assign]
+
+    import primer.graph._agent_node as agent_node_mod
+
+    async def _spy(**kwargs):
+        agent = kwargs["agent"]
+        call_counts[agent.id] = call_counts.get(agent.id, 0) + 1
+        if agent.id == "agent-x":
+            if call_counts["agent-x"] == 1:
+                return
+                yield  # pragma: no cover - unreachable, keeps this a generator
+            raise _tool_wait_park("X", "2")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-a" and call_counts["agent-a"] == 1:
+            raise _tool_wait_park("A", "1")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-b" and call_counts["agent-b"] == 1:
+            raise _tool_wait_park("B", "1")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        if agent.id == "agent-e" and call_counts["agent-e"] == 1:
+            raise _tool_wait_park("E", "1")
+            yield  # pragma: no cover - unreachable, keeps this a generator
+        return
+        yield  # pragma: no cover - unreachable, keeps this a generator
+
+    monkeypatch.setattr(agent_node_mod, "run_agent_turn", _spy)
+
+    with pytest.raises(ToolWaitPark) as excinfo:
+        async for _ev in ex.invoke([]):
+            pass
+    first_park = excinfo.value
+
+    result_a = ToolResultPart(id="A:tool:0:1", output="result A", error=False)
+    with pytest.raises(ToolWaitPark) as excinfo2:
+        async for _ev in ex.resume_from_checkpoint(
+            first_park.graph_checkpoint,
+            resolved_tool_wait={"A": [result_a]},
+        ):
+            pass
+    repark1 = excinfo2.value
+
+    result_b = ToolResultPart(id="B:tool:0:1", output="result B", error=False)
+    with pytest.raises(ToolWaitPark) as excinfo3:
+        async for _ev in ex.resume_from_checkpoint(
+            repark1.graph_checkpoint,
+            resolved_tool_wait={"B": [result_b]},
+        ):
+            pass
+    repark2 = excinfo3.value
+
+    result_e = ToolResultPart(id="E:tool:0:1", output="result E", error=False)
+    with pytest.raises(ToolWaitPark) as excinfo4:
+        async for _ev in ex.resume_from_checkpoint(
+            repark2.graph_checkpoint,
+            resolved_tool_wait={"E": [result_e]},
+        ):
+            pass
+
+    # The actual empirical proof: at least one loop-tail fold happened
+    # (the invariant would be vacuous otherwise), and EVERY one of them
+    # found self._ready_set already empty - a bare assignment at that
+    # fold site would have been byte-identical to the union, every
+    # single time, across a run specifically engineered to stress
+    # same-superstep collisions and multi-resume accumulation.
+    assert len(ready_set_snapshots_from_loop_tail) > 0
+    assert all(s == set() for s in ready_set_snapshots_from_loop_tail), (
+        ready_set_snapshots_from_loop_tail
+    )
+


### PR DESCRIPTION
Replaces the accumulate-then-subtract ready-set formula with a live invariant: `self._ready_set` is discarded at the exact site a node settles (success or failure, never a park) and added at every admission site, so there is no second exclusion set that can drift out of sync across resumes.

Adds sticky `_pending_ended_reason`/`_pending_ended_detail` so a fail-fast failure survives a park instead of being discarded by the re-park exception unwind, and round-trips them through the checkpoint.

## Review this one carefully — it is NOT flag-gated

Despite originating in the `tool_calls_as_claims_enabled` arc, this alters behaviour with the flag **off** at five sites: `_run_superstep_loop` reads `self._ready_set` directly instead of a threaded parameter; the `self._ready_set = set(ready_ordered)` reset in the park/snapshot branch is **deleted** (so snapshots capture a smaller frontier for ordinary approval round-trips); the edge-walk is reordered before the re-park check; `context.iteration` bumps once per drained superstep rather than per partial resume; and a seeded failure now stops fresh dispatch.

The edge-walk reorder also absorbs the pre-existing sibling-successor drop (01a08016) — previously a re-park exited before a node's own successors were ever computed.

## Why the union is not a bare assignment

Four prior rounds each patched this expression and each introduced a new bug. `self._ready_set = next_ready` was tried, reviewed, ruled "provably safe", and then falsified live by two tests. The emptiness argument is now backed by an executable test (`test_ready_set_is_actually_empty_at_every_loop_tail_fold`) that taps `_compute_next_ready` and asserts at every call across a multi-resume collision run — not a paper proof.

## Verification

Both previously-xfail specification tests un-xfailed and green for the right reason (stash-red/restore-green proven on both). Full M1–M10 scenario matrix.

tests/graph 396 · tests/worker 232 · tests/session 378 (+1 pre-existing xfail) · tests/toolset 588 (+1 pre-existing skip) · tests/api 1218 · **tests/e2e 954 passed, zero assertion failures in graph/session/resume behaviour**. Remaining e2e failures traced to the hardcoded-DSN class (fixed in the companion PR) and a missing `primer-ai[huggingface]` optional dep, each confirmed against merge-base code.

🤖 Generated with [Claude Code](https://claude.com/claude-code)