### PR TITLE
fix(ui): SSP delete confirmation stops claiming "safe" on an unresolved check

### DIFF
--- a/tests/ui/test_semantic_search_p4.py
+++ b/tests/ui/test_semantic_search_p4.py
@@ -231,6 +231,46 @@ def test_saved_test_connect_result_renders_ok_or_error() -> None:
     assert 'data-testid="ssp-test-connect-saved-error"' in detail
 
 
+def test_delete_safety_claim_never_fires_on_an_unresolved_collections_check() -> None:
+    """UI/API-response sweep (2026-09-10): the delete-confirmation modal
+    rendered "No collections reference this provider. Deletion is safe."
+    and enabled the destructive button whenever `referencingCollections`
+    (derived from `collections.data?.items ?? []`) was empty - which is
+    indistinguishable from the /collections fetch still loading,
+    degraded, or having failed outright. An affirmative safety claim
+    produced by a check that may never have completed.
+
+    resourceState() (ui/foundation/use-resource.js, landed for the same
+    class of bug in nv-system.jsx/health.jsx) collapses that ambiguity
+    correctly: "ready" only once collections.data has genuinely arrived,
+    so an empty array only reads as a real zero once the fetch actually
+    resolved. Not a data-loss risk either way - the file's own comment
+    notes the backend independently enforces a 409 cascade-block - but
+    the UI must stop asserting "verified safe" for a check it never ran.
+    """
+    detail = _detail_src()
+    assert "resourceState(collections)" in detail, (
+        "the collections resource must be run through resourceState(), "
+        "not read as a bare data == null / array-length check"
+    )
+
+    # The delete button must be disabled whenever collectionsState isn't
+    # "ready" - not just when referencingCollections.length > 0.
+    btn_start = detail.index('kind="danger"\n                icon="trash"')
+    btn_disabled = detail[btn_start:detail.index("onClick=", btn_start)]
+    assert 'collectionsState !== "ready"' in btn_disabled
+
+    # The modal body must branch on collectionsState BEFORE it ever
+    # reaches the "no collections -> Deletion is safe" copy, so that
+    # copy can only render once the check has actually resolved.
+    modal_start = detail.index('title={`Delete ${sspId}?`}')
+    modal_body = detail[modal_start:detail.index("Deletion is safe", modal_start)]
+    assert 'collectionsState === "stuck"' in modal_body
+    assert 'collectionsState !== "ready"' in modal_body
+    assert 'data-testid="ssp-delete-collections-unknown"' in modal_body
+    assert 'data-testid="ssp-delete-collections-loading"' in modal_body
+
+
 def test_bundle_transpiles_with_semantic_search_p4() -> None:
     from primer.api._jsx_bundle import build_jsx_bundle
 

--- a/ui/components/semantic-search.jsx
+++ b/ui/components/semantic-search.jsx
@@ -747,6 +747,12 @@ function SSPDetail({ sspId, pushToast }) {
     (signal) => apiFetch("GET", "/collections?limit=200", null, { signal }),
     { deps: [sspId] }
   );
+  // "ready" means the fetch genuinely completed at least once, so an
+  // empty referencingCollections is a real zero - not "loading" or
+  // "stuck" (>= MAX_ERRORS failures) silently read as the same zero.
+  // The delete-confirmation modal's "Deletion is safe" claim below must
+  // never fire on a check that hasn't actually resolved.
+  const collectionsState = window.primerApi.resourceState(collections);
   const referencingCollections = React.useMemo(() => {
     const items = collections.data?.items ?? [];
     return items.filter((c) => c.search_provider_id === sspId);
@@ -929,7 +935,7 @@ function SSPDetail({ sspId, pushToast }) {
               <Btn
                 kind="danger"
                 icon="trash"
-                disabled={referencingCollections.length > 0 || del.loading}
+                disabled={collectionsState !== "ready" || referencingCollections.length > 0 || del.loading}
                 onClick={() => del.mutate().catch(() => { /* onError handled */ })}
               >
                 {del.loading ? "Deleting…" : "Delete provider"}
@@ -941,6 +947,16 @@ function SSPDetail({ sspId, pushToast }) {
             <>
               <strong style={{ color: "var(--red)" }}>409 Conflict</strong> — {deleteError}
             </>
+          ) : collectionsState === "stuck" ? (
+            <div data-testid="ssp-delete-collections-unknown">
+              Couldn't check whether any collections reference this provider — the check has
+              failed repeatedly. Deletion is disabled until this is confirmed.{" "}
+              <Btn size="sm" icon="refresh" onClick={collections.refetch}>Retry</Btn>
+            </div>
+          ) : collectionsState !== "ready" ? (
+            <div data-testid="ssp-delete-collections-loading" className="muted text-sm">
+              Checking for collections that reference this provider…
+            </div>
           ) : referencingCollections.length > 0 ? (
             <>
               <strong style={{ color: "var(--red)" }}>409 Conflict</strong> — this provider is referenced by{" "}


### PR DESCRIPTION
## The defect

`ui/components/semantic-search.jsx`'s delete-provider modal derived `referencingCollections` from `collections.data?.items ?? []` and read neither `collections.error`, `.loading`, nor `.degraded` anywhere in the file. An empty array was indistinguishable from "the `/collections` fetch is still loading," "degraded," or "permanently failed" — all three collapsed into the same **"No collections reference this provider. Deletion is safe."** claim, with the destructive delete button enabled to match.

## Severity — bounded, not data loss

The file's own existing comment (`:743`) notes the backend delete route independently enforces a 409 cascade-block, so a false "safe" claim here can't actually destroy a referenced provider. The defect is the false claim itself and the confusing, unexplained 409 an operator would hit after being told it was safe.

## Fix

Reused `resourceState()` (`ui/foundation/use-resource.js`, landed in #266) rather than inventing a second ad-hoc loading/degraded check — it already distinguishes:
- **"ready"** — `collections.data` genuinely arrived; an empty array is a real zero.
- **"stuck"** — ≥ `MAX_ERRORS` consecutive failures.
- **"loading"** — still in flight or retrying.

The delete button is now disabled, and the modal shows an honest "checking…" or "couldn't verify" state (with a retry action for "stuck") instead of "safe" whenever `collectionsState !== "ready"`.

## Test plan
- [x] `test_delete_safety_claim_never_fires_on_an_unresolved_collections_check` (`tests/ui/test_semantic_search_p4.py`) — asserts `resourceState(collections)` gates both the button's `disabled` and the modal body's branch order
- [x] Proved it both ways: reverted the file locally, confirmed only this new test fails (19/20 others still pass); restored the fix, confirmed all 20 pass
- [x] Full `tests/ui` suite: 1685 passed, 1 skipped (unrelated, pre-existing)
- [x] `build_jsx_bundle` transpiles the edited file cleanly

## Deliberately out of scope
`SSPCollections` (the "Collections" tab panel, a separate render path fed the same `referencingCollections` array) still shows an ordinary "No collections bound" empty state on an unresolved fetch. Left alone — it's not a safety assertion, just an empty-state placeholder, and the `resourceState()` coverage guard's own docstring already scopes ordinary CRUD-list "still loading" gaps like this one out of the current round.

🤖 Generated with [Claude Code](https://claude.com/claude-code)