### PR TITLE
fix(console): dictation upload checks response status, surfaces real error

### DIFF
--- a/tests/ui/test_console_session_doc.py
+++ b/tests/ui/test_console_session_doc.py
@@ -118,9 +118,45 @@ def test_composer_never_locks_and_dictation_never_sends():
     # the R3 review's mic-unmount-cleanup fix added a prose comment that
     # also happens to say "onstop", which an unscoped search landed on
     # instead of the real handler.
-    m = re.search(r"rec\.onstop = function[\s\S]{0,700}", DOC)
+    m = re.search(r"rec\.onstop = function[\s\S]{0,1100}", DOC)
     assert m and "setVal" in m.group(0) and "send()" not in m.group(0), (
         "dictation lands as editable text, never auto-sends"
+    )
+
+
+def test_dictation_upload_checks_response_status_and_surfaces_the_real_error():
+    """UI/API-response sweep (2026-09-10): the transcription upload used a
+    bare `fetch(...).then(r => r.json())` with no `r.ok` check, so a non-
+    2xx response carrying this app's own RFC7807 body (title/detail, no
+    `text` field) resolved into the SUCCESS branch, `out.text` was
+    undefined, and the handler did nothing at all - no toast, no banner,
+    no console line. The better-formed the server's error, the more
+    completely it disappeared.
+
+    apiFetch (ui/foundation/api.js) already does exactly what this call
+    site needs: it checks res.ok, throws ApiError on any non-2xx (so a
+    bad response can no longer land in the success .then), and ApiError
+    already carries the real title/detail pulled from the backend's own
+    RFC7807 envelope. Reusing it here closes both the silent-no-op AND
+    the generic-string-in-catch defects in one change - no bespoke status
+    check needed.
+    """
+    onstop = re.search(r"rec\.onstop = function[\s\S]{0,1150}", DOC).group(0)
+    assert "window.primerApi.apiFetch(\"POST\", \"/audio/transcriptions\", form)" in onstop, (
+        "must go through apiFetch, not a bare fetch() with no status check"
+    )
+    assert re.search(r'fetch\(\s*"/v1/audio/transcriptions"', onstop) is None, (
+        "the bare fetch() that skipped the res.ok check must be gone"
+    )
+    catch_block = onstop[onstop.index(".catch(function"):]
+    assert re.match(r"\.catch\(function \(\)", catch_block) is None, (
+        "the catch handler must read its error argument, not discard it "
+        "with a no-parameter function"
+    )
+    assert "err.detail || err.title || err.message" in catch_block
+    assert '"Transcription failed"' in catch_block, (
+        "still falls back to a labelled generic string when the error "
+        "carries no detail/title/message of its own"
     )
 
 

--- a/ui/components/console/nv-session-doc.jsx
+++ b/ui/components/console/nv-session-doc.jsx
@@ -1497,8 +1497,10 @@ function NV_Composer(props) {
         var blob = new Blob(chunks, { type: rec.mimeType || "audio/webm" });
         var form = new FormData();
         form.append("file", blob, "dictation.webm");
-        fetch("/v1/audio/transcriptions", { method: "POST", body: form })
-          .then(function (r) { return r.json(); })
+        // apiFetch (not a bare fetch) so a non-2xx response is thrown as
+        // an ApiError instead of landing in this .then as JSON with no
+        // `.text` field - silently doing nothing was the actual bug.
+        window.primerApi.apiFetch("POST", "/audio/transcriptions", form)
           .then(function (out) {
             // Dictation ALWAYS lands as editable text; never auto-sends.
             if (out && out.text) {
@@ -1507,7 +1509,10 @@ function NV_Composer(props) {
               });
             }
           })
-          .catch(function () { con.toast("Transcription failed"); });
+          .catch(function (err) {
+            var msg = (err && (err.detail || err.title || err.message)) || "Transcription failed";
+            con.toast("Transcription failed: " + msg);
+          });
       };
       rec.start();
       recRef.current = rec;


### PR DESCRIPTION
## Summary
- `nv-session-doc.jsx`'s transcription upload (`micStart`'s `rec.onstop`) used a bare `fetch(...).then(r => r.json())` with no `r.ok` check, so a non-2xx response carrying this app's own RFC7807 body (`{title, detail, ...}`, no `text` field) resolved into the SUCCESS branch, `out.text` was undefined, and the handler did **nothing at all** — no toast, no banner, no console line.
- Genuine failures that did reach `.catch()` fared little better: the handler took no parameter and always showed a fixed `"Transcription failed"` string, discarding the real cause.
- Both fixed by routing the upload through `apiFetch`/`ApiError` (`ui/foundation/api.js`) instead of a bespoke `fetch` call — it already checks `res.ok`, throws `ApiError` on any non-2xx, and `ApiError` already carries the real title/detail pulled from the backend's RFC7807 envelope.
- `getUserMedia`'s own rejection handler (line 1326) is left as a fixed `"Microphone unavailable"` string on purpose — it's a browser permission API, not a backend response, so there's no RFC7807 detail to surface, and `DOMException.message` text varies by browser and is rarely more useful to an operator.

Found by the UI/API-response sweep for the "reports a state it never verified" class.

## Test plan
- [x] `tests/ui/test_console_session_doc.py` — added `test_dictation_upload_checks_response_status_and_surfaces_the_real_error`, proved it fails against the pre-fix code and passes against the fix
- [x] Widened two existing regex windows in the same file that the added code pushed past their old cutoff (`test_composer_never_locks_and_dictation_never_sends` and the new test) — re-ran the full file, 60/60 pass
- [x] `primer.api._jsx_bundle.build_jsx_bundle(ui)` — confirms the edited JSX still transpiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)