### PR TITLE
fix(ci): release smoke gate asserts scheduler health, not just HTTP status

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -92,9 +92,25 @@ jobs:
       - name: Smoke - boot the packaged app
         run: |
           uv run primer api --config tests/.e2e/config.yaml > tests/.e2e/logs/server.log 2>&1 &
-          for i in $(seq 1 60); do curl -sf http://localhost:8765/v1/health && break; sleep 1; done
-          if ! curl -sf http://localhost:8765/v1/health; then
+          body=""
+          for i in $(seq 1 60); do
+            body="$(curl -sf http://localhost:8765/v1/health)" && break
+            sleep 1
+          done
+          if [ -z "$body" ]; then
             echo "server did not become healthy; last 80 log lines:" >&2
+            tail -n 80 tests/.e2e/logs/server.log >&2 || true
+            exit 1
+          fi
+          # curl -f only checks the HTTP status. /v1/health's status field
+          # is a fixed Literal["ok"] and the route always returns 200 -
+          # even with a dead (alive=false) or degraded (in-memory scheduler
+          # under a multi-process runtime_mode) scheduler - so the status
+          # code alone certifies nothing about whether it is safe to route
+          # traffic here. Assert on the body instead.
+          if ! echo "$body" | jq -e '.scheduler.alive == true and .scheduler.degraded == false' > /dev/null; then
+            echo "server responded but its scheduler is not healthy (alive=false or degraded=true):" >&2
+            echo "$body" >&2
             tail -n 80 tests/.e2e/logs/server.log >&2 || true
             exit 1
           fi


### PR DESCRIPTION
## The finding

`curl -sf` only checks the HTTP status code. `/v1/health`'s `status` field is `Literal["ok"]` (`primer/api/routers/health.py:84`), and the route always returns 200 regardless of `scheduler.alive`/`scheduler.degraded` — by design, per its own docstring ("does not check downstream dependencies"). A release could pass `release.yml`'s smoke gate with a dead or degraded scheduler and no one would know until traffic hit it.

## Scope — the safe half only

This changes the **gate**, not the endpoint's response shape. Widening `status` to include `"degraded"`, or returning a non-2xx when degraded, is a contract change that needs a separate consumer audit — k8s liveness probes especially, since a probe that starts failing on "degraded" would restart-loop a pod that is merely degraded, which is strictly worse than today's silence. **Not touched here** — reporting it separately for a conscious call, per the request that assigned this.

## Proof, red-to-green, with a real degraded scheduler (not stubbed)

A config with no `scheduler:` key defaults `runtime_mode` to `api+worker` and auto-selects the in-memory scheduler (`primer/api/_app_lifespan.py:72-87`), which then trips the existing degraded check at `:385-398` (in-memory scheduler under a non-`api` runtime_mode is unsafe for multi-process/external-worker topologies). Booted that against a disposable Postgres+pgvector container and got:

```json
{"status":"ok", "scheduler":{"alive":true,"degraded":true,"degraded_reason":"in-memory scheduler with runtime_mode=api+worker is not safe for multi-process or external-worker deployment: ..."}}
```

- **OLD gate** (`curl -sf .../v1/health`) against that payload: exit 0 (PASS) — the bug, confirmed live, not inferred.
- **NEW gate** (`jq -e '.scheduler.alive == true and .scheduler.degraded == false'`) against the **same** payload: exit 1 (FAIL) — confirmed against the literal script text extracted from this file via `yaml.safe_load`, not a hand-copied approximation of it.
- **NEW gate** against a genuinely healthy boot (`scheduler: provider: postgres`, matching `release.yml`'s own `tests/.e2e/config.yaml`): exit 0 (PASS) — confirms no false positive on the real, currently-passing path.

## Test plan
- [x] YAML re-parses cleanly (`yaml.safe_load`)
- [x] Extracted the literal `run:` script from the committed file and executed it against a live degraded server: fails as intended
- [x] Same extracted script against a live healthy server (real Postgres scheduler): passes
- [x] `jq` is preinstalled on `ubuntu-latest` GitHub Actions runners — no new dependency

🤖 Generated with [Claude Code](https://claude.com/claude-code)