### PR TITLE
fix(ui): internal-collections bootstrap feedback reads the response body, not a poll transition

### DIFF
--- a/tests/ui/test_internal_collections_bootstrap_feedback.py
+++ b/tests/ui/test_internal_collections_bootstrap_feedback.py
@@ -1,0 +1,102 @@
+"""internal-collections.jsx's bootstrap mutation must report the REAL
+terminal outcome, not an interim "started" state the backend no longer
+has.
+
+01a08c05: POST /internal_collections/bootstrap (primer/api/routers/
+internal_collections.py) is fully synchronous - its handler `await`s
+enable_search(...) inline, no background task, and returns the real
+terminal {status, state, error} as its response body. But both
+ConfiguredCard's and ActiveCard's `bootstrap` mutations had an
+`onSuccess: () => {...}` that never read the `data` argument it was
+handed, pushing a fixed "Bootstrap started - running in the background,
+leave this page if you like" toast instead - actively false once the
+route stopped being asynchronous, and describing a process model the
+backend doesn't have. Success/failure feedback instead depended on a
+poll-observed `prevStatusRef.current === "running" && curr ===
+"succeeded"` transition, which synchronicity makes very unlikely to
+ever fire for a bootstrap the client itself triggered (the response
+already carries the answer before any poll of the status row can
+observe an interim "running" tick).
+
+Static-source checks, matching the rest of this file's suite
+(test_internal_collections_mobile.py) - no jsdom in this toolchain.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+SRC = ROOT / "ui" / "components" / "internal-collections.jsx"
+
+
+def _src() -> str:
+    return SRC.read_text(encoding="utf-8")
+
+
+def _fn_body(name: str) -> str:
+    src = _src()
+    start = src.index(f"function {name}(")
+    # Matches this file's own function boundaries: top-level functions are
+    # separated by a blank line then the next `function `/`// ====` marker.
+    end = src.index("\nfunction ", start + 1)
+    return src[start:end]
+
+
+def test_stale_started_in_background_copy_is_gone() -> None:
+    src = _src()
+    assert "Bootstrap started" not in src
+    assert "Running in the background" not in src
+
+
+def test_configured_card_on_success_reads_the_response_body() -> None:
+    body = _fn_body("ConfiguredCard")
+    on_success_start = body.index("onSuccess: (data) => {")
+    on_success_end = body.index("},\n      onError:", on_success_start)
+    on_success = body[on_success_start:on_success_end]
+    assert 'data?.status === "succeeded"' in on_success
+    assert "Bootstrap complete" in on_success
+    assert "onRefresh()" in on_success, (
+        "onSuccess must call onRefresh() itself so ConfiguredCard flips to "
+        "ActiveCard immediately, not after the page-level 30s poll or the "
+        "poll-transition effect (whose own 'running' tick this client is "
+        "unlikely to ever observe for its own synchronous request)"
+    )
+    assert "Bootstrap failed" in on_success
+    assert "data?.error" in on_success
+
+
+def test_active_card_on_success_reads_the_response_body() -> None:
+    body = _fn_body("ActiveCard")
+    on_success_start = body.index("onSuccess: (data) => {")
+    on_success_end = body.index("},\n      onError:", on_success_start)
+    on_success = body[on_success_start:on_success_end]
+    assert 'data?.status === "succeeded"' in on_success
+    assert "Re-bootstrap complete" in on_success
+    assert "onRefresh()" in on_success
+    assert "Re-bootstrap failed" in on_success
+    assert "data?.error" in on_success
+
+
+def test_poll_transition_fallback_still_present_for_cross_client_sync() -> None:
+    """The poll-observed transition effect must NOT be deleted outright -
+    it is still the only way a client learns about a bootstrap started
+    from elsewhere (a different tab, or the 409-already-running case),
+    which never calls this client's own onSuccess."""
+    src = _src()
+    assert src.count('prev === "running" && curr === "succeeded"') == 2
+    assert src.count('prev === "running" && curr === "failed"') == 2
+
+
+def test_409_already_running_still_defers_to_the_poll_fallback() -> None:
+    """The 409 branch genuinely has no terminal outcome to report from
+    ITS OWN request (the run belongs to whoever else triggered it) -
+    unlike the happy path, this one is correctly left depending on the
+    poll-transition effect, not the response body."""
+    for name in ("ConfiguredCard", "ActiveCard"):
+        body = _fn_body(name)
+        on_error_start = body.index("onError: (err) => {")
+        on_error_end = body.index("},\n    }\n  );", on_error_start)
+        on_error = body[on_error_start:on_error_end]
+        assert "err?.status === 409" in on_error
+        assert "bootstrapStatus.refetch();" in on_error

--- a/ui/components/internal-collections.jsx
+++ b/ui/components/internal-collections.jsx
@@ -185,13 +185,41 @@ function ConfiguredCard({ config, onRefresh, pushToast }) {
     () => apiFetch("POST", "/internal_collections/bootstrap"),
     {
       invalidates: [IC_CACHE_CONFIG, IC_CACHE_BOOTSTRAP],
-      onSuccess: () => {
-        pushToast({ kind: "info", title: "Bootstrap started", detail: "Running in the background — leave this page if you like." });
+      // 01a08c05: the route is fully synchronous (the backend handler
+      // awaits enable_search(...) inline, no background task - see
+      // primer/api/routers/internal_collections.py's own bootstrap
+      // docstring: "the old asynchronous bootstrap pipeline is gone").
+      // Its response body already carries the real terminal {status,
+      // state, error} - by the time onSuccess fires, the operation is
+      // DONE, not "started". Read that body directly instead of
+      // announcing an interim state that no longer exists (telling an
+      // operator they may leave the page during a synchronous call is
+      // worse than saying nothing) and waiting on the poll-transition
+      // effect below, whose own `prev === "running"` condition
+      // synchronicity makes very unlikely to ever fire for a bootstrap
+      // THIS client triggered: bootstrapStatus's own refetch (kicked
+      // off by `invalidates` above, before onSuccess runs) resolves
+      // straight to the already-terminal status - there is no
+      // "running" tick for this client's own poll to observe.
+      onSuccess: (data) => {
         bootstrapStatus.refetch();
+        if (data?.status === "succeeded") {
+          pushToast({ kind: "success", title: "Bootstrap complete", detail: "Subsystem is now active." });
+          onRefresh();
+        } else {
+          pushToast({
+            kind: "error",
+            title: "Bootstrap failed",
+            detail: data?.error || "See server logs for details.",
+          });
+        }
       },
       onError: (err) => {
         if (err?.status === 409) {
-          // Already running — just sync the status and let the UI render.
+          // Already running (started elsewhere) - genuinely nothing
+          // terminal to report from THIS request; sync the status and
+          // let the poll-transition effect below catch its eventual
+          // completion, same as any other out-of-band run.
           bootstrapStatus.refetch();
           return;
         }
@@ -200,9 +228,15 @@ function ConfiguredCard({ config, onRefresh, pushToast }) {
     }
   );
 
-  // When a running bootstrap finishes, sync the config (which now has
-  // activated_at set). The page-level useResource flips us from
-  // ConfiguredCard to ActiveCard on the next render.
+  // Fallback path for a bootstrap started from elsewhere (a different
+  // tab/client, or the 409-already-running case above): this client
+  // never gets an onSuccess callback for a run it did not trigger, so
+  // it can only learn the outcome by observing the status row's own
+  // transition via its poll. NOT the primary path for a bootstrap this
+  // client itself triggers - onSuccess above handles that synchronously
+  // and accurately, straight from the response body, and flips
+  // ConfiguredCard to ActiveCard immediately via onRefresh() rather than
+  // waiting on this effect (or the page-level 30s poll) to notice.
   const prevStatusRef = React.useRef(null);
   React.useEffect(() => {
     const prev = prevStatusRef.current;
@@ -286,9 +320,23 @@ function ActiveCard({ config, onRefresh, pushToast }) {
     () => apiFetch("POST", "/internal_collections/bootstrap"),
     {
       invalidates: [IC_CACHE_CONFIG, IC_CACHE_BOOTSTRAP],
-      onSuccess: () => {
-        pushToast({ kind: "info", title: "Re-bootstrap started", detail: "Running in the background — leave this page if you like." });
+      // 01a08c05: same fix as ConfiguredCard's own bootstrap mutation
+      // above (this route is fully synchronous; its response body
+      // already carries the real terminal {status, state, error}) -
+      // read it directly instead of announcing a "started... running in
+      // the background" state that no longer exists.
+      onSuccess: (data) => {
         bootstrapStatus.refetch();
+        if (data?.status === "succeeded") {
+          pushToast({ kind: "success", title: "Re-bootstrap complete" });
+          onRefresh();
+        } else {
+          pushToast({
+            kind: "error",
+            title: "Re-bootstrap failed",
+            detail: data?.error || "See server logs for details.",
+          });
+        }
       },
       onError: (err) => {
         if (err?.status === 409) {
@@ -300,6 +348,8 @@ function ActiveCard({ config, onRefresh, pushToast }) {
     }
   );
 
+  // Fallback path for a re-bootstrap started elsewhere - see
+  // ConfiguredCard's own identical comment above.
   const prevStatusRef = React.useRef(null);
   React.useEffect(() => {
     const prev = prevStatusRef.current;


### PR DESCRIPTION
The internal-collections bootstrap route is **fully synchronous** — it awaits `enable_search(...)` inline, spawns no background task, and returns the real terminal `{status, state, error}` as its response body.

Both bootstrap mutations ignored that. `onSuccess: () => {...}` never read `data`, the argument it is handed. Success feedback instead depended on a poll-observed transition (`prev === "running" && curr === "succeeded"`) that synchronicity makes very likely unobservable — by the time any poll fires, the status is already terminal.

Two consequences for an operator:

- **Up to a 30s dead gap** after a completed action, until the parent's own 30s poll flips the card.
- **An actively false interim message:** *"Bootstrap started — running in the background, leave this page if you like."* Telling someone they may leave the page during a synchronous call is worse than saying nothing.

## It was in two places

The second occurrence was found by grepping the marker string *after* fixing the first — and it still matched. `ActiveCard`'s "Re-bootstrap" mutation had the byte-identical pattern. Both are fixed.

## Fix

`onSuccess: (data) => {...}` in both cards now branches on `data.status`, reports the real outcome, and calls `onRefresh()` directly rather than waiting on a transition.

The poll-transition effect and both 409-already-running `onError` branches are **unchanged in logic** (comments only). They remain the fallback for cross-tab and out-of-band bootstraps, where the 409 case genuinely has no terminal outcome of its own to report.

## Verification

5 new tests. Stash-red/restore-green against pre-fix source: 3 of 5 fail for the right reason (missing the `onSuccess: (data)` pattern, stale copy still present), all 5 green once restored. Full `tests/ui`: 1728 passed, 1 pre-existing skip. Bundler transpile clean.

## Pattern

Seventh instance in this batch of **the correct data already being present and simply unread** — alongside `degraded`, `fieldErrors`, `_CONFIG_EXC`, and the response `.ok` check. The terminal status was in the response body the whole time.

🤖 Generated with [Claude Code](https://claude.com/claude-code)