### PR TITLE
fix(docker): HEALTHCHECK asserts scheduler health, not just HTTP status

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -27,7 +27,14 @@ ENV PYTHONUNBUFFERED=1 \
     PATH="/app/.venv/bin:$PATH"
 
 # System deps:
-# - curl              the HEALTHCHECK and for installing uv
+# - curl              was the HEALTHCHECK's own fetch tool; the HEALTHCHECK
+#                     now uses python3 instead (see below) so it can assert
+#                     on the response body, not just the HTTP status. uv
+#                     itself installs via the COPY --from below, not curl,
+#                     so nothing in this image still calls curl directly -
+#                     kept installed only in case an operator execs in to
+#                     debug connectivity; flagging for the Dockerfile owner
+#                     to decide whether to drop it.
 # - ca-certificates   HTTPS during uv install + runtime fetches
 # - git               required by primer/workspace/local/state.py:LocalStateRepo
 #                     which uses `git init` / `git commit` for the
@@ -83,8 +90,14 @@ EXPOSE 8000
 
 # Health: the FastAPI app exposes /v1/health. Honour PRIMER_PORT (compose sets
 # 8765; a bare `docker run` defaults to 8000) so the check follows the server.
+# curl -f only checks the HTTP status. /v1/health's `status` field is a
+# fixed Literal["ok"] and the route always returns 200 even with a dead
+# (alive=false) or degraded (in-memory scheduler under a multi-process
+# runtime_mode) scheduler - so the status code alone certifies nothing.
+# python3 is already on PATH (this is the app's own venv); reuse it to
+# fetch and assert on the body instead of adding a new dependency (jq).
 HEALTHCHECK --interval=10s --timeout=5s --start-period=20s --retries=6 \
-    CMD curl -fsS "http://127.0.0.1:${PRIMER_PORT:-8000}/v1/health" || exit 1
+    CMD python3 -c "import json,sys,urllib.request; d=json.load(urllib.request.urlopen('http://127.0.0.1:${PRIMER_PORT:-8000}/v1/health', timeout=4)); s=d.get('scheduler',{}); sys.exit(0 if s.get('alive') is True and s.get('degraded') is False else 1)"
 
 # Entrypoint renders /app/config.yaml from PRIMER_* env vars, then
 # exec's CMD. The primer CLI requires --config; the rendered file is


### PR DESCRIPTION
## The finding

Same defect as release.yml's smoke gate (#277), in a second, **live** consumer: `curl -fsS .../v1/health || exit 1` (`Dockerfile:86-87`) only checks the HTTP status. `/v1/health`'s `status` field is a fixed `Literal["ok"]` and the route always returns 200 regardless of `scheduler.alive`/`scheduler.degraded` (`primer/api/routers/health.py:84,107-147`) — the status code alone certifies nothing.

Unlike the k8s probes (confirmed live on the cluster: `readinessProbe` is a bare `tcpSocket` check, `livenessProbe` is absent entirely — neither points at `/v1/health`), **this Dockerfile `HEALTHCHECK` IS a real, live consumer** of the endpoint's implicit "always ok" behavior, for every `docker run`/compose deployment.

## Fix

Switched the fetch+assert to `python3` (already on `PATH` — this is the app's own venv) rather than adding `jq` as a new system dependency:

```dockerfile
CMD python3 -c "import json,sys,urllib.request; d=json.load(urllib.request.urlopen('http://127.0.0.1:${PRIMER_PORT:-8000}/v1/health', timeout=4)); s=d.get('scheduler',{}); sys.exit(0 if s.get('alive') is True and s.get('degraded') is False else 1)"
```

Also corrected the now-stale `# - curl   the HEALTHCHECK and for installing uv` comment — `uv` installs via the `COPY --from` stage, not `curl`, and `curl` is no longer used by anything in this image. Left it installed and flagged in the comment for the Dockerfile owner to decide whether it's still worth keeping — a decision, not made here; out of scope for this fix.

## Proof, red-to-green, with a real degraded scheduler (not stubbed) — same method as #277

A config with no `scheduler:` key auto-selects the in-memory scheduler under the default `api+worker` runtime_mode, which trips the existing degraded check on its own. Booted that against a disposable Postgres+pgvector container and extracted the **literal `CMD` text from the committed Dockerfile via regex** (not a hand-copied approximation):

| Scenario | Old (`curl -fsS`) | New (this commit) |
|---|---|---|
| Degraded scheduler (`alive:true, degraded:true`) | exit 0 (PASS) — **the bug** | exit 1 (FAIL) ✓ |
| Genuinely healthy boot (`scheduler: provider: postgres`) | exit 0 | exit 0 (PASS) ✓ no false positive |
| Nothing listening on the port | exit 1 | exit 1 (FAIL) ✓ original purpose preserved |

## Test plan
- [x] `docker build --check -f Dockerfile .`: no warnings
- [x] Literal `CMD` text (regex-extracted from the file) executed against a live degraded server, a live healthy server, and an unreachable port — all three behave as intended
- [x] No new system dependency added (reuses `python3`, already present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)