### PR TITLE
fix(session): terminal-state writes stop reporting success without verifying it

### DIFF
--- a/primer/session/dispatch.py
+++ b/primer/session/dispatch.py
@@ -2027,13 +2027,16 @@ async def _transition_session_status(
             updates["ended_reason"] = ended_reason
         if ended_detail is not None:
             updates["ended_detail"] = ended_detail
-    try:
-        await session_storage.update(fresh.model_copy(update=updates))
-    except Exception:  # noqa: BLE001
-        logger.exception(
-            "dispatch: failed to transition session %s to %s",
-            session.id, new_status.value,
-        )
+    # 01a08bf0: let a genuine storage failure propagate instead of swallowing
+    # it. run_one_session_turn's single production caller
+    # (WorkerPool._run_engine_session) pre-sets a safe
+    # ReleaseOutcome(success=False, drop_lease=True) before its try and
+    # releases with it in a finally regardless of what raises, so an
+    # exception here converges on an honest failed-release rather than
+    # stranding the lease -- and it means the ENDED-only code below (the
+    # on-disk AgentSession mirror, and the caller's _publish_terminal) never
+    # runs for a status this process never actually persisted.
+    await session_storage.update(fresh.model_copy(update=updates))
     if new_status == SessionStatus.ENDED:
         await _sync_agent_session_ended(
             executor, ended_reason,

--- a/primer/worker/pool.py
+++ b/primer/worker/pool.py
@@ -828,6 +828,20 @@ class WorkerPool:
             })
             await storage.update(ended)
         else:
+            # 01a08bf0: "vanished because something else already ended it"
+            # and "vanished unexpectedly" are genuinely indistinguishable
+            # here -- fresh is None carries no reason. success=True is left
+            # as-is deliberately rather than hardened, because it is
+            # observably inert: SessionClaimAdapter.on_release does its OWN
+            # independent re-fetch of this row and returns immediately if
+            # that ALSO finds nothing (primer/claim/adapters/sessions.py
+            # :87-89), so a genuinely-gone row never reaches the
+            # outcome.success branch that would otherwise write a terminal
+            # error record or bump turn_no. This is a COINCIDENTAL property
+            # of on_release's re-check, not a designed guarantee -- see
+            # test_end_session_vanished_row_mislabel_is_inert_via_on_release_recheck
+            # in tests/worker/test_pool.py, which would need updating if
+            # on_release's re-check ever changes.
             logger.warning(
                 "end_session: row %s vanished before terminal write (reason=%r)",
                 session.id, reason,
@@ -850,6 +864,10 @@ class WorkerPool:
             paused = fresh.model_copy(update={"status": SessionStatus.PAUSED})
             await storage.update(paused)
         else:
+            # 01a08bf0: same reasoning as _end_session's vanished-row branch
+            # above -- success=True is left as-is; on_release's own re-fetch
+            # (primer/claim/adapters/sessions.py:87-89) makes this inert
+            # today, coincidentally rather than by design.
             logger.warning(
                 "pause_session: row %s vanished before pause write", session.id,
             )

--- a/tests/session/test_dispatch.py
+++ b/tests/session/test_dispatch.py
@@ -859,6 +859,74 @@ async def test_clean_completion_transitions_to_ended_completed(
 
 
 @pytest.mark.asyncio
+async def test_clean_completion_storage_failure_propagates_not_swallowed(
+    fake_workspace_io: FakeWorkspaceIO,
+    fake_event_bus: InMemoryEventBus,
+    fake_storage_provider,
+) -> None:
+    """01a08bf0: before this fix, _transition_session_status swallowed a
+    session_storage.update() failure with a bare except+log and returned
+    normally, so run_one_session_turn still reported
+    ReleaseOutcome(success=True, ...) and _publish_terminal still announced
+    the caller-supplied status as settled fact -- even though the row never
+    actually changed. Now the write's exception must propagate: the row
+    stays at its pre-turn status (not silently ENDED), and the caller-side
+    safety net (proven in tests/worker/test_pool.py's
+    test_run_engine_session_survives_a_raised_terminal_write_failure) is
+    what turns this into an honest success=False release instead of a
+    stranded lease."""
+    session = await _seed_session(fake_storage_provider, autonomous=True)
+    fake_executor = FakeExecutor([
+        TextDelta(text="4", index=0),
+        Done(stop_reason="stop", raw_reason="stop"),
+    ])
+
+    async def _build_executor(session: WorkspaceSession):
+        return fake_executor
+
+    storage = fake_storage_provider.get_storage(WorkspaceSession)
+    orig_update = storage.update
+
+    async def _failing_update(entity, *, conn=None):
+        if entity.status == SessionStatus.ENDED:
+            raise RuntimeError("simulated storage failure")
+        return await orig_update(entity, conn=conn)
+
+    storage.update = _failing_update
+
+    published: list[tuple[str, dict]] = []
+    orig_publish = fake_event_bus.publish
+
+    async def _capture_publish(topic, payload):
+        published.append((topic, payload))
+        return await orig_publish(topic, payload)
+
+    fake_event_bus.publish = _capture_publish
+
+    deps = SessionDispatchDeps(
+        storage_provider=fake_storage_provider,
+        workspace_io=fake_workspace_io,
+        event_bus=fake_event_bus,
+        build_executor=_build_executor,
+    )
+    lease = _make_lease(session.id)
+    with pytest.raises(RuntimeError, match="simulated storage failure"):
+        await run_one_session_turn(lease, deps)
+
+    # The row must still show its pre-failure state -- never silently ENDED.
+    row = await storage.get(session.id)
+    assert row.status == SessionStatus.RUNNING
+    assert row.ended_reason is None
+    # And no terminal event went out for a status we never actually
+    # persisted -- publishing an unpersisted reason is the actual defect
+    # this fix closes (01a08bf0 Q2).
+    terminal_events = [p for p in published if p[0] == f"session:{session.id}:terminal"]
+    assert terminal_events == [], (
+        "must not publish a terminal status the write never persisted"
+    )
+
+
+@pytest.mark.asyncio
 async def test_clean_completion_ends_for_interactive_session(
     fake_workspace_io: FakeWorkspaceIO,
     fake_event_bus: InMemoryEventBus,

--- a/tests/worker/test_pool.py
+++ b/tests/worker/test_pool.py
@@ -942,6 +942,196 @@ async def test_run_engine_session_releases_engine_lease_on_success(
     assert released[0][1].success is True
 
 
+async def test_run_engine_session_survives_a_raised_terminal_write_failure(
+    scheduler, engine, monkeypatch,
+):
+    """01a08bf0: the safety-net claim, proven at the layer that matters.
+
+    dispatch.py's _transition_session_status now lets a genuine storage
+    write failure propagate instead of swallowing it (see
+    tests/session/test_dispatch.py's
+    test_clean_completion_storage_failure_propagates_not_swallowed for that
+    half). This is the OTHER half: proving the exception does not strand
+    the lease when it reaches run_one_session_turn's single production
+    caller. Simulates the propagated failure directly (raising out of
+    run_one_session_turn) rather than re-deriving it from a real storage
+    double, since that trace already lives in test_dispatch.py — this test
+    is only responsible for what _run_engine_session does with it."""
+    sid = "sess-raise-1"
+    scheduler.register_session_for_test(sid, status=SessionStatus.RUNNING)
+
+    pool = WorkerPool(
+        config=WorkerConfig(concurrency=1),
+        scheduler=scheduler,
+        storage=None,               # type: ignore[arg-type]
+        workspace_registry=None,    # type: ignore[arg-type]
+        provider_registry=None,     # type: ignore[arg-type]
+        engine=engine,
+        event_bus=None,
+    )
+    pool._worker_id = "wrk-test"
+
+    fake_session = WorkspaceSession(
+        id=sid, workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="ag-1"),
+        status=SessionStatus.RUNNING,
+        created_at=datetime.now(timezone.utc),
+        turn_no=0,
+    )
+    monkeypatch.setattr(pool, "_load_session",
+                        lambda _sid: _async_return(fake_session))
+
+    released: list = []
+    orig_release = engine.release
+
+    async def _capture_release(lease, *, outcome):
+        released.append((lease, outcome))
+        return await orig_release(lease, outcome=outcome)
+
+    monkeypatch.setattr(engine, "release", _capture_release)
+
+    await engine.upsert(ClaimKind.SESSION, sid, priority=100)
+    [engine_lease] = await engine.claim_due("wrk-test", max_count=1)
+    assert engine_lease.entity_id == sid
+    assert await engine.has_live_lease(ClaimKind.SESSION, sid) is True
+
+    with patch(
+        "primer.worker.pool.run_one_session_turn",
+        side_effect=RuntimeError("simulated propagated storage failure"),
+    ):
+        # _run_engine_session must NOT let this escape -- it's caught by
+        # its own generic except and converted into a safe release.
+        await pool._run_engine_session(engine_lease)
+
+    assert len(released) == 1, "release must still run despite the raise"
+    released_lease, outcome = released[0]
+    assert released_lease.entity_id == sid
+    assert outcome.success is False, (
+        "an unhandled exception must never be reported as success"
+    )
+    assert outcome.drop_lease is True, (
+        "the lease must still be dropped, not left claimed forever"
+    )
+    # The lease is actually gone afterward -- not merely marked
+    # drop_lease=True in an outcome nobody consumed.
+    assert await engine.has_live_lease(ClaimKind.SESSION, sid) is False
+
+
+async def test_end_session_genuine_write_failure_already_propagates():
+    """01a08bf0 Site B — unlike the vanished-row branch, _end_session's
+    storage.update() call has no try/except today: a real write failure
+    (row exists, write itself errors) already propagates uncaught. This
+    was true before this task and needed no code change, but was
+    UNTESTED -- pinning it now since the whole "propagate is safe" design
+    for Site B rests on this being what actually happens, not an
+    assumption. Safety is the same claim proven for Site A: this raises
+    inside run_one_session_turn's sibling caller path, which shares the
+    identical WorkerPool._run_engine_session safety net (see
+    test_run_engine_session_survives_a_raised_terminal_write_failure)."""
+    from tests.conftest import _FakeStorageProvider
+
+    sid = "sess-write-fails-1"
+    sp = _FakeStorageProvider()
+    session_storage = sp.get_storage(WorkspaceSession)
+    fake_session = WorkspaceSession(
+        id=sid, workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="ag-1"),
+        status=SessionStatus.RUNNING,
+        created_at=datetime.now(timezone.utc),
+        turn_no=0,
+    )
+    await session_storage.create(fake_session)
+
+    async def _failing_update(entity, *, conn=None):
+        raise RuntimeError("simulated storage failure")
+
+    session_storage.update = _failing_update
+
+    pool = WorkerPool(
+        config=WorkerConfig(concurrency=1),
+        scheduler=None,               # type: ignore[arg-type]
+        storage=sp,
+        workspace_registry=None,      # type: ignore[arg-type]
+        provider_registry=None,       # type: ignore[arg-type]
+        engine=None,                  # type: ignore[arg-type]
+    )
+
+    with pytest.raises(RuntimeError, match="simulated storage failure"):
+        await pool._end_session(fake_session, reason="failed")
+
+    # The row must still show its pre-failure state.
+    row = await session_storage.get(sid)
+    assert row.status == SessionStatus.RUNNING
+
+
+async def test_end_session_vanished_row_mislabel_is_inert_via_on_release_recheck():
+    """01a08bf0 Q3 — pin test, NOT a designed guarantee.
+
+    'Vanished because something else already ended it' and 'vanished
+    unexpectedly' are genuinely indistinguishable at the point
+    _end_session runs: fresh is None carries no reason either way. Its
+    success=True on that branch is left unchanged (see the comment in
+    pool.py) because it is observably inert today -- but ONLY because
+    SessionClaimAdapter.on_release does its OWN independent re-fetch of
+    the row and returns immediately, before ever consulting
+    outcome.success, if that re-fetch ALSO finds nothing. That is a
+    COINCIDENTAL property of on_release's re-check, not a contract either
+    function was written to guarantee. If on_release is ever changed to
+    trust the caller's outcome instead of re-fetching, this test starts
+    failing -- and the vanished-row branch's success=True actually needs
+    to be revisited at that point, not just this test's assertion."""
+    from tests.conftest import _FakeStorageProvider
+    from primer.claim.adapters.sessions import SessionClaimAdapter
+
+    sid = "sess-vanished-1"
+    sp = _FakeStorageProvider()
+    # Deliberately never created in storage -- this IS "vanished".
+    session_stub = WorkspaceSession(
+        id=sid, workspace_id="ws-1",
+        binding=AgentSessionBinding(agent_id="ag-1"),
+        status=SessionStatus.RUNNING,
+        created_at=datetime.now(timezone.utc),
+        turn_no=3,
+    )
+
+    pool = WorkerPool(
+        config=WorkerConfig(concurrency=1),
+        scheduler=None,               # type: ignore[arg-type]
+        storage=sp,
+        workspace_registry=None,      # type: ignore[arg-type]
+        provider_registry=None,       # type: ignore[arg-type]
+        engine=None,                  # type: ignore[arg-type]
+    )
+
+    outcome = await pool._end_session(session_stub, reason="failed")
+    # Today's mislabel, left deliberately unchanged (01a08bf0 design call).
+    assert outcome.success is True
+    assert outcome.drop_lease is True
+
+    registry_calls: list[str] = []
+
+    class _TrackingRegistry:
+        async def get_workspace(self, workspace_id: str):
+            registry_calls.append(workspace_id)
+            raise AssertionError(
+                "on_release must never reach the terminal-error-record "
+                "path for a row that is genuinely gone"
+            )
+
+    adapter = SessionClaimAdapter(
+        session_storage=sp.get_storage(WorkspaceSession),
+        workspace_registry=_TrackingRegistry(),
+        event_bus=None,
+    )
+    # Must no-op cleanly: on_release's own re-fetch also finds nothing.
+    await adapter.on_release(conn=None, entity_id=sid, outcome=outcome)
+    assert registry_calls == [], (
+        "on_release's re-check no longer absorbs the vanished-row "
+        "mislabel -- _end_session's success=True is no longer inert and "
+        "needs a real fix, not just a pin"
+    )
+
+
 # ---------------------------------------------------------------------------
 # C1 — steering a RUNNING (leased) session must not strand the queued turn
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Task 01a08bf0. Two sites where a terminal-state write's failure was invisible to everyone but the log:

**Site A** — `dispatch.py::_transition_session_status` swallowed a `session_storage.update()` failure behind a bare `except Exception: logger.exception(...)`. 3 of its 5 call sites (pause, cancel, clean-completion) then returned `ReleaseOutcome(success=True, ...)` unconditionally regardless of whether the write actually landed, and 2 of those 3 called `_publish_terminal` right after with the caller-supplied status. On a transient storage blip: the row stays at its prior status forever, but the durable `session.ended` event and the `session:{id}:terminal` bus event (which `trigger/hold.py`'s webhook hold awaits "instead of polling the row") tell consumers a specific terminal reason as settled fact. Durable row and durable event disagree, and the event wins.

**Fix**: let the write's exception propagate. This is safe, traced not assumed — `run_one_session_turn` has exactly one production caller (`WorkerPool._run_engine_session`), which pre-sets a safe `ReleaseOutcome(success=False, drop_lease=True)` before its try and releases with it in a `finally` regardless of what raises, including through the `asyncio.CancelledError` preempt path. The per-session `KeyedLock.acquire` held across every call site is a real try/finally asynccontextmanager, so raising while holding it doesn't leak. `_end_session`/`_pause_session`'s 25+ call sites across 4 files all funnel through the same one indirection point inside the identical safety net, so the same conclusion applies there too. Publish-on-failure is solved by construction: `_publish_terminal` always runs strictly after its transition call, so a raised write means it's simply never reached.

Checked specifically whether propagating trades "stuck row" for "duplicate execution" (a session becoming re-claimable and re-running a turn that already completed). It doesn't: `drop_lease=True` releases the claim-table lease unconditionally either way (swallow and raise are identical there); the only re-arm trigger is `wake_session()`, which unconditionally re-arms on any new user message regardless of current row status — true today under the swallow too; and a wake-triggered re-run processes newly-enqueued input, not a replay of the previous turn's already-flushed output. `turn_no` now stays unbumped on a failure (today it silently bumps even under the swallow), which is more correct.

**Site B** — `pool.py::_end_session`/`_pause_session`'s vanished-row branch is left unchanged. "Vanished because something else already ended it" vs. "vanished unexpectedly" are genuinely indistinguishable there, but today's `success=True` is provably inert: `SessionClaimAdapter.on_release` does its own independent re-fetch and no-ops before ever consulting `outcome.success` if that also finds nothing. That's a coincidental property of `on_release`'s re-check, not a designed guarantee — pinned with a regression test whose docstring says so explicitly, rather than hardened beyond what's proven necessary.

## Test plan

- `test_clean_completion_storage_failure_propagates_not_swallowed` (dispatch.py level): forces a real `storage.update()` failure, asserts it propagates, the row stays at its pre-failure state, and no terminal event is published.
- `test_run_engine_session_survives_a_raised_terminal_write_failure` (pool.py integration level, not just a dispatch.py unit test): forces the same failure through `run_one_session_turn`, proves `_run_engine_session`'s safety net converts it into an honest `success=False, drop_lease=True` release with the lease actually gone afterward — this is what the whole "propagate is safe" design rests on.
- `test_end_session_genuine_write_failure_already_propagates`: pins that Site B's genuine-write-failure path already propagates uncaught (no code change needed there, but previously unverified).
- `test_end_session_vanished_row_mislabel_is_inert_via_on_release_recheck`: pins the vanished-row inertness via `on_release`'s re-check, with a docstring stating plainly that this is coincidental and would need revisiting if `on_release` ever changes.

All four new tests plus the full `tests/session/`, `tests/worker/`, `tests/claim/` suites pass locally (729+ passed, 0 failed).